### PR TITLE
Fixed the MapEditor compatibility issue(windows macOs) and Items now are showing up. 

### DIFF
--- a/Assets/scripts/Editor/MapEditor/MapEditorWindow.cs
+++ b/Assets/scripts/Editor/MapEditor/MapEditorWindow.cs
@@ -30,10 +30,16 @@ namespace MapEditor {
 
         public void Initialize() {
             string path = Application.dataPath;
-            IEnumerable<string> files = Directory.GetDirectories(path + "/Prefabs", "*.*", SearchOption.AllDirectories);
-            categories = new CategoryView[] { new StructuresView(files,path), new ObjectsView(files,path), new ItemsView(files,path) };
+            string[] files = Directory.GetDirectories(path + "/Prefabs", "*.*", SearchOption.AllDirectories);
+            //fix the "\" that might show up in windows versions.
+            for (int i = 0; i < files.Length; i++)
+            {
+                files[i] = files[i].Replace('\\', '/');
+            }
+            categories = new CategoryView[] { new StructuresView(files, path), new ObjectsView(files, path), new ItemsView(files, path) };
             categoryNames = new string[categories.Length];
-            for(int i = 0; i < categoryNames.Length; i++) {
+            for (int i = 0; i < categoryNames.Length; i++)
+            {
                 categoryNames[i] = categories[i].Name;
             }
         }

--- a/Assets/scripts/Editor/MapEditor/Util/GridData.cs
+++ b/Assets/scripts/Editor/MapEditor/Util/GridData.cs
@@ -42,7 +42,7 @@ namespace MapEditor {
             var content = new List<Texture2D>();
 
             foreach(var p in prefabs) {
-                if (p.GetComponent<Matrix.RegisterTile>() != null) {
+                if (p.GetComponent<Matrix.RegisterTile>() != null|| (p.GetComponent<EditModeControl>() != null)) {
                 Texture2D texture;
                 do {
                     texture = AssetPreview.GetAssetPreview(p);

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.6.2p2
+m_EditorVersion: 5.6.2p3


### PR DESCRIPTION
- fixed the MapEditor compatibility issue caused by foward and backslashes. now all the paths will show up using foward slashes.

- Items folder is also showing now.

Known bugs :
menu items are funky since i could not manage to filter empty folders. New fixes soon. 
