### PR TITLE
Fix burst out of closet

### DIFF
--- a/Assets/scripts/PlayGroups/PlayerSync.cs
+++ b/Assets/scripts/PlayGroups/PlayerSync.cs
@@ -301,7 +301,7 @@ namespace PlayGroup
 		{
 			serverState = newState;
 			if (pendingActions != null) {
-				while (pendingActions.Count > (predictedState.MoveNumber - serverState.MoveNumber)) {
+				while (pendingActions.Count > 0 && pendingActions.Count > (predictedState.MoveNumber - serverState.MoveNumber)) {
 					pendingActions.Dequeue();
 				}
 				UpdatePredictedState();


### PR DESCRIPTION
### Purpose
Fixes #495 

### Approach
Made sure PlayerSync doesn't try to dequeue and empty action queue. 

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.