### PR TITLE
Added previewsprite cleanup

### DIFF
--- a/Assets/Scripts/EditorTools/PreviewCleanup.cs
+++ b/Assets/Scripts/EditorTools/PreviewCleanup.cs
@@ -1,0 +1,59 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System.IO;
+using System;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+
+public class PreviewCleanup : EditorWindow
+{
+	[MenuItem("Tools/PreviewCleanup")]
+	public static void Apply()
+	{
+		//Moving old tiles  
+		string path = Application.dataPath + "/textures/TilePreviews/Resources/Prefabs/Objects/";
+		int counter = 0;
+		int exist = 0;
+		int cleaned = 0;
+		string[] scan = Directory.GetFiles(path, "*.png", SearchOption.AllDirectories);
+		foreach (String file in scan)
+		{
+			counter++;
+			int t = scan.Length;
+			EditorUtility.DisplayProgressBar(counter.ToString() + "/" + scan.Length + " Removing abundant preview sprites", "Sprite: " + counter, (float) counter / (float) scan.Length);
+			//			Debug.Log ("Longpath data: " + file);
+
+			//Get the filename without extention and path
+			string name = Path.GetFileNameWithoutExtension(file);
+			//			Debug.Log ("Creating tile for prefab: " + name);
+
+			//Generating the path needed to chose the right tile output sub-folder
+			string subPath = file.Substring(file.IndexOf("Objects") + 7);
+			//			Debug.Log ("subPath data: " + subPath);
+			string barePath = subPath.Substring(0, subPath.LastIndexOf(Path.DirectorySeparatorChar));
+			//			Debug.Log ("barePath data: " + barePath);
+
+			//Check if tile already exists
+			if (System.IO.File.Exists (Application.dataPath +  "/Resources/Prefabs/Objects" + barePath + "/" + name + ".prefab")) {
+//				Debug.Log ("A prefab for " + name + " exists... Skipping...");
+				exist++;
+			} 
+			else {
+				FileUtil.DeleteFileOrDirectory(file);
+				FileUtil.DeleteFileOrDirectory(file + ".meta");
+//				Debug.Log("DESTROY");
+				cleaned++;
+				UnityEditor.AssetDatabase.Refresh ();
+			}
+		}
+		EditorUtility.ClearProgressBar();
+		Debug.Log (counter + " Preview Sprites Processed");
+		Debug.Log (exist + " Previes Sprites skipped, Prefab exists");
+		Debug.Log(cleaned + " Preview Sprites deleted, prefab does not exist");
+	}
+}

--- a/Assets/Scripts/EditorTools/PreviewCleanup.cs.meta
+++ b/Assets/Scripts/EditorTools/PreviewCleanup.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 0b36a5fcf652a476ba42ae38f7312af2
+timeCreated: 1512042902
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Preview sprites tend to pile up, which they shouldn't.

### Approach
Instead of adding check to everything related previewsprite, I just made a script to clean the objects previewsprite which are the most likely to pile up

### Open Questions and Pre-Merge TODOs

- [X]  The issue this PR refers to still exists in the branch it's PR'ed to.
- [X]  This PR has less than 5 commits or is squashed beforehand
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors

### Notes:

### In case of feature: How to use the feature:
Run the damn thing under tools and wait.