### PR TITLE
Fix for #496 (Fix for lockers being openable at 2 tiles away)

### DIFF
--- a/Assets/scripts/PlayGroups/PlayerScript.cs
+++ b/Assets/scripts/PlayGroups/PlayerScript.cs
@@ -11,7 +11,7 @@ namespace PlayGroup
 	public class PlayerScript: ManagedNetworkBehaviour
 	{
 		// the maximum distance the player needs to be to an object to interact with it
-		public const float interactionDistance = 2f;
+		public const float interactionDistance = 1.5f;
 
 		public PlayerNetworkActions playerNetworkActions { get; set; }
 


### PR DESCRIPTION
### Purpose
You could click the edge of lockers to open them.
I suspected the acceptance distance being 2 instead of 1.5.

### Approach
I checked and indeed 2f was accepted as distance to open them.
As in 99.9 (everything but some wallmounts) of cases you only want to be able to click the nearest tile, it should be 1.5f.

Set it to 1.5f and that Fixes #496

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors
- [X]  This PR does not include scenes without specific need to do so.

### Notes:
In the future a override for this distance for some wallmounts may be needed.

### In case of feature: How to use the feature: