### PR TITLE
Fixed wallmounts prefab2tile

### DIFF
--- a/Assets/Tilemaps/Editor/Prefab2Tile.cs
+++ b/Assets/Tilemaps/Editor/Prefab2Tile.cs
@@ -43,9 +43,13 @@ public class Prefab2Tile : EditorWindow
 
             //Cast the gameobject
             var cast = AssetDatabase.LoadAssetAtPath(smallPath, (typeof(GameObject))) as GameObject;
-			if (barePath == "/Wallmounts") {
+			if (barePath == "/WallMounts") {
 				tile.Rotatable = true;
 				tile.Offset = true;
+			} 
+			else {
+				tile.Rotatable = false;
+				tile.Offset = false;
 			}
             tile.Object = cast;
             //Create the tile

--- a/Assets/Tilemaps/Editor/Prefab2Tile.cs
+++ b/Assets/Tilemaps/Editor/Prefab2Tile.cs
@@ -21,7 +21,7 @@ public class Prefab2Tile : EditorWindow
         {
             counter++;
             int t = scan.Length;
-            EditorUtility.DisplayProgressBar(t.ToString() + "/" + scan.Length + " Generating Tiles", "Tile: " + counter, (float) counter / (float) scan.Length);
+			EditorUtility.DisplayProgressBar(counter.ToString() + "/" + scan.Length + " Generating Tiles", "Tile: " + counter, (float) counter / (float) scan.Length);
 //			Debug.Log ("Longpath data: " + file);
 
             //Get the filename without extention and path
@@ -43,7 +43,10 @@ public class Prefab2Tile : EditorWindow
 
             //Cast the gameobject
             var cast = AssetDatabase.LoadAssetAtPath(smallPath, (typeof(GameObject))) as GameObject;
-
+			if (barePath == "/Wallmounts") {
+				tile.Rotatable = true;
+				tile.Offset = true;
+			}
             tile.Object = cast;
             //Create the tile
             TileBuilder.CreateAsset(tile, name, "Assets/Tilemaps/Tiles/Objects" + barePath);


### PR DESCRIPTION
### Purpose
Solves #471 #472

### Approach
Changes Prefab2Tile to give the different settings to objects in /WallMounts objects

### Open Questions and Pre-Merge TODOs

- [X]  The issue this PR refers to still exists in the branch it's PR'ed to.
- [X]  This PR has less than 5 commits or is squashed beforehand
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors

### Notes:
We need to check if this also fixes 473

### In case of feature: How to use the feature:
Do not create wallmounts in subfolders of /WallMounts