### PR TITLE
Remove unnecessary garbage allocation in Weapon.Update()

### DIFF
--- a/Assets/scripts/Equipment/Equipment.cs
+++ b/Assets/scripts/Equipment/Equipment.cs
@@ -121,7 +121,7 @@ namespace Equipment
 		public void SetHandItem(string eventName, GameObject obj)
 		{
 			ItemAttributes att = obj.GetComponent<ItemAttributes>();
-			EquipmentPool.AddGameObject(gameObject.name, obj);
+			EquipmentPool.AddGameObject(gameObject, obj);
             SetHandItemSprite(eventName, att);
             RpcSendMessage(eventName, obj);
 		}
@@ -155,7 +155,7 @@ namespace Equipment
 			GameObject item = Instantiate(prefab, Vector2.zero, Quaternion.identity) as GameObject;
 			NetworkServer.Spawn(item);
 			ItemAttributes att = item.GetComponent<ItemAttributes>();
-			EquipmentPool.AddGameObject(gameObject.name, item);
+			EquipmentPool.AddGameObject(gameObject, item);
 
 			playerNetworkActions.TrySetItem(eventName, item);
 			//Sync all clothing items across network using SyncListInt syncEquipSprites

--- a/Assets/scripts/Equipment/EquipmentPool.cs
+++ b/Assets/scripts/Equipment/EquipmentPool.cs
@@ -24,20 +24,24 @@ namespace Equipment
 		private GameObject objectPoolPrefab;
 		private Dictionary<string,ObjectPool> equipPools = new Dictionary<string, ObjectPool>();
 
-		void Init(){
+		void Init()
+		{
 			Instance.transform.position = Vector2.zero;
 			Instance.objectPoolPrefab = Resources.Load("ObjectPool")as GameObject;
 		}
 
-		public static void AddGameObject (string playerName, GameObject gObj){
-
-			if(Instance.equipPools.ContainsKey(playerName)){
+		public static void AddGameObject(GameObject player, GameObject gObj)
+		{
+			var playerName = player.name;
+			if (Instance.equipPools.ContainsKey(playerName)) {
 				//add obj to pool
 				Instance.equipPools[playerName].AddGameObject(gObj);
-                gObj.BroadcastMessage("OnAddToPool", playerName, SendMessageOptions.DontRequireReceiver);
+
+				var ownerId = player.GetComponent<NetworkIdentity>().netId;
+				gObj.BroadcastMessage("OnAddToPool", ownerId, SendMessageOptions.DontRequireReceiver);
 			} else {
 				//set up new pool and then add the obj
-				GameObject newPool = Instantiate(Instance.objectPoolPrefab,Vector2.zero,Quaternion.identity) as GameObject;
+				GameObject newPool = Instantiate(Instance.objectPoolPrefab, Vector2.zero, Quaternion.identity) as GameObject;
 				newPool.transform.parent = Instance.transform;
 				newPool.name = playerName;
 				Instance.equipPools.Add(playerName, newPool.GetComponent<ObjectPool>());
@@ -46,22 +50,22 @@ namespace Equipment
 		}
 
 		//When dropping items etc, remove them from the player equipment pool and place in scene
-		public static void DropGameObject (string playerName, GameObject gObj){
+		public static void DropGameObject(string playerName, GameObject gObj)
+		{
 			if (Instance.equipPools.ContainsKey(playerName)) {
 				Instance.equipPools[playerName].DropGameObject(gObj, PlayerList.Instance.connectedPlayers[playerName].transform.position);
-                gObj.BroadcastMessage("OnRemoveFromPool", null, SendMessageOptions.DontRequireReceiver);
-            }
-		}
-
-		//When placing items at a position etc also removes them from the player equipment pool and places it in scene
-		public static void DropGameObject (string playerName, GameObject gObj, Vector3 pos){
-			if (Instance.equipPools.ContainsKey(playerName)) {
-				Instance.equipPools[playerName].DropGameObject(gObj, pos);
-                gObj.BroadcastMessage("OnRemoveFromPool", null, SendMessageOptions.DontRequireReceiver);
-
+				gObj.BroadcastMessage("OnRemoveFromPool", null, SendMessageOptions.DontRequireReceiver);
 			}
 		}
 
+		//When placing items at a position etc also removes them from the player equipment pool and places it in scene
+		public static void DropGameObject(string playerName, GameObject gObj, Vector3 pos)
+		{
+			if (Instance.equipPools.ContainsKey(playerName)) {
+				Instance.equipPools[playerName].DropGameObject(gObj, pos);
+				gObj.BroadcastMessage("OnRemoveFromPool", null, SendMessageOptions.DontRequireReceiver);
 
+			}
+		}
 	}
 }

--- a/Assets/scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/Assets/scripts/PlayGroups/PlayerNetworkActions.cs
@@ -102,7 +102,7 @@ public class PlayerNetworkActions : NetworkBehaviour
         {
             if (ServerCache[eventName] == null || ServerCache[eventName] == obj)
             {
-                EquipmentPool.AddGameObject(gameObject.name, obj);
+                EquipmentPool.AddGameObject(gameObject, obj);
                 ServerCache[eventName] = obj;
                 equipment.SetHandItem(eventName, obj);
             }
@@ -117,7 +117,7 @@ public class PlayerNetworkActions : NetworkBehaviour
 	[Command]
 	public void CmdTryAddToEquipmentPool(GameObject obj){
 
-		EquipmentPool.AddGameObject(gameObject.name, obj);
+		EquipmentPool.AddGameObject(gameObject, obj);
 	}
 
     [Command]
@@ -128,7 +128,7 @@ public class PlayerNetworkActions : NetworkBehaviour
             {
                 GameObject item = Instantiate(prefab, Vector3.zero, Quaternion.identity) as GameObject;
                 NetworkServer.Spawn(item);
-                EquipmentPool.AddGameObject(gameObject.name, item);
+                EquipmentPool.AddGameObject(gameObject, item);
                 ServerCache[eventName] = item;
                 equipment.SetHandItem(eventName, item);
                 RpcInstantiateInHand(gameObject.name, item);

--- a/Assets/scripts/Weapons/Weapon.cs
+++ b/Assets/scripts/Weapons/Weapon.cs
@@ -85,7 +85,7 @@ namespace Weapons
 		public NetworkInstanceId MagNetID;
 
 		[SyncVar]
-		public string ControlledByPlayer;
+		public NetworkInstanceId ControlledByPlayer;
 
 		void Start()
 		{
@@ -98,12 +98,15 @@ namespace Weapons
 		}
 
 		void Update () {
+			if (ControlledByPlayer == NetworkInstanceId.Invalid)
+				return;
+
 			//don't start it too early:
 			if (!PlayerManager.LocalPlayer)
 				return;
 			
 			//Only update if it is inhand of localplayer
-			if (PlayerManager.LocalPlayer.name != ControlledByPlayer)
+			if (PlayerManager.LocalPlayer != ClientScene.FindLocalObject(ControlledByPlayer))
 				return;
 			
 			if (FireCountDown > 0 )
@@ -286,10 +289,10 @@ namespace Weapons
 
 		#region Weapon Pooling
 		//This is only called on the serverside
-		public void OnAddToPool(string playerName)
+		public void OnAddToPool(NetworkInstanceId ownerId)
 		{
-			ControlledByPlayer = playerName;
-			if (CurrentMagazine != null && PlayerManager.LocalPlayer.name == playerName) {
+			ControlledByPlayer = ownerId;
+			if (CurrentMagazine != null && PlayerManager.LocalPlayer == ClientScene.FindLocalObject(ownerId)) {
 				//As the magazine loaded is part of the weapon, then we do not need to add to server cache, we only need to add the item to the equipment pool
 				PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryAddToEquipmentPool(CurrentMagazine.gameObject);
 			}
@@ -297,7 +300,7 @@ namespace Weapons
 
 		public void OnRemoveFromPool()
 		{
-			ControlledByPlayer = "";
+			ControlledByPlayer = NetworkInstanceId.Invalid;
 		}
 		#endregion
 


### PR DESCRIPTION
I was playing around with the Profiler tool and happened to notice that `Weapon.Update()` calls `PlayerManager.LocalPlayer.name` which creates an object allocation, generating garbage every single frame. 

Spoke with @DooblyNoobly who told me that it is better to use `NetworkIdentity` to compare player references across the network, instead of player name.