### PR TITLE
Fixed push-items off tables bug.

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Accessories/Resources/Space Cigarettes.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Accessories/Resources/Space Cigarettes.prefab
@@ -123,6 +123,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!114 &114348495363464762
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -213,7 +214,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0

--- a/UnityProject/Assets/Prefabs/Items/Clothing/Resources/UniCloth.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Clothing/Resources/UniCloth.prefab
@@ -138,7 +138,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0
@@ -168,6 +168,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!114 &114790008314547624
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Food/Resources/Meat Steak.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Resources/Meat Steak.prefab
@@ -112,6 +112,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!114 &114360428989312324
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -213,7 +214,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0

--- a/UnityProject/Assets/Prefabs/Items/Food/Resources/Meat.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Resources/Meat.prefab
@@ -138,7 +138,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0
@@ -221,6 +221,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!212 &212964861154144586
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/IDs/Resources/ID.prefab
+++ b/UnityProject/Assets/Prefabs/Items/IDs/Resources/ID.prefab
@@ -113,6 +113,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!114 &114415532299363170
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -214,7 +215,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0

--- a/UnityProject/Assets/Prefabs/Items/Kitchen/Resources/Pepper Shaker.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Kitchen/Resources/Pepper Shaker.prefab
@@ -170,7 +170,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0
@@ -221,6 +221,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!212 &212804965856308220
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Kitchen/Resources/RollingPin.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Kitchen/Resources/RollingPin.prefab
@@ -133,6 +133,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!114 &114130006931618576
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -149,7 +150,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0

--- a/UnityProject/Assets/Prefabs/Items/Kitchen/Resources/Salt Shaker.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Kitchen/Resources/Salt Shaker.prefab
@@ -138,7 +138,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0
@@ -221,6 +221,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!212 &212084795858203154
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_12mm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_12mm.prefab
@@ -145,6 +145,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!114 &114525660935982552
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -214,7 +215,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_5.56mm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_5.56mm.prefab
@@ -139,6 +139,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!114 &114415944281988084
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -176,7 +177,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0

--- a/UnityProject/Assets/Prefabs/Items/Resources/Extinguisher.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Resources/Extinguisher.prefab
@@ -181,7 +181,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0
@@ -221,6 +221,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!212 &212125191403727516
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Storage/Resources/Backpack.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Storage/Resources/Backpack.prefab
@@ -149,7 +149,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0
@@ -200,6 +200,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!114 &114830978506282360
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/C20rSMG_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/C20rSMG_Ballistic.prefab
@@ -182,7 +182,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0
@@ -201,6 +201,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!114 &114960268025394048
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/L6SAW_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/L6SAW_Ballistic.prefab
@@ -167,6 +167,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!114 &114606480918356138
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -183,7 +184,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0

--- a/UnityProject/Assets/Prefabs/Items/Weapons_Melee/Resources/Knife.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons_Melee/Resources/Knife.prefab
@@ -219,6 +219,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ObjectType: 0
 --- !u!114 &114457471827933586
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -235,7 +236,7 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   moveSpeed: 7
   allowedToMove: 1
-  isPushable: 1
+  isPushable: 0
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0

--- a/UnityProject/Assets/Scripts/Editor/Objects/ObjectBehaviourEditor.cs
+++ b/UnityProject/Assets/Scripts/Editor/Objects/ObjectBehaviourEditor.cs
@@ -11,8 +11,11 @@ public class ObjectBehaviourEditor : Editor
     {
         ObjectBehaviour oTarget = (ObjectBehaviour)target;
         serializedObject.Update();
-        SerializedProperty isPushable = serializedObject.FindProperty("isPushable");
-        EditorGUILayout.PropertyField(isPushable);
+		var isPushable = serializedObject.FindProperty("isPushable");
+		EditorGUI.BeginChangeCheck();
+		EditorGUILayout.PropertyField(isPushable, true);
+		if (EditorGUI.EndChangeCheck())
+			serializedObject.ApplyModifiedProperties();
     }
 
 }


### PR DESCRIPTION
### Purpose
Items could be pushed off tables and push shouldn't even be possible on them

### Approach
There already was a behaviour variable "isPushable" present, but this one was bugged.
After fixing the related script to make it function, it was a mater of disabling push on all the items

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors
- [X]  This PR does not include scenes without specific need to do so.

### Notes:
This fixes #555 

### In case of feature: How to use the feature: