### PR TITLE
Resolves #314 by laying the groundwork for test automation

### DIFF
--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1422d3ef815cc4532b82c26b30e34f05
+folderAsset: yes
+timeCreated: 1497232940
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/ExplodeWhenShotTest.cs
+++ b/Assets/Tests/ExplodeWhenShotTest.cs
@@ -1,0 +1,37 @@
+﻿using UnityEngine;
+using UnityEngine.TestTools;
+using NUnit.Framework;
+using System.Collections;
+
+public class ExplodeWhenShotTest {
+	ExplodeWhenShot subject;
+
+	[SetUp]
+	public void SetUp() {
+		var obj = new GameObject();
+		obj.AddComponent<SoundManager>();
+		subject = obj.AddComponent<ExplodeWhenShot>();
+	}
+
+	[UnityTest]
+	public IEnumerator Should_Destroy_Bullet() {
+		var bullet = new GameObject();
+		var collider = bullet.AddComponent<BoxCollider2D>();
+		bullet.AddComponent<Bullet_12mm>();
+
+		subject.SendMessage("OnTriggerEnter2D", collider);
+
+		yield return 0;
+
+		Assert.That(bullet == null);
+	}
+
+	[UnityTest]
+	public IEnumerator Should_Destroy_Object() {
+		subject.Explode(null);
+
+		yield return 0;
+
+		Assert.That(subject == null);
+	}
+}

--- a/Assets/Tests/ExplodeWhenShotTest.cs.meta
+++ b/Assets/Tests/ExplodeWhenShotTest.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a82c9a46954a5439187e0353e4076595
+timeCreated: 1497232986
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/scripts/Managers/SoundManager.cs
+++ b/Assets/scripts/Managers/SoundManager.cs
@@ -32,7 +32,8 @@ public class SoundManager: MonoBehaviour {
 
 	public AudioSource this [string key] {
 		get {
-			return sounds[key];
+			AudioSource source;
+			return sounds.TryGetValue(key, out source) ? source : null;
 		}
 	}
 

--- a/Assets/scripts/Objects/ExplodeWhenShot.cs
+++ b/Assets/scripts/Objects/ExplodeWhenShot.cs
@@ -20,8 +20,10 @@ public class ExplodeWhenShot : NetworkBehaviour {
 		}
 	}
 
+	#if !ENABLE_PLAYMODE_TESTS_RUNNER
 	[Server]
-	void Explode(string bulletOwnedBy) {
+	#endif
+	public void Explode(string bulletOwnedBy) {
 		// TODO: Damage people
 		NetworkServer.Destroy(gameObject);
 	}
@@ -30,7 +32,9 @@ public class ExplodeWhenShot : NetworkBehaviour {
 		// Instantiate a clone of the source so that multiple explosions can play at the same time.
 		var name = explosions[Random.Range(0, explosions.Length)];
 		var source = SoundManager.Instance[name];
-		Instantiate<AudioSource>(source, transform.position, Quaternion.identity).Play();
+		if (source != null) {
+			Instantiate<AudioSource>(source, transform.position, Quaternion.identity).Play();
+		}
 
 		var parent = Resources.Load<GameObject>("effects/FireRing");
 		Instantiate(parent, transform.position, Quaternion.identity);

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -355,7 +355,7 @@ PlayerSettings:
   wiiUGamePadStartupScreen: {fileID: 0}
   wiiUDrcBufferDisabled: 0
   wiiUProfilerLibPath: 
-  playModeTestRunnerEnabled: 0
+  playModeTestRunnerEnabled: 1
   actionOnDotNetUnhandledException: 1
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.6.1p1
+m_EditorVersion: 5.6.1f1


### PR DESCRIPTION
Some lessons I learned regarding testing Unity behaviors:

- Instead of instantiating MonoBehaviors directly, create a new `GameObject` and add the behavior plus any dependencies to it.
- Messages are MonoBehaviour event handlers, such as `Awake` or `OnTriggerEnter2D`. Similar to `Page_Load` auto event wire-up in ASPX. Since messages in-game are triggered by the Unity engine, to invoke them for testing you can use `gameObject.SendMessage(...)`
- I could not figure out how to mock the server context to run `[Server]` methods in tests, so I worked around the issue by wrapping the attribute in an `#if !ENABLE_PLAYMODE_TESTS_RUNNER ` macro.
- To test if an object has been destroyed, you must wait one frame and then test if it is null. To wait a frame, use the `[UnityTest]` attribute and `IEnumerator` as the test return type. Then `yield return 0;` to wait. Finally, you must `Assert.That(subject == null);` to check if its destroyed. `Assert.IsNull(subject);` won't work because the object reference is not actually null, Unity just overloaded the equality operator. Why on earth they did that instead of just having an `isDestroyed` prop is beyond me.