### PR TITLE
Fix for #430 (Ghost not dropping items)

### DIFF
--- a/Assets/Scripts/Health/Living/PlayerHealth.cs
+++ b/Assets/Scripts/Health/Living/PlayerHealth.cs
@@ -167,11 +167,9 @@ namespace PlayGroup
 		protected override void OnDeathActions()
 		{
 			if (CustomNetworkManager.Instance._isServer) {
-				playerNetworkActions.RpcSpawnGhost();
 
 				PlayerMove pM = GetComponent<PlayerMove>();
-				pM.isGhost = true;
-				pM.allowInput = true;
+
 				if (LastDamagedBy == gameObject.name) {
 					playerNetworkActions.CmdSendAlertMessage("<color=red><b>" + gameObject.name + " commited suicide</b></color>",
 						true); //killfeed
@@ -185,10 +183,18 @@ namespace PlayGroup
 					playerNetworkActions.CmdSendAlertMessage(
 						"<color=red><b>" + LastDamagedBy + "</b> has killed <b>" + gameObject.name + "</b></color>", true); //killfeed
 				}
-				playerNetworkActions.ValidateDropItem("leftHand", true);
-				playerNetworkActions.ValidateDropItem("rightHand", true);
+				var currentSlot = UI.UIManager.Hands.CurrentSlot;
+				var otherSlot = UI.UIManager.Hands.OtherSlot;
+				currentSlot.Clear();
+				otherSlot.Clear ();
+				playerNetworkActions.ValidateDropItem(currentSlot.eventName, true);
+				playerNetworkActions.ValidateDropItem(otherSlot.eventName, true);
 				if (isServer)
 					EffectsFactory.Instance.BloodSplat(transform.position, BloodSplatSize.large);
+				
+				playerNetworkActions.RpcSpawnGhost();
+				pM.isGhost = true;
+				pM.allowInput = true;
 
 				//FIXME Remove for next demo
 				playerNetworkActions.RespawnPlayer(10);


### PR DESCRIPTION
### Purpose
When Ghosting the item sprite in hands does not get removed, while the item does get dropped.

### Approach
When investigating it first seemed clear that the hands where called as string, instead of as slot... 
After that it seemed that ValidateDropItem did not rightly clear the slot, so that was added.

Also ghosting was moved from the start of OnDeathActions, to the end of OnDeathActions. This to make sure further error's will not creep in. You should end your life, before going into your afterlife! 

So this fixes #430

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors
- [X]  This PR does not include scenes without specific need to do so.

### Notes:

### In case of feature: How to use the feature:
