### PR TITLE
Readding tables

### DIFF
--- a/Assets/Tilemaps/Editor/Palettes/Furniture.prefab
+++ b/Assets/Tilemaps/Editor/Palettes/Furniture.prefab
@@ -140,75 +140,185 @@ Tilemap:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1273235126634244}
   m_Enabled: 1
-  m_Tiles: {}
+  m_Tiles:
+  - first: {x: 1, y: -2, z: 0}
+    second:
+      m_TileIndex: 7
+      m_TileSpriteIndex: 8
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 11
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 0
+  - first: {x: 2, y: -2, z: 0}
+    second:
+      m_TileIndex: 6
+      m_TileSpriteIndex: 7
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 11
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 0
+  - first: {x: 1, y: -1, z: 0}
+    second:
+      m_TileIndex: 10
+      m_TileSpriteIndex: 11
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 11
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 0
+  - first: {x: 2, y: -1, z: 0}
+    second:
+      m_TileIndex: 9
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 11
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 0
+  - first: {x: 3, y: -1, z: 0}
+    second:
+      m_TileIndex: 8
+      m_TileSpriteIndex: 9
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 11
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 0
+  - first: {x: 1, y: 0, z: 0}
+    second:
+      m_TileIndex: 11
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 11
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 0
+  - first: {x: 1, y: 1, z: 0}
+    second:
+      m_TileIndex: 2
+      m_TileSpriteIndex: 3
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 11
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 0
+  - first: {x: 2, y: 1, z: 0}
+    second:
+      m_TileIndex: 1
+      m_TileSpriteIndex: 2
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 11
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 0
+  - first: {x: 3, y: 1, z: 0}
+    second:
+      m_TileIndex: 0
+      m_TileSpriteIndex: 1
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 11
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 0
+  - first: {x: 1, y: 2, z: 0}
+    second:
+      m_TileIndex: 5
+      m_TileSpriteIndex: 6
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 11
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 0
+  - first: {x: 2, y: 2, z: 0}
+    second:
+      m_TileIndex: 4
+      m_TileSpriteIndex: 5
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 11
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 0
+  - first: {x: 3, y: 2, z: 0}
+    second:
+      m_TileIndex: 3
+      m_TileSpriteIndex: 4
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 11
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 0
   m_AnimatedTiles: {}
   m_TileAssetArray:
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: f4baab928017d40e2b30259d0b0a7566, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: bc43c001b1d90430099be45a745030a1, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 0c1e0a24a2e9547a39086e7843eeac3f, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 9728bbeac664a457eb998f532ab33775, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: bc9d55ad8fd774e21834d17321ecaf6c, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: faf3026f1a38e4a26bdbff9e5fba137e, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 67c4061d03a804403a48b3c56a2bda4f, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 71416f6cff737438f9dd90a1cd47c640, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 53ea310ed0a914bf1bb7adf8caa5b2be, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: bd5274eeb48464753b12714bb88a6bff, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: cf31da1d9b545944fb7423aac9d9b7d3, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: cd23550cdef9f4482b44763bc2987dff, type: 2}
   m_TileSpriteArray:
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: 33dfb54470bd4bd4bae6ff49a6f5a2ee, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: 2123fa43a63e0de40b2d31d5e541cee7, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: 4a1d20c6bcfdeb642a5af0b8de8c9579, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: 33d7bc41561595643b30573286492268, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: 4b63bc4f2481fea419aed55476d33130, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: f0d5f8d3cf6ad9547bcc804fd30caed7, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: 73a18822259f7c943b00759f48878062, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: 74b59c4a7e5407245a23b4af42f4d1ac, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: c2a766fe0315373409b87a70f5366f91, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: 63e37241e643b2642929b6d9c26ad3f6, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: 5d7e38e76d499414a9e5533e2a883c54, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 0
+  - m_RefCount: 12
     m_Data:
-      e00: -5.6887423e-36
-      e01: NaN
-      e02: 8.788989e-39
-      e03: -7.5342417e-32
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
       e10: 0
-      e11: NaN
+      e11: 1
       e12: 0
-      e13: 4.5915e-41
-      e20: 0.0011523571
-      e21: -7.5342417e-32
-      e22: NaN
-      e23: 0.000000012346147
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
       e30: 0
-      e31: 4.5915e-41
+      e31: 0
       e32: 0
-      e33: 0
+      e33: 1
   m_TileColorArray:
   - m_RefCount: 0
     m_Data: {r: -5.1939157e-27, g: 0, b: 21.407335, a: 1e-45}
@@ -232,12 +342,12 @@ Tilemap:
     m_Data: {r: -5.6887423e-36, g: 0, b: -0.00040804897, a: 0}
   - m_RefCount: 0
     m_Data: {r: -5.6887423e-36, g: 0, b: -0.00040804897, a: 0}
-  - m_RefCount: 0
-    m_Data: {r: -5.6887423e-36, g: 0, b: -0.00040804897, a: 0}
+  - m_RefCount: 12
+    m_Data: {r: 1, g: 1, b: 1, a: 1}
   m_AnimationFrameRate: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Origin: {x: -1, y: 0, z: 0}
-  m_Size: {x: 6, y: 2, z: 1}
+  m_Origin: {x: -1, y: -2, z: 0}
+  m_Size: {x: 6, y: 5, z: 1}
   m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
   m_TileOrientation: 0
   m_TileOrientationMatrix:
@@ -259,24 +369,26 @@ Tilemap:
     e33: 1
   m_TileRefreshArray:
   - serializedVersion: 1
-    m_DirtyIndex: 1
+    m_DirtyIndex: 0
   - serializedVersion: 1
-    m_DirtyIndex: 1
+    m_DirtyIndex: 0
   - serializedVersion: 1
-    m_DirtyIndex: 1
+    m_DirtyIndex: 0
   - serializedVersion: 1
-    m_DirtyIndex: 1
+    m_DirtyIndex: 0
   - serializedVersion: 1
-    m_DirtyIndex: 1
+    m_DirtyIndex: 0
   - serializedVersion: 1
-    m_DirtyIndex: 1
+    m_DirtyIndex: 0
   - serializedVersion: 1
-    m_DirtyIndex: 1
+    m_DirtyIndex: 0
   - serializedVersion: 1
-    m_DirtyIndex: 1
+    m_DirtyIndex: 0
   - serializedVersion: 1
-    m_DirtyIndex: 1
+    m_DirtyIndex: 0
   - serializedVersion: 1
-    m_DirtyIndex: 1
+    m_DirtyIndex: 0
   - serializedVersion: 1
-    m_DirtyIndex: 1
+    m_DirtyIndex: 0
+  - serializedVersion: 1
+    m_DirtyIndex: 0

--- a/Assets/Tilemaps/Mapping.csv
+++ b/Assets/Tilemaps/Mapping.csv
@@ -158,9 +158,9 @@ bed,Objects/Furniture/Bed
 Stool,Objects/Furniture/Stool
 Shuttle_engine_E,Objects/Machines/Shuttle/Shuttle_Engine_E
 Shuttle_engine_W,Objects/Machines/Shuttle/Shuttle_Engine_W
-Table,Objects/Furniture/Table
-Table_Wood,Objects/Furniture/Table_Wood
-Table_Reinforced,Objects/Furniture/Table_Reinforced
+Table,Tables/Table
+Table_Wood,Tables/Table_Wood
+Table_Reinforced,Tables/Table_Reinforced
 shuttle_wall_Skew1,Walls/Shuttle_Wall_Corner
 shuttle_wall,Walls/Shuttle_Wall
 shuttle_wall_Skew_SW,Walls/Shuttle_Wall_Corner

--- a/Assets/Tilemaps/Tiles/Tables.meta
+++ b/Assets/Tilemaps/Tiles/Tables.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 4616c2868802b455cb79e6d8c1cdccbb
+folderAsset: yes
+timeCreated: 1511950468
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemaps/Tiles/Tables/Table.asset
+++ b/Assets/Tilemaps/Tiles/Tables/Table.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
+  m_Name: Table
+  m_EditorClassIdentifier: 
+  LayerType: 1
+  RequiredTiles: []
+  Passable: 0
+  AtmosPassable: 1
+  IsSealed: 0
+  spriteSheet: {fileID: 2800000, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
+  texturePath: Tables
+  connectCategory: 2
+  connectType: 1

--- a/Assets/Tilemaps/Tiles/Tables/Table.asset.meta
+++ b/Assets/Tilemaps/Tiles/Tables/Table.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: cf31da1d9b545944fb7423aac9d9b7d3
+timeCreated: 1508538701
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemaps/Tiles/Tables/table_glass.asset
+++ b/Assets/Tilemaps/Tiles/Tables/table_glass.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
+  m_Name: table_glass
+  m_EditorClassIdentifier: 
+  LayerType: 1
+  RequiredTiles: []
+  Passable: 0
+  AtmosPassable: 1
+  IsSealed: 0
+  spriteSheet: {fileID: 2800000, guid: 5d7e38e76d499414a9e5533e2a883c54, type: 3}
+  texturePath: Tables
+  connectCategory: 2
+  connectType: 1

--- a/Assets/Tilemaps/Tiles/Tables/table_glass.asset.meta
+++ b/Assets/Tilemaps/Tiles/Tables/table_glass.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: bd5274eeb48464753b12714bb88a6bff
+timeCreated: 1508538701
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemaps/Tiles/Tables/table_poker.asset
+++ b/Assets/Tilemaps/Tiles/Tables/table_poker.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
+  m_Name: table_poker
+  m_EditorClassIdentifier: 
+  LayerType: 1
+  RequiredTiles: []
+  Passable: 0
+  AtmosPassable: 1
+  IsSealed: 0
+  spriteSheet: {fileID: 2800000, guid: 63e37241e643b2642929b6d9c26ad3f6, type: 3}
+  texturePath: Tables
+  connectCategory: 2
+  connectType: 1

--- a/Assets/Tilemaps/Tiles/Tables/table_poker.asset.meta
+++ b/Assets/Tilemaps/Tiles/Tables/table_poker.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 53ea310ed0a914bf1bb7adf8caa5b2be
+timeCreated: 1508538701
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemaps/Tiles/Tables/table_reinforced.asset
+++ b/Assets/Tilemaps/Tiles/Tables/table_reinforced.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
+  m_Name: table_reinforced
+  m_EditorClassIdentifier: 
+  LayerType: 1
+  RequiredTiles: []
+  Passable: 0
+  AtmosPassable: 1
+  IsSealed: 0
+  spriteSheet: {fileID: 2800000, guid: c2a766fe0315373409b87a70f5366f91, type: 3}
+  texturePath: Tables
+  connectCategory: 2
+  connectType: 1

--- a/Assets/Tilemaps/Tiles/Tables/table_reinforced.asset.meta
+++ b/Assets/Tilemaps/Tiles/Tables/table_reinforced.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 71416f6cff737438f9dd90a1cd47c640
+timeCreated: 1508538701
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemaps/Tiles/Tables/table_wood.asset
+++ b/Assets/Tilemaps/Tiles/Tables/table_wood.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
+  m_Name: table_wood
+  m_EditorClassIdentifier: 
+  LayerType: 1
+  RequiredTiles: []
+  Passable: 0
+  AtmosPassable: 1
+  IsSealed: 0
+  spriteSheet: {fileID: 2800000, guid: 74b59c4a7e5407245a23b4af42f4d1ac, type: 3}
+  texturePath: Tables
+  connectCategory: 2
+  connectType: 1

--- a/Assets/Tilemaps/Tiles/Tables/table_wood.asset.meta
+++ b/Assets/Tilemaps/Tiles/Tables/table_wood.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 67c4061d03a804403a48b3c56a2bda4f
+timeCreated: 1508538701
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Tile assets for tables got removed by accident because they where a non-object tile, in the object folder.

### Approach
Readded them into /tilemaps/tiles/tables to prevent the deletion issue from happening 

### Open Questions and Pre-Merge TODOs

- [X]  The issue this PR refers to still exists in the branch it's PR'ed to.
- [X]  This PR has less than 5 commits or is squashed beforehand
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors

### Notes:
NA

### In case of feature: How to use the feature:
In the future please place table tiles into /tilemaps/tiles/tables