### PR TITLE
fix for bug 394: cannot pick up unloaded magazines

### DIFF
--- a/Assets/Prefabs/Items/Magazines/Resources/Magazine_12mm.prefab
+++ b/Assets/Prefabs/Items/Magazines/Resources/Magazine_12mm.prefab
@@ -20,7 +20,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4983823999050406}
   - component: {fileID: 212969402576888992}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: sprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -42,7 +42,7 @@ GameObject:
   - component: {fileID: 114914131618505528}
   - component: {fileID: 114383132860473892}
   - component: {fileID: 114331908573625224}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: Magazine_12mm
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -144,13 +144,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  cloth: 0
+  hierarchy: 
   itemName: Magazine
+  itemDescription: 
   spriteType: 0
+  type: 0
   inHandReferenceRight: -1
   inHandReferenceLeft: -1
   clothingReference: -1
   size: 0
-  type: 0
 --- !u!114 &114748270286923348
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -252,3 +255,5 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0


### PR DESCRIPTION
Changed default layer in unity inspector from "default" to "item" for Magazine_12mm.prefab