### PR TITLE
Fix altlmb spawning knives, dead people seeing ghosts, players doing diagonal moonwalking

### DIFF
--- a/Assets/Scripts/UI/UITileList.cs
+++ b/Assets/Scripts/UI/UITileList.cs
@@ -33,12 +33,11 @@ public class UITileList : MonoBehaviour {
 	public static List<GameObject> GetItemsAtPosition(Vector3 position)
 	{
 		LayerMask layerMaskWithFloors = LayerMask.GetMask("Default", "Furniture", "Walls", "Windows", "Machines",
-			"Players", "Items", "Door Open", "Door Closed", "WallMounts", "HiddenWalls");
+			"Items", "Door Open", "Door Closed", "WallMounts", "HiddenWalls");
 		var hits = Physics2D.RaycastAll(position, Vector2.zero, 10f, layerMaskWithFloors);
 		List<GameObject> tiles = new List<GameObject>();
 
-		foreach (var hit in hits)
-		{
+		foreach (var hit in hits) {
 			tiles.Add(hit.collider.gameObject);
 		}
 
@@ -102,7 +101,8 @@ public class UITileList : MonoBehaviour {
 	/// <summary>
 	/// Removes all itemList from the Item List Tab
 	/// </summary>
-	public static void ClearItemPanel() {
+	public static void ClearItemPanel()
+	{
 		foreach(GameObject gameObject in Instance.listedObjects) {
 			Destroy(gameObject);
 		} 
@@ -116,7 +116,7 @@ public class UITileList : MonoBehaviour {
 	/// <param name="tileListItemObject">The GameObject to be removed</param>
 	public static void RemoveTileListItem(GameObject tileListItemObject)
 	{
-		if (!Instance.listedObjects.Contains(tileListItemObject)){
+		if (!Instance.listedObjects.Contains(tileListItemObject)) {
 			Debug.LogError("Attempted to remove tileListItem not on list");
 			return;
 		}

--- a/Assets/scripts/PlayGroups/Input/InputController.cs
+++ b/Assets/scripts/PlayGroups/Input/InputController.cs
@@ -63,7 +63,7 @@ namespace InputControl
 		{
 			if (Input.GetMouseButtonDown(0) && !Input.GetKey(KeyCode.LeftControl) && !Input.GetKey(KeyCode.LeftAlt)) {
 				//change the facingDirection of player on click
-				changeDirection();
+				ChangeDirection();
 
 				//if we found nothing at all to click on try to use whats in our hands (might be shooting at someone in space)
 				if (!RayHit()) {
@@ -84,7 +84,7 @@ namespace InputControl
 			}
 		}
 
-		private void changeDirection()
+		private void ChangeDirection()
 		{
 			Vector2 dir = (Camera.main.ScreenToWorldPoint(Input.mousePosition) -
 						   transform.position).normalized;

--- a/Assets/scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/Assets/scripts/PlayGroups/PlayerNetworkActions.cs
@@ -403,8 +403,11 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 			SoundManager.Stop("Critstate");
 			Camera2DFollow.followControl.target = playerScript.ghost.transform;
 			var fovScript = GetComponent<FieldOfView>();
-			if (fovScript != null)
+			if (fovScript != null) {
 				fovScript.enabled = false;
+			}
+				
+			Camera.main.cullingMask |= (1 << LayerMask.NameToLayer("Ghosts"));
 		}
 	}
 
@@ -436,6 +439,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	private void RpcAdjustForRespawn()
 	{
 		playerScript.ghost.SetActive(false);
+		Camera.main.cullingMask &= ~(1 << LayerMask.NameToLayer("Ghosts"));
 		gameObject.GetComponent<InputController>().enabled = false;
 	}
 

--- a/Assets/scripts/PlayGroups/PlayerSprites.cs
+++ b/Assets/scripts/PlayGroups/PlayerSprites.cs
@@ -66,6 +66,19 @@ namespace PlayGroup
 				foreach (var c in clothes.Values) {
 					c.Direction = direction;
 				}
+
+				//If both values are set, we're trying to face a diagonal sprite direction, which doesn't exist. To resolve, randomly select one of the appropriate cardinal directions.
+				if(direction.x != 0 && direction.y != 0) {
+					switch(Random.Range(0, 1)) {
+						case 0:
+							direction.x = 0;
+							break;
+						case 1:
+							direction.y = 0;
+							break;
+					}
+				}
+
                 currentDirection = direction;
 			}
 		}


### PR DESCRIPTION
### Purpose
Fixes alt+lmb on a tile with a player showing knives
Fixes #425 
Fixes living players seeing ghost players
Minor code styling fixes

### Approach
alt+lmb is fixed by removing the player layer from the raycast. Players should not show up in the tile item tab anyway.
#425 is fixed by randomly picking one of the diagonal directions, as we have no diagonal sprites.
visible ghosts are fixed by adding them to their own layer and culling it on living players.

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This PR has less than 5 commits or is squashed beforehand.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors