### PR TITLE
Basic implementation of the Equip (E) Button

### DIFF
--- a/Assets/Prefabs/SceneConstruction/Managers.prefab
+++ b/Assets/Prefabs/SceneConstruction/Managers.prefab
@@ -1852,6 +1852,7 @@ GameObject:
   - component: {fileID: 224342957805719492}
   - component: {fileID: 222471197423101600}
   - component: {fileID: 114102425676477964}
+  - component: {fileID: 114173723418728806}
   m_Layer: 5
   m_Name: Panel_HUD_Bottom
   m_TagString: Untagged
@@ -5782,6 +5783,34 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+--- !u!114 &114173723418728806
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1773735637013182}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6805bdeef480645908801c265e9d7aaf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  BeltSlot: {fileID: 114441514707964098}
+  BackSlot: {fileID: 114873687107902260}
+  SuitStorageSlot: {fileID: 114090887444817894}
+  IDSlot: {fileID: 114733848698575016}
+  LeftPocketSlot: {fileID: 114599336391617244}
+  RightPocketSlot: {fileID: 114162380104524076}
+  RightHandSlot: {fileID: 114695327282671848}
+  LeftHandSlot: {fileID: 114979991419574136}
+  HeadSlot: {fileID: 114395034210449304}
+  SuitSlot: {fileID: 114710482248211062}
+  HandsSlot: {fileID: 114704855797085276}
+  ShoeSlot: {fileID: 114158696084396008}
+  UniformSlot: {fileID: 114648632171505646}
+  EarSlot: {fileID: 114389007849843196}
+  EyesSlot: {fileID: 114232450015027486}
+  NeckSlot: {fileID: 114842981520721370}
+  MaskSlot: {fileID: 114712411679979280}
 --- !u!114 &114173813145052830
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -7897,8 +7926,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c2a726eeaef8432419b74dfe18ce9f81, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  RightSlot: {fileID: 114695327282671848}
-  LeftSlot: {fileID: 114979991419574136}
   selector: {fileID: 224945965584951848}
 --- !u!114 &114514712987587426
 MonoBehaviour:
@@ -10397,6 +10424,7 @@ MonoBehaviour:
   playerHealth: {fileID: 114643588251052962}
   playerListUIControl: {fileID: 114827065861498824}
   toolTip: {fileID: 114819375966709390}
+  inventorySlotCache: {fileID: 114173723418728806}
 --- !u!114 &114902798441274010
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -13190,7 +13218,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 63.15002, y: 33.850037}
+  m_AnchoredPosition: {x: 63.150024, y: 33.850037}
   m_SizeDelta: {x: 34, y: 64}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224679394288512756

--- a/Assets/UI/InventorySlotCache.cs
+++ b/Assets/UI/InventorySlotCache.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UI
+{
+	/// <summary>
+	/// A pseudo-array/dictionary for retrieving inventory slots. 
+	/// Supports multiple interactions to make it easier to access the slot you want to reference.
+	/// </summary>
+	/// <example>
+	/// var beltSlot = inventorySlotCache.BeltSlot;
+	/// </example>
+	/// <example>
+	/// var firstSlot = inventorySlotCache[0];
+	/// </example>
+	/// <example>
+	/// var hatSlot = inventorySlotCache[ItemType.Hat];
+	/// </example>
+	/// <example>
+	/// var idSlot = inventorySlotCache["id"];
+	/// </example>
+	/// <example>
+	/// foreach (var slot in inventorySlotCache)
+	/// </example>
+	/// <example>
+	/// inventorySlotCache.GetSlotByItem(CurrentSlot.Item)
+	/// </example>
+	public class InventorySlotCache : MonoBehaviour, IEnumerable<UI_ItemSlot>
+	{
+		public UI_ItemSlot BeltSlot;
+		public UI_ItemSlot BackSlot;
+		public UI_ItemSlot SuitStorageSlot;
+		public UI_ItemSlot IDSlot;
+		public UI_ItemSlot LeftPocketSlot;
+		public UI_ItemSlot RightPocketSlot;
+		public UI_ItemSlot RightHandSlot;
+		public UI_ItemSlot LeftHandSlot;
+		public UI_ItemSlot HeadSlot;
+		public UI_ItemSlot SuitSlot;
+		public UI_ItemSlot HandsSlot;
+		public UI_ItemSlot ShoeSlot;
+		public UI_ItemSlot UniformSlot;
+		public UI_ItemSlot EarSlot;
+		public UI_ItemSlot EyesSlot;
+		public UI_ItemSlot NeckSlot;
+		public UI_ItemSlot MaskSlot;
+
+		private UI_ItemSlot[] slots;
+
+		void Start()
+		{
+			slots = new[] {
+				BackSlot,
+				BeltSlot,
+				EarSlot,
+				EyesSlot,
+				HandsSlot,
+				HeadSlot,
+				IDSlot,
+				LeftHandSlot,
+				LeftPocketSlot,
+				MaskSlot,
+				NeckSlot,
+				RightHandSlot,
+				RightPocketSlot,
+				SuitSlot,
+				SuitStorageSlot,
+				ShoeSlot,
+				UniformSlot,
+			};
+		}
+
+		public UI_ItemSlot this [int index] {
+			get {
+				return slots[index];
+			}
+		}
+
+		public UI_ItemSlot this [ItemType type] {
+			get {
+				return GetSlotByItemType(type);
+			}
+		}
+
+		public UI_ItemSlot this [string eventName] {
+			get {
+				return GetSlotByEvent(eventName);
+			}
+		}
+
+		IEnumerator<UI_ItemSlot> IEnumerable<UI_ItemSlot>.GetEnumerator()
+		{
+			return (IEnumerator<UI_ItemSlot>)slots.GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return slots.GetEnumerator();
+		}
+
+		public int Length {
+			get {
+				return slots != null ? slots.Length : 0;
+			}
+		}
+
+		/// <summary>
+		/// Returns the most fitting slot for a given item to be equipped.
+		/// </summary>
+		/// <remarks>
+		/// Returns the left pocket for non-equippable items.
+		/// </remarks>
+		public UI_ItemSlot GetSlotByItem(GameObject obj)
+		{
+			var item = obj.GetComponent<ItemAttributes>();
+			return GetSlotByItemType(item.type);
+		}
+
+		public UI_ItemSlot GetSlotByItemType(ItemType type)
+		{
+			switch (type) {
+				case ItemType.Back:
+					return BackSlot;
+				case ItemType.Belt:
+					return BeltSlot;
+				case ItemType.Ear:
+					return EarSlot;
+				case ItemType.Glasses:
+					return EyesSlot;
+				case ItemType.Gloves:
+					return HandsSlot;
+				case ItemType.Hat:
+					return HeadSlot;
+				case ItemType.ID:
+				case ItemType.PDA:
+					return IDSlot;
+				case ItemType.Mask:
+					return MaskSlot;
+				case ItemType.Neck:
+					return NeckSlot;
+				case ItemType.Shoes:
+					return ShoeSlot;
+				case ItemType.Suit:
+					return SuitSlot;
+				case ItemType.Uniform:
+					return UniformSlot;
+				case ItemType.Gun:
+					return SuitStorageSlot;
+				default:
+					return LeftPocketSlot;
+			}
+		}
+
+		public UI_ItemSlot GetSlotByEvent(string eventName)
+		{
+			switch (eventName) {
+				case "feet":
+				case "shoes":
+					return ShoeSlot;
+				case "uniform":
+					return UniformSlot;
+				case "suit":
+					return SuitSlot;
+				case "suitStorage":
+					return SuitStorageSlot;
+				case "gloves":
+				case "hands":
+					return HandsSlot;
+				case "neck":
+					return NeckSlot;
+				case "mask":
+					return MaskSlot;
+				case "ear":
+				case "ears":
+					return EarSlot;
+				case "glasses":
+				case "eyes":
+					return EyesSlot;
+				case "hat":
+				case "head":
+					return HeadSlot;
+				case "id":
+				case "pda":
+					return IDSlot;
+				case "belt":
+					return BeltSlot;
+				case "bag":
+				case "back":
+					return BackSlot;
+				case "rightHand":
+					return RightHandSlot;
+				case "leftHand":
+					return LeftHandSlot;
+				case "leftPocket":
+				case "storage01":
+					return LeftPocketSlot;
+				case "rightPocket":
+				case "storage02":
+					return RightPocketSlot;
+			}
+
+			throw new InvalidOperationException("Unrecognized event name: " + eventName);
+		}
+	}
+}

--- a/Assets/UI/InventorySlotCache.cs.meta
+++ b/Assets/UI/InventorySlotCache.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6805bdeef480645908801c265e9d7aaf
+timeCreated: 1496279793
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/scenes/TestMap.unity
+++ b/Assets/scenes/TestMap.unity
@@ -7225,7 +7225,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4000011140861540, guid: 462ac978126b468baa6b4ba377070a17, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -0.2
+      value: -0.4
       objectReference: {fileID: 0}
     - target: {fileID: 4000011140861540, guid: 462ac978126b468baa6b4ba377070a17, type: 2}
       propertyPath: m_LocalRotation.x
@@ -13083,18 +13083,13 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 224454349079915406, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 0.0000038663466
-      objectReference: {fileID: 0}
-    - target: {fileID: 224454349079915406, guid: 829f4ca992b848d6bb4d007fb9c112e1,
-        type: 2}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 224454349079915406, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 2}
       propertyPath: m_AnchorMax.y
-      value: 0.9787272
+      value: 0.9787234
       objectReference: {fileID: 0}
     - target: {fileID: 224660059574265910, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 2}

--- a/Assets/scripts/UI/UI Bottom/ControlAction.cs
+++ b/Assets/scripts/UI/UI Bottom/ControlAction.cs
@@ -30,6 +30,10 @@ namespace UI {
 			if(Input.GetKeyDown(KeyCode.X)) {
 				UIManager.Hands.Swap();
 			}
+
+			if (Input.GetKeyDown(KeyCode.E)) {
+				UIManager.Hands.Use();
+			}
         }
 
         public void Resist() {

--- a/Assets/scripts/UI/UI Bottom/Hands.cs
+++ b/Assets/scripts/UI/UI Bottom/Hands.cs
@@ -3,53 +3,72 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 
-namespace UI {
-    public class Hands: MonoBehaviour {
-        public UI_ItemSlot CurrentSlot { get; private set; } //set primary hand
-		public UI_ItemSlot OtherSlot { get; private set; } //set secondary hand
-        public bool IsRight { get; private set; }
+namespace UI
+{
+	public class Hands: MonoBehaviour
+	{
+		public UI_ItemSlot CurrentSlot { get; private set; }
+		public UI_ItemSlot OtherSlot { get; private set; }
+		public bool IsRight { get; private set; }
+		public Transform selector;
 
-        public UI_ItemSlot RightSlot;
-        public UI_ItemSlot LeftSlot;
-        public Transform selector;
+		void Start()
+		{
+			CurrentSlot = Slots.RightHandSlot;
+			OtherSlot = Slots.LeftHandSlot;
+			IsRight = true;
+		}
 
-        void Start() {
-            CurrentSlot = RightSlot;
-			OtherSlot = LeftSlot;
-            IsRight = true;
-        }
+		public void Swap()
+		{
+			SetHand(!IsRight);
+		}
 
-        public void Swap() {
-            SetHand(!IsRight);
-        }
+		public void SetHand(bool right)
+		{
+			if (right) {
+				CurrentSlot = Slots.RightHandSlot;
+				OtherSlot = Slots.LeftHandSlot;
+			} else {
+				CurrentSlot = Slots.LeftHandSlot;
+				OtherSlot = Slots.RightHandSlot;
+			}
 
-        public void SetHand(bool right) {
-            if(right) {
-                CurrentSlot = RightSlot;
-				OtherSlot = LeftSlot;
-            } else {
-                CurrentSlot = LeftSlot;
-				OtherSlot = RightSlot;
-            }
+			IsRight = right;
+			selector.position = CurrentSlot.transform.position;
+		}
 
-            IsRight = right;
-            selector.position = CurrentSlot.transform.position;
-        }
+		public void SwapItem(UI_ItemSlot itemSlot)
+		{
+			if (CurrentSlot != itemSlot) {
+				if (!CurrentSlot.IsFull) {
+					Swap(CurrentSlot, itemSlot);
+				} else {
+					Swap(itemSlot, CurrentSlot);
+				}
+			}
+		}
 
-        public void SwapItem(UI_ItemSlot itemSlot) {
-            if(CurrentSlot != itemSlot) {
-                if(!CurrentSlot.IsFull) {
-                    Swap(CurrentSlot, itemSlot);
-                } else {
-                    Swap(itemSlot, CurrentSlot);
-                }
-            }
-        }
+		public void Use()
+		{
+			if (!CurrentSlot.IsFull)
+				return;
 
-        private void Swap(UI_ItemSlot slot1, UI_ItemSlot slot2) {
-            if(slot1.TrySetItem(slot2.Item)) {
-                slot2.Clear();
-            }
-        }
-    }
+			var slot = Slots.GetSlotByItem(CurrentSlot.Item);
+			SwapItem(slot);
+		}
+
+		private void Swap(UI_ItemSlot slot1, UI_ItemSlot slot2)
+		{
+			if (slot1.TrySetItem(slot2.Item)) {
+				slot2.Clear();
+			}
+		}
+
+		private InventorySlotCache Slots {
+			get {
+				return UIManager.InventorySlots;
+			}
+		}
+	}
 }

--- a/Assets/scripts/UI/UIManager.cs
+++ b/Assets/scripts/UI/UIManager.cs
@@ -3,74 +3,74 @@ using System.Collections;
 using PlayGroup;
 using UnityEngine.UI;
 
-namespace UI {
-    public class UIManager: MonoBehaviour {
-
-        public ControlChat chatControl;
-        public Hands hands;
-        public ControlIntent intentControl;
-        public ControlAction actionControl;
-        public ControlWalkRun walkRunControl;
-        public ControlDisplays displayControl;
-        public PlayerHealth playerHealth;
+namespace UI
+{
+	public class UIManager: MonoBehaviour
+	{
+		public ControlChat chatControl;
+		public Hands hands;
+		public ControlIntent intentControl;
+		public ControlAction actionControl;
+		public ControlWalkRun walkRunControl;
+		public ControlDisplays displayControl;
+		public PlayerHealth playerHealth;
 		public PlayerListUI playerListUIControl;
 		public Text toolTip;
+		public InventorySlotCache inventorySlotCache;
 
-        private static UIManager uiManager;
+		private static UIManager uiManager;
 
-        public static UIManager Instance {
-            get {
-                if(!uiManager) {
-                    uiManager = FindObjectOfType<UIManager>();
-                }
+		public static UIManager Instance {
+			get {
+				if (!uiManager) {
+					uiManager = FindObjectOfType<UIManager>();
+				}
 
-                return uiManager;
-            }
-        }
+				return uiManager;
+			}
+		}
 
-        public static ControlChat Chat {
-            get {
-                return Instance.chatControl;
-            }
-        }
+		public static ControlChat Chat {
+			get {
+				return Instance.chatControl;
+			}
+		}
 
-        public static PlayerHealth PlayerHealth
-        {
-            get
-            {
-                return Instance.playerHealth;
-            }
-        }
+		public static PlayerHealth PlayerHealth {
+			get {
+				return Instance.playerHealth;
+			}
+		}
 
-        public static Hands Hands {
-            get {
-                return Instance.hands;
-            }
-        }
+		public static Hands Hands {
+			get {
+				return Instance.hands;
+			}
+		}
 
-        public static ControlIntent Intent {
-            get {
-                return Instance.intentControl;
-            }
-        }
+		public static ControlIntent Intent {
+			get {
+				return Instance.intentControl;
+			}
+		}
 
-        public static ControlAction Action {
-            get {
-                return Instance.actionControl;
-            }
-        }
+		public static ControlAction Action {
+			get {
+				return Instance.actionControl;
+			}
+		}
 
-        public static ControlWalkRun WalkRun {
-            get {
-                return Instance.walkRunControl;
-            }
-        }
+		public static ControlWalkRun WalkRun {
+			get {
+				return Instance.walkRunControl;
+			}
+		}
 
-        public static ControlDisplays Display {
-            get {
-                return Instance.displayControl;
-            }
-        }
+		public static ControlDisplays Display {
+			get {
+				return Instance.displayControl;
+			}
+		}
 
 		public static PlayerListUI PlayerListUI {
 			get {
@@ -78,31 +78,36 @@ namespace UI {
 			}
 		}
 
-		public static string SetToolTip{
+		public static string SetToolTip {
 			set { 
 				Instance.toolTip.text = value;
 			}
 		}
 
+		public static InventorySlotCache InventorySlots {
+			get {
+				return Instance.inventorySlotCache;
+			}
+		}
 
-        /// <summary>
-        /// Current Intent status
-        /// </summary>
-        public static Intent CurrentIntent { get; set; }
+		/// <summary>
+		/// Current Intent status
+		/// </summary>
+		public static Intent CurrentIntent { get; set; }
 
-        /// <summary>
-        /// What is DamageZoneSeclector currently set at
-        /// </summary>
-        public static DamageZoneSelector DamageZone { get; set; }
+		/// <summary>
+		/// What is DamageZoneSeclector currently set at
+		/// </summary>
+		public static DamageZoneSelector DamageZone { get; set; }
 
-        /// <summary>
-        /// Is throw selected?
-        /// </summary>
-        public static bool IsThrow { get; set; }
+		/// <summary>
+		/// Is throw selected?
+		/// </summary>
+		public static bool IsThrow { get; set; }
 
-        /// <summary>
-        /// Is Oxygen On?
-        /// </summary>
-        public static bool IsOxygen { get; set; }
-    }
+		/// <summary>
+		/// Is Oxygen On?
+		/// </summary>
+		public static bool IsOxygen { get; set; }
+	}
 }

--- a/Assets/scripts/Weapons/Weapon.cs
+++ b/Assets/scripts/Weapons/Weapon.cs
@@ -195,7 +195,7 @@ namespace Weapons
 				return;
 
 			//if the hand with the weapon in it is selected
-			if (UIManager.Hands.CurrentSlot == UIManager.Hands.LeftSlot || UIManager.Hands.CurrentSlot == UIManager.Hands.RightSlot) {
+			if (UIManager.Hands.CurrentSlot == UIManager.InventorySlots.LeftHandSlot || UIManager.Hands.CurrentSlot == UIManager.InventorySlots.RightHandSlot) {
 				//if we have no mag/clip loaded play empty sound
 				if (CurrentMagazine == null) {
 					InAutomaticAction = false;

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.6.0p4
+m_EditorVersion: 5.6.1f1


### PR DESCRIPTION
- Clicking the Equip button or pressing the E key will attempt to equip the current item
- If the equipment slot is already filled, nothing happens
- If the current item is not equippable, try to put it in the first pocket slot
- Refactors UI_ItemSlot refs into a new InventorySlotCache class
- Accessable via `UIManager.InventorySlots`
- InventorySlots can be used as an array, dictionary, or direct reference to a particular slot

I ran Code Formatting using the K&S style, which is why some lines that were not related to this change got minor refactors.

Example usages:

```
// Direct access fields
var beltSlot = UIManager.InventorySlots.BeltSlot;

// Array indexer
var firstSlot = UIManager.InventorySlots[0];

// Lookup by ItemType
var hatSlot = UIManager.InventorySlots[ItemType.Hat];

// Lookup by eventName
var idSlot = UIManager.InventorySlots["id"];

// Enumerator
foreach (var slot in UIManager.InventorySlots)

// Return the appropriate slot for an item
var slot = UIManager.InventorySlots.GetSlotByItem(CurrentSlot.Item)
```