### PR TITLE
Fuel tanks deal damage to nearby players when they explode

### DIFF
--- a/Assets/Prefabs/Canisters/WeldingFuel.prefab
+++ b/Assets/Prefabs/Canisters/WeldingFuel.prefab
@@ -138,6 +138,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7ab49f7209d2b4a9d94184d4ea24e312, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  damage: 150
+  radius: 3
 --- !u!114 &114759220295053954
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Player/Resources/Player_V3(uNet).prefab
+++ b/Assets/Prefabs/Player/Resources/Player_V3(uNet).prefab
@@ -149,6 +149,7 @@ GameObject:
   - component: {fileID: 114600992077934460}
   - component: {fileID: 114448356827088240}
   - component: {fileID: 114285504268110804}
+  - component: {fileID: 61260641920390224}
   m_Layer: 8
   m_Name: Player_V3(uNet)
   m_TagString: Untagged
@@ -565,7 +566,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1133514949248654}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1843.988, y: 1143, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4077080561960782}
@@ -963,6 +964,31 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1175863687298716}
   m_Mesh: {fileID: 0}
+--- !u!61 &61260641920390224
+BoxCollider2D:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1133514949248654}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!61 &61619160360543986
 BoxCollider2D:
   m_ObjectHideFlags: 1

--- a/Assets/Tests/ExplodeWhenShotTest.cs
+++ b/Assets/Tests/ExplodeWhenShotTest.cs
@@ -1,20 +1,24 @@
 ﻿using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
+using System;
 using System.Collections;
 
-public class ExplodeWhenShotTest {
-	ExplodeWhenShot subject;
+public class ExplodeWhenShotTest
+{
+	MockExplodeWhenShot subject;
 
 	[SetUp]
-	public void SetUp() {
+	public void SetUp()
+	{
 		var obj = new GameObject();
 		obj.AddComponent<SoundManager>();
-		subject = obj.AddComponent<ExplodeWhenShot>();
+		subject = obj.AddComponent<MockExplodeWhenShot>();
 	}
 
 	[UnityTest]
-	public IEnumerator Should_Destroy_Bullet() {
+	public IEnumerator Should_Destroy_Bullet()
+	{
 		var bullet = new GameObject();
 		var collider = bullet.AddComponent<BoxCollider2D>();
 		bullet.AddComponent<Bullet_12mm>();
@@ -27,11 +31,65 @@ public class ExplodeWhenShotTest {
 	}
 
 	[UnityTest]
-	public IEnumerator Should_Destroy_Object() {
+	public IEnumerator Should_Destroy_Object()
+	{
 		subject.Explode(null);
 
 		yield return 0;
 
 		Assert.That(subject == null);
+	}
+
+	[Test]
+	public void Should_Damage_Nearby_Player()
+	{
+		var player = new GameObject();
+
+		player.AddComponent<BoxCollider2D>();
+		var living = player.AddComponent<Living>();
+		player.layer = LayerMask.NameToLayer("Players");
+
+		Living damaged = null;
+		subject.callback = t => damaged = t;
+
+		subject.Explode(null);
+
+		Assert.That(living == damaged);
+	}
+
+	[Test]
+	public void Should_Not_Damage_Player_Through_Wall()
+	{
+		var player = new GameObject();
+		player.AddComponent<BoxCollider2D>();
+		player.AddComponent<Living>();
+		player.layer = LayerMask.NameToLayer("Players");
+		player.transform.position = new Vector3(2, 0);
+
+		var wall = new GameObject();
+		wall.AddComponent<BoxCollider2D>();
+		wall.layer = LayerMask.NameToLayer("Walls");
+		wall.transform.position = new Vector3(1, 0);
+
+		Living damaged = null;
+		subject.callback = t => damaged = t;
+
+		subject.Explode(null);
+
+		Assert.That(damaged == null);
+	}
+
+	// TODO: Add a unity-friendly mock library. A few blogs mention a unity flavor of NSubstitute, but development
+	// doesn't appear to be ongoing, no activity in 3+ years, so let's just do a manual mock instead.
+	class MockExplodeWhenShot : ExplodeWhenShot
+	{
+		public Action<Living> callback;
+
+		internal override void HurtPeople(Living living, string damagedBy, int damage)
+		{
+			if (callback != null) {
+				callback(living);
+			}
+		}
 	}
 }

--- a/Assets/scripts/Managers/PlayerList.cs
+++ b/Assets/scripts/Managers/PlayerList.cs
@@ -55,7 +55,7 @@ public class PlayerList : NetworkBehaviour
 	//Called on the server when a kill is confirmed
 	[Server]
 	public void UpdateKillScore(string playerName){
-		if (playerScores.ContainsKey(playerName)) {
+		if (playerName != null && playerScores.ContainsKey(playerName)) {
 			playerScores[playerName]++;
 		}
 	}

--- a/Assets/scripts/Mob/Living/Living.cs
+++ b/Assets/scripts/Mob/Living/Living.cs
@@ -92,7 +92,7 @@ public class Living : Mob
 
 		StartCoroutine(ShotDamageCoolDown());
 		shotDmgCoolDown = true;
-		RpcReceiveDamage(bulletOwnedBy);
+		RpcReceiveDamage(bulletOwnedBy, 20);
 		BloodSplat(transform.position,BloodSplatSize.medium);
 
 	}
@@ -115,13 +115,13 @@ public class Living : Mob
 	//TODO the headless server is running as a host, so ClientRPC will also call on the server
 	//If the server is turned into a straight server, this will need to be fixed
 	[ClientRpc]
-	public virtual void RpcReceiveDamage(string damagedBy)
+	public virtual void RpcReceiveDamage(string damagedBy, int damage)
     {
 		if (CustomNetworkManager.Instance._isServer) {
 			lastDamager = damagedBy;
 		}
         // TODO read from items damage values etc
-        ApplyDamage(20, DamageType.BRUTE, "chest");
+        ApplyDamage(damage, DamageType.BRUTE, "chest");
     }
 
 

--- a/Assets/scripts/Objects/ExplodeWhenShot.cs
+++ b/Assets/scripts/Objects/ExplodeWhenShot.cs
@@ -4,10 +4,27 @@ using UnityEngine;
 using UnityEngine.Networking;
 using PlayGroup;
 
-public class ExplodeWhenShot : NetworkBehaviour {
-	string[] explosions = new[] {"Explosion1", "Explosion2"};
+public class ExplodeWhenShot : NetworkBehaviour
+{
+	public int damage = 150;
+	public float radius = 3f;
 
-	void OnTriggerEnter2D(Collider2D coll){
+	const int MAX_TARGETS = 44;
+
+	readonly string[] explosions = new[] { "Explosion1", "Explosion2" };
+	readonly Collider2D[] colliders = new Collider2D[MAX_TARGETS];
+
+	int playerMask;
+	int obstacleMask;
+
+	void Start()
+	{
+		playerMask = LayerMask.GetMask("Players");
+		obstacleMask = LayerMask.GetMask("Walls", "Door Closed");
+	}
+
+	void OnTriggerEnter2D(Collider2D coll)
+	{
 		var bullet = coll.GetComponent<BulletBehaviour>();
 		if (bullet != null) {
 			if (isServer) {
@@ -23,12 +40,32 @@ public class ExplodeWhenShot : NetworkBehaviour {
 	#if !ENABLE_PLAYMODE_TESTS_RUNNER
 	[Server]
 	#endif
-	public void Explode(string bulletOwnedBy) {
-		// TODO: Damage people
+	public void Explode(string bulletOwnedBy)
+	{
+		var pos = (Vector2)transform.position;
+		var length = Physics2D.OverlapCircleNonAlloc(pos, radius, colliders, playerMask);
+
 		NetworkServer.Destroy(gameObject);
+
+		for (int i = 0; i < length; i++) {
+			var collider = colliders[i];
+			var living = collider.gameObject.GetComponent<Living>();
+			if (living != null) {
+				var livingPos = (Vector2)living.transform.position;
+				var distance = Vector3.Distance(pos, livingPos);
+
+				var hit = Physics2D.Raycast(pos, livingPos - pos, distance, obstacleMask);
+				if (hit.collider == null) {
+					var effect = 1 - ((distance * distance) / (radius * radius));
+					var actualDamage = (int)(damage * effect);
+					HurtPeople(living, bulletOwnedBy, actualDamage);
+				}
+			}
+		}
 	}
-		
-	void GoBoom() {
+
+	void GoBoom()
+	{
 		// Instantiate a clone of the source so that multiple explosions can play at the same time.
 		var name = explosions[Random.Range(0, explosions.Length)];
 		var source = SoundManager.Instance[name];
@@ -38,5 +75,10 @@ public class ExplodeWhenShot : NetworkBehaviour {
 
 		var parent = Resources.Load<GameObject>("effects/FireRing");
 		Instantiate(parent, transform.position, Quaternion.identity);
+	}
+
+	internal virtual void HurtPeople(Living living, string damagedBy, int damage)
+	{
+		living.RpcReceiveDamage(damagedBy, damage);
 	}
 }

--- a/Assets/scripts/Weapons/WeaponNetworkActions.cs
+++ b/Assets/scripts/Weapons/WeaponNetworkActions.cs
@@ -111,7 +111,7 @@ public class WeaponNetworkActions: NetworkBehaviour {
         if(npcObj != gameObject) {
             RpcKnifeAttackLerp(stabDirection);
         }
-        attackTarget.RpcReceiveDamage(gameObject.name);
+        attackTarget.RpcReceiveDamage(gameObject.name, 20);
         BloodSplat(npcObj.transform.position, BloodSplatSize.medium);
         soundNetworkActions.RpcPlayNetworkSound("BladeSlice", transform.position);
 

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.6.1p1
+m_EditorVersion: 5.6.1f1


### PR DESCRIPTION
Standing too close to a fuel tank when you shoot it will cause you to suffer catastrophic injury or death.

- Populates an array of players within range of the blast, then rayscans each player to see if they are obstructed by a wall or closed door. Unobstructed players receive damage.
- Only tested locally (could not get the latest build to work to test networking)
- Even more complicated test scripts!