### PR TITLE
Finished OutpostDeathmatch and crushed Item bug...

### DIFF
--- a/Assets/Tilemaps/Scripts/Tiles/ObjectTile.cs
+++ b/Assets/Tilemaps/Scripts/Tiles/ObjectTile.cs
@@ -70,9 +70,13 @@ namespace Tilemaps.Scripts.Tiles
 
             go.name = Object.name;
 
-            var registerObject = go.GetComponent<RegisterObject>() ?? go.AddComponent<RegisterObject>();
+			if (IsItem == true) {
 
-            registerObject.Offset = Vector3Int.RoundToInt(-objectOffset);
+			} else {
+				var registerObject = go.GetComponent<RegisterObject> () ?? go.AddComponent<RegisterObject> ();
+				registerObject.Offset = Vector3Int.RoundToInt(-objectOffset);
+			}
+            
 
             go.SetActive(true);
         }

--- a/Assets/Tilemaps/Scripts/Tiles/ObjectTile.cs
+++ b/Assets/Tilemaps/Scripts/Tiles/ObjectTile.cs
@@ -14,7 +14,7 @@ namespace Tilemaps.Scripts.Tiles
         public bool Rotatable;
         public bool KeepOrientation;
         public bool Offset;
-        public bool IsItem { get; private set; }
+		public bool IsItem;
 
         private GameObject _objectCurrent;
 
@@ -43,9 +43,11 @@ namespace Tilemaps.Scripts.Tiles
             _objectCurrent = Object;
 
 			if (_objectCurrent != null && _objectCurrent.GetComponentInChildren<RegisterItem>() != null)
-            {
-                IsItem = true;
-            }
+			{
+				IsItem = true;
+			}
+
+
 
         }
 

--- a/Assets/Tilemaps/Scripts/Tiles/ObjectTile.cs
+++ b/Assets/Tilemaps/Scripts/Tiles/ObjectTile.cs
@@ -42,10 +42,11 @@ namespace Tilemaps.Scripts.Tiles
 
             _objectCurrent = Object;
 
-            if (_objectCurrent != null)
+			if (_objectCurrent != null && _objectCurrent.GetComponentInChildren<RegisterItem>() != null)
             {
-                IsItem = _objectCurrent.GetComponentInChildren<RegisterItem>() != null;
+                IsItem = true;
             }
+
         }
 
         public void SpawnObject(Vector3Int position, Tilemap tilemap, Matrix4x4 transformMatrix)


### PR DESCRIPTION
### Purpose
For the new OutpostDeathmatch map, items needed to be in closets and crates.
Both Closets, Crates and other objects with an item on the same tile tend to get deleted.

### Approach
The bug originated due to "RegisterObject" being assigned to items, which prevented them to be placed ontop of other relevant objects.

So first I made sure the "IsItem" state of the tile was added correctly, I also made the option publicly accessable instead of a private variable.
Second I made sure "RegisteObject" was not added when something is an item.
Third I manually removed "RegisterObject" from all already existing items.

Furthermore I added some more weapons and crates.
A big portion of weapons and ammo where moved inside of containers, so it becomes more of a challenge in DM.

Weapons and Ammo are spread evenly and not every container actually contains a weapon or Ammo. Also weapons and ammo of the same type are spread out from each other on a lot of occasions.   

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This PR has less than 5 commits or is squashed beforehand.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors

### Notes:


### In case of feature: How to use the feature:
View the map.