### PR TITLE
To prevent unneeded edits of scenes

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@ _explain how you fixed the issue or added the feature and if it is a permanent f
 - [ ]  This fix is tested on the branch it is PR'ed to.
 - [ ]  This PR is checked for side effects and it has none
 - [ ]  This PR does not bring up any new compile errors
+- [ ]  This PR does not include scenes without specific need to do so.
 
 ### Notes:
 _Please enter any further information here_

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,6 @@ _explain how you fixed the issue or added the feature and if it is a permanent f
 ### Open Questions and Pre-Merge TODOs
 
 - [ ]  The issue solved or feature added is still open/missing in the branch you PR to.
-- [ ]  This PR has less than 5 commits or is squashed beforehand.
 - [ ]  This fix is tested on the branch it is PR'ed to.
 - [ ]  This PR is checked for side effects and it has none
 - [ ]  This PR does not bring up any new compile errors


### PR DESCRIPTION
### Purpose
@Em3rgencyLT made clear it was not clear unneeded changes to scenes where a problem.
This is a problem, because unity 👎 

### Approach
Added a control question to the PR form, to push people into checking before placing the PR. 👍 

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This PR has less than 5 commits or is squashed beforehand.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors

### Notes:

### In case of feature: How to use the feature:
1. Make a PR
2. Check your PR
3. Check the checkbox