### PR TITLE
Added code of conduct.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,54 @@
+**UnityStation Code of Conduct**
+
+**Intro**
+
+This code of conduct outlines our expectations for participants within the  **UnityStation** community, as well as steps to reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored. Anyone who violates this code of conduct may be banned from the community.
+
+Our open source community strives to:
+
+- **Be friendly and patient.**
+- **Be welcoming** : We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+- **Be considerate** : Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we&#39;re a world-wide community, so you might not be communicating in someone else&#39;s primary language.
+- **Be respectful** : Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It&#39;s important to remember that a community where people feel uncomfortable or threatened is not a productive one.
+- **Be careful in the words that we choose** : we are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren&#39;t acceptable.
+- **Try to understand why we disagree** : Disagreements, both social and technical, happen all the time. It is important that we resolve disagreements and differing views constructively. Remember that we&#39;re different. The strength of our community comes from its diversity, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn&#39;t mean that they&#39;re wrong. Don&#39;t forget that it is human to err and blaming each other doesn&#39;t get us anywhere. Instead, focus on helping t resolve issues and learning from mistakes.
+
+## **Definitions**
+
+Harassment includes, but is not limited to:
+
+- Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, age, regional discrimination, political or religious affiliation
+- Repeated unwelcome comments regarding a person&#39;s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment
+- Deliberate misnaming. This includes deadnaming or persistently using a pronoun that does not correctly reflect a person&#39;s gender identity for malicious purposes. You must address people by the name they give you when not addressing them by their username or handle
+- Threats of violence, both physical and psychological
+- Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm
+- Deliberate intimidation
+- Stalking this includes following, tracking, recording, logging, (repeat)messaging and contact requests on other media/real-life, as long as there is a reasonable expectation that this person may not appreciate this.
+- Sustained disruption of discussion
+- Unwelcome sexual attention, including gratuitous or off-topic sexual images or behaviour
+- Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+- Deliberate &quot;outing&quot; of any aspect of a person&#39;s identity without their consent except as necessary to protect others from intentional abuse
+- Publication of private communication without consent or approval from a moderator on the platform used.
+
+Our open source community prioritizes open communications and marginalized people&#39;s safety over privileged people&#39;s comfort. We will not act on complaints regarding:
+
+- Reasonable communication of boundaries, such as &quot;leave me alone,&quot; &quot;go away,&quot; or &quot;I&#39;m not discussing this with you&quot;
+- Communicating in a &#39;tone&#39; you don&#39;t find congenial
+
+**Diversity Statement**
+
+We encourage everyone to participate and are committed to building a community for all. Although we will fail at times, we seek to treat everyone both as fairly and equally as possible. Whenever a participant has made a mistake, we expect them to take responsibility for it. If someone has been harmed or offended, it is our responsibility to listen carefully and respectfully, and do our best to right the wrong.
+
+Although this list cannot be exhaustive, we explicitly honor diversity in age, gender, gender identity or expression, culture, ethnicity, language, national origin, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, and technical ability. We will not tolerate discrimination based on any of the protected characteristics above, including participants with disabilities.
+
+### **Reporting Issues**
+
+If you experience or witness unacceptable behavior—or have any other concerns—please report it contacting one of the community moderators, preferable of the platform involved. All reports will be handled with discretion. In your report please include:
+
+- Your contact information.
+- Names (real, nicknames, or pseudonyms) of any individuals involved. If there are additional witnesses, please include them as well. Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger), please include a link.
+- Any additional information that may be helpful.
+
+After filing a report, a representative will contact you personally, review the incident, follow up with any additional questions, and make a decision as to how to respond. All communication, including the complaint(s), response(s) and decision(s) are confidential and will only be shared at the discretion of a community moderator.
+
+If the person who is harassing you is part of the response team, they will recuse themselves from handling your incident. If the complaint originates from a member of the response team, it will be handled by a different member of the response team. We will respect confidentiality requests for the purpose of protecting victims of abuse.


### PR DESCRIPTION
Its customised to be as politically neutral as possible, so its addition would not annoy any one person or group.

Also it both stricter and broader defines the harassment definitions in comparison to GIT-hubs "open code of conduct" and gives more freedom for moderators to moderate discussions.

For the time being, this fits the community perfectly. But it may need to be edited as the community (and moderation structure) changes.