### PR TITLE
Fixed wall collider and FOV

### DIFF
--- a/UnityProject/Assets/Prefabs/Station.prefab
+++ b/UnityProject/Assets/Prefabs/Station.prefab
@@ -120,8 +120,11 @@ GameObject:
   - component: {fileID: 4274591903187528}
   - component: {fileID: 8195094280620862736}
   - component: {fileID: 3664157344845249752}
+  - component: {fileID: 2113883505444413980}
+  - component: {fileID: 50287073987087428}
+  - component: {fileID: 66940514737597546}
   - component: {fileID: 114668254107574584}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Structures
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -348,6 +351,46 @@ Transform:
   m_Father: {fileID: 4308661069076000}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &50287073987087428
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1328768433727656}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!66 &66940514737597546
+CompositeCollider2D:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1328768433727656}
+  m_Enabled: 0
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 0
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths: []
+  m_CompositePaths:
+    m_Paths: []
+  m_VertexDistance: 0.0005
 --- !u!114 &114158422661485394
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -462,6 +505,19 @@ MonoBehaviour:
   m_Script: {fileID: -1050975500, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!19719996 &2113883505444413980
+TilemapCollider2D:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1328768433727656}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: 0, y: 0}
 --- !u!156049354 &2569400267726922214
 Grid:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Scenes/Outpost.unity
+++ b/UnityProject/Assets/Scenes/Outpost.unity
@@ -3132,8 +3132,11 @@ GameObject:
   - component: {fileID: 224555821}
   - component: {fileID: 224555824}
   - component: {fileID: 224555823}
+  - component: {fileID: 224555827}
+  - component: {fileID: 224555826}
+  - component: {fileID: 224555825}
   - component: {fileID: 224555822}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Structures
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3224,7 +3227,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -3233,7 +3236,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -3242,7 +3245,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -3251,7 +3254,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -3260,7 +3263,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -3269,7 +3272,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -3278,7 +3281,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -3287,7 +3290,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 0, z: 0}
     second:
       m_TileIndex: 5
@@ -3296,7 +3299,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 0, z: 0}
     second:
       m_TileIndex: 5
@@ -3305,7 +3308,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 0, z: 0}
     second:
       m_TileIndex: 5
@@ -3314,7 +3317,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 0, z: 0}
     second:
       m_TileIndex: 5
@@ -3323,7 +3326,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -3332,7 +3335,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -3341,7 +3344,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -3350,7 +3353,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -3359,7 +3362,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 0, z: 0}
     second:
       m_TileIndex: 0
@@ -3368,7 +3371,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 1, z: 0}
     second:
       m_TileIndex: 0
@@ -3377,7 +3380,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 1, z: 0}
     second:
       m_TileIndex: 1
@@ -3386,7 +3389,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 1, z: 0}
     second:
       m_TileIndex: 5
@@ -3395,7 +3398,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 1, z: 0}
     second:
       m_TileIndex: 1
@@ -3404,7 +3407,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 1, z: 0}
     second:
       m_TileIndex: 1
@@ -3413,7 +3416,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 1, z: 0}
     second:
       m_TileIndex: 1
@@ -3422,7 +3425,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 1, z: 0}
     second:
       m_TileIndex: 1
@@ -3431,7 +3434,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 1, z: 0}
     second:
       m_TileIndex: 0
@@ -3440,7 +3443,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 2, z: 0}
     second:
       m_TileIndex: 5
@@ -3449,7 +3452,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 2, z: 0}
     second:
       m_TileIndex: 1
@@ -3458,7 +3461,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 2, z: 0}
     second:
       m_TileIndex: 0
@@ -3467,7 +3470,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 2, z: 0}
     second:
       m_TileIndex: 0
@@ -3476,7 +3479,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 3, z: 0}
     second:
       m_TileIndex: 1
@@ -3485,7 +3488,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 3, z: 0}
     second:
       m_TileIndex: 5
@@ -3494,7 +3497,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 4, z: 0}
     second:
       m_TileIndex: 5
@@ -3503,7 +3506,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 4, z: 0}
     second:
       m_TileIndex: 1
@@ -3512,7 +3515,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 4, z: 0}
     second:
       m_TileIndex: 5
@@ -3521,7 +3524,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 5, z: 0}
     second:
       m_TileIndex: 1
@@ -3530,7 +3533,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 5, z: 0}
     second:
       m_TileIndex: 1
@@ -3539,7 +3542,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 5, z: 0}
     second:
       m_TileIndex: 1
@@ -3548,7 +3551,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 5, z: 0}
     second:
       m_TileIndex: 1
@@ -3557,7 +3560,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 5, z: 0}
     second:
       m_TileIndex: 5
@@ -3566,7 +3569,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 6, z: 0}
     second:
       m_TileIndex: 1
@@ -3575,7 +3578,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 6, z: 0}
     second:
       m_TileIndex: 1
@@ -3584,7 +3587,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 6, z: 0}
     second:
       m_TileIndex: 5
@@ -3593,7 +3596,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 6, z: 0}
     second:
       m_TileIndex: 5
@@ -3602,7 +3605,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 6, z: 0}
     second:
       m_TileIndex: 1
@@ -3611,7 +3614,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 6, z: 0}
     second:
       m_TileIndex: 5
@@ -3620,7 +3623,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 7, z: 0}
     second:
       m_TileIndex: 1
@@ -3629,7 +3632,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 7, z: 0}
     second:
       m_TileIndex: 1
@@ -3638,7 +3641,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 7, z: 0}
     second:
       m_TileIndex: 5
@@ -3647,7 +3650,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 8, z: 0}
     second:
       m_TileIndex: 1
@@ -3656,7 +3659,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 8, z: 0}
     second:
       m_TileIndex: 1
@@ -3665,7 +3668,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 8, z: 0}
     second:
       m_TileIndex: 1
@@ -3674,7 +3677,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -3683,7 +3686,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -3692,7 +3695,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 9, z: 0}
     second:
       m_TileIndex: 0
@@ -3701,7 +3704,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -3710,7 +3713,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -3719,7 +3722,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -3728,7 +3731,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -3737,7 +3740,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -3746,7 +3749,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -3755,7 +3758,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -3764,7 +3767,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 9, z: 0}
     second:
       m_TileIndex: 0
@@ -3773,7 +3776,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 10, z: 0}
     second:
       m_TileIndex: 0
@@ -3782,7 +3785,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -3791,7 +3794,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -3800,7 +3803,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -3809,7 +3812,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -3818,7 +3821,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -3827,7 +3830,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -3836,7 +3839,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 10, z: 0}
     second:
       m_TileIndex: 5
@@ -3845,7 +3848,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 10, z: 0}
     second:
       m_TileIndex: 5
@@ -3854,7 +3857,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -3863,7 +3866,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -3872,7 +3875,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -3881,7 +3884,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -3890,7 +3893,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 10, z: 0}
     second:
       m_TileIndex: 0
@@ -3899,7 +3902,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 11, z: 0}
     second:
       m_TileIndex: 2
@@ -3908,7 +3911,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 11, z: 0}
     second:
       m_TileIndex: 2
@@ -3917,7 +3920,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 11, z: 0}
     second:
       m_TileIndex: 2
@@ -3926,7 +3929,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 11, z: 0}
     second:
       m_TileIndex: 2
@@ -3935,7 +3938,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 11, z: 0}
     second:
       m_TileIndex: 2
@@ -3944,7 +3947,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 12, z: 0}
     second:
       m_TileIndex: 2
@@ -3953,7 +3956,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 12, z: 0}
     second:
       m_TileIndex: 2
@@ -3962,7 +3965,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 12, z: 0}
     second:
       m_TileIndex: 2
@@ -3971,7 +3974,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 12, z: 0}
     second:
       m_TileIndex: 2
@@ -3980,7 +3983,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 12, z: 0}
     second:
       m_TileIndex: 2
@@ -3989,7 +3992,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 13, z: 0}
     second:
       m_TileIndex: 3
@@ -3998,7 +4001,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -4007,7 +4010,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -4016,7 +4019,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -4025,7 +4028,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -4034,7 +4037,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -4043,7 +4046,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -4052,7 +4055,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -4061,7 +4064,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -4070,7 +4073,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -4079,7 +4082,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -4088,7 +4091,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 14, z: 0}
     second:
       m_TileIndex: 3
@@ -4097,7 +4100,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -4106,7 +4109,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -4115,7 +4118,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -4124,7 +4127,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -4133,7 +4136,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -4142,7 +4145,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -4151,7 +4154,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -4160,7 +4163,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 15, z: 0}
     second:
       m_TileIndex: 3
@@ -4169,7 +4172,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 15, z: 0}
     second:
       m_TileIndex: 3
@@ -4178,7 +4181,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 15, z: 0}
     second:
       m_TileIndex: 3
@@ -4187,7 +4190,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -4196,7 +4199,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -4205,7 +4208,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -4214,7 +4217,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -4223,7 +4226,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -4232,7 +4235,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -4241,7 +4244,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -4250,7 +4253,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -4259,7 +4262,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -4268,7 +4271,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -4277,7 +4280,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -4286,7 +4289,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -4295,7 +4298,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -4304,7 +4307,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -4313,7 +4316,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -4322,7 +4325,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 18, z: 0}
     second:
       m_TileIndex: 3
@@ -4331,7 +4334,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 18, z: 0}
     second:
       m_TileIndex: 3
@@ -4340,7 +4343,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 18, z: 0}
     second:
       m_TileIndex: 3
@@ -4349,7 +4352,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 18, z: 0}
     second:
       m_TileIndex: 3
@@ -4358,7 +4361,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 18, z: 0}
     second:
       m_TileIndex: 3
@@ -4367,7 +4370,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -4376,7 +4379,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -4385,7 +4388,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -4394,7 +4397,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -4403,7 +4406,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -4412,7 +4415,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -4421,7 +4424,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -4430,7 +4433,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -4439,7 +4442,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -4448,7 +4451,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 19, z: 0}
     second:
       m_TileIndex: 3
@@ -4457,7 +4460,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 19, z: 0}
     second:
       m_TileIndex: 3
@@ -4466,7 +4469,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 19, z: 0}
     second:
       m_TileIndex: 3
@@ -4475,7 +4478,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -4484,7 +4487,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -4493,7 +4496,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -4502,7 +4505,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -4511,7 +4514,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -4520,7 +4523,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -4529,7 +4532,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -4538,7 +4541,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -4547,7 +4550,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -4556,7 +4559,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 21, z: 0}
     second:
       m_TileIndex: 3
@@ -4565,7 +4568,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 21, z: 0}
     second:
       m_TileIndex: 3
@@ -4574,7 +4577,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 21, z: 0}
     second:
       m_TileIndex: 3
@@ -4583,7 +4586,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -4592,7 +4595,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -4601,7 +4604,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -4610,7 +4613,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -4619,7 +4622,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -4628,7 +4631,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -4637,7 +4640,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -4646,7 +4649,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -4655,7 +4658,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -4664,7 +4667,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -4673,7 +4676,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -4682,7 +4685,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4691,7 +4694,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4700,7 +4703,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4709,7 +4712,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4718,7 +4721,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4727,7 +4730,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4736,7 +4739,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4745,7 +4748,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4754,7 +4757,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4763,7 +4766,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4772,7 +4775,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4781,7 +4784,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4790,7 +4793,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 22, z: 0}
     second:
       m_TileIndex: 2
@@ -4799,7 +4802,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4808,7 +4811,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 22, z: 0}
     second:
       m_TileIndex: 2
@@ -4817,7 +4820,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -4826,7 +4829,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 22, z: 0}
     second:
       m_TileIndex: 1
@@ -4835,7 +4838,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 22, z: 0}
     second:
       m_TileIndex: 1
@@ -4844,7 +4847,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 22, z: 0}
     second:
       m_TileIndex: 0
@@ -4853,7 +4856,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -4862,7 +4865,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -4871,7 +4874,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -4880,7 +4883,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -4889,7 +4892,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -4898,7 +4901,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -4907,7 +4910,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -4916,7 +4919,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -4925,7 +4928,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -4934,7 +4937,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 23, z: 0}
     second:
       m_TileIndex: 2
@@ -4943,7 +4946,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 24, z: 0}
     second:
       m_TileIndex: 3
@@ -4952,7 +4955,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 24, z: 0}
     second:
       m_TileIndex: 3
@@ -4961,7 +4964,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 24, z: 0}
     second:
       m_TileIndex: 3
@@ -4970,7 +4973,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 24, z: 0}
     second:
       m_TileIndex: 3
@@ -4979,7 +4982,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 24, z: 0}
     second:
       m_TileIndex: 1
@@ -4988,7 +4991,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 24, z: 0}
     second:
       m_TileIndex: 1
@@ -4997,7 +5000,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 24, z: 0}
     second:
       m_TileIndex: 0
@@ -5006,7 +5009,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -5015,7 +5018,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -5024,7 +5027,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -5033,7 +5036,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -5042,7 +5045,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -5051,7 +5054,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -5060,7 +5063,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -5069,7 +5072,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 25, z: 0}
     second:
       m_TileIndex: 2
@@ -5078,7 +5081,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 25, z: 0}
     second:
       m_TileIndex: 2
@@ -5087,7 +5090,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 25, z: 0}
     second:
       m_TileIndex: 2
@@ -5096,7 +5099,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 26, z: 0}
     second:
       m_TileIndex: 3
@@ -5105,7 +5108,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 26, z: 0}
     second:
       m_TileIndex: 3
@@ -5114,7 +5117,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 26, z: 0}
     second:
       m_TileIndex: 3
@@ -5123,7 +5126,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 26, z: 0}
     second:
       m_TileIndex: 2
@@ -5132,7 +5135,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 27, z: 0}
     second:
       m_TileIndex: 3
@@ -5141,7 +5144,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 27, z: 0}
     second:
       m_TileIndex: 3
@@ -5150,7 +5153,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 27, z: 0}
     second:
       m_TileIndex: 3
@@ -5159,7 +5162,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 27, z: 0}
     second:
       m_TileIndex: 2
@@ -5168,7 +5171,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 27, z: 0}
     second:
       m_TileIndex: 2
@@ -5177,7 +5180,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 27, z: 0}
     second:
       m_TileIndex: 2
@@ -5186,7 +5189,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 27, z: 0}
     second:
       m_TileIndex: 2
@@ -5195,7 +5198,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 27, z: 0}
     second:
       m_TileIndex: 4
@@ -5204,7 +5207,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 27, z: 0}
     second:
       m_TileIndex: 4
@@ -5213,7 +5216,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 27, z: 0}
     second:
       m_TileIndex: 4
@@ -5222,7 +5225,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 28, z: 0}
     second:
       m_TileIndex: 3
@@ -5231,7 +5234,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 28, z: 0}
     second:
       m_TileIndex: 3
@@ -5240,7 +5243,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 28, z: 0}
     second:
       m_TileIndex: 3
@@ -5249,7 +5252,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 28, z: 0}
     second:
       m_TileIndex: 2
@@ -5258,7 +5261,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 28, z: 0}
     second:
       m_TileIndex: 2
@@ -5267,7 +5270,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 28, z: 0}
     second:
       m_TileIndex: 2
@@ -5276,7 +5279,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 28, z: 0}
     second:
       m_TileIndex: 2
@@ -5285,7 +5288,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 28, z: 0}
     second:
       m_TileIndex: 2
@@ -5294,7 +5297,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 28, z: 0}
     second:
       m_TileIndex: 4
@@ -5303,7 +5306,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 28, z: 0}
     second:
       m_TileIndex: 4
@@ -5312,7 +5315,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 28, z: 0}
     second:
       m_TileIndex: 4
@@ -5321,7 +5324,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 28, z: 0}
     second:
       m_TileIndex: 4
@@ -5330,7 +5333,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 29, z: 0}
     second:
       m_TileIndex: 3
@@ -5339,7 +5342,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 29, z: 0}
     second:
       m_TileIndex: 3
@@ -5348,7 +5351,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 29, z: 0}
     second:
       m_TileIndex: 3
@@ -5357,7 +5360,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 29, z: 0}
     second:
       m_TileIndex: 3
@@ -5366,7 +5369,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 29, z: 0}
     second:
       m_TileIndex: 2
@@ -5375,7 +5378,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 29, z: 0}
     second:
       m_TileIndex: 2
@@ -5384,7 +5387,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 29, z: 0}
     second:
       m_TileIndex: 4
@@ -5393,7 +5396,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 29, z: 0}
     second:
       m_TileIndex: 4
@@ -5402,7 +5405,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 30, z: 0}
     second:
       m_TileIndex: 3
@@ -5411,7 +5414,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 30, z: 0}
     second:
       m_TileIndex: 3
@@ -5420,7 +5423,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 30, z: 0}
     second:
       m_TileIndex: 3
@@ -5429,7 +5432,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 30, z: 0}
     second:
       m_TileIndex: 2
@@ -5438,7 +5441,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 30, z: 0}
     second:
       m_TileIndex: 4
@@ -5447,7 +5450,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 30, z: 0}
     second:
       m_TileIndex: 4
@@ -5456,7 +5459,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5465,7 +5468,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5474,7 +5477,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5483,7 +5486,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5492,7 +5495,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5501,7 +5504,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5510,7 +5513,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5519,7 +5522,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5528,7 +5531,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5537,7 +5540,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5546,7 +5549,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5555,7 +5558,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5564,7 +5567,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5573,7 +5576,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -5582,7 +5585,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 31, z: 0}
     second:
       m_TileIndex: 2
@@ -5591,7 +5594,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 31, z: 0}
     second:
       m_TileIndex: 4
@@ -5600,7 +5603,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 31, z: 0}
     second:
       m_TileIndex: 4
@@ -5609,7 +5612,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 32, z: 0}
     second:
       m_TileIndex: 3
@@ -5618,7 +5621,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 32, z: 0}
     second:
       m_TileIndex: 3
@@ -5627,7 +5630,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 32, z: 0}
     second:
       m_TileIndex: 3
@@ -5636,7 +5639,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 32, z: 0}
     second:
       m_TileIndex: 2
@@ -5645,7 +5648,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 32, z: 0}
     second:
       m_TileIndex: 4
@@ -5654,7 +5657,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 32, z: 0}
     second:
       m_TileIndex: 4
@@ -5663,7 +5666,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5672,7 +5675,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5681,7 +5684,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5690,7 +5693,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5699,7 +5702,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5708,7 +5711,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5717,7 +5720,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5726,7 +5729,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5735,7 +5738,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5744,7 +5747,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5753,7 +5756,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5762,7 +5765,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5771,7 +5774,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5780,7 +5783,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5789,7 +5792,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5798,7 +5801,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5807,7 +5810,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5816,7 +5819,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -5825,7 +5828,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 33, z: 0}
     second:
       m_TileIndex: 2
@@ -5834,7 +5837,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 33, z: 0}
     second:
       m_TileIndex: 2
@@ -5843,7 +5846,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 33, z: 0}
     second:
       m_TileIndex: 4
@@ -5852,7 +5855,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 33, z: 0}
     second:
       m_TileIndex: 4
@@ -5861,7 +5864,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -5870,7 +5873,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 34, z: 0}
     second:
       m_TileIndex: 3
@@ -5879,7 +5882,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -5888,7 +5891,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -5897,7 +5900,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -5906,7 +5909,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -5915,7 +5918,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -5924,7 +5927,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -5933,7 +5936,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -5942,7 +5945,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -5951,7 +5954,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -5960,7 +5963,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -5969,7 +5972,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 34, z: 0}
     second:
       m_TileIndex: 3
@@ -5978,7 +5981,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 34, z: 0}
     second:
       m_TileIndex: 3
@@ -5987,7 +5990,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -5996,7 +5999,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -6005,7 +6008,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 34, z: 0}
     second:
       m_TileIndex: 3
@@ -6014,7 +6017,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 34, z: 0}
     second:
       m_TileIndex: 3
@@ -6023,7 +6026,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -6032,7 +6035,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -6041,7 +6044,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -6050,7 +6053,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -6059,7 +6062,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -6068,7 +6071,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -6077,7 +6080,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 35, z: 0}
     second:
       m_TileIndex: 2
@@ -6086,7 +6089,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 35, z: 0}
     second:
       m_TileIndex: 3
@@ -6095,7 +6098,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 35, z: 0}
     second:
       m_TileIndex: 4
@@ -6104,7 +6107,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 35, z: 0}
     second:
       m_TileIndex: 3
@@ -6113,7 +6116,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 35, z: 0}
     second:
       m_TileIndex: 3
@@ -6122,7 +6125,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 35, z: 0}
     second:
       m_TileIndex: 2
@@ -6131,7 +6134,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 35, z: 0}
     second:
       m_TileIndex: 2
@@ -6140,7 +6143,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 35, z: 0}
     second:
       m_TileIndex: 2
@@ -6149,7 +6152,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 35, z: 0}
     second:
       m_TileIndex: 4
@@ -6158,7 +6161,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 35, z: 0}
     second:
       m_TileIndex: 4
@@ -6167,7 +6170,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 35, z: 0}
     second:
       m_TileIndex: 4
@@ -6176,7 +6179,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 35, z: 0}
     second:
       m_TileIndex: 4
@@ -6185,7 +6188,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -6194,7 +6197,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 36, z: 0}
     second:
       m_TileIndex: 3
@@ -6203,7 +6206,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 36, z: 0}
     second:
       m_TileIndex: 4
@@ -6212,7 +6215,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 36, z: 0}
     second:
       m_TileIndex: 4
@@ -6221,7 +6224,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 36, z: 0}
     second:
       m_TileIndex: 3
@@ -6230,7 +6233,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 36, z: 0}
     second:
       m_TileIndex: 3
@@ -6239,7 +6242,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -6248,7 +6251,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -6257,7 +6260,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -6266,7 +6269,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 37, z: 0}
     second:
       m_TileIndex: 2
@@ -6275,7 +6278,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 37, z: 0}
     second:
       m_TileIndex: 3
@@ -6284,7 +6287,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 37, z: 0}
     second:
       m_TileIndex: 4
@@ -6293,7 +6296,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 37, z: 0}
     second:
       m_TileIndex: 2
@@ -6302,7 +6305,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 37, z: 0}
     second:
       m_TileIndex: 3
@@ -6311,7 +6314,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 37, z: 0}
     second:
       m_TileIndex: 2
@@ -6320,7 +6323,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 37, z: 0}
     second:
       m_TileIndex: 2
@@ -6329,7 +6332,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 38, z: 0}
     second:
       m_TileIndex: 2
@@ -6338,7 +6341,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 38, z: 0}
     second:
       m_TileIndex: 3
@@ -6347,7 +6350,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 38, z: 0}
     second:
       m_TileIndex: 4
@@ -6356,7 +6359,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 38, z: 0}
     second:
       m_TileIndex: 4
@@ -6365,7 +6368,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 38, z: 0}
     second:
       m_TileIndex: 3
@@ -6374,7 +6377,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 38, z: 0}
     second:
       m_TileIndex: 3
@@ -6383,7 +6386,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 38, z: 0}
     second:
       m_TileIndex: 4
@@ -6392,7 +6395,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 38, z: 0}
     second:
       m_TileIndex: 2
@@ -6401,7 +6404,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6410,7 +6413,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 39, z: 0}
     second:
       m_TileIndex: 2
@@ -6419,7 +6422,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 39, z: 0}
     second:
       m_TileIndex: 2
@@ -6428,7 +6431,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 39, z: 0}
     second:
       m_TileIndex: 2
@@ -6437,7 +6440,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6446,7 +6449,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6455,7 +6458,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6464,7 +6467,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6473,7 +6476,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6482,7 +6485,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6491,7 +6494,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6500,7 +6503,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6509,7 +6512,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6518,7 +6521,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6527,7 +6530,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6536,7 +6539,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6545,7 +6548,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6554,7 +6557,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6563,7 +6566,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6572,7 +6575,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6581,7 +6584,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6590,7 +6593,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6599,7 +6602,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6608,7 +6611,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6617,7 +6620,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6626,7 +6629,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6635,7 +6638,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6644,7 +6647,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -6653,7 +6656,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 39, z: 0}
     second:
       m_TileIndex: 2
@@ -6662,7 +6665,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 39, z: 0}
     second:
       m_TileIndex: 2
@@ -6671,7 +6674,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6680,7 +6683,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6689,7 +6692,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6698,7 +6701,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6707,7 +6710,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6716,7 +6719,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 76, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6725,7 +6728,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -6734,7 +6737,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 40, z: 0}
     second:
       m_TileIndex: 2
@@ -6743,7 +6746,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 40, z: 0}
     second:
       m_TileIndex: 3
@@ -6752,7 +6755,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 40, z: 0}
     second:
       m_TileIndex: 3
@@ -6761,7 +6764,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 40, z: 0}
     second:
       m_TileIndex: 2
@@ -6770,7 +6773,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 40, z: 0}
     second:
       m_TileIndex: 2
@@ -6779,7 +6782,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 40, z: 0}
     second:
       m_TileIndex: 3
@@ -6788,7 +6791,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 40, z: 0}
     second:
       m_TileIndex: 2
@@ -6797,7 +6800,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 40, z: 0}
     second:
       m_TileIndex: 4
@@ -6806,7 +6809,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 40, z: 0}
     second:
       m_TileIndex: 4
@@ -6815,7 +6818,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -6824,7 +6827,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6833,7 +6836,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6842,7 +6845,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6851,7 +6854,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6860,7 +6863,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6869,7 +6872,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6878,7 +6881,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6887,7 +6890,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6896,7 +6899,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6905,7 +6908,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6914,7 +6917,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6923,7 +6926,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6932,7 +6935,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6941,7 +6944,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6950,7 +6953,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6959,7 +6962,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -6968,7 +6971,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -6977,7 +6980,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -6986,7 +6989,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -6995,7 +6998,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -7004,7 +7007,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -7013,7 +7016,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -7022,7 +7025,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -7031,7 +7034,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -7040,7 +7043,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 41, z: 0}
     second:
       m_TileIndex: 4
@@ -7049,7 +7052,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 41, z: 0}
     second:
       m_TileIndex: 4
@@ -7058,7 +7061,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 42, z: 0}
     second:
       m_TileIndex: 2
@@ -7067,7 +7070,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -7076,7 +7079,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -7085,7 +7088,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -7094,7 +7097,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -7103,7 +7106,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -7112,7 +7115,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -7121,7 +7124,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -7130,7 +7133,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -7139,7 +7142,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -7148,7 +7151,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -7157,7 +7160,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -7166,7 +7169,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 42, z: 0}
     second:
       m_TileIndex: 4
@@ -7175,7 +7178,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 42, z: 0}
     second:
       m_TileIndex: 4
@@ -7184,7 +7187,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 42, z: 0}
     second:
       m_TileIndex: 4
@@ -7193,7 +7196,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 42, z: 0}
     second:
       m_TileIndex: 4
@@ -7202,7 +7205,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 42, z: 0}
     second:
       m_TileIndex: 4
@@ -7211,7 +7214,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -7220,7 +7223,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -7229,7 +7232,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -7238,7 +7241,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -7247,7 +7250,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -7256,7 +7259,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -7265,7 +7268,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 43, z: 0}
     second:
       m_TileIndex: 4
@@ -7274,7 +7277,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -7283,7 +7286,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -7292,7 +7295,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -7301,7 +7304,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 43, z: 0}
     second:
       m_TileIndex: 4
@@ -7310,7 +7313,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -7319,7 +7322,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -7328,7 +7331,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -7337,7 +7340,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 43, z: 0}
     second:
       m_TileIndex: 4
@@ -7346,7 +7349,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -7355,7 +7358,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 43, z: 0}
     second:
       m_TileIndex: 4
@@ -7364,7 +7367,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -7373,7 +7376,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 43, z: 0}
     second:
       m_TileIndex: 4
@@ -7382,7 +7385,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7391,7 +7394,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7400,7 +7403,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7409,7 +7412,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7418,7 +7421,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7427,7 +7430,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 44, z: 0}
     second:
       m_TileIndex: 3
@@ -7436,7 +7439,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 44, z: 0}
     second:
       m_TileIndex: 3
@@ -7445,7 +7448,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 44, z: 0}
     second:
       m_TileIndex: 3
@@ -7454,7 +7457,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 44, z: 0}
     second:
       m_TileIndex: 3
@@ -7463,7 +7466,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7472,7 +7475,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7481,7 +7484,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7490,7 +7493,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7499,7 +7502,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7508,7 +7511,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7517,7 +7520,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7526,7 +7529,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -7535,7 +7538,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 44, z: 0}
     second:
       m_TileIndex: 3
@@ -7544,7 +7547,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -7553,7 +7556,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -7562,7 +7565,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -7571,7 +7574,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -7580,7 +7583,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -7589,7 +7592,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -7598,7 +7601,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -7607,7 +7610,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -7616,7 +7619,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -7625,7 +7628,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -7634,7 +7637,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 44, z: 0}
     second:
       m_TileIndex: 3
@@ -7643,7 +7646,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -7652,7 +7655,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -7661,7 +7664,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -7670,7 +7673,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -7679,7 +7682,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -7688,7 +7691,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -7697,7 +7700,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -7706,7 +7709,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -7715,7 +7718,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -7724,7 +7727,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7733,7 +7736,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7742,7 +7745,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7751,7 +7754,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7760,7 +7763,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7769,7 +7772,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7778,7 +7781,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7787,7 +7790,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -7796,7 +7799,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7805,7 +7808,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7814,7 +7817,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7823,7 +7826,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7832,7 +7835,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7841,7 +7844,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -7850,7 +7853,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -7859,7 +7862,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -7868,7 +7871,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 76, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -7877,7 +7880,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -7886,7 +7889,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -7895,7 +7898,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -7904,7 +7907,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -7913,7 +7916,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -7922,7 +7925,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 46, z: 0}
     second:
       m_TileIndex: 2
@@ -7931,7 +7934,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 46, z: 0}
     second:
       m_TileIndex: 2
@@ -7940,7 +7943,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -7949,7 +7952,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -7958,7 +7961,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -7967,7 +7970,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -7976,7 +7979,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -7985,7 +7988,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 46, z: 0}
     second:
       m_TileIndex: 2
@@ -7994,7 +7997,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -8003,7 +8006,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -8012,7 +8015,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 46, z: 0}
     second:
       m_TileIndex: 2
@@ -8021,7 +8024,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -8030,7 +8033,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -8039,7 +8042,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -8048,7 +8051,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -8057,7 +8060,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -8066,7 +8069,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -8075,7 +8078,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -8084,7 +8087,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -8093,7 +8096,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -8102,7 +8105,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8111,7 +8114,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8120,7 +8123,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8129,7 +8132,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8138,7 +8141,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8147,7 +8150,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8156,7 +8159,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8165,7 +8168,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8174,7 +8177,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8183,7 +8186,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8192,7 +8195,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 47, z: 0}
     second:
       m_TileIndex: 2
@@ -8201,7 +8204,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8210,7 +8213,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8219,7 +8222,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -8228,7 +8231,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -8237,7 +8240,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -8246,7 +8249,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -8255,7 +8258,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -8264,7 +8267,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -8273,7 +8276,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 47, z: 0}
     second:
       m_TileIndex: 2
@@ -8282,7 +8285,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 47, z: 0}
     second:
       m_TileIndex: 2
@@ -8291,7 +8294,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 47, z: 0}
     second:
       m_TileIndex: 2
@@ -8300,7 +8303,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 76, y: 47, z: 0}
     second:
       m_TileIndex: 2
@@ -8309,7 +8312,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -8318,7 +8321,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -8327,7 +8330,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -8336,7 +8339,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -8345,7 +8348,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -8354,7 +8357,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -8363,7 +8366,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 48, z: 0}
     second:
       m_TileIndex: 2
@@ -8372,7 +8375,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 48, z: 0}
     second:
       m_TileIndex: 2
@@ -8381,7 +8384,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 48, z: 0}
     second:
       m_TileIndex: 2
@@ -8390,7 +8393,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 48, z: 0}
     second:
       m_TileIndex: 2
@@ -8399,7 +8402,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -8408,7 +8411,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -8417,7 +8420,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -8426,7 +8429,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -8435,7 +8438,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -8444,7 +8447,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -8453,7 +8456,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -8462,7 +8465,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -8471,7 +8474,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -8480,7 +8483,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -8489,7 +8492,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 48, z: 0}
     second:
       m_TileIndex: 2
@@ -8498,7 +8501,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -8507,7 +8510,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -8516,7 +8519,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -8525,7 +8528,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -8534,7 +8537,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -8543,7 +8546,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -8552,7 +8555,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -8561,7 +8564,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -8570,7 +8573,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -8579,7 +8582,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -8588,7 +8591,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -8597,7 +8600,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -8606,7 +8609,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -8615,7 +8618,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -8624,7 +8627,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -8633,7 +8636,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -8642,7 +8645,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 49, z: 0}
     second:
       m_TileIndex: 2
@@ -8651,7 +8654,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -8660,7 +8663,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -8669,7 +8672,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -8678,7 +8681,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -8687,7 +8690,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -8696,7 +8699,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -8705,7 +8708,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -8714,7 +8717,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -8723,7 +8726,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -8732,7 +8735,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 50, z: 0}
     second:
       m_TileIndex: 4
@@ -8741,7 +8744,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 50, z: 0}
     second:
       m_TileIndex: 4
@@ -8750,7 +8753,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 50, z: 0}
     second:
       m_TileIndex: 4
@@ -8759,7 +8762,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -8768,7 +8771,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 50, z: 0}
     second:
       m_TileIndex: 4
@@ -8777,7 +8780,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 50, z: 0}
     second:
       m_TileIndex: 4
@@ -8786,7 +8789,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 50, z: 0}
     second:
       m_TileIndex: 2
@@ -8795,7 +8798,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8804,7 +8807,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8813,7 +8816,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8822,7 +8825,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8831,7 +8834,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8840,7 +8843,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8849,7 +8852,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8858,7 +8861,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8867,7 +8870,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8876,7 +8879,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8885,7 +8888,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8894,7 +8897,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8903,7 +8906,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8912,7 +8915,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8921,7 +8924,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8930,7 +8933,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8939,7 +8942,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8948,7 +8951,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8957,7 +8960,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8966,7 +8969,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8975,7 +8978,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8984,7 +8987,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -8993,7 +8996,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -9002,7 +9005,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -9011,7 +9014,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -9020,7 +9023,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -9029,7 +9032,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -9038,7 +9041,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -9047,7 +9050,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -9056,7 +9059,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -9065,7 +9068,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -9074,7 +9077,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9083,7 +9086,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9092,7 +9095,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9101,7 +9104,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9110,7 +9113,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9119,7 +9122,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9128,7 +9131,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9137,7 +9140,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9146,7 +9149,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9155,7 +9158,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9164,7 +9167,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9173,7 +9176,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9182,7 +9185,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9191,7 +9194,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9200,7 +9203,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9209,7 +9212,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -9218,7 +9221,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -9227,7 +9230,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -9236,7 +9239,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9245,7 +9248,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9254,7 +9257,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9263,7 +9266,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9272,7 +9275,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9281,7 +9284,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -9290,7 +9293,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 51, z: 0}
     second:
       m_TileIndex: 2
@@ -9299,7 +9302,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 52, z: 0}
     second:
       m_TileIndex: 3
@@ -9308,7 +9311,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 52, z: 0}
     second:
       m_TileIndex: 3
@@ -9317,7 +9320,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 52, z: 0}
     second:
       m_TileIndex: 3
@@ -9326,7 +9329,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 52, z: 0}
     second:
       m_TileIndex: 4
@@ -9335,7 +9338,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 52, z: 0}
     second:
       m_TileIndex: 2
@@ -9344,7 +9347,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 53, z: 0}
     second:
       m_TileIndex: 2
@@ -9353,7 +9356,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 53, z: 0}
     second:
       m_TileIndex: 3
@@ -9362,7 +9365,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 53, z: 0}
     second:
       m_TileIndex: 2
@@ -9371,7 +9374,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 53, z: 0}
     second:
       m_TileIndex: 3
@@ -9380,7 +9383,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 53, z: 0}
     second:
       m_TileIndex: 2
@@ -9389,7 +9392,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -9398,7 +9401,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -9407,7 +9410,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -9416,7 +9419,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -9425,7 +9428,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -9434,7 +9437,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -9443,7 +9446,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -9452,7 +9455,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -9461,7 +9464,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 54, z: 0}
     second:
       m_TileIndex: 4
@@ -9470,7 +9473,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 54, z: 0}
     second:
       m_TileIndex: 2
@@ -9479,7 +9482,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9488,7 +9491,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9497,7 +9500,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9506,7 +9509,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9515,7 +9518,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9524,7 +9527,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9533,7 +9536,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9542,7 +9545,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9551,7 +9554,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9560,7 +9563,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9569,7 +9572,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9578,7 +9581,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9587,7 +9590,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9596,7 +9599,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9605,7 +9608,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9614,7 +9617,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9623,7 +9626,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9632,7 +9635,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9641,7 +9644,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9650,7 +9653,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9659,7 +9662,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9668,7 +9671,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9677,7 +9680,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9686,7 +9689,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9695,7 +9698,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9704,7 +9707,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9713,7 +9716,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9722,7 +9725,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9731,7 +9734,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9740,7 +9743,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9749,7 +9752,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9758,7 +9761,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9767,7 +9770,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9776,7 +9779,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9785,7 +9788,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9794,7 +9797,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9803,7 +9806,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9812,7 +9815,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -9821,7 +9824,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9830,7 +9833,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9839,7 +9842,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9848,7 +9851,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9857,7 +9860,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9866,7 +9869,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -9875,7 +9878,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 55, z: 0}
     second:
       m_TileIndex: 2
@@ -9884,7 +9887,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -9893,7 +9896,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -9902,7 +9905,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -9911,7 +9914,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 56, z: 0}
     second:
       m_TileIndex: 2
@@ -9920,7 +9923,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -9929,7 +9932,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 56, z: 0}
     second:
       m_TileIndex: 2
@@ -9938,7 +9941,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -9947,7 +9950,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -9956,7 +9959,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -9965,7 +9968,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -9974,7 +9977,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -9983,7 +9986,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -9992,7 +9995,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -10001,7 +10004,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -10010,7 +10013,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -10019,7 +10022,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -10028,7 +10031,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -10037,7 +10040,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -10046,7 +10049,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -10055,7 +10058,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -10064,7 +10067,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -10073,7 +10076,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -10082,7 +10085,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -10091,7 +10094,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 56, z: 0}
     second:
       m_TileIndex: 2
@@ -10100,7 +10103,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -10109,7 +10112,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -10118,7 +10121,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 56, z: 0}
     second:
       m_TileIndex: 2
@@ -10127,7 +10130,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 57, z: 0}
     second:
       m_TileIndex: 0
@@ -10136,7 +10139,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 1, y: 57, z: 0}
     second:
       m_TileIndex: 1
@@ -10145,7 +10148,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 5, y: 57, z: 0}
     second:
       m_TileIndex: 1
@@ -10154,7 +10157,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 57, z: 0}
     second:
       m_TileIndex: 0
@@ -10163,7 +10166,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -10172,7 +10175,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -10181,7 +10184,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -10190,7 +10193,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -10199,7 +10202,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -10208,7 +10211,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -10217,7 +10220,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 57, z: 0}
     second:
       m_TileIndex: 4
@@ -10226,7 +10229,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 57, z: 0}
     second:
       m_TileIndex: 2
@@ -10235,7 +10238,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 57, z: 0}
     second:
       m_TileIndex: 2
@@ -10244,7 +10247,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 57, z: 0}
     second:
       m_TileIndex: 4
@@ -10253,7 +10256,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -10262,7 +10265,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -10271,7 +10274,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -10280,7 +10283,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 57, z: 0}
     second:
       m_TileIndex: 4
@@ -10289,7 +10292,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 57, z: 0}
     second:
       m_TileIndex: 2
@@ -10298,7 +10301,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 58, z: 0}
     second:
       m_TileIndex: 1
@@ -10307,7 +10310,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 1, y: 58, z: 0}
     second:
       m_TileIndex: 0
@@ -10316,7 +10319,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 5, y: 58, z: 0}
     second:
       m_TileIndex: 0
@@ -10325,7 +10328,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 58, z: 0}
     second:
       m_TileIndex: 1
@@ -10334,7 +10337,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -10343,7 +10346,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -10352,7 +10355,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -10361,7 +10364,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -10370,7 +10373,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -10379,7 +10382,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -10388,7 +10391,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -10397,7 +10400,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -10406,7 +10409,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -10415,7 +10418,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -10424,7 +10427,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -10433,7 +10436,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -10442,7 +10445,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -10451,7 +10454,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -10460,7 +10463,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 58, z: 0}
     second:
       m_TileIndex: 2
@@ -10469,7 +10472,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -10478,7 +10481,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -10487,7 +10490,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -10496,7 +10499,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -10505,7 +10508,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -10514,7 +10517,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 59, z: 0}
     second:
       m_TileIndex: 1
@@ -10523,7 +10526,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 59, z: 0}
     second:
       m_TileIndex: 1
@@ -10532,7 +10535,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 59, z: 0}
     second:
       m_TileIndex: 2
@@ -10541,7 +10544,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 59, z: 0}
     second:
       m_TileIndex: 2
@@ -10550,7 +10553,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 59, z: 0}
     second:
       m_TileIndex: 2
@@ -10559,7 +10562,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 59, z: 0}
     second:
       m_TileIndex: 2
@@ -10568,7 +10571,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10577,7 +10580,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10586,7 +10589,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10595,7 +10598,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10604,7 +10607,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10613,7 +10616,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10622,7 +10625,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10631,7 +10634,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10640,7 +10643,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10649,7 +10652,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10658,7 +10661,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10667,7 +10670,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -10676,7 +10679,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -10685,7 +10688,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -10694,7 +10697,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -10703,7 +10706,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10712,7 +10715,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10721,7 +10724,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10730,7 +10733,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10739,7 +10742,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10748,7 +10751,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10757,7 +10760,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10766,7 +10769,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10775,7 +10778,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10784,7 +10787,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10793,7 +10796,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10802,7 +10805,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -10811,7 +10814,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -10820,7 +10823,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 76, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -10829,7 +10832,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -10838,7 +10841,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 60, z: 0}
     second:
       m_TileIndex: 1
@@ -10847,7 +10850,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -10856,7 +10859,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -10865,7 +10868,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -10874,7 +10877,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -10883,7 +10886,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -10892,7 +10895,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -10901,7 +10904,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -10910,7 +10913,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -10919,7 +10922,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -10928,7 +10931,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -10937,7 +10940,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -10946,7 +10949,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -10955,7 +10958,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -10964,7 +10967,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -10973,7 +10976,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -10982,7 +10985,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -10991,7 +10994,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -11000,7 +11003,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -11009,7 +11012,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 61, z: 0}
     second:
       m_TileIndex: 1
@@ -11018,7 +11021,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -11027,7 +11030,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -11036,7 +11039,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -11045,7 +11048,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -11054,7 +11057,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -11063,7 +11066,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -11072,7 +11075,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -11081,7 +11084,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -11090,7 +11093,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 61, z: 0}
     second:
       m_TileIndex: 4
@@ -11099,7 +11102,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -11108,7 +11111,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -11117,7 +11120,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -11126,7 +11129,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 61, z: 0}
     second:
       m_TileIndex: 4
@@ -11135,7 +11138,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 62, z: 0}
     second:
       m_TileIndex: 1
@@ -11144,7 +11147,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 62, z: 0}
     second:
       m_TileIndex: 1
@@ -11153,7 +11156,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 62, z: 0}
     second:
       m_TileIndex: 2
@@ -11162,7 +11165,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 62, z: 0}
     second:
       m_TileIndex: 2
@@ -11171,7 +11174,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 62, z: 0}
     second:
       m_TileIndex: 2
@@ -11180,7 +11183,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -11189,7 +11192,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -11198,7 +11201,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -11207,7 +11210,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -11216,7 +11219,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 62, z: 0}
     second:
       m_TileIndex: 4
@@ -11225,7 +11228,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 62, z: 0}
     second:
       m_TileIndex: 4
@@ -11234,7 +11237,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -11243,7 +11246,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -11252,7 +11255,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -11261,7 +11264,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -11270,7 +11273,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -11279,7 +11282,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -11288,7 +11291,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -11297,7 +11300,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 62, z: 0}
     second:
       m_TileIndex: 4
@@ -11306,7 +11309,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 63, z: 0}
     second:
       m_TileIndex: 1
@@ -11315,7 +11318,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11324,7 +11327,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11333,7 +11336,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11342,7 +11345,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11351,7 +11354,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11360,7 +11363,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11369,7 +11372,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11378,7 +11381,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11387,7 +11390,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11396,7 +11399,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11405,7 +11408,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11414,7 +11417,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11423,7 +11426,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 63, z: 0}
     second:
       m_TileIndex: 4
@@ -11432,7 +11435,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -11441,7 +11444,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -11450,7 +11453,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -11459,7 +11462,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 63, z: 0}
     second:
       m_TileIndex: 4
@@ -11468,7 +11471,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -11477,7 +11480,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -11486,7 +11489,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -11495,7 +11498,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 63, z: 0}
     second:
       m_TileIndex: 4
@@ -11504,7 +11507,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 63, z: 0}
     second:
       m_TileIndex: 4
@@ -11513,7 +11516,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11522,7 +11525,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -11531,7 +11534,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11540,7 +11543,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11549,7 +11552,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11558,7 +11561,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11567,7 +11570,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11576,7 +11579,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11585,7 +11588,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11594,7 +11597,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11603,7 +11606,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11612,7 +11615,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11621,7 +11624,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11630,7 +11633,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11639,7 +11642,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -11648,7 +11651,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 63, z: 0}
     second:
       m_TileIndex: 4
@@ -11657,7 +11660,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 64, z: 0}
     second:
       m_TileIndex: 1
@@ -11666,7 +11669,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 64, z: 0}
     second:
       m_TileIndex: 4
@@ -11675,7 +11678,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 64, z: 0}
     second:
       m_TileIndex: 4
@@ -11684,7 +11687,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 64, z: 0}
     second:
       m_TileIndex: 4
@@ -11693,7 +11696,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 64, z: 0}
     second:
       m_TileIndex: 3
@@ -11702,7 +11705,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 64, z: 0}
     second:
       m_TileIndex: 3
@@ -11711,7 +11714,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 64, z: 0}
     second:
       m_TileIndex: 4
@@ -11720,7 +11723,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 65, z: 0}
     second:
       m_TileIndex: 1
@@ -11729,7 +11732,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 65, z: 0}
     second:
       m_TileIndex: 1
@@ -11738,7 +11741,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -11747,7 +11750,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -11756,7 +11759,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -11765,7 +11768,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -11774,7 +11777,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -11783,7 +11786,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -11792,7 +11795,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -11801,7 +11804,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -11810,7 +11813,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -11819,7 +11822,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -11828,7 +11831,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -11837,7 +11840,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -11846,7 +11849,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -11855,7 +11858,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -11864,7 +11867,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -11873,7 +11876,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -11882,7 +11885,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -11891,7 +11894,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -11900,7 +11903,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -11909,7 +11912,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -11918,7 +11921,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -11927,7 +11930,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -11936,7 +11939,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -11945,7 +11948,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -11954,7 +11957,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -11963,7 +11966,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -11972,7 +11975,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -11981,7 +11984,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -11990,7 +11993,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -11999,7 +12002,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -12008,7 +12011,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -12017,7 +12020,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -12026,7 +12029,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -12035,7 +12038,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -12044,7 +12047,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -12053,7 +12056,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -12062,7 +12065,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -12071,7 +12074,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -12080,7 +12083,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -12089,7 +12092,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -12098,7 +12101,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 66, z: 0}
     second:
       m_TileIndex: 1
@@ -12107,7 +12110,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 66, z: 0}
     second:
       m_TileIndex: 1
@@ -12116,7 +12119,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 66, z: 0}
     second:
       m_TileIndex: 2
@@ -12125,7 +12128,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 66, z: 0}
     second:
       m_TileIndex: 3
@@ -12134,7 +12137,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 66, z: 0}
     second:
       m_TileIndex: 3
@@ -12143,7 +12146,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 66, z: 0}
     second:
       m_TileIndex: 3
@@ -12152,7 +12155,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 66, z: 0}
     second:
       m_TileIndex: 3
@@ -12161,7 +12164,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 67, z: 0}
     second:
       m_TileIndex: 0
@@ -12170,7 +12173,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 1, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -12179,7 +12182,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 2, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -12188,7 +12191,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 3, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -12197,7 +12200,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 4, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -12206,7 +12209,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 5, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -12215,7 +12218,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 67, z: 0}
     second:
       m_TileIndex: 0
@@ -12224,7 +12227,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 67, z: 0}
     second:
       m_TileIndex: 2
@@ -12233,7 +12236,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12242,7 +12245,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12251,7 +12254,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12260,7 +12263,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12269,7 +12272,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12278,7 +12281,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12287,7 +12290,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12296,7 +12299,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12305,7 +12308,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12314,7 +12317,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12323,7 +12326,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12332,7 +12335,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12341,7 +12344,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12350,7 +12353,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12359,7 +12362,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12368,7 +12371,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12377,7 +12380,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12386,7 +12389,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 67, z: 0}
     second:
       m_TileIndex: 2
@@ -12395,7 +12398,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 67, z: 0}
     second:
       m_TileIndex: 2
@@ -12404,7 +12407,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12413,7 +12416,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12422,7 +12425,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12431,7 +12434,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12440,7 +12443,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12449,7 +12452,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12458,7 +12461,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12467,7 +12470,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12476,7 +12479,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12485,7 +12488,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12494,7 +12497,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12503,7 +12506,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12512,7 +12515,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12521,7 +12524,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12530,7 +12533,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12539,7 +12542,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -12548,7 +12551,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12557,7 +12560,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12566,7 +12569,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12575,7 +12578,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12584,7 +12587,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12593,7 +12596,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12602,7 +12605,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12611,7 +12614,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12620,7 +12623,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12629,7 +12632,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12638,7 +12641,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12647,7 +12650,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12656,7 +12659,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12665,7 +12668,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12674,7 +12677,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12683,7 +12686,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12692,7 +12695,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -12701,7 +12704,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -12710,7 +12713,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -12719,7 +12722,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -12728,7 +12731,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -12737,7 +12740,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -12746,7 +12749,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -12755,7 +12758,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -12764,7 +12767,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -12773,7 +12776,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -12782,7 +12785,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -12791,7 +12794,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -12800,7 +12803,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 70, z: 0}
     second:
       m_TileIndex: 0
@@ -12809,7 +12812,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 70, z: 0}
     second:
       m_TileIndex: 1
@@ -12818,7 +12821,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 70, z: 0}
     second:
       m_TileIndex: 1
@@ -12827,7 +12830,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 70, z: 0}
     second:
       m_TileIndex: 0
@@ -12836,7 +12839,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -12845,7 +12848,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -12854,7 +12857,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -12863,7 +12866,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 70, z: 0}
     second:
       m_TileIndex: 2
@@ -12872,7 +12875,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -12881,7 +12884,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -12890,7 +12893,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -12899,7 +12902,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -12908,7 +12911,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -12917,7 +12920,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -12926,7 +12929,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 71, z: 0}
     second:
       m_TileIndex: 2
@@ -12935,7 +12938,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 71, z: 0}
     second:
       m_TileIndex: 2
@@ -12944,7 +12947,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 71, z: 0}
     second:
       m_TileIndex: 2
@@ -12953,7 +12956,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 71, z: 0}
     second:
       m_TileIndex: 3
@@ -12962,7 +12965,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 71, z: 0}
     second:
       m_TileIndex: 3
@@ -12971,7 +12974,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 71, z: 0}
     second:
       m_TileIndex: 3
@@ -12980,7 +12983,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 71, z: 0}
     second:
       m_TileIndex: 2
@@ -12989,7 +12992,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 71, z: 0}
     second:
       m_TileIndex: 2
@@ -12998,7 +13001,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 71, z: 0}
     second:
       m_TileIndex: 2
@@ -13007,7 +13010,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 72, z: 0}
     second:
       m_TileIndex: 5
@@ -13016,7 +13019,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 72, z: 0}
     second:
       m_TileIndex: 5
@@ -13025,7 +13028,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -13034,7 +13037,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 72, z: 0}
     second:
       m_TileIndex: 3
@@ -13043,7 +13046,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 72, z: 0}
     second:
       m_TileIndex: 3
@@ -13052,7 +13055,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 72, z: 0}
     second:
       m_TileIndex: 3
@@ -13061,7 +13064,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -13070,7 +13073,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -13079,7 +13082,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -13088,7 +13091,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -13097,7 +13100,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 73, z: 0}
     second:
       m_TileIndex: 1
@@ -13106,7 +13109,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -13115,7 +13118,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -13124,7 +13127,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -13133,7 +13136,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -13142,7 +13145,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -13151,7 +13154,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -13160,7 +13163,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -13169,7 +13172,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 74, z: 0}
     second:
       m_TileIndex: 5
@@ -13178,7 +13181,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 74, z: 0}
     second:
       m_TileIndex: 5
@@ -13187,7 +13190,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 74, z: 0}
     second:
       m_TileIndex: 2
@@ -13196,7 +13199,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 74, z: 0}
     second:
       m_TileIndex: 3
@@ -13205,7 +13208,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 74, z: 0}
     second:
       m_TileIndex: 3
@@ -13214,7 +13217,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 75, z: 0}
     second:
       m_TileIndex: 1
@@ -13223,7 +13226,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 75, z: 0}
     second:
       m_TileIndex: 1
@@ -13232,7 +13235,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 75, z: 0}
     second:
       m_TileIndex: 2
@@ -13241,7 +13244,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 75, z: 0}
     second:
       m_TileIndex: 2
@@ -13250,7 +13253,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 75, z: 0}
     second:
       m_TileIndex: 2
@@ -13259,7 +13262,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -13268,7 +13271,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -13277,7 +13280,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -13286,7 +13289,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -13295,7 +13298,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -13304,7 +13307,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -13313,7 +13316,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -13322,7 +13325,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -13331,7 +13334,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 76, z: 0}
     second:
       m_TileIndex: 0
@@ -13340,7 +13343,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 76, z: 0}
     second:
       m_TileIndex: 1
@@ -13349,7 +13352,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 76, z: 0}
     second:
       m_TileIndex: 5
@@ -13358,7 +13361,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 76, z: 0}
     second:
       m_TileIndex: 1
@@ -13367,7 +13370,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 76, z: 0}
     second:
       m_TileIndex: 0
@@ -13376,7 +13379,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   m_AnimatedTiles: {}
   m_TileAssetArray:
   - m_RefCount: 24
@@ -13666,6 +13669,2167 @@ Tilemap:
     m_DirtyIndex: 0
   - serializedVersion: 1
     m_DirtyIndex: 0
+--- !u!66 &224555825
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 224555820}
+  m_Enabled: 0
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 0
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: 224555827}
+    m_ColliderPaths:
+    - - X: 120000000
+        Y: 760625024
+      - X: 110625000
+        Y: 770000000
+      - X: 100000000
+        Y: 770000000
+      - X: 100000000
+        Y: 760000000
+      - X: 110000000
+        Y: 760000000
+      - X: 110000000
+        Y: 750000000
+      - X: 120000000
+        Y: 750000000
+    - - X: 80000000
+        Y: 760000000
+      - X: 90000000
+        Y: 760000000
+      - X: 90000000
+        Y: 770000000
+      - X: 79062496
+        Y: 770000000
+      - X: 70000000
+        Y: 760937472
+      - X: 70000000
+        Y: 750000000
+      - X: 80000000
+        Y: 750000000
+    - - X: 270000000
+        Y: 720000000
+      - X: 260000000
+        Y: 720000000
+      - X: 260000000
+        Y: 680000000
+      - X: 230000000
+        Y: 680000000
+      - X: 230000000
+        Y: 730000000
+      - X: 280000000
+        Y: 730000000
+      - X: 280000000
+        Y: 720000000
+      - X: 290000000
+        Y: 720000000
+      - X: 290000000
+        Y: 740000000
+      - X: 230000000
+        Y: 740000000
+      - X: 230000000
+        Y: 760000000
+      - X: 150000000
+        Y: 760000000
+      - X: 150000000
+        Y: 740000000
+      - X: 160000000
+        Y: 740000000
+      - X: 160000000
+        Y: 750000000
+      - X: 220000000
+        Y: 750000000
+      - X: 220000000
+        Y: 670000000
+      - X: 270000000
+        Y: 670000000
+    - - X: 80000000
+        Y: 740000000
+      - X: 70000000
+        Y: 740000000
+      - X: 70000000
+        Y: 730000000
+      - X: 80000000
+        Y: 730000000
+    - - X: 160000000
+        Y: 730000000
+      - X: 150000000
+        Y: 730000000
+      - X: 150000000
+        Y: 690000000
+      - X: 90000000
+        Y: 690000000
+      - X: 90000000
+        Y: 680000000
+      - X: 160000000
+        Y: 680000000
+    - - X: 120000000
+        Y: 709374976
+      - X: 120000000
+        Y: 720000000
+      - X: 110000000
+        Y: 720000000
+      - X: 110000000
+        Y: 710000000
+      - X: 100000000
+        Y: 710000000
+      - X: 100000000
+        Y: 700000000
+      - X: 110625000
+        Y: 700000000
+    - - X: 90000000
+        Y: 710000000
+      - X: 80000000
+        Y: 710000000
+      - X: 80000000
+        Y: 720000000
+      - X: 70000000
+        Y: 720000000
+      - X: 70000000
+        Y: 709062528
+      - X: 79062496
+        Y: 700000000
+      - X: 90000000
+        Y: 700000000
+    - - X: 390000000
+        Y: 710000000
+      - X: 370000000
+        Y: 710000000
+      - X: 370000000
+        Y: 700000000
+      - X: 390000000
+        Y: 700000000
+    - - X: 360000000
+        Y: 710000000
+      - X: 340000000
+        Y: 710000000
+      - X: 340000000
+        Y: 700000000
+      - X: 360000000
+        Y: 700000000
+    - - X: 690000000
+        Y: 690000000
+      - X: 720000000
+        Y: 690000000
+      - X: 720000000
+        Y: 660000000
+      - X: 700000000
+        Y: 660000000
+      - X: 700000000
+        Y: 650000000
+      - X: 730000000
+        Y: 650000000
+      - X: 730000000
+        Y: 700000000
+      - X: 680000000
+        Y: 700000000
+      - X: 680000000
+        Y: 660000000
+      - X: 540000000
+        Y: 660000000
+      - X: 540000000
+        Y: 650000000
+      - X: 690000000
+        Y: 650000000
+    - - X: 360000000
+        Y: 680000000
+      - X: 350000000
+        Y: 680000000
+      - X: 350000000
+        Y: 690000000
+      - X: 340000000
+        Y: 690000000
+      - X: 340000000
+        Y: 680000000
+      - X: 290000000
+        Y: 680000000
+      - X: 290000000
+        Y: 690000000
+      - X: 280000000
+        Y: 690000000
+      - X: 280000000
+        Y: 670000000
+      - X: 360000000
+        Y: 670000000
+    - - X: 390000000
+        Y: 690000000
+      - X: 380000000
+        Y: 690000000
+      - X: 380000000
+        Y: 680000000
+      - X: 370000000
+        Y: 680000000
+      - X: 370000000
+        Y: 670000000
+      - X: 390000000
+        Y: 670000000
+    - - X: 200000000
+        Y: 670000000
+      - X: 210000000
+        Y: 670000000
+      - X: 210000000
+        Y: 680000000
+      - X: 200000000
+        Y: 680000000
+      - X: 200000000
+        Y: 690000000
+      - X: 170000000
+        Y: 690000000
+      - X: 170000000
+        Y: 680000000
+      - X: 190000000
+        Y: 680000000
+      - X: 190000000
+        Y: 650000000
+      - X: 200000000
+        Y: 650000000
+    - - X: 20000000
+        Y: 580625024
+      - X: 10625000
+        Y: 590000000
+      - X: 10000000
+        Y: 590000000
+      - X: 10000000
+        Y: 670000000
+      - X: 60000000
+        Y: 670000000
+      - X: 60000000
+        Y: 650000000
+      - X: 70000000
+        Y: 650000000
+      - X: 70000000
+        Y: 670625024
+      - X: 60625000
+        Y: 680000000
+      - X: 9062500
+        Y: 680000000
+      - X: 0
+        Y: 670937472
+      - X: 0
+        Y: 579062528
+      - X: 9062500
+        Y: 570000000
+      - X: 20000000
+        Y: 570000000
+    - - X: 530000000
+        Y: 630000000
+      - X: 500000000
+        Y: 630000000
+      - X: 500000000
+        Y: 670000000
+      - X: 550000000
+        Y: 670000000
+      - X: 550000000
+        Y: 680000000
+      - X: 410000000
+        Y: 680000000
+      - X: 410000000
+        Y: 670000000
+      - X: 490000000
+        Y: 670000000
+      - X: 490000000
+        Y: 620000000
+      - X: 530000000
+        Y: 620000000
+    - - X: 480000000
+        Y: 560000000
+      - X: 510000000
+        Y: 560000000
+      - X: 510000000
+        Y: 550000000
+      - X: 530000000
+        Y: 550000000
+      - X: 530000000
+        Y: 610000000
+      - X: 480000000
+        Y: 610000000
+      - X: 480000000
+        Y: 660000000
+      - X: 360000000
+        Y: 660000000
+      - X: 360000000
+        Y: 620000000
+      - X: 370000000
+        Y: 620000000
+      - X: 370000000
+        Y: 650000000
+      - X: 400000000
+        Y: 650000000
+      - X: 400000000
+        Y: 630000000
+      - X: 410000000
+        Y: 630000000
+      - X: 410000000
+        Y: 650000000
+      - X: 440000000
+        Y: 650000000
+      - X: 440000000
+        Y: 630000000
+      - X: 450000000
+        Y: 630000000
+      - X: 450000000
+        Y: 650000000
+      - X: 470000000
+        Y: 650000000
+      - X: 470000000
+        Y: 580000000
+      - X: 490000000
+        Y: 580000000
+      - X: 490000000
+        Y: 600000000
+      - X: 520000000
+        Y: 600000000
+      - X: 520000000
+        Y: 570000000
+      - X: 470000000
+        Y: 570000000
+      - X: 470000000
+        Y: 560000000
+      - X: 410000000
+        Y: 560000000
+      - X: 410000000
+        Y: 550000000
+      - X: 480000000
+        Y: 550000000
+    - - X: 760000000
+        Y: 590000000
+      - X: 770000000
+        Y: 590000000
+      - X: 770000000
+        Y: 580000000
+      - X: 790000000
+        Y: 580000000
+      - X: 790000000
+        Y: 570000000
+      - X: 800000000
+        Y: 570000000
+      - X: 800000000
+        Y: 590000000
+      - X: 780000000
+        Y: 590000000
+      - X: 780000000
+        Y: 600000000
+      - X: 760000000
+        Y: 600000000
+      - X: 760000000
+        Y: 660000000
+      - X: 750000000
+        Y: 660000000
+      - X: 750000000
+        Y: 560000000
+      - X: 720000000
+        Y: 560000000
+      - X: 720000000
+        Y: 550000000
+      - X: 750000000
+        Y: 550000000
+      - X: 750000000
+        Y: 540000000
+      - X: 760000000
+        Y: 540000000
+    - - X: 600000000
+        Y: 560000000
+      - X: 550000000
+        Y: 560000000
+      - X: 550000000
+        Y: 590000000
+      - X: 590000000
+        Y: 590000000
+      - X: 590000000
+        Y: 600000000
+      - X: 550000000
+        Y: 600000000
+      - X: 550000000
+        Y: 630000000
+      - X: 610000000
+        Y: 630000000
+      - X: 610000000
+        Y: 600000000
+      - X: 600000000
+        Y: 600000000
+      - X: 600000000
+        Y: 590000000
+      - X: 620000000
+        Y: 590000000
+      - X: 620000000
+        Y: 640000000
+      - X: 540000000
+        Y: 640000000
+      - X: 540000000
+        Y: 550000000
+      - X: 600000000
+        Y: 550000000
+    - - X: 230000000
+        Y: 550000000
+      - X: 240000000
+        Y: 550000000
+      - X: 240000000
+        Y: 560000000
+      - X: 230000000
+        Y: 560000000
+      - X: 230000000
+        Y: 630000000
+      - X: 250000000
+        Y: 630000000
+      - X: 250000000
+        Y: 610000000
+      - X: 240000000
+        Y: 610000000
+      - X: 240000000
+        Y: 600000000
+      - X: 260000000
+        Y: 600000000
+      - X: 260000000
+        Y: 630000000
+      - X: 280000000
+        Y: 630000000
+      - X: 280000000
+        Y: 610000000
+      - X: 270000000
+        Y: 610000000
+      - X: 270000000
+        Y: 600000000
+      - X: 290000000
+        Y: 600000000
+      - X: 290000000
+        Y: 630000000
+      - X: 340000000
+        Y: 630000000
+      - X: 340000000
+        Y: 640000000
+      - X: 220000000
+        Y: 640000000
+      - X: 220000000
+        Y: 530000000
+      - X: 230000000
+        Y: 530000000
+    - - X: 700000000
+        Y: 560000000
+      - X: 680000000
+        Y: 560000000
+      - X: 680000000
+        Y: 640000000
+      - X: 630000000
+        Y: 640000000
+      - X: 630000000
+        Y: 630000000
+      - X: 670000000
+        Y: 630000000
+      - X: 670000000
+        Y: 600000000
+      - X: 630000000
+        Y: 600000000
+      - X: 630000000
+        Y: 590000000
+      - X: 670000000
+        Y: 590000000
+      - X: 670000000
+        Y: 560000000
+      - X: 620000000
+        Y: 560000000
+      - X: 620000000
+        Y: 550000000
+      - X: 700000000
+        Y: 550000000
+    - - X: 210000000
+        Y: 570000000
+      - X: 200000000
+        Y: 570000000
+      - X: 200000000
+        Y: 630000000
+      - X: 190000000
+        Y: 630000000
+      - X: 190000000
+        Y: 600000000
+      - X: 110000000
+        Y: 600000000
+      - X: 110000000
+        Y: 590000000
+      - X: 190000000
+        Y: 590000000
+      - X: 190000000
+        Y: 570000000
+      - X: 160000000
+        Y: 570000000
+      - X: 160000000
+        Y: 560000000
+      - X: 210000000
+        Y: 560000000
+    - - X: 70000000
+        Y: 630000000
+      - X: 60000000
+        Y: 630000000
+      - X: 60000000
+        Y: 620000000
+      - X: 70000000
+        Y: 620000000
+    - - X: 340000000
+        Y: 620000000
+      - X: 300000000
+        Y: 620000000
+      - X: 300000000
+        Y: 600000000
+      - X: 310000000
+        Y: 600000000
+      - X: 310000000
+        Y: 610000000
+      - X: 330000000
+        Y: 610000000
+      - X: 330000000
+        Y: 590000000
+      - X: 300000000
+        Y: 590000000
+      - X: 300000000
+        Y: 570000000
+      - X: 310000000
+        Y: 570000000
+      - X: 310000000
+        Y: 580000000
+      - X: 330000000
+        Y: 580000000
+      - X: 330000000
+        Y: 560000000
+      - X: 290000000
+        Y: 560000000
+      - X: 290000000
+        Y: 590000000
+      - X: 270000000
+        Y: 590000000
+      - X: 270000000
+        Y: 580000000
+      - X: 280000000
+        Y: 580000000
+      - X: 280000000
+        Y: 560000000
+      - X: 260000000
+        Y: 560000000
+      - X: 260000000
+        Y: 590000000
+      - X: 250000000
+        Y: 590000000
+      - X: 250000000
+        Y: 550000000
+      - X: 340000000
+        Y: 550000000
+    - - X: 400000000
+        Y: 560000000
+      - X: 370000000
+        Y: 560000000
+      - X: 370000000
+        Y: 600000000
+      - X: 360000000
+        Y: 600000000
+      - X: 360000000
+        Y: 560000000
+      - X: 350000000
+        Y: 560000000
+      - X: 350000000
+        Y: 550000000
+      - X: 400000000
+        Y: 550000000
+    - - X: 70000000
+        Y: 579374976
+      - X: 70000000
+        Y: 600000000
+      - X: 60000000
+        Y: 600000000
+      - X: 60000000
+        Y: 590000000
+      - X: 59062500
+        Y: 590000000
+      - X: 50000000
+        Y: 580937472
+      - X: 50000000
+        Y: 570000000
+      - X: 60625000
+        Y: 570000000
+    - - X: 150000000
+        Y: 570000000
+      - X: 140000000
+        Y: 570000000
+      - X: 140000000
+        Y: 560000000
+      - X: 150000000
+        Y: 560000000
+    - - X: 120000000
+        Y: 550000000
+      - X: 110000000
+        Y: 550000000
+      - X: 110000000
+        Y: 560000000
+      - X: 130000000
+        Y: 560000000
+      - X: 130000000
+        Y: 570000000
+      - X: 100000000
+        Y: 570000000
+      - X: 100000000
+        Y: 540000000
+      - X: 120000000
+        Y: 540000000
+    - - X: 240000000
+        Y: 400000000
+      - X: 230000000
+        Y: 400000000
+      - X: 230000000
+        Y: 480000000
+      - X: 170000000
+        Y: 480000000
+      - X: 170000000
+        Y: 510000000
+      - X: 180000000
+        Y: 510000000
+      - X: 180000000
+        Y: 490000000
+      - X: 190000000
+        Y: 490000000
+      - X: 190000000
+        Y: 510000000
+      - X: 200000000
+        Y: 510000000
+      - X: 200000000
+        Y: 490000000
+      - X: 210000000
+        Y: 490000000
+      - X: 210000000
+        Y: 510000000
+      - X: 220000000
+        Y: 510000000
+      - X: 220000000
+        Y: 490000000
+      - X: 230000000
+        Y: 490000000
+      - X: 230000000
+        Y: 520000000
+      - X: 170000000
+        Y: 520000000
+      - X: 170000000
+        Y: 540000000
+      - X: 210000000
+        Y: 540000000
+      - X: 210000000
+        Y: 550000000
+      - X: 160000000
+        Y: 550000000
+      - X: 160000000
+        Y: 520000000
+      - X: 120000000
+        Y: 520000000
+      - X: 120000000
+        Y: 530000000
+      - X: 100000000
+        Y: 530000000
+      - X: 100000000
+        Y: 520000000
+      - X: 110000000
+        Y: 520000000
+      - X: 110000000
+        Y: 510000000
+      - X: 160000000
+        Y: 510000000
+      - X: 160000000
+        Y: 470000000
+      - X: 220000000
+        Y: 470000000
+      - X: 220000000
+        Y: 390000000
+      - X: 240000000
+        Y: 390000000
+    - - X: 780000000
+        Y: 420000000
+      - X: 810000000
+        Y: 420000000
+      - X: 810000000
+        Y: 470000000
+      - X: 800000000
+        Y: 470000000
+      - X: 800000000
+        Y: 490000000
+      - X: 790000000
+        Y: 490000000
+      - X: 790000000
+        Y: 480000000
+      - X: 770000000
+        Y: 480000000
+      - X: 770000000
+        Y: 460000000
+      - X: 800000000
+        Y: 460000000
+      - X: 800000000
+        Y: 430000000
+      - X: 770000000
+        Y: 430000000
+      - X: 770000000
+        Y: 400000000
+      - X: 720000000
+        Y: 400000000
+      - X: 720000000
+        Y: 510000000
+      - X: 760000000
+        Y: 510000000
+      - X: 760000000
+        Y: 530000000
+      - X: 750000000
+        Y: 530000000
+      - X: 750000000
+        Y: 520000000
+      - X: 680000000
+        Y: 520000000
+      - X: 680000000
+        Y: 510000000
+      - X: 700000000
+        Y: 510000000
+      - X: 700000000
+        Y: 460000000
+      - X: 670000000
+        Y: 460000000
+      - X: 670000000
+        Y: 520000000
+      - X: 660000000
+        Y: 520000000
+      - X: 660000000
+        Y: 420000000
+      - X: 650000000
+        Y: 420000000
+      - X: 650000000
+        Y: 410000000
+      - X: 670000000
+        Y: 410000000
+      - X: 670000000
+        Y: 450000000
+      - X: 710000000
+        Y: 450000000
+      - X: 710000000
+        Y: 390000000
+      - X: 780000000
+        Y: 390000000
+    - - X: 340000000
+        Y: 520000000
+      - X: 260000000
+        Y: 520000000
+      - X: 260000000
+        Y: 500000000
+      - X: 270000000
+        Y: 500000000
+      - X: 270000000
+        Y: 510000000
+      - X: 330000000
+        Y: 510000000
+      - X: 330000000
+        Y: 430000000
+      - X: 340000000
+        Y: 430000000
+    - - X: 570000000
+        Y: 470000000
+      - X: 550000000
+        Y: 470000000
+      - X: 550000000
+        Y: 450000000
+      - X: 530000000
+        Y: 450000000
+      - X: 530000000
+        Y: 460000000
+      - X: 520000000
+        Y: 460000000
+      - X: 520000000
+        Y: 480000000
+      - X: 530000000
+        Y: 480000000
+      - X: 530000000
+        Y: 490000000
+      - X: 550000000
+        Y: 490000000
+      - X: 550000000
+        Y: 480000000
+      - X: 560000000
+        Y: 480000000
+      - X: 560000000
+        Y: 510000000
+      - X: 590000000
+        Y: 510000000
+      - X: 590000000
+        Y: 520000000
+      - X: 490000000
+        Y: 520000000
+      - X: 490000000
+        Y: 440000000
+      - X: 560000000
+        Y: 440000000
+      - X: 560000000
+        Y: 430000000
+      - X: 570000000
+        Y: 430000000
+    - - X: 650000000
+        Y: 520000000
+      - X: 600000000
+        Y: 520000000
+      - X: 600000000
+        Y: 510000000
+      - X: 640000000
+        Y: 510000000
+      - X: 640000000
+        Y: 500000000
+      - X: 650000000
+        Y: 500000000
+    - - X: 360000000
+        Y: 510000000
+      - X: 410000000
+        Y: 510000000
+      - X: 410000000
+        Y: 470000000
+      - X: 420000000
+        Y: 470000000
+      - X: 420000000
+        Y: 510000000
+      - X: 450000000
+        Y: 510000000
+      - X: 450000000
+        Y: 490000000
+      - X: 460000000
+        Y: 490000000
+      - X: 460000000
+        Y: 520000000
+      - X: 350000000
+        Y: 520000000
+      - X: 350000000
+        Y: 470000000
+      - X: 360000000
+        Y: 470000000
+    - - X: 500000000
+        Y: 450000000
+      - X: 500000000
+        Y: 510000000
+      - X: 550000000
+        Y: 510000000
+      - X: 550000000
+        Y: 500000000
+      - X: 520000000
+        Y: 500000000
+      - X: 520000000
+        Y: 490000000
+      - X: 510000000
+        Y: 490000000
+      - X: 510000000
+        Y: 450000000
+    - - X: 650000000
+        Y: 490000000
+      - X: 640000000
+        Y: 490000000
+      - X: 640000000
+        Y: 470000000
+      - X: 630000000
+        Y: 470000000
+      - X: 630000000
+        Y: 460000000
+      - X: 640000000
+        Y: 460000000
+      - X: 640000000
+        Y: 430000000
+      - X: 650000000
+        Y: 430000000
+    - - X: 340000000
+        Y: 420000000
+      - X: 270000000
+        Y: 420000000
+      - X: 270000000
+        Y: 480000000
+      - X: 260000000
+        Y: 480000000
+      - X: 260000000
+        Y: 410000000
+      - X: 340000000
+        Y: 410000000
+    - - X: 460000000
+        Y: 480000000
+      - X: 450000000
+        Y: 480000000
+      - X: 450000000
+        Y: 410000000
+      - X: 460000000
+        Y: 410000000
+    - - X: 610000000
+        Y: 470000000
+      - X: 590000000
+        Y: 470000000
+      - X: 590000000
+        Y: 460000000
+      - X: 600000000
+        Y: 460000000
+      - X: 600000000
+        Y: 430000000
+      - X: 610000000
+        Y: 430000000
+    - - X: 360000000
+        Y: 340000000
+      - X: 430000000
+        Y: 340000000
+      - X: 430000000
+        Y: 350000000
+      - X: 360000000
+        Y: 350000000
+      - X: 360000000
+        Y: 390000000
+      - X: 450000000
+        Y: 390000000
+      - X: 450000000
+        Y: 380000000
+      - X: 460000000
+        Y: 380000000
+      - X: 460000000
+        Y: 400000000
+      - X: 360000000
+        Y: 400000000
+      - X: 360000000
+        Y: 460000000
+      - X: 350000000
+        Y: 460000000
+      - X: 350000000
+        Y: 330000000
+      - X: 360000000
+        Y: 330000000
+    - - X: 500000000
+        Y: 420000000
+      - X: 540000000
+        Y: 420000000
+      - X: 540000000
+        Y: 410000000
+      - X: 570000000
+        Y: 410000000
+      - X: 570000000
+        Y: 420000000
+      - X: 550000000
+        Y: 420000000
+      - X: 550000000
+        Y: 430000000
+      - X: 490000000
+        Y: 430000000
+      - X: 490000000
+        Y: 410000000
+      - X: 500000000
+        Y: 410000000
+    - - X: 620000000
+        Y: 410000000
+      - X: 640000000
+        Y: 410000000
+      - X: 640000000
+        Y: 420000000
+      - X: 600000000
+        Y: 420000000
+      - X: 600000000
+        Y: 410000000
+      - X: 610000000
+        Y: 410000000
+      - X: 610000000
+        Y: 360000000
+      - X: 620000000
+        Y: 360000000
+    - - X: 500000000
+        Y: 400000000
+      - X: 490000000
+        Y: 400000000
+      - X: 490000000
+        Y: 380000000
+      - X: 500000000
+        Y: 380000000
+    - - X: 180000000
+        Y: 400000000
+      - X: 170000000
+        Y: 400000000
+      - X: 170000000
+        Y: 390000000
+      - X: 180000000
+        Y: 390000000
+    - - X: 340000000
+        Y: 400000000
+      - X: 250000000
+        Y: 400000000
+      - X: 250000000
+        Y: 390000000
+      - X: 330000000
+        Y: 390000000
+      - X: 330000000
+        Y: 340000000
+      - X: 240000000
+        Y: 340000000
+      - X: 240000000
+        Y: 330000000
+      - X: 340000000
+        Y: 330000000
+    - - X: 640000000
+        Y: 390000000
+      - X: 630000000
+        Y: 390000000
+      - X: 630000000
+        Y: 380000000
+      - X: 640000000
+        Y: 380000000
+    - - X: 460000000
+        Y: 370000000
+      - X: 450000000
+        Y: 370000000
+      - X: 450000000
+        Y: 340000000
+      - X: 460000000
+        Y: 340000000
+    - - X: 500000000
+        Y: 370000000
+      - X: 490000000
+        Y: 370000000
+      - X: 490000000
+        Y: 340000000
+      - X: 500000000
+        Y: 340000000
+    - - X: 750000000
+        Y: 280000000
+      - X: 760000000
+        Y: 280000000
+      - X: 760000000
+        Y: 360000000
+      - X: 740000000
+        Y: 360000000
+      - X: 740000000
+        Y: 350000000
+      - X: 750000000
+        Y: 350000000
+      - X: 750000000
+        Y: 290000000
+      - X: 740000000
+        Y: 290000000
+      - X: 740000000
+        Y: 280000000
+      - X: 730000000
+        Y: 280000000
+      - X: 730000000
+        Y: 290000000
+      - X: 720000000
+        Y: 290000000
+      - X: 720000000
+        Y: 350000000
+      - X: 730000000
+        Y: 350000000
+      - X: 730000000
+        Y: 360000000
+      - X: 710000000
+        Y: 360000000
+      - X: 710000000
+        Y: 280000000
+      - X: 720000000
+        Y: 280000000
+      - X: 720000000
+        Y: 270000000
+      - X: 750000000
+        Y: 270000000
+    - - X: 540000000
+        Y: 350000000
+      - X: 520000000
+        Y: 350000000
+      - X: 520000000
+        Y: 340000000
+      - X: 530000000
+        Y: 340000000
+      - X: 530000000
+        Y: 310000000
+      - X: 540000000
+        Y: 310000000
+    - - X: 330000000
+        Y: 320000000
+      - X: 230000000
+        Y: 320000000
+      - X: 230000000
+        Y: 340000000
+      - X: 170000000
+        Y: 340000000
+      - X: 170000000
+        Y: 330000000
+      - X: 220000000
+        Y: 330000000
+      - X: 220000000
+        Y: 310000000
+      - X: 320000000
+        Y: 310000000
+      - X: 320000000
+        Y: 260000000
+      - X: 280000000
+        Y: 260000000
+      - X: 280000000
+        Y: 250000000
+      - X: 330000000
+        Y: 250000000
+    - - X: 460000000
+        Y: 230000000
+      - X: 420000000
+        Y: 230000000
+      - X: 420000000
+        Y: 330000000
+      - X: 410000000
+        Y: 330000000
+      - X: 410000000
+        Y: 230000000
+      - X: 380000000
+        Y: 230000000
+      - X: 380000000
+        Y: 220000000
+      - X: 460000000
+        Y: 220000000
+    - - X: 380000000
+        Y: 160000000
+      - X: 390000000
+        Y: 160000000
+      - X: 390000000
+        Y: 170000000
+      - X: 380000000
+        Y: 170000000
+      - X: 380000000
+        Y: 200000000
+      - X: 390000000
+        Y: 200000000
+      - X: 390000000
+        Y: 210000000
+      - X: 370000000
+        Y: 210000000
+      - X: 370000000
+        Y: 230000000
+      - X: 360000000
+        Y: 230000000
+      - X: 360000000
+        Y: 320000000
+      - X: 350000000
+        Y: 320000000
+      - X: 350000000
+        Y: 240000000
+      - X: 280000000
+        Y: 240000000
+      - X: 280000000
+        Y: 230000000
+      - X: 350000000
+        Y: 230000000
+      - X: 350000000
+        Y: 220000000
+      - X: 360000000
+        Y: 220000000
+      - X: 360000000
+        Y: 200000000
+      - X: 370000000
+        Y: 200000000
+      - X: 370000000
+        Y: 130000000
+      - X: 380000000
+        Y: 130000000
+    - - X: 540000000
+        Y: 300000000
+      - X: 530000000
+        Y: 300000000
+      - X: 530000000
+        Y: 290000000
+      - X: 540000000
+        Y: 290000000
+    - - X: 540000000
+        Y: 250000000
+      - X: 530000000
+        Y: 250000000
+      - X: 530000000
+        Y: 240000000
+      - X: 540000000
+        Y: 240000000
+    - - X: 560000000
+        Y: 250000000
+      - X: 550000000
+        Y: 250000000
+      - X: 550000000
+        Y: 240000000
+      - X: 560000000
+        Y: 240000000
+    - - X: 600000000
+        Y: 250000000
+      - X: 570000000
+        Y: 250000000
+      - X: 570000000
+        Y: 240000000
+      - X: 600000000
+        Y: 240000000
+    - - X: 540000000
+        Y: 230000000
+      - X: 530000000
+        Y: 230000000
+      - X: 530000000
+        Y: 220000000
+      - X: 540000000
+        Y: 220000000
+    - - X: 600000000
+        Y: 230000000
+      - X: 570000000
+        Y: 230000000
+      - X: 570000000
+        Y: 220000000
+      - X: 600000000
+        Y: 220000000
+    - - X: 560000000
+        Y: 230000000
+      - X: 550000000
+        Y: 230000000
+      - X: 550000000
+        Y: 220000000
+      - X: 560000000
+        Y: 220000000
+    - - X: 520000000
+        Y: 230000000
+      - X: 500000000
+        Y: 230000000
+      - X: 500000000
+        Y: 210000000
+      - X: 520000000
+        Y: 210000000
+    - - X: 440000000
+        Y: 170000000
+      - X: 460000000
+        Y: 170000000
+      - X: 460000000
+        Y: 210000000
+      - X: 400000000
+        Y: 210000000
+      - X: 400000000
+        Y: 200000000
+      - X: 410000000
+        Y: 200000000
+      - X: 410000000
+        Y: 190000000
+      - X: 420000000
+        Y: 190000000
+      - X: 420000000
+        Y: 200000000
+      - X: 450000000
+        Y: 200000000
+      - X: 450000000
+        Y: 180000000
+      - X: 430000000
+        Y: 180000000
+      - X: 430000000
+        Y: 170000000
+      - X: 420000000
+        Y: 170000000
+      - X: 420000000
+        Y: 180000000
+      - X: 410000000
+        Y: 180000000
+      - X: 410000000
+        Y: 170000000
+      - X: 400000000
+        Y: 170000000
+      - X: 400000000
+        Y: 160000000
+      - X: 430000000
+        Y: 160000000
+      - X: 430000000
+        Y: 150000000
+      - X: 440000000
+        Y: 150000000
+    - - X: 530000000
+        Y: 190000000
+      - X: 500000000
+        Y: 190000000
+      - X: 500000000
+        Y: 170000000
+      - X: 520000000
+        Y: 170000000
+      - X: 520000000
+        Y: 150000000
+      - X: 530000000
+        Y: 150000000
+    - - X: 510000000
+        Y: 110000000
+      - X: 500000000
+        Y: 110000000
+      - X: 500000000
+        Y: 60000000
+      - X: 510000000
+        Y: 60000000
+    - - X: 550000000
+        Y: 90000000
+      - X: 580000000
+        Y: 90000000
+      - X: 580000000
+        Y: 89062496
+      - X: 589062528
+        Y: 80000000
+      - X: 600000000
+        Y: 80000000
+      - X: 600000000
+        Y: 90000000
+      - X: 590000000
+        Y: 90000000
+      - X: 590000000
+        Y: 90625000
+      - X: 580625024
+        Y: 100000000
+      - X: 550000000
+        Y: 100000000
+      - X: 550000000
+        Y: 100625000
+      - X: 540625024
+        Y: 110000000
+      - X: 520000000
+        Y: 110000000
+      - X: 520000000
+        Y: 100000000
+      - X: 540000000
+        Y: 100000000
+      - X: 540000000
+        Y: 60000000
+      - X: 550000000
+        Y: 60000000
+    - - X: 430000000
+        Y: 100000000
+      - X: 440000000
+        Y: 100000000
+      - X: 440000000
+        Y: 110000000
+      - X: 389062496
+        Y: 110000000
+      - X: 380000000
+        Y: 100937504
+      - X: 380000000
+        Y: 100000000
+      - X: 370000000
+        Y: 100000000
+      - X: 370000000
+        Y: 90000000
+      - X: 390000000
+        Y: 90000000
+      - X: 390000000
+        Y: 100000000
+      - X: 420000000
+        Y: 100000000
+      - X: 420000000
+        Y: 80000000
+      - X: 430000000
+        Y: 80000000
+    - - X: 460000000
+        Y: 110000000
+      - X: 450000000
+        Y: 110000000
+      - X: 450000000
+        Y: 100000000
+      - X: 460000000
+        Y: 100000000
+    - - X: 490000000
+        Y: 110000000
+      - X: 480000000
+        Y: 110000000
+      - X: 480000000
+        Y: 100000000
+      - X: 490000000
+        Y: 100000000
+    - - X: 430000000
+        Y: 70000000
+      - X: 420000000
+        Y: 70000000
+      - X: 420000000
+        Y: 60000000
+      - X: 390000000
+        Y: 60000000
+      - X: 390000000
+        Y: 50000000
+      - X: 430000000
+        Y: 50000000
+    - - X: 550000000
+        Y: 9375000
+      - X: 550000000
+        Y: 10000000
+      - X: 580625024
+        Y: 10000000
+      - X: 590000000
+        Y: 19375000
+      - X: 590000000
+        Y: 20000000
+      - X: 600000000
+        Y: 20000000
+      - X: 600000000
+        Y: 30000000
+      - X: 589062528
+        Y: 30000000
+      - X: 580000000
+        Y: 20937500
+      - X: 580000000
+        Y: 20000000
+      - X: 550000000
+        Y: 20000000
+      - X: 550000000
+        Y: 50000000
+      - X: 540000000
+        Y: 50000000
+      - X: 540000000
+        Y: 10000000
+      - X: 500000000
+        Y: 10000000
+      - X: 500000000
+        Y: 0
+      - X: 540625024
+        Y: 0
+    - - X: 460000000
+        Y: 10000000
+      - X: 390000000
+        Y: 10000000
+      - X: 390000000
+        Y: 20000000
+      - X: 370000000
+        Y: 20000000
+      - X: 370000000
+        Y: 10000000
+      - X: 380000000
+        Y: 10000000
+      - X: 380000000
+        Y: 9062500
+      - X: 389062496
+        Y: 0
+      - X: 460000000
+        Y: 0
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 12, y: 76.0625}
+      - {x: 11.0625, y: 77}
+      - {x: 10, y: 77}
+      - {x: 10, y: 76}
+      - {x: 11, y: 76}
+      - {x: 11, y: 75}
+      - {x: 12, y: 75}
+    - - {x: 8, y: 76}
+      - {x: 9, y: 76}
+      - {x: 9, y: 77}
+      - {x: 7.9062495, y: 77}
+      - {x: 7, y: 76.09375}
+      - {x: 7, y: 75}
+      - {x: 8, y: 75}
+    - - {x: 27, y: 72}
+      - {x: 26, y: 72}
+      - {x: 26, y: 68}
+      - {x: 23, y: 68}
+      - {x: 23, y: 73}
+      - {x: 28, y: 73}
+      - {x: 28, y: 72}
+      - {x: 29, y: 72}
+      - {x: 29, y: 74}
+      - {x: 23, y: 74}
+      - {x: 23, y: 76}
+      - {x: 15, y: 76}
+      - {x: 15, y: 74}
+      - {x: 16, y: 74}
+      - {x: 16, y: 75}
+      - {x: 22, y: 75}
+      - {x: 22, y: 67}
+      - {x: 27, y: 67}
+    - - {x: 8, y: 74}
+      - {x: 7, y: 74}
+      - {x: 7, y: 73}
+      - {x: 8, y: 73}
+    - - {x: 16, y: 73}
+      - {x: 15, y: 73}
+      - {x: 15, y: 69}
+      - {x: 9, y: 69}
+      - {x: 9, y: 68}
+      - {x: 16, y: 68}
+    - - {x: 12, y: 70.9375}
+      - {x: 12, y: 72}
+      - {x: 11, y: 72}
+      - {x: 11, y: 71}
+      - {x: 10, y: 71}
+      - {x: 10, y: 70}
+      - {x: 11.0625, y: 70}
+    - - {x: 9, y: 71}
+      - {x: 8, y: 71}
+      - {x: 8, y: 72}
+      - {x: 7, y: 72}
+      - {x: 7, y: 70.90625}
+      - {x: 7.9062495, y: 70}
+      - {x: 9, y: 70}
+    - - {x: 39, y: 71}
+      - {x: 37, y: 71}
+      - {x: 37, y: 70}
+      - {x: 39, y: 70}
+    - - {x: 36, y: 71}
+      - {x: 34, y: 71}
+      - {x: 34, y: 70}
+      - {x: 36, y: 70}
+    - - {x: 69, y: 69}
+      - {x: 72, y: 69}
+      - {x: 72, y: 66}
+      - {x: 70, y: 66}
+      - {x: 70, y: 65}
+      - {x: 73, y: 65}
+      - {x: 73, y: 70}
+      - {x: 68, y: 70}
+      - {x: 68, y: 66}
+      - {x: 54, y: 66}
+      - {x: 54, y: 65}
+      - {x: 69, y: 65}
+    - - {x: 20, y: 67}
+      - {x: 21, y: 67}
+      - {x: 21, y: 68}
+      - {x: 20, y: 68}
+      - {x: 20, y: 69}
+      - {x: 17, y: 69}
+      - {x: 17, y: 68}
+      - {x: 19, y: 68}
+      - {x: 19, y: 65}
+      - {x: 20, y: 65}
+    - - {x: 39, y: 69}
+      - {x: 38, y: 69}
+      - {x: 38, y: 68}
+      - {x: 37, y: 68}
+      - {x: 37, y: 67}
+      - {x: 39, y: 67}
+    - - {x: 36, y: 68}
+      - {x: 35, y: 68}
+      - {x: 35, y: 69}
+      - {x: 34, y: 69}
+      - {x: 34, y: 68}
+      - {x: 29, y: 68}
+      - {x: 29, y: 69}
+      - {x: 28, y: 69}
+      - {x: 28, y: 67}
+      - {x: 36, y: 67}
+    - - {x: 2, y: 58.062504}
+      - {x: 1.0625, y: 59}
+      - {x: 1, y: 59}
+      - {x: 1, y: 67}
+      - {x: 6, y: 67}
+      - {x: 6, y: 65}
+      - {x: 7, y: 65}
+      - {x: 7, y: 67.0625}
+      - {x: 6.0625, y: 68}
+      - {x: 0.90625, y: 68}
+      - {x: 0, y: 67.09375}
+      - {x: 0, y: 57.906254}
+      - {x: 0.90625, y: 57}
+      - {x: 2, y: 57}
+    - - {x: 53, y: 63}
+      - {x: 50, y: 63}
+      - {x: 50, y: 67}
+      - {x: 55, y: 67}
+      - {x: 55, y: 68}
+      - {x: 41, y: 68}
+      - {x: 41, y: 67}
+      - {x: 49, y: 67}
+      - {x: 49, y: 62}
+      - {x: 53, y: 62}
+    - - {x: 48, y: 56}
+      - {x: 51, y: 56}
+      - {x: 51, y: 55}
+      - {x: 53, y: 55}
+      - {x: 53, y: 61}
+      - {x: 48, y: 61}
+      - {x: 48, y: 66}
+      - {x: 36, y: 66}
+      - {x: 36, y: 62}
+      - {x: 37, y: 62}
+      - {x: 37, y: 65}
+      - {x: 40, y: 65}
+      - {x: 40, y: 63}
+      - {x: 41, y: 63}
+      - {x: 41, y: 65}
+      - {x: 44, y: 65}
+      - {x: 44, y: 63}
+      - {x: 45, y: 63}
+      - {x: 45, y: 65}
+      - {x: 47, y: 65}
+      - {x: 47, y: 58}
+      - {x: 49, y: 58}
+      - {x: 49, y: 60}
+      - {x: 52, y: 60}
+      - {x: 52, y: 57}
+      - {x: 47, y: 57}
+      - {x: 47, y: 56}
+      - {x: 41, y: 56}
+      - {x: 41, y: 55}
+      - {x: 48, y: 55}
+    - - {x: 76, y: 59}
+      - {x: 77, y: 59}
+      - {x: 77, y: 58}
+      - {x: 79, y: 58}
+      - {x: 79, y: 57}
+      - {x: 80, y: 57}
+      - {x: 80, y: 59}
+      - {x: 78, y: 59}
+      - {x: 78, y: 60}
+      - {x: 76, y: 60}
+      - {x: 76, y: 66}
+      - {x: 75, y: 66}
+      - {x: 75, y: 56}
+      - {x: 72, y: 56}
+      - {x: 72, y: 55}
+      - {x: 75, y: 55}
+      - {x: 75, y: 54}
+      - {x: 76, y: 54}
+    - - {x: 70, y: 56}
+      - {x: 68, y: 56}
+      - {x: 68, y: 64}
+      - {x: 63, y: 64}
+      - {x: 63, y: 63}
+      - {x: 67, y: 63}
+      - {x: 67, y: 60}
+      - {x: 63, y: 60}
+      - {x: 63, y: 59}
+      - {x: 67, y: 59}
+      - {x: 67, y: 56}
+      - {x: 62, y: 56}
+      - {x: 62, y: 55}
+      - {x: 70, y: 55}
+    - - {x: 23, y: 55}
+      - {x: 24, y: 55}
+      - {x: 24, y: 56}
+      - {x: 23, y: 56}
+      - {x: 23, y: 63}
+      - {x: 25, y: 63}
+      - {x: 25, y: 61}
+      - {x: 24, y: 61}
+      - {x: 24, y: 60}
+      - {x: 26, y: 60}
+      - {x: 26, y: 63}
+      - {x: 28, y: 63}
+      - {x: 28, y: 61}
+      - {x: 27, y: 61}
+      - {x: 27, y: 60}
+      - {x: 29, y: 60}
+      - {x: 29, y: 63}
+      - {x: 34, y: 63}
+      - {x: 34, y: 64}
+      - {x: 22, y: 64}
+      - {x: 22, y: 53}
+      - {x: 23, y: 53}
+    - - {x: 60, y: 56}
+      - {x: 55, y: 56}
+      - {x: 55, y: 59}
+      - {x: 59, y: 59}
+      - {x: 59, y: 60}
+      - {x: 55, y: 60}
+      - {x: 55, y: 63}
+      - {x: 61, y: 63}
+      - {x: 61, y: 60}
+      - {x: 60, y: 60}
+      - {x: 60, y: 59}
+      - {x: 62, y: 59}
+      - {x: 62, y: 64}
+      - {x: 54, y: 64}
+      - {x: 54, y: 55}
+      - {x: 60, y: 55}
+    - - {x: 7, y: 63}
+      - {x: 6, y: 63}
+      - {x: 6, y: 62}
+      - {x: 7, y: 62}
+    - - {x: 21, y: 57}
+      - {x: 20, y: 57}
+      - {x: 20, y: 63}
+      - {x: 19, y: 63}
+      - {x: 19, y: 60}
+      - {x: 11, y: 60}
+      - {x: 11, y: 59}
+      - {x: 19, y: 59}
+      - {x: 19, y: 57}
+      - {x: 16, y: 57}
+      - {x: 16, y: 56}
+      - {x: 21, y: 56}
+    - - {x: 34, y: 62}
+      - {x: 30, y: 62}
+      - {x: 30, y: 60}
+      - {x: 31, y: 60}
+      - {x: 31, y: 61}
+      - {x: 33, y: 61}
+      - {x: 33, y: 59}
+      - {x: 30, y: 59}
+      - {x: 30, y: 57}
+      - {x: 31, y: 57}
+      - {x: 31, y: 58}
+      - {x: 33, y: 58}
+      - {x: 33, y: 56}
+      - {x: 29, y: 56}
+      - {x: 29, y: 59}
+      - {x: 27, y: 59}
+      - {x: 27, y: 58}
+      - {x: 28, y: 58}
+      - {x: 28, y: 56}
+      - {x: 26, y: 56}
+      - {x: 26, y: 59}
+      - {x: 25, y: 59}
+      - {x: 25, y: 55}
+      - {x: 34, y: 55}
+    - - {x: 40, y: 56}
+      - {x: 37, y: 56}
+      - {x: 37, y: 60}
+      - {x: 36, y: 60}
+      - {x: 36, y: 56}
+      - {x: 35, y: 56}
+      - {x: 35, y: 55}
+      - {x: 40, y: 55}
+    - - {x: 7, y: 57.9375}
+      - {x: 7, y: 60}
+      - {x: 6, y: 60}
+      - {x: 6, y: 59}
+      - {x: 5.90625, y: 59}
+      - {x: 5, y: 58.093746}
+      - {x: 5, y: 57}
+      - {x: 6.0625, y: 57}
+    - - {x: 15, y: 57}
+      - {x: 14, y: 57}
+      - {x: 14, y: 56}
+      - {x: 15, y: 56}
+    - - {x: 12, y: 55}
+      - {x: 11, y: 55}
+      - {x: 11, y: 56}
+      - {x: 13, y: 56}
+      - {x: 13, y: 57}
+      - {x: 10, y: 57}
+      - {x: 10, y: 54}
+      - {x: 12, y: 54}
+    - - {x: 24, y: 40}
+      - {x: 23, y: 40}
+      - {x: 23, y: 48}
+      - {x: 17, y: 48}
+      - {x: 17, y: 51}
+      - {x: 18, y: 51}
+      - {x: 18, y: 49}
+      - {x: 19, y: 49}
+      - {x: 19, y: 51}
+      - {x: 20, y: 51}
+      - {x: 20, y: 49}
+      - {x: 21, y: 49}
+      - {x: 21, y: 51}
+      - {x: 22, y: 51}
+      - {x: 22, y: 49}
+      - {x: 23, y: 49}
+      - {x: 23, y: 52}
+      - {x: 17, y: 52}
+      - {x: 17, y: 54}
+      - {x: 21, y: 54}
+      - {x: 21, y: 55}
+      - {x: 16, y: 55}
+      - {x: 16, y: 52}
+      - {x: 12, y: 52}
+      - {x: 12, y: 53}
+      - {x: 10, y: 53}
+      - {x: 10, y: 52}
+      - {x: 11, y: 52}
+      - {x: 11, y: 51}
+      - {x: 16, y: 51}
+      - {x: 16, y: 47}
+      - {x: 22, y: 47}
+      - {x: 22, y: 39}
+      - {x: 24, y: 39}
+    - - {x: 78, y: 42}
+      - {x: 81, y: 42}
+      - {x: 81, y: 47}
+      - {x: 80, y: 47}
+      - {x: 80, y: 49}
+      - {x: 79, y: 49}
+      - {x: 79, y: 48}
+      - {x: 77, y: 48}
+      - {x: 77, y: 46}
+      - {x: 80, y: 46}
+      - {x: 80, y: 43}
+      - {x: 77, y: 43}
+      - {x: 77, y: 40}
+      - {x: 72, y: 40}
+      - {x: 72, y: 51}
+      - {x: 76, y: 51}
+      - {x: 76, y: 53}
+      - {x: 75, y: 53}
+      - {x: 75, y: 52}
+      - {x: 68, y: 52}
+      - {x: 68, y: 51}
+      - {x: 70, y: 51}
+      - {x: 70, y: 46}
+      - {x: 67, y: 46}
+      - {x: 67, y: 52}
+      - {x: 66, y: 52}
+      - {x: 66, y: 42}
+      - {x: 65, y: 42}
+      - {x: 65, y: 41}
+      - {x: 67, y: 41}
+      - {x: 67, y: 45}
+      - {x: 71, y: 45}
+      - {x: 71, y: 39}
+      - {x: 78, y: 39}
+    - - {x: 34, y: 52}
+      - {x: 26, y: 52}
+      - {x: 26, y: 50}
+      - {x: 27, y: 50}
+      - {x: 27, y: 51}
+      - {x: 33, y: 51}
+      - {x: 33, y: 43}
+      - {x: 34, y: 43}
+    - - {x: 36, y: 51}
+      - {x: 41, y: 51}
+      - {x: 41, y: 47}
+      - {x: 42, y: 47}
+      - {x: 42, y: 51}
+      - {x: 45, y: 51}
+      - {x: 45, y: 49}
+      - {x: 46, y: 49}
+      - {x: 46, y: 52}
+      - {x: 35, y: 52}
+      - {x: 35, y: 47}
+      - {x: 36, y: 47}
+    - - {x: 57, y: 47}
+      - {x: 55, y: 47}
+      - {x: 55, y: 45}
+      - {x: 53, y: 45}
+      - {x: 53, y: 46}
+      - {x: 52, y: 46}
+      - {x: 52, y: 48}
+      - {x: 53, y: 48}
+      - {x: 53, y: 49}
+      - {x: 55, y: 49}
+      - {x: 55, y: 48}
+      - {x: 56, y: 48}
+      - {x: 56, y: 51}
+      - {x: 59, y: 51}
+      - {x: 59, y: 52}
+      - {x: 49, y: 52}
+      - {x: 49, y: 44}
+      - {x: 56, y: 44}
+      - {x: 56, y: 43}
+      - {x: 57, y: 43}
+    - - {x: 65, y: 52}
+      - {x: 60, y: 52}
+      - {x: 60, y: 51}
+      - {x: 64, y: 51}
+      - {x: 64, y: 50}
+      - {x: 65, y: 50}
+    - - {x: 50, y: 45}
+      - {x: 50, y: 51}
+      - {x: 55, y: 51}
+      - {x: 55, y: 50}
+      - {x: 52, y: 50}
+      - {x: 52, y: 49}
+      - {x: 51, y: 49}
+      - {x: 51, y: 45}
+    - - {x: 65, y: 49}
+      - {x: 64, y: 49}
+      - {x: 64, y: 47}
+      - {x: 63, y: 47}
+      - {x: 63, y: 46}
+      - {x: 64, y: 46}
+      - {x: 64, y: 43}
+      - {x: 65, y: 43}
+    - - {x: 34, y: 42}
+      - {x: 27, y: 42}
+      - {x: 27, y: 48}
+      - {x: 26, y: 48}
+      - {x: 26, y: 41}
+      - {x: 34, y: 41}
+    - - {x: 46, y: 48}
+      - {x: 45, y: 48}
+      - {x: 45, y: 41}
+      - {x: 46, y: 41}
+    - - {x: 61, y: 47}
+      - {x: 59, y: 47}
+      - {x: 59, y: 46}
+      - {x: 60, y: 46}
+      - {x: 60, y: 43}
+      - {x: 61, y: 43}
+    - - {x: 36, y: 34}
+      - {x: 43, y: 34}
+      - {x: 43, y: 35}
+      - {x: 36, y: 35}
+      - {x: 36, y: 39}
+      - {x: 45, y: 39}
+      - {x: 45, y: 38}
+      - {x: 46, y: 38}
+      - {x: 46, y: 40}
+      - {x: 36, y: 40}
+      - {x: 36, y: 46}
+      - {x: 35, y: 46}
+      - {x: 35, y: 33}
+      - {x: 36, y: 33}
+    - - {x: 50, y: 42}
+      - {x: 54, y: 42}
+      - {x: 54, y: 41}
+      - {x: 57, y: 41}
+      - {x: 57, y: 42}
+      - {x: 55, y: 42}
+      - {x: 55, y: 43}
+      - {x: 49, y: 43}
+      - {x: 49, y: 41}
+      - {x: 50, y: 41}
+    - - {x: 62, y: 41}
+      - {x: 64, y: 41}
+      - {x: 64, y: 42}
+      - {x: 60, y: 42}
+      - {x: 60, y: 41}
+      - {x: 61, y: 41}
+      - {x: 61, y: 36}
+      - {x: 62, y: 36}
+    - - {x: 50, y: 40}
+      - {x: 49, y: 40}
+      - {x: 49, y: 38}
+      - {x: 50, y: 38}
+    - - {x: 18, y: 40}
+      - {x: 17, y: 40}
+      - {x: 17, y: 39}
+      - {x: 18, y: 39}
+    - - {x: 34, y: 40}
+      - {x: 25, y: 40}
+      - {x: 25, y: 39}
+      - {x: 33, y: 39}
+      - {x: 33, y: 34}
+      - {x: 24, y: 34}
+      - {x: 24, y: 33}
+      - {x: 34, y: 33}
+    - - {x: 64, y: 39}
+      - {x: 63, y: 39}
+      - {x: 63, y: 38}
+      - {x: 64, y: 38}
+    - - {x: 50, y: 37}
+      - {x: 49, y: 37}
+      - {x: 49, y: 34}
+      - {x: 50, y: 34}
+    - - {x: 46, y: 37}
+      - {x: 45, y: 37}
+      - {x: 45, y: 34}
+      - {x: 46, y: 34}
+    - - {x: 75, y: 28}
+      - {x: 76, y: 28}
+      - {x: 76, y: 36}
+      - {x: 74, y: 36}
+      - {x: 74, y: 35}
+      - {x: 75, y: 35}
+      - {x: 75, y: 29}
+      - {x: 74, y: 29}
+      - {x: 74, y: 28}
+      - {x: 73, y: 28}
+      - {x: 73, y: 29}
+      - {x: 72, y: 29}
+      - {x: 72, y: 35}
+      - {x: 73, y: 35}
+      - {x: 73, y: 36}
+      - {x: 71, y: 36}
+      - {x: 71, y: 28}
+      - {x: 72, y: 28}
+      - {x: 72, y: 27}
+      - {x: 75, y: 27}
+    - - {x: 54, y: 35}
+      - {x: 52, y: 35}
+      - {x: 52, y: 34}
+      - {x: 53, y: 34}
+      - {x: 53, y: 31}
+      - {x: 54, y: 31}
+    - - {x: 33, y: 32}
+      - {x: 23, y: 32}
+      - {x: 23, y: 34}
+      - {x: 17, y: 34}
+      - {x: 17, y: 33}
+      - {x: 22, y: 33}
+      - {x: 22, y: 31}
+      - {x: 32, y: 31}
+      - {x: 32, y: 26}
+      - {x: 28, y: 26}
+      - {x: 28, y: 25}
+      - {x: 33, y: 25}
+    - - {x: 46, y: 23}
+      - {x: 42, y: 23}
+      - {x: 42, y: 33}
+      - {x: 41, y: 33}
+      - {x: 41, y: 23}
+      - {x: 38, y: 23}
+      - {x: 38, y: 22}
+      - {x: 46, y: 22}
+    - - {x: 38, y: 16}
+      - {x: 39, y: 16}
+      - {x: 39, y: 17}
+      - {x: 38, y: 17}
+      - {x: 38, y: 20}
+      - {x: 39, y: 20}
+      - {x: 39, y: 21}
+      - {x: 37, y: 21}
+      - {x: 37, y: 23}
+      - {x: 36, y: 23}
+      - {x: 36, y: 32}
+      - {x: 35, y: 32}
+      - {x: 35, y: 24}
+      - {x: 28, y: 24}
+      - {x: 28, y: 23}
+      - {x: 35, y: 23}
+      - {x: 35, y: 22}
+      - {x: 36, y: 22}
+      - {x: 36, y: 20}
+      - {x: 37, y: 20}
+      - {x: 37, y: 13}
+      - {x: 38, y: 13}
+    - - {x: 54, y: 30}
+      - {x: 53, y: 30}
+      - {x: 53, y: 29}
+      - {x: 54, y: 29}
+    - - {x: 60, y: 25}
+      - {x: 57, y: 25}
+      - {x: 57, y: 24}
+      - {x: 60, y: 24}
+    - - {x: 56, y: 25}
+      - {x: 55, y: 25}
+      - {x: 55, y: 24}
+      - {x: 56, y: 24}
+    - - {x: 54, y: 25}
+      - {x: 53, y: 25}
+      - {x: 53, y: 24}
+      - {x: 54, y: 24}
+    - - {x: 54, y: 23}
+      - {x: 53, y: 23}
+      - {x: 53, y: 22}
+      - {x: 54, y: 22}
+    - - {x: 60, y: 23}
+      - {x: 57, y: 23}
+      - {x: 57, y: 22}
+      - {x: 60, y: 22}
+    - - {x: 56, y: 23}
+      - {x: 55, y: 23}
+      - {x: 55, y: 22}
+      - {x: 56, y: 22}
+    - - {x: 52, y: 23}
+      - {x: 50, y: 23}
+      - {x: 50, y: 21}
+      - {x: 52, y: 21}
+    - - {x: 44, y: 17}
+      - {x: 46, y: 17}
+      - {x: 46, y: 21}
+      - {x: 40, y: 21}
+      - {x: 40, y: 20}
+      - {x: 41, y: 20}
+      - {x: 41, y: 19}
+      - {x: 42, y: 19}
+      - {x: 42, y: 20}
+      - {x: 45, y: 20}
+      - {x: 45, y: 18}
+      - {x: 43, y: 18}
+      - {x: 43, y: 17}
+      - {x: 42, y: 17}
+      - {x: 42, y: 18}
+      - {x: 41, y: 18}
+      - {x: 41, y: 17}
+      - {x: 40, y: 17}
+      - {x: 40, y: 16}
+      - {x: 43, y: 16}
+      - {x: 43, y: 15}
+      - {x: 44, y: 15}
+    - - {x: 53, y: 19}
+      - {x: 50, y: 19}
+      - {x: 50, y: 17}
+      - {x: 52, y: 17}
+      - {x: 52, y: 15}
+      - {x: 53, y: 15}
+    - - {x: 49, y: 11}
+      - {x: 48, y: 11}
+      - {x: 48, y: 10}
+      - {x: 49, y: 10}
+    - - {x: 46, y: 11}
+      - {x: 45, y: 11}
+      - {x: 45, y: 10}
+      - {x: 46, y: 10}
+    - - {x: 43, y: 10}
+      - {x: 44, y: 10}
+      - {x: 44, y: 11}
+      - {x: 38.90625, y: 11}
+      - {x: 38, y: 10.093751}
+      - {x: 38, y: 10}
+      - {x: 37, y: 10}
+      - {x: 37, y: 9}
+      - {x: 39, y: 9}
+      - {x: 39, y: 10}
+      - {x: 42, y: 10}
+      - {x: 42, y: 8}
+      - {x: 43, y: 8}
+    - - {x: 55, y: 9}
+      - {x: 58, y: 9}
+      - {x: 58, y: 8.90625}
+      - {x: 58.906254, y: 8}
+      - {x: 60, y: 8}
+      - {x: 60, y: 9}
+      - {x: 59, y: 9}
+      - {x: 59, y: 9.0625}
+      - {x: 58.062504, y: 10}
+      - {x: 55, y: 10}
+      - {x: 55, y: 10.0625}
+      - {x: 54.062504, y: 11}
+      - {x: 52, y: 11}
+      - {x: 52, y: 10}
+      - {x: 54, y: 10}
+      - {x: 54, y: 6}
+      - {x: 55, y: 6}
+    - - {x: 51, y: 11}
+      - {x: 50, y: 11}
+      - {x: 50, y: 6}
+      - {x: 51, y: 6}
+    - - {x: 43, y: 7}
+      - {x: 42, y: 7}
+      - {x: 42, y: 6}
+      - {x: 39, y: 6}
+      - {x: 39, y: 5}
+      - {x: 43, y: 5}
+    - - {x: 55, y: 0.9375}
+      - {x: 55, y: 1}
+      - {x: 58.062504, y: 1}
+      - {x: 59, y: 1.9375}
+      - {x: 59, y: 2}
+      - {x: 60, y: 2}
+      - {x: 60, y: 3}
+      - {x: 58.906254, y: 3}
+      - {x: 58, y: 2.09375}
+      - {x: 58, y: 2}
+      - {x: 55, y: 2}
+      - {x: 55, y: 5}
+      - {x: 54, y: 5}
+      - {x: 54, y: 1}
+      - {x: 50, y: 1}
+      - {x: 50, y: 0}
+      - {x: 54.062504, y: 0}
+    - - {x: 46, y: 1}
+      - {x: 39, y: 1}
+      - {x: 39, y: 2}
+      - {x: 37, y: 2}
+      - {x: 37, y: 1}
+      - {x: 38, y: 1}
+      - {x: 38, y: 0.90625}
+      - {x: 38.90625, y: 0}
+      - {x: 46, y: 0}
+  m_VertexDistance: 0.0005
+--- !u!50 &224555826
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 224555820}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!19719996 &224555827
+TilemapCollider2D:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 224555820}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: 0, y: 0}
 --- !u!1001 &225909004
 Prefab:
   m_ObjectHideFlags: 0
@@ -49594,7 +51758,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 0, z: 0}
     second:
       m_TileIndex: 0
@@ -49603,7 +51767,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 0, z: 0}
     second:
       m_TileIndex: 0
@@ -49612,7 +51776,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 0, z: 0}
     second:
       m_TileIndex: 0
@@ -49621,7 +51785,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -49702,7 +51866,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 1, z: 0}
     second:
       m_TileIndex: 1
@@ -49882,7 +52046,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 2, z: 0}
     second:
       m_TileIndex: 1
@@ -50224,7 +52388,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 4, z: 0}
     second:
       m_TileIndex: 0
@@ -50233,7 +52397,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 4, z: 0}
     second:
       m_TileIndex: 0
@@ -50242,7 +52406,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 4, z: 0}
     second:
       m_TileIndex: 0
@@ -50251,7 +52415,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 4, z: 0}
     second:
       m_TileIndex: 0
@@ -50260,7 +52424,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 4, z: 0}
     second:
       m_TileIndex: 0
@@ -50269,7 +52433,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 4, z: 0}
     second:
       m_TileIndex: 1
@@ -50314,7 +52478,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 4, z: 0}
     second:
       m_TileIndex: 1
@@ -50467,7 +52631,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 5, z: 0}
     second:
       m_TileIndex: 0
@@ -50476,7 +52640,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 5, z: 0}
     second:
       m_TileIndex: 0
@@ -50485,7 +52649,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 5, z: 0}
     second:
       m_TileIndex: 0
@@ -50494,7 +52658,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 5, z: 0}
     second:
       m_TileIndex: 1
@@ -50692,7 +52856,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 6, z: 0}
     second:
       m_TileIndex: 0
@@ -50701,7 +52865,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 6, z: 0}
     second:
       m_TileIndex: 0
@@ -50710,7 +52874,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 6, z: 0}
     second:
       m_TileIndex: 0
@@ -50719,7 +52883,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 6, z: 0}
     second:
       m_TileIndex: 0
@@ -50728,7 +52892,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 6, z: 0}
     second:
       m_TileIndex: 1
@@ -50854,7 +53018,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 6, z: 0}
     second:
       m_TileIndex: 1
@@ -50872,7 +53036,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 6, z: 0}
     second:
       m_TileIndex: 1
@@ -50926,7 +53090,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -50935,7 +53099,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -50944,7 +53108,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -50953,7 +53117,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -50962,7 +53126,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -50971,7 +53135,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -50980,7 +53144,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -50989,7 +53153,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 7, z: 0}
     second:
       m_TileIndex: 2
@@ -50998,7 +53162,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -51007,7 +53171,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -51016,7 +53180,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -51025,7 +53189,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -51034,7 +53198,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -51043,7 +53207,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -51052,7 +53216,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -51061,7 +53225,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 7, z: 0}
     second:
       m_TileIndex: 1
@@ -51259,7 +53423,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -51268,7 +53432,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -51277,7 +53441,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -51286,7 +53450,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 8, z: 0}
     second:
       m_TileIndex: 2
@@ -51295,7 +53459,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -51304,7 +53468,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -51313,7 +53477,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -51322,7 +53486,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 8, z: 0}
     second:
       m_TileIndex: 1
@@ -51520,7 +53684,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 9, z: 0}
     second:
       m_TileIndex: 0
@@ -51529,7 +53693,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -51583,7 +53747,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -51637,7 +53801,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 9, z: 0}
     second:
       m_TileIndex: 0
@@ -51646,7 +53810,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -51844,7 +54008,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51853,7 +54017,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51862,7 +54026,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51871,7 +54035,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51880,7 +54044,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51889,7 +54053,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51898,7 +54062,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51907,7 +54071,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51916,7 +54080,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51925,7 +54089,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51934,7 +54098,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51943,7 +54107,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51952,7 +54116,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -51961,7 +54125,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 10, z: 0}
     second:
       m_TileIndex: 0
@@ -51970,7 +54134,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -52042,7 +54206,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 10, z: 0}
     second:
       m_TileIndex: 0
@@ -52051,7 +54215,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -52114,7 +54278,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 11, z: 0}
     second:
       m_TileIndex: 0
@@ -52123,7 +54287,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 11, z: 0}
     second:
       m_TileIndex: 1
@@ -52177,7 +54341,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 11, z: 0}
     second:
       m_TileIndex: 1
@@ -52231,7 +54395,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 11, z: 0}
     second:
       m_TileIndex: 0
@@ -52240,7 +54404,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 11, z: 0}
     second:
       m_TileIndex: 0
@@ -52249,7 +54413,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 11, z: 0}
     second:
       m_TileIndex: 1
@@ -52267,7 +54431,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 11, z: 0}
     second:
       m_TileIndex: 0
@@ -52276,7 +54440,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 11, z: 0}
     second:
       m_TileIndex: 1
@@ -52294,7 +54458,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 11, z: 0}
     second:
       m_TileIndex: 1
@@ -52312,7 +54476,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 12, z: 0}
     second:
       m_TileIndex: 0
@@ -52321,7 +54485,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 12, z: 0}
     second:
       m_TileIndex: 0
@@ -52330,7 +54494,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 12, z: 0}
     second:
       m_TileIndex: 2
@@ -52339,7 +54503,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 12, z: 0}
     second:
       m_TileIndex: 0
@@ -52348,7 +54512,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 12, z: 0}
     second:
       m_TileIndex: 0
@@ -52357,7 +54521,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 12, z: 0}
     second:
       m_TileIndex: 0
@@ -52366,7 +54530,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 12, z: 0}
     second:
       m_TileIndex: 1
@@ -52384,7 +54548,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 12, z: 0}
     second:
       m_TileIndex: 0
@@ -52393,7 +54557,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 12, z: 0}
     second:
       m_TileIndex: 1
@@ -52411,7 +54575,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 12, z: 0}
     second:
       m_TileIndex: 1
@@ -52429,7 +54593,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -52438,7 +54602,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -52447,7 +54611,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 13, z: 0}
     second:
       m_TileIndex: 1
@@ -52501,7 +54665,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 13, z: 0}
     second:
       m_TileIndex: 1
@@ -52555,7 +54719,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -52564,7 +54728,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 13, z: 0}
     second:
       m_TileIndex: 1
@@ -52582,7 +54746,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -52591,7 +54755,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -52600,7 +54764,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -52609,7 +54773,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -52618,7 +54782,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -52627,7 +54791,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 13, z: 0}
     second:
       m_TileIndex: 1
@@ -52645,7 +54809,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -52654,7 +54818,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 13, z: 0}
     second:
       m_TileIndex: 1
@@ -52672,7 +54836,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 13, z: 0}
     second:
       m_TileIndex: 1
@@ -52690,7 +54854,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 14, z: 0}
     second:
       m_TileIndex: 0
@@ -52699,7 +54863,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52708,7 +54872,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52717,7 +54881,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52726,7 +54890,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52735,7 +54899,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52744,7 +54908,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52753,7 +54917,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52762,7 +54926,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52771,7 +54935,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52780,7 +54944,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52789,7 +54953,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52798,7 +54962,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52807,7 +54971,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -52816,7 +54980,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 14, z: 0}
     second:
       m_TileIndex: 0
@@ -52825,7 +54989,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 14, z: 0}
     second:
       m_TileIndex: 1
@@ -52888,7 +55052,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 14, z: 0}
     second:
       m_TileIndex: 1
@@ -52906,7 +55070,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 14, z: 0}
     second:
       m_TileIndex: 0
@@ -52915,7 +55079,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 14, z: 0}
     second:
       m_TileIndex: 0
@@ -52924,7 +55088,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 14, z: 0}
     second:
       m_TileIndex: 0
@@ -52933,7 +55097,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 14, z: 0}
     second:
       m_TileIndex: 1
@@ -52951,7 +55115,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 14, z: 0}
     second:
       m_TileIndex: 1
@@ -52969,7 +55133,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 15, z: 0}
     second:
       m_TileIndex: 0
@@ -52978,7 +55142,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 15, z: 0}
     second:
       m_TileIndex: 0
@@ -52987,7 +55151,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 15, z: 0}
     second:
       m_TileIndex: 1
@@ -53041,7 +55205,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 15, z: 0}
     second:
       m_TileIndex: 1
@@ -53095,7 +55259,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 15, z: 0}
     second:
       m_TileIndex: 1
@@ -53248,7 +55412,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 16, z: 0}
     second:
       m_TileIndex: 0
@@ -53257,7 +55421,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 16, z: 0}
     second:
       m_TileIndex: 2
@@ -53266,7 +55430,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 16, z: 0}
     second:
       m_TileIndex: 0
@@ -53275,7 +55439,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 16, z: 0}
     second:
       m_TileIndex: 1
@@ -53428,7 +55592,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 17, z: 0}
     second:
       m_TileIndex: 0
@@ -53437,7 +55601,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 17, z: 0}
     second:
       m_TileIndex: 1
@@ -53491,7 +55655,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 17, z: 0}
     second:
       m_TileIndex: 1
@@ -53545,7 +55709,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 17, z: 0}
     second:
       m_TileIndex: 1
@@ -53698,7 +55862,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53707,7 +55871,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53716,7 +55880,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53725,7 +55889,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53734,7 +55898,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53743,7 +55907,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53752,7 +55916,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53761,7 +55925,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53770,7 +55934,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53779,7 +55943,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53788,7 +55952,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53797,7 +55961,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53806,7 +55970,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -53815,7 +55979,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -53824,7 +55988,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 18, z: 0}
     second:
       m_TileIndex: 1
@@ -53977,7 +56141,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -53986,7 +56150,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -53995,7 +56159,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -54004,7 +56168,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -54013,7 +56177,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -54022,7 +56186,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -54031,7 +56195,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -54040,7 +56204,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -54049,7 +56213,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -54058,7 +56222,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -54067,7 +56231,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -54076,7 +56240,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -54085,7 +56249,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 18, z: 0}
     second:
       m_TileIndex: 1
@@ -54103,7 +56267,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -54112,7 +56276,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -54121,7 +56285,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 19, z: 0}
     second:
       m_TileIndex: 0
@@ -54130,7 +56294,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 19, z: 0}
     second:
       m_TileIndex: 0
@@ -54139,7 +56303,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 19, z: 0}
     second:
       m_TileIndex: 1
@@ -54193,7 +56357,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 19, z: 0}
     second:
       m_TileIndex: 1
@@ -54247,7 +56411,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 19, z: 0}
     second:
       m_TileIndex: 0
@@ -54256,7 +56420,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 19, z: 0}
     second:
       m_TileIndex: 1
@@ -54535,7 +56699,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 19, z: 0}
     second:
       m_TileIndex: 0
@@ -54544,7 +56708,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 19, z: 0}
     second:
       m_TileIndex: 0
@@ -54553,7 +56717,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 19, z: 0}
     second:
       m_TileIndex: 0
@@ -54562,7 +56726,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -54571,7 +56735,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -54580,7 +56744,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -54589,7 +56753,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 20, z: 0}
     second:
       m_TileIndex: 2
@@ -54598,7 +56762,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -54607,7 +56771,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -54616,7 +56780,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 20, z: 0}
     second:
       m_TileIndex: 1
@@ -54886,7 +57050,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 20, z: 0}
     second:
       m_TileIndex: 1
@@ -54913,7 +57077,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -54922,7 +57086,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -54931,7 +57095,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -54940,7 +57104,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -54949,7 +57113,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -54958,7 +57122,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -54967,7 +57131,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -54976,7 +57140,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -54985,7 +57149,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -54994,7 +57158,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55003,7 +57167,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -55012,7 +57176,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55021,7 +57185,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55030,7 +57194,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55039,7 +57203,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55048,7 +57212,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55057,7 +57221,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55066,7 +57230,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55075,7 +57239,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 21, z: 0}
     second:
       m_TileIndex: 1
@@ -55228,7 +57392,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55237,7 +57401,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55246,7 +57410,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55255,7 +57419,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55264,7 +57428,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55273,7 +57437,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55282,7 +57446,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55291,7 +57455,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55300,7 +57464,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55309,7 +57473,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55318,7 +57482,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55327,7 +57491,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55336,7 +57500,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55345,7 +57509,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55354,7 +57518,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -55363,7 +57527,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 21, z: 0}
     second:
       m_TileIndex: 1
@@ -55381,7 +57545,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 22, z: 0}
     second:
       m_TileIndex: 0
@@ -55390,7 +57554,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 22, z: 0}
     second:
       m_TileIndex: 2
@@ -55399,7 +57563,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 22, z: 0}
     second:
       m_TileIndex: 2
@@ -55408,7 +57572,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 22, z: 0}
     second:
       m_TileIndex: 1
@@ -55570,7 +57734,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 22, z: 0}
     second:
       m_TileIndex: 1
@@ -55588,7 +57752,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 22, z: 0}
     second:
       m_TileIndex: 1
@@ -55624,7 +57788,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 23, z: 0}
     second:
       m_TileIndex: 0
@@ -55633,7 +57797,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 23, z: 0}
     second:
       m_TileIndex: 2
@@ -55642,7 +57806,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 23, z: 0}
     second:
       m_TileIndex: 1
@@ -55930,7 +58094,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 24, z: 0}
     second:
       m_TileIndex: 0
@@ -55939,7 +58103,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 24, z: 0}
     second:
       m_TileIndex: 0
@@ -55948,7 +58112,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 24, z: 0}
     second:
       m_TileIndex: 0
@@ -55957,7 +58121,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 24, z: 0}
     second:
       m_TileIndex: 2
@@ -55966,7 +58130,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 24, z: 0}
     second:
       m_TileIndex: 1
@@ -56245,7 +58409,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 25, z: 0}
     second:
       m_TileIndex: 0
@@ -56254,7 +58418,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 25, z: 0}
     second:
       m_TileIndex: 0
@@ -56263,7 +58427,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 25, z: 0}
     second:
       m_TileIndex: 1
@@ -56497,7 +58661,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 25, z: 0}
     second:
       m_TileIndex: 0
@@ -56506,7 +58670,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 25, z: 0}
     second:
       m_TileIndex: 0
@@ -56515,7 +58679,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 25, z: 0}
     second:
       m_TileIndex: 0
@@ -56524,7 +58688,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 26, z: 0}
     second:
       m_TileIndex: 0
@@ -56533,7 +58697,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 26, z: 0}
     second:
       m_TileIndex: 0
@@ -56542,7 +58706,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 26, z: 0}
     second:
       m_TileIndex: 0
@@ -56551,7 +58715,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 26, z: 0}
     second:
       m_TileIndex: 1
@@ -56749,7 +58913,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 26, z: 0}
     second:
       m_TileIndex: 0
@@ -56758,7 +58922,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 27, z: 0}
     second:
       m_TileIndex: 0
@@ -56767,7 +58931,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 27, z: 0}
     second:
       m_TileIndex: 0
@@ -56776,7 +58940,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 27, z: 0}
     second:
       m_TileIndex: 0
@@ -56785,7 +58949,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 27, z: 0}
     second:
       m_TileIndex: 1
@@ -56983,7 +59147,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 27, z: 0}
     second:
       m_TileIndex: 0
@@ -56992,7 +59156,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 27, z: 0}
     second:
       m_TileIndex: 0
@@ -57001,7 +59165,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 27, z: 0}
     second:
       m_TileIndex: 0
@@ -57010,7 +59174,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 27, z: 0}
     second:
       m_TileIndex: 1
@@ -57046,7 +59210,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -57055,7 +59219,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -57064,7 +59228,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 28, z: 0}
     second:
       m_TileIndex: 1
@@ -57262,7 +59426,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -57271,7 +59435,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -57280,7 +59444,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 28, z: 0}
     second:
       m_TileIndex: 1
@@ -57298,7 +59462,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -57307,7 +59471,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 28, z: 0}
     second:
       m_TileIndex: 1
@@ -57361,7 +59525,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -57370,7 +59534,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -57379,7 +59543,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -57388,7 +59552,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 29, z: 0}
     second:
       m_TileIndex: 0
@@ -57397,7 +59561,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 29, z: 0}
     second:
       m_TileIndex: 0
@@ -57406,7 +59570,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 29, z: 0}
     second:
       m_TileIndex: 0
@@ -57415,7 +59579,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 29, z: 0}
     second:
       m_TileIndex: 1
@@ -57658,7 +59822,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 29, z: 0}
     second:
       m_TileIndex: 0
@@ -57667,7 +59831,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 29, z: 0}
     second:
       m_TileIndex: 1
@@ -57721,7 +59885,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 30, z: 0}
     second:
       m_TileIndex: 0
@@ -57730,7 +59894,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 30, z: 0}
     second:
       m_TileIndex: 0
@@ -57739,7 +59903,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 30, z: 0}
     second:
       m_TileIndex: 1
@@ -57973,7 +60137,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 30, z: 0}
     second:
       m_TileIndex: 2
@@ -57982,7 +60146,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 30, z: 0}
     second:
       m_TileIndex: 2
@@ -57991,7 +60155,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 30, z: 0}
     second:
       m_TileIndex: 2
@@ -58000,7 +60164,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 30, z: 0}
     second:
       m_TileIndex: 1
@@ -58387,7 +60551,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 31, z: 0}
     second:
       m_TileIndex: 1
@@ -58774,7 +60938,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 32, z: 0}
     second:
       m_TileIndex: 1
@@ -59197,7 +61361,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 33, z: 0}
     second:
       m_TileIndex: 0
@@ -59206,7 +61370,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 33, z: 0}
     second:
       m_TileIndex: 1
@@ -59260,7 +61424,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -59494,7 +61658,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 34, z: 0}
     second:
       m_TileIndex: 0
@@ -59503,7 +61667,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -59557,7 +61721,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 34, z: 0}
     second:
       m_TileIndex: 0
@@ -59566,7 +61730,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -59593,7 +61757,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 34, z: 0}
     second:
       m_TileIndex: 0
@@ -59602,7 +61766,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -59620,7 +61784,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 34, z: 0}
     second:
       m_TileIndex: 0
@@ -59629,7 +61793,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 34, z: 0}
     second:
       m_TileIndex: 0
@@ -59638,7 +61802,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -59692,7 +61856,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 35, z: 0}
     second:
       m_TileIndex: 1
@@ -59989,7 +62153,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 35, z: 0}
     second:
       m_TileIndex: 0
@@ -59998,7 +62162,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 35, z: 0}
     second:
       m_TileIndex: 0
@@ -60007,7 +62171,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 35, z: 0}
     second:
       m_TileIndex: 0
@@ -60016,7 +62180,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 35, z: 0}
     second:
       m_TileIndex: 0
@@ -60025,7 +62189,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 35, z: 0}
     second:
       m_TileIndex: 0
@@ -60034,7 +62198,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 35, z: 0}
     second:
       m_TileIndex: 1
@@ -60088,7 +62252,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 36, z: 0}
     second:
       m_TileIndex: 1
@@ -60385,7 +62549,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -60394,7 +62558,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 36, z: 0}
     second:
       m_TileIndex: 1
@@ -60421,7 +62585,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 36, z: 0}
     second:
       m_TileIndex: 0
@@ -60430,7 +62594,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 36, z: 0}
     second:
       m_TileIndex: 0
@@ -60439,7 +62603,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -60448,7 +62612,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -60457,7 +62621,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -60466,7 +62630,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -60475,7 +62639,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -60484,7 +62648,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -60493,7 +62657,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -60502,7 +62666,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -60511,7 +62675,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 37, z: 0}
     second:
       m_TileIndex: 0
@@ -60520,7 +62684,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 37, z: 0}
     second:
       m_TileIndex: 1
@@ -60808,7 +62972,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 37, z: 0}
     second:
       m_TileIndex: 0
@@ -60817,7 +62981,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 37, z: 0}
     second:
       m_TileIndex: 2
@@ -60826,7 +62990,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 37, z: 0}
     second:
       m_TileIndex: 1
@@ -60853,7 +63017,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 37, z: 0}
     second:
       m_TileIndex: 1
@@ -60871,7 +63035,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 37, z: 0}
     second:
       m_TileIndex: 0
@@ -60880,7 +63044,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 37, z: 0}
     second:
       m_TileIndex: 0
@@ -60889,7 +63053,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 38, z: 0}
     second:
       m_TileIndex: 0
@@ -60898,7 +63062,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 38, z: 0}
     second:
       m_TileIndex: 1
@@ -61195,7 +63359,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 38, z: 0}
     second:
       m_TileIndex: 2
@@ -61204,7 +63368,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 38, z: 0}
     second:
       m_TileIndex: 1
@@ -61249,7 +63413,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 38, z: 0}
     second:
       m_TileIndex: 0
@@ -61258,7 +63422,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 38, z: 0}
     second:
       m_TileIndex: 0
@@ -61267,7 +63431,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 39, z: 0}
     second:
       m_TileIndex: 0
@@ -61276,7 +63440,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 39, z: 0}
     second:
       m_TileIndex: 1
@@ -61294,7 +63458,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 39, z: 0}
     second:
       m_TileIndex: 1
@@ -61312,7 +63476,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 39, z: 0}
     second:
       m_TileIndex: 0
@@ -61321,7 +63485,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 39, z: 0}
     second:
       m_TileIndex: 1
@@ -61582,7 +63746,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 39, z: 0}
     second:
       m_TileIndex: 0
@@ -61591,7 +63755,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 39, z: 0}
     second:
       m_TileIndex: 2
@@ -61600,7 +63764,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 39, z: 0}
     second:
       m_TileIndex: 1
@@ -61627,7 +63791,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 39, z: 0}
     second:
       m_TileIndex: 1
@@ -61645,7 +63809,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 39, z: 0}
     second:
       m_TileIndex: 0
@@ -61654,7 +63818,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 39, z: 0}
     second:
       m_TileIndex: 0
@@ -61663,7 +63827,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 39, z: 0}
     second:
       m_TileIndex: 1
@@ -61735,7 +63899,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 40, z: 0}
     second:
       m_TileIndex: 1
@@ -61906,7 +64070,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -61915,7 +64079,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -61924,7 +64088,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -61933,7 +64097,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -61942,7 +64106,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -61951,7 +64115,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -61960,7 +64124,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -61969,7 +64133,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -61978,7 +64142,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -61987,7 +64151,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 40, z: 0}
     second:
       m_TileIndex: 1
@@ -62023,7 +64187,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -62032,7 +64196,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -62041,7 +64205,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 40, z: 0}
     second:
       m_TileIndex: 2
@@ -62050,7 +64214,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 40, z: 0}
     second:
       m_TileIndex: 1
@@ -62095,7 +64259,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 40, z: 0}
     second:
       m_TileIndex: 1
@@ -62167,7 +64331,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -62176,7 +64340,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -62185,7 +64349,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 81, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -62194,7 +64358,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 82, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -62203,7 +64367,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 83, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -62212,7 +64376,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 84, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -62221,7 +64385,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 41, z: 0}
     second:
       m_TileIndex: 0
@@ -62230,7 +64394,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 41, z: 0}
     second:
       m_TileIndex: 1
@@ -62401,7 +64565,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -62410,7 +64574,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -62419,7 +64583,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -62428,7 +64592,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -62437,7 +64601,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -62446,7 +64610,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -62455,7 +64619,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -62464,7 +64628,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -62473,7 +64637,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 41, z: 0}
     second:
       m_TileIndex: 1
@@ -62527,7 +64691,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 41, z: 0}
     second:
       m_TileIndex: 0
@@ -62536,7 +64700,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 41, z: 0}
     second:
       m_TileIndex: 0
@@ -62545,7 +64709,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 41, z: 0}
     second:
       m_TileIndex: 1
@@ -62581,7 +64745,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 41, z: 0}
     second:
       m_TileIndex: 0
@@ -62590,7 +64754,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 41, z: 0}
     second:
       m_TileIndex: 0
@@ -62599,7 +64763,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 41, z: 0}
     second:
       m_TileIndex: 1
@@ -62734,7 +64898,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 42, z: 0}
     second:
       m_TileIndex: 1
@@ -62905,7 +65069,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -62914,7 +65078,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -62923,7 +65087,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -62932,7 +65096,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -62941,7 +65105,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -62950,7 +65114,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -62959,7 +65123,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -62968,7 +65132,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -62977,7 +65141,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 42, z: 0}
     second:
       m_TileIndex: 1
@@ -63274,7 +65438,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 43, z: 0}
     second:
       m_TileIndex: 1
@@ -63553,7 +65717,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 43, z: 0}
     second:
       m_TileIndex: 0
@@ -63562,7 +65726,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 43, z: 0}
     second:
       m_TileIndex: 0
@@ -63571,7 +65735,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 43, z: 0}
     second:
       m_TileIndex: 1
@@ -63589,7 +65753,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 43, z: 0}
     second:
       m_TileIndex: 0
@@ -63598,7 +65762,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 43, z: 0}
     second:
       m_TileIndex: 0
@@ -63607,7 +65771,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 43, z: 0}
     second:
       m_TileIndex: 1
@@ -63697,7 +65861,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 43, z: 0}
     second:
       m_TileIndex: 1
@@ -63733,7 +65897,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -63742,7 +65906,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -63751,7 +65915,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -63760,7 +65924,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -63769,7 +65933,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 44, z: 0}
     second:
       m_TileIndex: 1
@@ -63904,7 +66068,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -63913,7 +66077,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -63922,7 +66086,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -63931,7 +66095,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -63940,7 +66104,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -63949,7 +66113,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -63958,7 +66122,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -63967,7 +66131,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 44, z: 0}
     second:
       m_TileIndex: 1
@@ -64174,7 +66338,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -64183,7 +66347,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -64192,7 +66356,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -64201,7 +66365,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 44, z: 0}
     second:
       m_TileIndex: 1
@@ -64453,7 +66617,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 45, z: 0}
     second:
       m_TileIndex: 0
@@ -64462,7 +66626,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 45, z: 0}
     second:
       m_TileIndex: 1
@@ -64732,7 +66896,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 45, z: 0}
     second:
       m_TileIndex: 0
@@ -64741,7 +66905,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 45, z: 0}
     second:
       m_TileIndex: 1
@@ -64759,7 +66923,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 76, y: 45, z: 0}
     second:
       m_TileIndex: 0
@@ -64768,7 +66932,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 45, z: 0}
     second:
       m_TileIndex: 0
@@ -64777,7 +66941,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 45, z: 0}
     second:
       m_TileIndex: 1
@@ -64966,7 +67130,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 46, z: 0}
     second:
       m_TileIndex: 0
@@ -64975,7 +67139,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 46, z: 0}
     second:
       m_TileIndex: 1
@@ -65110,7 +67274,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 46, z: 0}
     second:
       m_TileIndex: 1
@@ -65146,7 +67310,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 46, z: 0}
     second:
       m_TileIndex: 1
@@ -65533,7 +67697,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 47, z: 0}
     second:
       m_TileIndex: 1
@@ -65812,7 +67976,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 47, z: 0}
     second:
       m_TileIndex: 0
@@ -65821,7 +67985,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 47, z: 0}
     second:
       m_TileIndex: 1
@@ -65839,7 +68003,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 76, y: 47, z: 0}
     second:
       m_TileIndex: 0
@@ -65848,7 +68012,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 47, z: 0}
     second:
       m_TileIndex: 1
@@ -66064,7 +68228,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 48, z: 0}
     second:
       m_TileIndex: 0
@@ -66073,7 +68237,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 48, z: 0}
     second:
       m_TileIndex: 0
@@ -66082,7 +68246,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 48, z: 0}
     second:
       m_TileIndex: 0
@@ -66091,7 +68255,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 48, z: 0}
     second:
       m_TileIndex: 1
@@ -66442,7 +68606,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 49, z: 0}
     second:
       m_TileIndex: 0
@@ -66451,7 +68615,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 49, z: 0}
     second:
       m_TileIndex: 1
@@ -66973,7 +69137,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 50, z: 0}
     second:
       m_TileIndex: 0
@@ -66982,7 +69146,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 50, z: 0}
     second:
       m_TileIndex: 1
@@ -67477,7 +69641,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 51, z: 0}
     second:
       m_TileIndex: 1
@@ -68107,7 +70271,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 52, z: 0}
     second:
       m_TileIndex: 1
@@ -68746,7 +70910,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 53, z: 0}
     second:
       m_TileIndex: 2
@@ -68755,7 +70919,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 53, z: 0}
     second:
       m_TileIndex: 0
@@ -68764,7 +70928,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 53, z: 0}
     second:
       m_TileIndex: 1
@@ -69394,7 +71558,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 54, z: 0}
     second:
       m_TileIndex: 1
@@ -70033,7 +72197,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 55, z: 0}
     second:
       m_TileIndex: 1
@@ -70672,7 +72836,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 56, z: 0}
     second:
       m_TileIndex: 0
@@ -70681,7 +72845,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 56, z: 0}
     second:
       m_TileIndex: 1
@@ -70717,7 +72881,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 56, z: 0}
     second:
       m_TileIndex: 1
@@ -70735,7 +72899,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 56, z: 0}
     second:
       m_TileIndex: 1
@@ -71122,7 +73286,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 56, z: 0}
     second:
       m_TileIndex: 1
@@ -71320,7 +73484,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 1, y: 57, z: 0}
     second:
       m_TileIndex: 1
@@ -71374,7 +73538,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 57, z: 0}
     second:
       m_TileIndex: 1
@@ -71635,7 +73799,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 57, z: 0}
     second:
       m_TileIndex: 0
@@ -71644,7 +73808,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 57, z: 0}
     second:
       m_TileIndex: 1
@@ -71932,7 +74096,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 58, z: 0}
     second:
       m_TileIndex: 1
@@ -72004,7 +74168,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 58, z: 0}
     second:
       m_TileIndex: 1
@@ -72364,7 +74528,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 58, z: 0}
     second:
       m_TileIndex: 1
@@ -72625,7 +74789,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 59, z: 0}
     second:
       m_TileIndex: 0
@@ -72634,7 +74798,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 59, z: 0}
     second:
       m_TileIndex: 0
@@ -72643,7 +74807,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 59, z: 0}
     second:
       m_TileIndex: 0
@@ -72652,7 +74816,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 59, z: 0}
     second:
       m_TileIndex: 1
@@ -73264,7 +75428,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 60, z: 0}
     second:
       m_TileIndex: 1
@@ -73957,7 +76121,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 61, z: 0}
     second:
       m_TileIndex: 1
@@ -74650,7 +76814,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 62, z: 0}
     second:
       m_TileIndex: 1
@@ -74722,7 +76886,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 62, z: 0}
     second:
       m_TileIndex: 0
@@ -74731,7 +76895,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 62, z: 0}
     second:
       m_TileIndex: 0
@@ -74740,7 +76904,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 62, z: 0}
     second:
       m_TileIndex: 1
@@ -75343,7 +77507,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 63, z: 0}
     second:
       m_TileIndex: 1
@@ -75685,7 +77849,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 63, z: 0}
     second:
       m_TileIndex: 0
@@ -75694,7 +77858,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 63, z: 0}
     second:
       m_TileIndex: 0
@@ -75703,7 +77867,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 63, z: 0}
     second:
       m_TileIndex: 1
@@ -75721,7 +77885,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 63, z: 0}
     second:
       m_TileIndex: 0
@@ -75730,7 +77894,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 63, z: 0}
     second:
       m_TileIndex: 0
@@ -75739,7 +77903,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 63, z: 0}
     second:
       m_TileIndex: 1
@@ -75820,7 +77984,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 63, z: 0}
     second:
       m_TileIndex: 1
@@ -76036,7 +78200,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 63, z: 0}
     second:
       m_TileIndex: 0
@@ -76045,7 +78209,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 64, z: 0}
     second:
       m_TileIndex: 1
@@ -76738,7 +78902,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 81, y: 64, z: 0}
     second:
       m_TileIndex: 0
@@ -76747,7 +78911,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 65, z: 0}
     second:
       m_TileIndex: 1
@@ -76819,7 +78983,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 65, z: 0}
     second:
       m_TileIndex: 0
@@ -76828,7 +78992,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 65, z: 0}
     second:
       m_TileIndex: 0
@@ -76837,7 +79001,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 65, z: 0}
     second:
       m_TileIndex: 1
@@ -77224,7 +79388,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 65, z: 0}
     second:
       m_TileIndex: 0
@@ -77233,7 +79397,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 65, z: 0}
     second:
       m_TileIndex: 1
@@ -77413,7 +79577,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 65, z: 0}
     second:
       m_TileIndex: 0
@@ -77422,7 +79586,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 65, z: 0}
     second:
       m_TileIndex: 1
@@ -77440,7 +79604,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 65, z: 0}
     second:
       m_TileIndex: 0
@@ -77449,7 +79613,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 66, z: 0}
     second:
       m_TileIndex: 1
@@ -77521,7 +79685,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 66, z: 0}
     second:
       m_TileIndex: 1
@@ -77944,7 +80108,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 66, z: 0}
     second:
       m_TileIndex: 1
@@ -77998,7 +80162,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 66, z: 0}
     second:
       m_TileIndex: 0
@@ -78007,7 +80171,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 1, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -78061,7 +80225,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -78331,7 +80495,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 67, z: 0}
     second:
       m_TileIndex: 0
@@ -78340,7 +80504,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -78475,7 +80639,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 67, z: 0}
     second:
       m_TileIndex: 0
@@ -78484,7 +80648,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -78538,7 +80702,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 68, z: 0}
     second:
       m_TileIndex: 0
@@ -78547,7 +80711,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 68, z: 0}
     second:
       m_TileIndex: 1
@@ -78736,7 +80900,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 68, z: 0}
     second:
       m_TileIndex: 0
@@ -78745,7 +80909,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 68, z: 0}
     second:
       m_TileIndex: 1
@@ -78799,7 +80963,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 68, z: 0}
     second:
       m_TileIndex: 0
@@ -78808,7 +80972,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 68, z: 0}
     second:
       m_TileIndex: 1
@@ -78835,7 +80999,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 68, z: 0}
     second:
       m_TileIndex: 1
@@ -78862,7 +81026,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 68, z: 0}
     second:
       m_TileIndex: 1
@@ -78916,7 +81080,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 69, z: 0}
     second:
       m_TileIndex: 1
@@ -79042,7 +81206,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 69, z: 0}
     second:
       m_TileIndex: 0
@@ -79051,7 +81215,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 69, z: 0}
     second:
       m_TileIndex: 0
@@ -79060,7 +81224,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 69, z: 0}
     second:
       m_TileIndex: 0
@@ -79069,7 +81233,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 69, z: 0}
     second:
       m_TileIndex: 0
@@ -79078,7 +81242,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 69, z: 0}
     second:
       m_TileIndex: 0
@@ -79087,7 +81251,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 69, z: 0}
     second:
       m_TileIndex: 1
@@ -79123,7 +81287,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 69, z: 0}
     second:
       m_TileIndex: 0
@@ -79132,7 +81296,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 69, z: 0}
     second:
       m_TileIndex: 1
@@ -79150,7 +81314,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -79159,7 +81323,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -79168,7 +81332,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -79177,7 +81341,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -79186,7 +81350,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 69, z: 0}
     second:
       m_TileIndex: 1
@@ -79204,7 +81368,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 69, z: 0}
     second:
       m_TileIndex: 1
@@ -79276,7 +81440,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 70, z: 0}
     second:
       m_TileIndex: 1
@@ -79402,7 +81566,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 70, z: 0}
     second:
       m_TileIndex: 0
@@ -79411,7 +81575,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 70, z: 0}
     second:
       m_TileIndex: 0
@@ -79420,7 +81584,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 70, z: 0}
     second:
       m_TileIndex: 0
@@ -79429,7 +81593,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 70, z: 0}
     second:
       m_TileIndex: 1
@@ -79483,7 +81647,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 70, z: 0}
     second:
       m_TileIndex: 1
@@ -79510,7 +81674,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 70, z: 0}
     second:
       m_TileIndex: 1
@@ -79537,7 +81701,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -79591,7 +81755,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 71, z: 0}
     second:
       m_TileIndex: 0
@@ -79600,7 +81764,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 71, z: 0}
     second:
       m_TileIndex: 0
@@ -79609,7 +81773,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -79735,7 +81899,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 71, z: 0}
     second:
       m_TileIndex: 0
@@ -79744,7 +81908,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 71, z: 0}
     second:
       m_TileIndex: 0
@@ -79753,7 +81917,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 71, z: 0}
     second:
       m_TileIndex: 0
@@ -79762,7 +81926,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -79798,7 +81962,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 71, z: 0}
     second:
       m_TileIndex: 0
@@ -79807,7 +81971,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -79834,7 +81998,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -79861,7 +82025,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -79870,7 +82034,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 72, z: 0}
     second:
       m_TileIndex: 1
@@ -79906,7 +82070,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -79915,7 +82079,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 72, z: 0}
     second:
       m_TileIndex: 1
@@ -80068,7 +82232,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -80077,7 +82241,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -80086,7 +82250,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -80095,7 +82259,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -80104,7 +82268,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -80113,7 +82277,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 72, z: 0}
     second:
       m_TileIndex: 1
@@ -80131,7 +82295,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -80140,7 +82304,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -80149,7 +82313,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -80158,7 +82322,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -80167,7 +82331,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 72, z: 0}
     second:
       m_TileIndex: 1
@@ -80185,7 +82349,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -80194,7 +82358,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -80203,7 +82367,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -80212,7 +82376,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -80221,7 +82385,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 72, z: 0}
     second:
       m_TileIndex: 1
@@ -80437,7 +82601,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 73, z: 0}
     second:
       m_TileIndex: 2
@@ -80446,7 +82610,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 73, z: 0}
     second:
       m_TileIndex: 2
@@ -80455,7 +82619,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 73, z: 0}
     second:
       m_TileIndex: 0
@@ -80464,7 +82628,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 73, z: 0}
     second:
       m_TileIndex: 1
@@ -80491,7 +82655,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 73, z: 0}
     second:
       m_TileIndex: 1
@@ -80518,7 +82682,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 74, z: 0}
     second:
       m_TileIndex: 0
@@ -80527,7 +82691,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 74, z: 0}
     second:
       m_TileIndex: 1
@@ -80563,7 +82727,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 74, z: 0}
     second:
       m_TileIndex: 0
@@ -80572,7 +82736,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 74, z: 0}
     second:
       m_TileIndex: 1
@@ -80671,7 +82835,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 74, z: 0}
     second:
       m_TileIndex: 0
@@ -80680,7 +82844,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 74, z: 0}
     second:
       m_TileIndex: 0
@@ -80689,7 +82853,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 75, z: 0}
     second:
       m_TileIndex: 1
@@ -80743,7 +82907,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -80752,7 +82916,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -80761,7 +82925,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 75, z: 0}
     second:
       m_TileIndex: 1
@@ -80842,7 +83006,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -80851,7 +83015,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -80860,7 +83024,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -80869,7 +83033,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -80878,7 +83042,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -80887,7 +83051,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -80896,7 +83060,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -80905,7 +83069,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -80914,7 +83078,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -80923,7 +83087,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -80932,7 +83096,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 76, z: 0}
     second:
       m_TileIndex: 1
@@ -80950,7 +83114,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 76, z: 0}
     second:
       m_TileIndex: 1
@@ -80968,7 +83132,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 76, z: 0}
     second:
       m_TileIndex: 0
@@ -80977,7 +83141,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 76, z: 0}
     second:
       m_TileIndex: 0
@@ -80986,7 +83150,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 77, z: 0}
     second:
       m_TileIndex: 0
@@ -80995,7 +83159,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 77, z: 0}
     second:
       m_TileIndex: 0
@@ -81004,7 +83168,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 78, z: 0}
     second:
       m_TileIndex: 0
@@ -81013,7 +83177,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 79, z: 0}
     second:
       m_TileIndex: 0
@@ -81022,7 +83186,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 80, z: 0}
     second:
       m_TileIndex: 0
@@ -81031,7 +83195,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   m_AnimatedTiles: {}
   m_TileAssetArray:
   - m_RefCount: 487
@@ -85635,7 +87799,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 1, z: 0}
     second:
       m_TileIndex: 3
@@ -85653,7 +87817,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 2, z: 0}
     second:
       m_TileIndex: 3
@@ -85671,7 +87835,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 3, z: 0}
     second:
       m_TileIndex: 0
@@ -85680,7 +87844,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 3, z: 0}
     second:
       m_TileIndex: 0
@@ -85689,7 +87853,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 3, z: 0}
     second:
       m_TileIndex: 0
@@ -85698,7 +87862,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 3, z: 0}
     second:
       m_TileIndex: 3
@@ -85770,7 +87934,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 4, z: 0}
     second:
       m_TileIndex: 3
@@ -85806,7 +87970,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 5, z: 0}
     second:
       m_TileIndex: 3
@@ -85950,7 +88114,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 7, z: 0}
     second:
       m_TileIndex: 3
@@ -85986,7 +88150,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 9, z: 0}
     second:
       m_TileIndex: 3
@@ -86292,7 +88456,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 14, z: 0}
     second:
       m_TileIndex: 1
@@ -86301,7 +88465,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 14, z: 0}
     second:
       m_TileIndex: 3
@@ -86427,7 +88591,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 18, z: 0}
     second:
       m_TileIndex: 3
@@ -87030,7 +89194,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -87039,7 +89203,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -87048,7 +89212,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -87057,7 +89221,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -87066,7 +89230,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -87075,7 +89239,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -87084,7 +89248,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -87093,7 +89257,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -87102,7 +89266,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -87111,7 +89275,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -87120,7 +89284,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -87129,7 +89293,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 34, z: 0}
     second:
       m_TileIndex: 3
@@ -87327,7 +89491,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 38, z: 0}
     second:
       m_TileIndex: 3
@@ -87471,7 +89635,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -87669,7 +89833,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -87678,7 +89842,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -87705,7 +89869,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -87714,7 +89878,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -87768,7 +89932,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -87795,7 +89959,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -87822,7 +89986,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -87840,7 +90004,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -87885,7 +90049,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -87930,7 +90094,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 48, z: 0}
     second:
       m_TileIndex: 0
@@ -87939,7 +90103,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 48, z: 0}
     second:
       m_TileIndex: 0
@@ -87948,7 +90112,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 48, z: 0}
     second:
       m_TileIndex: 0
@@ -87957,7 +90121,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -87975,7 +90139,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 49, z: 0}
     second:
       m_TileIndex: 2
@@ -87984,7 +90148,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -88002,7 +90166,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 50, z: 0}
     second:
       m_TileIndex: 0
@@ -88011,7 +90175,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 50, z: 0}
     second:
       m_TileIndex: 2
@@ -88020,7 +90184,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -88128,7 +90292,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -88164,7 +90328,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 57, z: 0}
     second:
       m_TileIndex: 2
@@ -88173,7 +90337,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 57, z: 0}
     second:
       m_TileIndex: 2
@@ -88182,7 +90346,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -88200,7 +90364,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -88254,7 +90418,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 60, z: 0}
     second:
       m_TileIndex: 0
@@ -88263,7 +90427,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 60, z: 0}
     second:
       m_TileIndex: 2
@@ -88272,7 +90436,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 61, z: 0}
     second:
       m_TileIndex: 2
@@ -88281,7 +90445,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -88317,7 +90481,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 62, z: 0}
     second:
       m_TileIndex: 0
@@ -88326,7 +90490,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 62, z: 0}
     second:
       m_TileIndex: 2
@@ -88335,7 +90499,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 62, z: 0}
     second:
       m_TileIndex: 2
@@ -88344,7 +90508,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -88542,7 +90706,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -88596,7 +90760,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -88821,7 +90985,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 75, z: 0}
     second:
       m_TileIndex: 2
@@ -88830,7 +90994,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 75, z: 0}
     second:
       m_TileIndex: 3

--- a/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
+++ b/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
@@ -6609,7 +6609,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 0, z: 0}
     second:
       m_TileIndex: 0
@@ -6618,7 +6618,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 0, z: 0}
     second:
       m_TileIndex: 0
@@ -6627,7 +6627,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 0, z: 0}
     second:
       m_TileIndex: 0
@@ -6636,7 +6636,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -6717,7 +6717,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 1, z: 0}
     second:
       m_TileIndex: 1
@@ -6897,7 +6897,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 2, z: 0}
     second:
       m_TileIndex: 1
@@ -7239,7 +7239,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 4, z: 0}
     second:
       m_TileIndex: 0
@@ -7248,7 +7248,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 4, z: 0}
     second:
       m_TileIndex: 0
@@ -7257,7 +7257,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 4, z: 0}
     second:
       m_TileIndex: 0
@@ -7266,7 +7266,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 4, z: 0}
     second:
       m_TileIndex: 0
@@ -7275,7 +7275,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 4, z: 0}
     second:
       m_TileIndex: 0
@@ -7284,7 +7284,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 4, z: 0}
     second:
       m_TileIndex: 1
@@ -7329,7 +7329,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 4, z: 0}
     second:
       m_TileIndex: 1
@@ -7482,7 +7482,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 5, z: 0}
     second:
       m_TileIndex: 0
@@ -7491,7 +7491,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 5, z: 0}
     second:
       m_TileIndex: 0
@@ -7500,7 +7500,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 5, z: 0}
     second:
       m_TileIndex: 0
@@ -7509,7 +7509,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 5, z: 0}
     second:
       m_TileIndex: 1
@@ -7707,7 +7707,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 6, z: 0}
     second:
       m_TileIndex: 0
@@ -7716,7 +7716,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 6, z: 0}
     second:
       m_TileIndex: 0
@@ -7725,7 +7725,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 6, z: 0}
     second:
       m_TileIndex: 0
@@ -7734,7 +7734,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 6, z: 0}
     second:
       m_TileIndex: 0
@@ -7743,7 +7743,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 6, z: 0}
     second:
       m_TileIndex: 1
@@ -7869,7 +7869,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 6, z: 0}
     second:
       m_TileIndex: 1
@@ -7887,7 +7887,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 6, z: 0}
     second:
       m_TileIndex: 1
@@ -7941,7 +7941,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -7950,7 +7950,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -7959,7 +7959,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -7968,7 +7968,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -7977,7 +7977,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -7986,7 +7986,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -7995,7 +7995,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -8004,7 +8004,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 7, z: 0}
     second:
       m_TileIndex: 2
@@ -8013,7 +8013,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -8022,7 +8022,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -8031,7 +8031,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -8040,7 +8040,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -8049,7 +8049,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -8058,7 +8058,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -8067,7 +8067,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 7, z: 0}
     second:
       m_TileIndex: 0
@@ -8076,7 +8076,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 7, z: 0}
     second:
       m_TileIndex: 1
@@ -8274,7 +8274,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -8283,7 +8283,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -8292,7 +8292,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -8301,7 +8301,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 8, z: 0}
     second:
       m_TileIndex: 2
@@ -8310,7 +8310,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -8319,7 +8319,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -8328,7 +8328,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -8337,7 +8337,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 8, z: 0}
     second:
       m_TileIndex: 1
@@ -8535,7 +8535,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 9, z: 0}
     second:
       m_TileIndex: 0
@@ -8544,7 +8544,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -8598,7 +8598,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -8652,7 +8652,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 9, z: 0}
     second:
       m_TileIndex: 0
@@ -8661,7 +8661,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -8859,7 +8859,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8868,7 +8868,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8877,7 +8877,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8886,7 +8886,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8895,7 +8895,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8904,7 +8904,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8913,7 +8913,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8922,7 +8922,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8931,7 +8931,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8940,7 +8940,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8949,7 +8949,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8958,7 +8958,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8967,7 +8967,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 10, z: 0}
     second:
       m_TileIndex: 2
@@ -8976,7 +8976,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 10, z: 0}
     second:
       m_TileIndex: 0
@@ -8985,7 +8985,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -9057,7 +9057,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 10, z: 0}
     second:
       m_TileIndex: 0
@@ -9066,7 +9066,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -9129,7 +9129,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 11, z: 0}
     second:
       m_TileIndex: 0
@@ -9138,7 +9138,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 11, z: 0}
     second:
       m_TileIndex: 1
@@ -9192,7 +9192,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 11, z: 0}
     second:
       m_TileIndex: 1
@@ -9246,7 +9246,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 11, z: 0}
     second:
       m_TileIndex: 0
@@ -9255,7 +9255,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 11, z: 0}
     second:
       m_TileIndex: 0
@@ -9264,7 +9264,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 11, z: 0}
     second:
       m_TileIndex: 1
@@ -9282,7 +9282,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 11, z: 0}
     second:
       m_TileIndex: 0
@@ -9291,7 +9291,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 11, z: 0}
     second:
       m_TileIndex: 1
@@ -9309,7 +9309,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 11, z: 0}
     second:
       m_TileIndex: 1
@@ -9327,7 +9327,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 12, z: 0}
     second:
       m_TileIndex: 0
@@ -9336,7 +9336,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 12, z: 0}
     second:
       m_TileIndex: 0
@@ -9345,7 +9345,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 12, z: 0}
     second:
       m_TileIndex: 2
@@ -9354,7 +9354,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 12, z: 0}
     second:
       m_TileIndex: 0
@@ -9363,7 +9363,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 12, z: 0}
     second:
       m_TileIndex: 0
@@ -9372,7 +9372,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 12, z: 0}
     second:
       m_TileIndex: 0
@@ -9381,7 +9381,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 12, z: 0}
     second:
       m_TileIndex: 1
@@ -9399,7 +9399,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 12, z: 0}
     second:
       m_TileIndex: 0
@@ -9408,7 +9408,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 12, z: 0}
     second:
       m_TileIndex: 1
@@ -9426,7 +9426,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 12, z: 0}
     second:
       m_TileIndex: 1
@@ -9444,7 +9444,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -9453,7 +9453,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -9462,7 +9462,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 13, z: 0}
     second:
       m_TileIndex: 1
@@ -9516,7 +9516,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 13, z: 0}
     second:
       m_TileIndex: 1
@@ -9570,7 +9570,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -9579,7 +9579,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 13, z: 0}
     second:
       m_TileIndex: 1
@@ -9597,7 +9597,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -9606,7 +9606,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -9615,7 +9615,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -9624,7 +9624,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -9633,7 +9633,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -9642,7 +9642,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 13, z: 0}
     second:
       m_TileIndex: 1
@@ -9660,7 +9660,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 13, z: 0}
     second:
       m_TileIndex: 0
@@ -9669,7 +9669,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 13, z: 0}
     second:
       m_TileIndex: 1
@@ -9687,7 +9687,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 13, z: 0}
     second:
       m_TileIndex: 1
@@ -9705,7 +9705,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 14, z: 0}
     second:
       m_TileIndex: 0
@@ -9714,7 +9714,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9723,7 +9723,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9732,7 +9732,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9741,7 +9741,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9750,7 +9750,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9759,7 +9759,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9768,7 +9768,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9777,7 +9777,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9786,7 +9786,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9795,7 +9795,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9804,7 +9804,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9813,7 +9813,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9822,7 +9822,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -9831,7 +9831,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 14, z: 0}
     second:
       m_TileIndex: 0
@@ -9840,7 +9840,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 14, z: 0}
     second:
       m_TileIndex: 1
@@ -9903,7 +9903,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 14, z: 0}
     second:
       m_TileIndex: 1
@@ -9921,7 +9921,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 14, z: 0}
     second:
       m_TileIndex: 0
@@ -9930,7 +9930,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 14, z: 0}
     second:
       m_TileIndex: 0
@@ -9939,7 +9939,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 14, z: 0}
     second:
       m_TileIndex: 0
@@ -9948,7 +9948,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 14, z: 0}
     second:
       m_TileIndex: 1
@@ -9966,7 +9966,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 14, z: 0}
     second:
       m_TileIndex: 1
@@ -9984,7 +9984,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 15, z: 0}
     second:
       m_TileIndex: 0
@@ -9993,7 +9993,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 15, z: 0}
     second:
       m_TileIndex: 0
@@ -10002,7 +10002,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 15, z: 0}
     second:
       m_TileIndex: 1
@@ -10056,7 +10056,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 15, z: 0}
     second:
       m_TileIndex: 1
@@ -10110,7 +10110,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 15, z: 0}
     second:
       m_TileIndex: 1
@@ -10263,7 +10263,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 16, z: 0}
     second:
       m_TileIndex: 0
@@ -10272,7 +10272,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 16, z: 0}
     second:
       m_TileIndex: 2
@@ -10281,7 +10281,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 16, z: 0}
     second:
       m_TileIndex: 0
@@ -10290,7 +10290,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 16, z: 0}
     second:
       m_TileIndex: 1
@@ -10443,7 +10443,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 17, z: 0}
     second:
       m_TileIndex: 0
@@ -10452,7 +10452,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 17, z: 0}
     second:
       m_TileIndex: 1
@@ -10506,7 +10506,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 17, z: 0}
     second:
       m_TileIndex: 1
@@ -10560,7 +10560,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 17, z: 0}
     second:
       m_TileIndex: 1
@@ -10713,7 +10713,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10722,7 +10722,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10731,7 +10731,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10740,7 +10740,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10749,7 +10749,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10758,7 +10758,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10767,7 +10767,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10776,7 +10776,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10785,7 +10785,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10794,7 +10794,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10803,7 +10803,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10812,7 +10812,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10821,7 +10821,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -10830,7 +10830,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -10839,7 +10839,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 18, z: 0}
     second:
       m_TileIndex: 1
@@ -10992,7 +10992,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11001,7 +11001,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11010,7 +11010,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11019,7 +11019,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11028,7 +11028,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11037,7 +11037,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11046,7 +11046,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11055,7 +11055,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11064,7 +11064,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11073,7 +11073,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11082,7 +11082,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11091,7 +11091,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11100,7 +11100,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 18, z: 0}
     second:
       m_TileIndex: 1
@@ -11118,7 +11118,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11127,7 +11127,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 18, z: 0}
     second:
       m_TileIndex: 0
@@ -11136,7 +11136,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 19, z: 0}
     second:
       m_TileIndex: 0
@@ -11145,7 +11145,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 19, z: 0}
     second:
       m_TileIndex: 0
@@ -11154,7 +11154,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 19, z: 0}
     second:
       m_TileIndex: 1
@@ -11208,7 +11208,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 19, z: 0}
     second:
       m_TileIndex: 1
@@ -11262,7 +11262,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 19, z: 0}
     second:
       m_TileIndex: 0
@@ -11271,7 +11271,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 19, z: 0}
     second:
       m_TileIndex: 1
@@ -11550,7 +11550,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 19, z: 0}
     second:
       m_TileIndex: 0
@@ -11559,7 +11559,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 19, z: 0}
     second:
       m_TileIndex: 0
@@ -11568,7 +11568,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 19, z: 0}
     second:
       m_TileIndex: 0
@@ -11577,7 +11577,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -11586,7 +11586,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -11595,7 +11595,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -11604,7 +11604,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 20, z: 0}
     second:
       m_TileIndex: 2
@@ -11613,7 +11613,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -11622,7 +11622,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -11631,7 +11631,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 20, z: 0}
     second:
       m_TileIndex: 1
@@ -11901,7 +11901,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 20, z: 0}
     second:
       m_TileIndex: 1
@@ -11928,7 +11928,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -11937,7 +11937,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 20, z: 0}
     second:
       m_TileIndex: 0
@@ -11946,7 +11946,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -11955,7 +11955,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -11964,7 +11964,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -11973,7 +11973,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -11982,7 +11982,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -11991,7 +11991,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12000,7 +12000,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12009,7 +12009,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12018,7 +12018,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -12027,7 +12027,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12036,7 +12036,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12045,7 +12045,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12054,7 +12054,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12063,7 +12063,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12072,7 +12072,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12081,7 +12081,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12090,7 +12090,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 21, z: 0}
     second:
       m_TileIndex: 1
@@ -12243,7 +12243,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12252,7 +12252,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12261,7 +12261,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12270,7 +12270,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12279,7 +12279,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12288,7 +12288,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12297,7 +12297,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12306,7 +12306,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12315,7 +12315,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12324,7 +12324,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12333,7 +12333,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12342,7 +12342,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12351,7 +12351,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12360,7 +12360,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12369,7 +12369,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 21, z: 0}
     second:
       m_TileIndex: 0
@@ -12378,7 +12378,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 21, z: 0}
     second:
       m_TileIndex: 1
@@ -12396,7 +12396,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 22, z: 0}
     second:
       m_TileIndex: 0
@@ -12405,7 +12405,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 22, z: 0}
     second:
       m_TileIndex: 2
@@ -12414,7 +12414,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 22, z: 0}
     second:
       m_TileIndex: 2
@@ -12423,7 +12423,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 22, z: 0}
     second:
       m_TileIndex: 1
@@ -12585,7 +12585,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 22, z: 0}
     second:
       m_TileIndex: 1
@@ -12603,7 +12603,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 22, z: 0}
     second:
       m_TileIndex: 1
@@ -12639,7 +12639,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 23, z: 0}
     second:
       m_TileIndex: 0
@@ -12648,7 +12648,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 23, z: 0}
     second:
       m_TileIndex: 2
@@ -12657,7 +12657,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 23, z: 0}
     second:
       m_TileIndex: 1
@@ -12945,7 +12945,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 24, z: 0}
     second:
       m_TileIndex: 0
@@ -12954,7 +12954,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 24, z: 0}
     second:
       m_TileIndex: 0
@@ -12963,7 +12963,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 24, z: 0}
     second:
       m_TileIndex: 0
@@ -12972,7 +12972,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 24, z: 0}
     second:
       m_TileIndex: 2
@@ -12981,7 +12981,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 24, z: 0}
     second:
       m_TileIndex: 1
@@ -13260,7 +13260,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 25, z: 0}
     second:
       m_TileIndex: 0
@@ -13269,7 +13269,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 25, z: 0}
     second:
       m_TileIndex: 0
@@ -13278,7 +13278,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 25, z: 0}
     second:
       m_TileIndex: 1
@@ -13512,7 +13512,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 25, z: 0}
     second:
       m_TileIndex: 0
@@ -13521,7 +13521,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 25, z: 0}
     second:
       m_TileIndex: 0
@@ -13530,7 +13530,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 25, z: 0}
     second:
       m_TileIndex: 0
@@ -13539,7 +13539,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 26, z: 0}
     second:
       m_TileIndex: 0
@@ -13548,7 +13548,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 26, z: 0}
     second:
       m_TileIndex: 0
@@ -13557,7 +13557,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 26, z: 0}
     second:
       m_TileIndex: 0
@@ -13566,7 +13566,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 26, z: 0}
     second:
       m_TileIndex: 1
@@ -13764,7 +13764,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 26, z: 0}
     second:
       m_TileIndex: 0
@@ -13773,7 +13773,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 27, z: 0}
     second:
       m_TileIndex: 0
@@ -13782,7 +13782,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 27, z: 0}
     second:
       m_TileIndex: 0
@@ -13791,7 +13791,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 27, z: 0}
     second:
       m_TileIndex: 0
@@ -13800,7 +13800,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 27, z: 0}
     second:
       m_TileIndex: 1
@@ -13998,7 +13998,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 27, z: 0}
     second:
       m_TileIndex: 0
@@ -14007,7 +14007,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 27, z: 0}
     second:
       m_TileIndex: 0
@@ -14016,7 +14016,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 27, z: 0}
     second:
       m_TileIndex: 0
@@ -14025,7 +14025,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 27, z: 0}
     second:
       m_TileIndex: 1
@@ -14061,7 +14061,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -14070,7 +14070,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -14079,7 +14079,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 28, z: 0}
     second:
       m_TileIndex: 1
@@ -14277,7 +14277,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -14286,7 +14286,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -14295,7 +14295,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 28, z: 0}
     second:
       m_TileIndex: 1
@@ -14313,7 +14313,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -14322,7 +14322,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 28, z: 0}
     second:
       m_TileIndex: 1
@@ -14376,7 +14376,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -14385,7 +14385,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -14394,7 +14394,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 28, z: 0}
     second:
       m_TileIndex: 0
@@ -14403,7 +14403,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 29, z: 0}
     second:
       m_TileIndex: 0
@@ -14412,7 +14412,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 29, z: 0}
     second:
       m_TileIndex: 0
@@ -14421,7 +14421,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 29, z: 0}
     second:
       m_TileIndex: 0
@@ -14430,7 +14430,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 29, z: 0}
     second:
       m_TileIndex: 1
@@ -14673,7 +14673,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 29, z: 0}
     second:
       m_TileIndex: 0
@@ -14682,7 +14682,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 29, z: 0}
     second:
       m_TileIndex: 1
@@ -14736,7 +14736,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 30, z: 0}
     second:
       m_TileIndex: 0
@@ -14745,7 +14745,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 30, z: 0}
     second:
       m_TileIndex: 0
@@ -14754,7 +14754,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 30, z: 0}
     second:
       m_TileIndex: 1
@@ -15006,7 +15006,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 30, z: 0}
     second:
       m_TileIndex: 2
@@ -15015,7 +15015,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 30, z: 0}
     second:
       m_TileIndex: 2
@@ -15024,7 +15024,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 30, z: 0}
     second:
       m_TileIndex: 2
@@ -15033,7 +15033,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 30, z: 0}
     second:
       m_TileIndex: 1
@@ -15420,7 +15420,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 31, z: 0}
     second:
       m_TileIndex: 1
@@ -15807,7 +15807,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 32, z: 0}
     second:
       m_TileIndex: 1
@@ -16230,7 +16230,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 33, z: 0}
     second:
       m_TileIndex: 0
@@ -16239,7 +16239,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 33, z: 0}
     second:
       m_TileIndex: 1
@@ -16293,7 +16293,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -16527,7 +16527,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 34, z: 0}
     second:
       m_TileIndex: 0
@@ -16536,7 +16536,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -16590,7 +16590,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 34, z: 0}
     second:
       m_TileIndex: 0
@@ -16599,7 +16599,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -16626,7 +16626,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 34, z: 0}
     second:
       m_TileIndex: 0
@@ -16635,7 +16635,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -16653,7 +16653,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 34, z: 0}
     second:
       m_TileIndex: 0
@@ -16662,7 +16662,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 34, z: 0}
     second:
       m_TileIndex: 0
@@ -16671,7 +16671,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -16725,7 +16725,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 35, z: 0}
     second:
       m_TileIndex: 1
@@ -17022,7 +17022,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 35, z: 0}
     second:
       m_TileIndex: 0
@@ -17031,7 +17031,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 35, z: 0}
     second:
       m_TileIndex: 0
@@ -17040,7 +17040,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 35, z: 0}
     second:
       m_TileIndex: 0
@@ -17049,7 +17049,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 35, z: 0}
     second:
       m_TileIndex: 0
@@ -17058,7 +17058,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 35, z: 0}
     second:
       m_TileIndex: 0
@@ -17067,7 +17067,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 35, z: 0}
     second:
       m_TileIndex: 1
@@ -17121,7 +17121,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 36, z: 0}
     second:
       m_TileIndex: 1
@@ -17418,7 +17418,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -17427,7 +17427,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 36, z: 0}
     second:
       m_TileIndex: 1
@@ -17454,7 +17454,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 36, z: 0}
     second:
       m_TileIndex: 0
@@ -17463,7 +17463,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 36, z: 0}
     second:
       m_TileIndex: 0
@@ -17472,7 +17472,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -17481,7 +17481,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -17490,7 +17490,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -17499,7 +17499,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -17508,7 +17508,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -17517,7 +17517,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -17526,7 +17526,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -17535,7 +17535,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -17544,7 +17544,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 37, z: 0}
     second:
       m_TileIndex: 0
@@ -17553,7 +17553,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 37, z: 0}
     second:
       m_TileIndex: 1
@@ -17841,7 +17841,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 37, z: 0}
     second:
       m_TileIndex: 0
@@ -17850,7 +17850,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 37, z: 0}
     second:
       m_TileIndex: 2
@@ -17859,7 +17859,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 37, z: 0}
     second:
       m_TileIndex: 1
@@ -17886,7 +17886,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 37, z: 0}
     second:
       m_TileIndex: 1
@@ -17904,7 +17904,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 37, z: 0}
     second:
       m_TileIndex: 0
@@ -17913,7 +17913,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 37, z: 0}
     second:
       m_TileIndex: 0
@@ -17922,7 +17922,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 38, z: 0}
     second:
       m_TileIndex: 0
@@ -17931,7 +17931,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 38, z: 0}
     second:
       m_TileIndex: 1
@@ -18228,7 +18228,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 38, z: 0}
     second:
       m_TileIndex: 2
@@ -18237,7 +18237,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 38, z: 0}
     second:
       m_TileIndex: 1
@@ -18282,7 +18282,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 38, z: 0}
     second:
       m_TileIndex: 0
@@ -18291,7 +18291,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 38, z: 0}
     second:
       m_TileIndex: 0
@@ -18300,7 +18300,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 39, z: 0}
     second:
       m_TileIndex: 0
@@ -18309,7 +18309,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 39, z: 0}
     second:
       m_TileIndex: 1
@@ -18327,7 +18327,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 39, z: 0}
     second:
       m_TileIndex: 1
@@ -18345,7 +18345,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 39, z: 0}
     second:
       m_TileIndex: 0
@@ -18354,7 +18354,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 39, z: 0}
     second:
       m_TileIndex: 1
@@ -18615,7 +18615,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 39, z: 0}
     second:
       m_TileIndex: 0
@@ -18624,7 +18624,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 39, z: 0}
     second:
       m_TileIndex: 2
@@ -18633,7 +18633,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 39, z: 0}
     second:
       m_TileIndex: 1
@@ -18660,7 +18660,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 39, z: 0}
     second:
       m_TileIndex: 1
@@ -18678,7 +18678,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 39, z: 0}
     second:
       m_TileIndex: 0
@@ -18687,7 +18687,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 39, z: 0}
     second:
       m_TileIndex: 0
@@ -18696,7 +18696,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 39, z: 0}
     second:
       m_TileIndex: 1
@@ -18768,7 +18768,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 40, z: 0}
     second:
       m_TileIndex: 1
@@ -18939,7 +18939,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -18948,7 +18948,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -18957,7 +18957,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -18966,7 +18966,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -18975,7 +18975,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -18984,7 +18984,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -18993,7 +18993,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -19002,7 +19002,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -19011,7 +19011,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -19020,7 +19020,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 40, z: 0}
     second:
       m_TileIndex: 1
@@ -19056,7 +19056,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -19065,7 +19065,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -19074,7 +19074,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 40, z: 0}
     second:
       m_TileIndex: 2
@@ -19083,7 +19083,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 40, z: 0}
     second:
       m_TileIndex: 1
@@ -19128,7 +19128,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 40, z: 0}
     second:
       m_TileIndex: 1
@@ -19200,7 +19200,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -19209,7 +19209,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -19218,7 +19218,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 81, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -19227,7 +19227,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 82, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -19236,7 +19236,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 83, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -19245,7 +19245,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 84, y: 40, z: 0}
     second:
       m_TileIndex: 0
@@ -19254,7 +19254,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 41, z: 0}
     second:
       m_TileIndex: 0
@@ -19263,7 +19263,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 41, z: 0}
     second:
       m_TileIndex: 1
@@ -19434,7 +19434,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -19443,7 +19443,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -19452,7 +19452,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -19461,7 +19461,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -19470,7 +19470,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -19479,7 +19479,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -19488,7 +19488,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -19497,7 +19497,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -19506,7 +19506,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 41, z: 0}
     second:
       m_TileIndex: 1
@@ -19560,7 +19560,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 41, z: 0}
     second:
       m_TileIndex: 0
@@ -19569,7 +19569,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 41, z: 0}
     second:
       m_TileIndex: 0
@@ -19578,7 +19578,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 41, z: 0}
     second:
       m_TileIndex: 1
@@ -19614,7 +19614,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 41, z: 0}
     second:
       m_TileIndex: 0
@@ -19623,7 +19623,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 41, z: 0}
     second:
       m_TileIndex: 0
@@ -19632,7 +19632,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 41, z: 0}
     second:
       m_TileIndex: 1
@@ -19767,7 +19767,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 42, z: 0}
     second:
       m_TileIndex: 1
@@ -19938,7 +19938,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -19947,7 +19947,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -19956,7 +19956,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -19965,7 +19965,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -19974,7 +19974,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -19983,7 +19983,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -19992,7 +19992,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -20001,7 +20001,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 42, z: 0}
     second:
       m_TileIndex: 0
@@ -20010,7 +20010,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 42, z: 0}
     second:
       m_TileIndex: 1
@@ -20307,7 +20307,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 43, z: 0}
     second:
       m_TileIndex: 1
@@ -20586,7 +20586,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 43, z: 0}
     second:
       m_TileIndex: 0
@@ -20595,7 +20595,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 43, z: 0}
     second:
       m_TileIndex: 0
@@ -20604,7 +20604,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 43, z: 0}
     second:
       m_TileIndex: 1
@@ -20622,7 +20622,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 43, z: 0}
     second:
       m_TileIndex: 0
@@ -20631,7 +20631,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 43, z: 0}
     second:
       m_TileIndex: 0
@@ -20640,7 +20640,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 43, z: 0}
     second:
       m_TileIndex: 1
@@ -20730,7 +20730,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 43, z: 0}
     second:
       m_TileIndex: 1
@@ -20766,7 +20766,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -20775,7 +20775,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -20784,7 +20784,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -20793,7 +20793,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -20802,7 +20802,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 44, z: 0}
     second:
       m_TileIndex: 1
@@ -20937,7 +20937,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -20946,7 +20946,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -20955,7 +20955,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -20964,7 +20964,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -20973,7 +20973,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -20982,7 +20982,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -20991,7 +20991,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -21000,7 +21000,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 44, z: 0}
     second:
       m_TileIndex: 1
@@ -21207,7 +21207,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -21216,7 +21216,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -21225,7 +21225,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 44, z: 0}
     second:
       m_TileIndex: 0
@@ -21234,7 +21234,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 44, z: 0}
     second:
       m_TileIndex: 1
@@ -21486,7 +21486,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 45, z: 0}
     second:
       m_TileIndex: 0
@@ -21495,7 +21495,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 45, z: 0}
     second:
       m_TileIndex: 1
@@ -21765,7 +21765,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 45, z: 0}
     second:
       m_TileIndex: 0
@@ -21774,7 +21774,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 45, z: 0}
     second:
       m_TileIndex: 1
@@ -21792,7 +21792,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 76, y: 45, z: 0}
     second:
       m_TileIndex: 0
@@ -21801,7 +21801,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 45, z: 0}
     second:
       m_TileIndex: 0
@@ -21810,7 +21810,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 45, z: 0}
     second:
       m_TileIndex: 1
@@ -21999,7 +21999,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 46, z: 0}
     second:
       m_TileIndex: 0
@@ -22008,7 +22008,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 46, z: 0}
     second:
       m_TileIndex: 1
@@ -22143,7 +22143,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 46, z: 0}
     second:
       m_TileIndex: 1
@@ -22179,7 +22179,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 46, z: 0}
     second:
       m_TileIndex: 1
@@ -22566,7 +22566,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 47, z: 0}
     second:
       m_TileIndex: 1
@@ -22845,7 +22845,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 47, z: 0}
     second:
       m_TileIndex: 0
@@ -22854,7 +22854,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 47, z: 0}
     second:
       m_TileIndex: 1
@@ -22872,7 +22872,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 76, y: 47, z: 0}
     second:
       m_TileIndex: 0
@@ -22881,7 +22881,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 47, z: 0}
     second:
       m_TileIndex: 1
@@ -23097,7 +23097,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 48, z: 0}
     second:
       m_TileIndex: 0
@@ -23106,7 +23106,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 48, z: 0}
     second:
       m_TileIndex: 0
@@ -23115,7 +23115,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 48, z: 0}
     second:
       m_TileIndex: 0
@@ -23124,7 +23124,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 48, z: 0}
     second:
       m_TileIndex: 1
@@ -23475,7 +23475,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 49, z: 0}
     second:
       m_TileIndex: 0
@@ -23484,7 +23484,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 49, z: 0}
     second:
       m_TileIndex: 1
@@ -24006,7 +24006,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 50, z: 0}
     second:
       m_TileIndex: 0
@@ -24015,7 +24015,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 50, z: 0}
     second:
       m_TileIndex: 1
@@ -24510,7 +24510,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 51, z: 0}
     second:
       m_TileIndex: 1
@@ -25140,7 +25140,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 52, z: 0}
     second:
       m_TileIndex: 1
@@ -25779,7 +25779,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 53, z: 0}
     second:
       m_TileIndex: 2
@@ -25788,7 +25788,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 53, z: 0}
     second:
       m_TileIndex: 0
@@ -25797,7 +25797,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 53, z: 0}
     second:
       m_TileIndex: 1
@@ -26427,7 +26427,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 54, z: 0}
     second:
       m_TileIndex: 1
@@ -27066,7 +27066,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 55, z: 0}
     second:
       m_TileIndex: 1
@@ -27705,7 +27705,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 56, z: 0}
     second:
       m_TileIndex: 0
@@ -27714,7 +27714,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 56, z: 0}
     second:
       m_TileIndex: 1
@@ -27750,7 +27750,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 56, z: 0}
     second:
       m_TileIndex: 1
@@ -27768,7 +27768,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 56, z: 0}
     second:
       m_TileIndex: 1
@@ -28155,7 +28155,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 56, z: 0}
     second:
       m_TileIndex: 1
@@ -28353,7 +28353,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 1, y: 57, z: 0}
     second:
       m_TileIndex: 1
@@ -28407,7 +28407,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 57, z: 0}
     second:
       m_TileIndex: 1
@@ -28668,7 +28668,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 57, z: 0}
     second:
       m_TileIndex: 0
@@ -28677,7 +28677,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 57, z: 0}
     second:
       m_TileIndex: 1
@@ -28965,7 +28965,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 58, z: 0}
     second:
       m_TileIndex: 1
@@ -29037,7 +29037,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 58, z: 0}
     second:
       m_TileIndex: 1
@@ -29397,7 +29397,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 58, z: 0}
     second:
       m_TileIndex: 1
@@ -29658,7 +29658,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 59, z: 0}
     second:
       m_TileIndex: 0
@@ -29667,7 +29667,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 59, z: 0}
     second:
       m_TileIndex: 0
@@ -29676,7 +29676,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 59, z: 0}
     second:
       m_TileIndex: 0
@@ -29685,7 +29685,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 59, z: 0}
     second:
       m_TileIndex: 1
@@ -30297,7 +30297,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 60, z: 0}
     second:
       m_TileIndex: 1
@@ -30990,7 +30990,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 61, z: 0}
     second:
       m_TileIndex: 1
@@ -31683,7 +31683,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 62, z: 0}
     second:
       m_TileIndex: 1
@@ -31755,7 +31755,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 62, z: 0}
     second:
       m_TileIndex: 0
@@ -31764,7 +31764,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 62, z: 0}
     second:
       m_TileIndex: 0
@@ -31773,7 +31773,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 62, z: 0}
     second:
       m_TileIndex: 1
@@ -32376,7 +32376,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 63, z: 0}
     second:
       m_TileIndex: 1
@@ -32718,7 +32718,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 63, z: 0}
     second:
       m_TileIndex: 0
@@ -32727,7 +32727,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 63, z: 0}
     second:
       m_TileIndex: 0
@@ -32736,7 +32736,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 63, z: 0}
     second:
       m_TileIndex: 1
@@ -32754,7 +32754,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 63, z: 0}
     second:
       m_TileIndex: 0
@@ -32763,7 +32763,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 63, z: 0}
     second:
       m_TileIndex: 0
@@ -32772,7 +32772,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 63, z: 0}
     second:
       m_TileIndex: 1
@@ -32853,7 +32853,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 63, z: 0}
     second:
       m_TileIndex: 1
@@ -33069,7 +33069,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 63, z: 0}
     second:
       m_TileIndex: 0
@@ -33078,7 +33078,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 64, z: 0}
     second:
       m_TileIndex: 1
@@ -33771,7 +33771,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 81, y: 64, z: 0}
     second:
       m_TileIndex: 0
@@ -33780,7 +33780,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 65, z: 0}
     second:
       m_TileIndex: 1
@@ -33852,7 +33852,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 65, z: 0}
     second:
       m_TileIndex: 0
@@ -33861,7 +33861,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 65, z: 0}
     second:
       m_TileIndex: 0
@@ -33870,7 +33870,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 65, z: 0}
     second:
       m_TileIndex: 1
@@ -34257,7 +34257,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 65, z: 0}
     second:
       m_TileIndex: 0
@@ -34266,7 +34266,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 65, z: 0}
     second:
       m_TileIndex: 1
@@ -34446,7 +34446,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 65, z: 0}
     second:
       m_TileIndex: 0
@@ -34455,7 +34455,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 65, z: 0}
     second:
       m_TileIndex: 1
@@ -34473,7 +34473,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 65, z: 0}
     second:
       m_TileIndex: 0
@@ -34482,7 +34482,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 66, z: 0}
     second:
       m_TileIndex: 1
@@ -34554,7 +34554,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 66, z: 0}
     second:
       m_TileIndex: 1
@@ -34977,7 +34977,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 66, z: 0}
     second:
       m_TileIndex: 1
@@ -35031,7 +35031,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 66, z: 0}
     second:
       m_TileIndex: 0
@@ -35040,7 +35040,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 1, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -35094,7 +35094,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -35364,7 +35364,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 67, z: 0}
     second:
       m_TileIndex: 0
@@ -35373,7 +35373,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -35508,7 +35508,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 67, z: 0}
     second:
       m_TileIndex: 0
@@ -35517,7 +35517,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -35571,7 +35571,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 68, z: 0}
     second:
       m_TileIndex: 0
@@ -35580,7 +35580,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 68, z: 0}
     second:
       m_TileIndex: 1
@@ -35769,7 +35769,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 68, z: 0}
     second:
       m_TileIndex: 0
@@ -35778,7 +35778,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 68, z: 0}
     second:
       m_TileIndex: 1
@@ -35832,7 +35832,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 68, z: 0}
     second:
       m_TileIndex: 0
@@ -35841,7 +35841,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 68, z: 0}
     second:
       m_TileIndex: 1
@@ -35868,7 +35868,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 68, z: 0}
     second:
       m_TileIndex: 1
@@ -35895,7 +35895,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 68, z: 0}
     second:
       m_TileIndex: 1
@@ -35949,7 +35949,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 69, z: 0}
     second:
       m_TileIndex: 1
@@ -36075,7 +36075,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 69, z: 0}
     second:
       m_TileIndex: 0
@@ -36084,7 +36084,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 69, z: 0}
     second:
       m_TileIndex: 0
@@ -36093,7 +36093,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 69, z: 0}
     second:
       m_TileIndex: 0
@@ -36102,7 +36102,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 69, z: 0}
     second:
       m_TileIndex: 0
@@ -36111,7 +36111,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 69, z: 0}
     second:
       m_TileIndex: 0
@@ -36120,7 +36120,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 69, z: 0}
     second:
       m_TileIndex: 1
@@ -36156,7 +36156,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 69, z: 0}
     second:
       m_TileIndex: 0
@@ -36165,7 +36165,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 69, z: 0}
     second:
       m_TileIndex: 1
@@ -36183,7 +36183,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -36192,7 +36192,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -36201,7 +36201,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -36210,7 +36210,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -36219,7 +36219,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 69, z: 0}
     second:
       m_TileIndex: 1
@@ -36237,7 +36237,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 69, z: 0}
     second:
       m_TileIndex: 1
@@ -36309,7 +36309,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 70, z: 0}
     second:
       m_TileIndex: 1
@@ -36435,7 +36435,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 70, z: 0}
     second:
       m_TileIndex: 0
@@ -36444,7 +36444,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 70, z: 0}
     second:
       m_TileIndex: 0
@@ -36453,7 +36453,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 70, z: 0}
     second:
       m_TileIndex: 0
@@ -36462,7 +36462,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 70, z: 0}
     second:
       m_TileIndex: 1
@@ -36516,7 +36516,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 70, z: 0}
     second:
       m_TileIndex: 1
@@ -36543,7 +36543,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 70, z: 0}
     second:
       m_TileIndex: 1
@@ -36570,7 +36570,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -36624,7 +36624,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 71, z: 0}
     second:
       m_TileIndex: 0
@@ -36633,7 +36633,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 71, z: 0}
     second:
       m_TileIndex: 0
@@ -36642,7 +36642,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -36768,7 +36768,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 71, z: 0}
     second:
       m_TileIndex: 0
@@ -36777,7 +36777,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 71, z: 0}
     second:
       m_TileIndex: 0
@@ -36786,7 +36786,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 71, z: 0}
     second:
       m_TileIndex: 0
@@ -36795,7 +36795,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -36831,7 +36831,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 71, z: 0}
     second:
       m_TileIndex: 0
@@ -36840,7 +36840,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -36867,7 +36867,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -36894,7 +36894,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -36903,7 +36903,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 72, z: 0}
     second:
       m_TileIndex: 1
@@ -36939,7 +36939,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -36948,7 +36948,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 72, z: 0}
     second:
       m_TileIndex: 1
@@ -37101,7 +37101,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -37110,7 +37110,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -37119,7 +37119,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -37128,7 +37128,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -37137,7 +37137,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -37146,7 +37146,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 72, z: 0}
     second:
       m_TileIndex: 1
@@ -37164,7 +37164,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -37173,7 +37173,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -37182,7 +37182,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -37191,7 +37191,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 72, z: 0}
     second:
       m_TileIndex: 0
@@ -37200,7 +37200,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 72, z: 0}
     second:
       m_TileIndex: 1
@@ -37218,7 +37218,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -37227,7 +37227,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -37236,7 +37236,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -37245,7 +37245,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -37254,7 +37254,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 72, z: 0}
     second:
       m_TileIndex: 1
@@ -37470,7 +37470,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 73, z: 0}
     second:
       m_TileIndex: 2
@@ -37479,7 +37479,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 73, z: 0}
     second:
       m_TileIndex: 2
@@ -37488,7 +37488,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 73, z: 0}
     second:
       m_TileIndex: 0
@@ -37497,7 +37497,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 73, z: 0}
     second:
       m_TileIndex: 1
@@ -37524,7 +37524,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 73, z: 0}
     second:
       m_TileIndex: 1
@@ -37551,7 +37551,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 74, z: 0}
     second:
       m_TileIndex: 0
@@ -37560,7 +37560,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 74, z: 0}
     second:
       m_TileIndex: 1
@@ -37596,7 +37596,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 74, z: 0}
     second:
       m_TileIndex: 0
@@ -37605,7 +37605,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 74, z: 0}
     second:
       m_TileIndex: 1
@@ -37704,7 +37704,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 74, z: 0}
     second:
       m_TileIndex: 0
@@ -37713,7 +37713,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 74, z: 0}
     second:
       m_TileIndex: 0
@@ -37722,7 +37722,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 75, z: 0}
     second:
       m_TileIndex: 1
@@ -37776,7 +37776,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -37785,7 +37785,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -37794,7 +37794,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 75, z: 0}
     second:
       m_TileIndex: 1
@@ -37875,7 +37875,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -37884,7 +37884,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -37893,7 +37893,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -37902,7 +37902,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -37911,7 +37911,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -37920,7 +37920,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -37929,7 +37929,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -37938,7 +37938,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -37947,7 +37947,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -37956,7 +37956,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 75, z: 0}
     second:
       m_TileIndex: 0
@@ -37965,7 +37965,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 76, z: 0}
     second:
       m_TileIndex: 1
@@ -37983,7 +37983,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 76, z: 0}
     second:
       m_TileIndex: 1
@@ -38001,7 +38001,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 76, z: 0}
     second:
       m_TileIndex: 0
@@ -38010,7 +38010,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 76, z: 0}
     second:
       m_TileIndex: 0
@@ -38019,7 +38019,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 77, z: 0}
     second:
       m_TileIndex: 0
@@ -38028,7 +38028,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 77, z: 0}
     second:
       m_TileIndex: 0
@@ -38037,7 +38037,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 78, z: 0}
     second:
       m_TileIndex: 0
@@ -38046,7 +38046,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 79, z: 0}
     second:
       m_TileIndex: 0
@@ -38055,7 +38055,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 80, z: 0}
     second:
       m_TileIndex: 0
@@ -38064,7 +38064,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   m_AnimatedTiles: {}
   m_TileAssetArray:
   - m_RefCount: 487
@@ -39054,6 +39054,21 @@ Transform:
   m_PrefabParentObject: {fileID: 4505898709889416, guid: 8df037bc1ed3b4d88bb0bee4f4607fd9,
     type: 2}
   m_PrefabInternal: {fileID: 374589977}
+--- !u!1 &375452728
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 2122784268}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2122784269}
+  m_Layer: 0
+  m_Name: Missing Prefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1001 &385281454
 Prefab:
   m_ObjectHideFlags: 0
@@ -48083,8 +48098,11 @@ GameObject:
   - component: {fileID: 817340206}
   - component: {fileID: 817340209}
   - component: {fileID: 817340208}
+  - component: {fileID: 817340212}
+  - component: {fileID: 817340211}
+  - component: {fileID: 817340210}
   - component: {fileID: 817340207}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Structures
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -48175,7 +48193,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -48184,7 +48202,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -48193,7 +48211,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -48202,7 +48220,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -48211,7 +48229,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -48220,7 +48238,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -48229,7 +48247,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -48238,7 +48256,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 0, z: 0}
     second:
       m_TileIndex: 5
@@ -48247,7 +48265,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 0, z: 0}
     second:
       m_TileIndex: 5
@@ -48256,7 +48274,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 0, z: 0}
     second:
       m_TileIndex: 5
@@ -48265,7 +48283,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 0, z: 0}
     second:
       m_TileIndex: 5
@@ -48274,7 +48292,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -48283,7 +48301,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -48292,7 +48310,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -48301,7 +48319,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 0, z: 0}
     second:
       m_TileIndex: 1
@@ -48310,7 +48328,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 0, z: 0}
     second:
       m_TileIndex: 0
@@ -48319,7 +48337,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 1, z: 0}
     second:
       m_TileIndex: 0
@@ -48328,7 +48346,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 1, z: 0}
     second:
       m_TileIndex: 1
@@ -48337,7 +48355,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 1, z: 0}
     second:
       m_TileIndex: 5
@@ -48346,7 +48364,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 1, z: 0}
     second:
       m_TileIndex: 1
@@ -48355,7 +48373,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 1, z: 0}
     second:
       m_TileIndex: 1
@@ -48364,7 +48382,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 1, z: 0}
     second:
       m_TileIndex: 1
@@ -48373,7 +48391,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 1, z: 0}
     second:
       m_TileIndex: 1
@@ -48382,7 +48400,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 1, z: 0}
     second:
       m_TileIndex: 0
@@ -48391,7 +48409,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 2, z: 0}
     second:
       m_TileIndex: 5
@@ -48400,7 +48418,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 2, z: 0}
     second:
       m_TileIndex: 1
@@ -48409,7 +48427,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 2, z: 0}
     second:
       m_TileIndex: 0
@@ -48418,7 +48436,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 2, z: 0}
     second:
       m_TileIndex: 0
@@ -48427,7 +48445,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 3, z: 0}
     second:
       m_TileIndex: 1
@@ -48436,7 +48454,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 3, z: 0}
     second:
       m_TileIndex: 5
@@ -48445,7 +48463,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 4, z: 0}
     second:
       m_TileIndex: 5
@@ -48454,7 +48472,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 4, z: 0}
     second:
       m_TileIndex: 1
@@ -48463,7 +48481,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 4, z: 0}
     second:
       m_TileIndex: 5
@@ -48472,7 +48490,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 5, z: 0}
     second:
       m_TileIndex: 1
@@ -48481,7 +48499,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 5, z: 0}
     second:
       m_TileIndex: 1
@@ -48490,7 +48508,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 5, z: 0}
     second:
       m_TileIndex: 1
@@ -48499,7 +48517,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 5, z: 0}
     second:
       m_TileIndex: 1
@@ -48508,7 +48526,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 5, z: 0}
     second:
       m_TileIndex: 5
@@ -48517,7 +48535,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 6, z: 0}
     second:
       m_TileIndex: 1
@@ -48526,7 +48544,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 6, z: 0}
     second:
       m_TileIndex: 1
@@ -48535,7 +48553,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 6, z: 0}
     second:
       m_TileIndex: 5
@@ -48544,7 +48562,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 6, z: 0}
     second:
       m_TileIndex: 5
@@ -48553,7 +48571,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 6, z: 0}
     second:
       m_TileIndex: 1
@@ -48562,7 +48580,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 6, z: 0}
     second:
       m_TileIndex: 5
@@ -48571,7 +48589,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 7, z: 0}
     second:
       m_TileIndex: 1
@@ -48580,7 +48598,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 7, z: 0}
     second:
       m_TileIndex: 1
@@ -48589,7 +48607,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 7, z: 0}
     second:
       m_TileIndex: 5
@@ -48598,7 +48616,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 8, z: 0}
     second:
       m_TileIndex: 1
@@ -48607,7 +48625,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 8, z: 0}
     second:
       m_TileIndex: 1
@@ -48616,7 +48634,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 8, z: 0}
     second:
       m_TileIndex: 1
@@ -48625,7 +48643,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -48634,7 +48652,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 8, z: 0}
     second:
       m_TileIndex: 0
@@ -48643,7 +48661,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 9, z: 0}
     second:
       m_TileIndex: 0
@@ -48652,7 +48670,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -48661,7 +48679,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -48670,7 +48688,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -48679,7 +48697,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -48688,7 +48706,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -48697,7 +48715,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -48706,7 +48724,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 9, z: 0}
     second:
       m_TileIndex: 1
@@ -48715,7 +48733,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 9, z: 0}
     second:
       m_TileIndex: 0
@@ -48724,7 +48742,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 10, z: 0}
     second:
       m_TileIndex: 0
@@ -48733,7 +48751,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -48742,7 +48760,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -48751,7 +48769,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -48760,7 +48778,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -48769,7 +48787,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -48778,7 +48796,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -48787,7 +48805,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 10, z: 0}
     second:
       m_TileIndex: 5
@@ -48796,7 +48814,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 10, z: 0}
     second:
       m_TileIndex: 5
@@ -48805,7 +48823,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -48814,7 +48832,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -48823,7 +48841,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -48832,7 +48850,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 10, z: 0}
     second:
       m_TileIndex: 1
@@ -48841,7 +48859,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 10, z: 0}
     second:
       m_TileIndex: 0
@@ -48850,7 +48868,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 11, z: 0}
     second:
       m_TileIndex: 2
@@ -48859,7 +48877,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 11, z: 0}
     second:
       m_TileIndex: 2
@@ -48868,7 +48886,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 11, z: 0}
     second:
       m_TileIndex: 2
@@ -48877,7 +48895,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 11, z: 0}
     second:
       m_TileIndex: 2
@@ -48886,7 +48904,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 11, z: 0}
     second:
       m_TileIndex: 2
@@ -48895,7 +48913,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 12, z: 0}
     second:
       m_TileIndex: 2
@@ -48904,7 +48922,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 12, z: 0}
     second:
       m_TileIndex: 2
@@ -48913,7 +48931,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 12, z: 0}
     second:
       m_TileIndex: 2
@@ -48922,7 +48940,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 12, z: 0}
     second:
       m_TileIndex: 2
@@ -48931,7 +48949,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 12, z: 0}
     second:
       m_TileIndex: 2
@@ -48940,7 +48958,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 13, z: 0}
     second:
       m_TileIndex: 3
@@ -48949,7 +48967,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -48958,7 +48976,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -48967,7 +48985,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -48976,7 +48994,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -48985,7 +49003,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -48994,7 +49012,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -49003,7 +49021,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -49012,7 +49030,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -49021,7 +49039,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -49030,7 +49048,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 13, z: 0}
     second:
       m_TileIndex: 2
@@ -49039,7 +49057,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 14, z: 0}
     second:
       m_TileIndex: 3
@@ -49048,7 +49066,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -49057,7 +49075,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -49066,7 +49084,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -49075,7 +49093,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -49084,7 +49102,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -49093,7 +49111,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -49102,7 +49120,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 14, z: 0}
     second:
       m_TileIndex: 2
@@ -49111,7 +49129,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 15, z: 0}
     second:
       m_TileIndex: 3
@@ -49120,7 +49138,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 15, z: 0}
     second:
       m_TileIndex: 3
@@ -49129,7 +49147,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 15, z: 0}
     second:
       m_TileIndex: 3
@@ -49138,7 +49156,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -49147,7 +49165,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -49156,7 +49174,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -49165,7 +49183,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -49174,7 +49192,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -49183,7 +49201,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -49192,7 +49210,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 16, z: 0}
     second:
       m_TileIndex: 3
@@ -49201,7 +49219,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -49210,7 +49228,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -49219,7 +49237,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -49228,7 +49246,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -49237,7 +49255,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -49246,7 +49264,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -49255,7 +49273,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -49264,7 +49282,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 17, z: 0}
     second:
       m_TileIndex: 3
@@ -49273,7 +49291,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 18, z: 0}
     second:
       m_TileIndex: 3
@@ -49282,7 +49300,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 18, z: 0}
     second:
       m_TileIndex: 3
@@ -49291,7 +49309,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 18, z: 0}
     second:
       m_TileIndex: 3
@@ -49300,7 +49318,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 18, z: 0}
     second:
       m_TileIndex: 3
@@ -49309,7 +49327,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 18, z: 0}
     second:
       m_TileIndex: 3
@@ -49318,7 +49336,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -49327,7 +49345,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -49336,7 +49354,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -49345,7 +49363,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -49354,7 +49372,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -49363,7 +49381,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -49372,7 +49390,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -49381,7 +49399,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -49390,7 +49408,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 18, z: 0}
     second:
       m_TileIndex: 2
@@ -49399,7 +49417,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 19, z: 0}
     second:
       m_TileIndex: 3
@@ -49408,7 +49426,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 19, z: 0}
     second:
       m_TileIndex: 3
@@ -49417,7 +49435,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 19, z: 0}
     second:
       m_TileIndex: 3
@@ -49426,7 +49444,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -49435,7 +49453,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -49444,7 +49462,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -49453,7 +49471,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -49462,7 +49480,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -49471,7 +49489,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -49480,7 +49498,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -49489,7 +49507,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -49498,7 +49516,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 20, z: 0}
     second:
       m_TileIndex: 3
@@ -49507,7 +49525,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 21, z: 0}
     second:
       m_TileIndex: 3
@@ -49516,7 +49534,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 21, z: 0}
     second:
       m_TileIndex: 3
@@ -49525,7 +49543,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 21, z: 0}
     second:
       m_TileIndex: 3
@@ -49534,7 +49552,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -49543,7 +49561,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -49552,7 +49570,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -49561,7 +49579,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -49570,7 +49588,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -49579,7 +49597,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -49588,7 +49606,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -49597,7 +49615,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -49606,7 +49624,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -49615,7 +49633,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -49624,7 +49642,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 21, z: 0}
     second:
       m_TileIndex: 2
@@ -49633,7 +49651,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49642,7 +49660,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49651,7 +49669,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49660,7 +49678,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49669,7 +49687,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49678,7 +49696,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49687,7 +49705,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49696,7 +49714,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49705,7 +49723,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49714,7 +49732,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49723,7 +49741,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49732,7 +49750,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49741,7 +49759,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 22, z: 0}
     second:
       m_TileIndex: 2
@@ -49750,7 +49768,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49759,7 +49777,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 22, z: 0}
     second:
       m_TileIndex: 2
@@ -49768,7 +49786,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 22, z: 0}
     second:
       m_TileIndex: 3
@@ -49777,7 +49795,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 22, z: 0}
     second:
       m_TileIndex: 1
@@ -49786,7 +49804,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 22, z: 0}
     second:
       m_TileIndex: 1
@@ -49795,7 +49813,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 22, z: 0}
     second:
       m_TileIndex: 0
@@ -49804,7 +49822,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -49813,7 +49831,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -49822,7 +49840,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -49831,7 +49849,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -49840,7 +49858,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -49849,7 +49867,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -49858,7 +49876,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -49867,7 +49885,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -49876,7 +49894,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 23, z: 0}
     second:
       m_TileIndex: 3
@@ -49885,7 +49903,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 23, z: 0}
     second:
       m_TileIndex: 5
@@ -49894,7 +49912,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 24, z: 0}
     second:
       m_TileIndex: 3
@@ -49903,7 +49921,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 24, z: 0}
     second:
       m_TileIndex: 3
@@ -49912,7 +49930,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 24, z: 0}
     second:
       m_TileIndex: 3
@@ -49921,7 +49939,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 24, z: 0}
     second:
       m_TileIndex: 3
@@ -49930,7 +49948,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 24, z: 0}
     second:
       m_TileIndex: 1
@@ -49939,7 +49957,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 24, z: 0}
     second:
       m_TileIndex: 1
@@ -49948,7 +49966,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 24, z: 0}
     second:
       m_TileIndex: 0
@@ -49957,7 +49975,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -49966,7 +49984,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -49975,7 +49993,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -49984,7 +50002,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -49993,7 +50011,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -50002,7 +50020,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -50011,7 +50029,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 25, z: 0}
     second:
       m_TileIndex: 3
@@ -50020,7 +50038,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 25, z: 0}
     second:
       m_TileIndex: 2
@@ -50029,7 +50047,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 25, z: 0}
     second:
       m_TileIndex: 2
@@ -50038,7 +50056,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 25, z: 0}
     second:
       m_TileIndex: 2
@@ -50047,7 +50065,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 26, z: 0}
     second:
       m_TileIndex: 3
@@ -50056,7 +50074,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 26, z: 0}
     second:
       m_TileIndex: 3
@@ -50065,7 +50083,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 26, z: 0}
     second:
       m_TileIndex: 3
@@ -50074,7 +50092,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 26, z: 0}
     second:
       m_TileIndex: 2
@@ -50083,7 +50101,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 27, z: 0}
     second:
       m_TileIndex: 3
@@ -50092,7 +50110,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 27, z: 0}
     second:
       m_TileIndex: 3
@@ -50101,7 +50119,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 27, z: 0}
     second:
       m_TileIndex: 3
@@ -50110,7 +50128,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 27, z: 0}
     second:
       m_TileIndex: 2
@@ -50119,7 +50137,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 27, z: 0}
     second:
       m_TileIndex: 2
@@ -50128,7 +50146,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 27, z: 0}
     second:
       m_TileIndex: 2
@@ -50137,7 +50155,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 27, z: 0}
     second:
       m_TileIndex: 2
@@ -50146,7 +50164,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 27, z: 0}
     second:
       m_TileIndex: 4
@@ -50155,7 +50173,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 27, z: 0}
     second:
       m_TileIndex: 4
@@ -50164,7 +50182,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 27, z: 0}
     second:
       m_TileIndex: 4
@@ -50173,7 +50191,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 28, z: 0}
     second:
       m_TileIndex: 3
@@ -50182,7 +50200,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 28, z: 0}
     second:
       m_TileIndex: 3
@@ -50191,7 +50209,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 28, z: 0}
     second:
       m_TileIndex: 3
@@ -50200,7 +50218,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 28, z: 0}
     second:
       m_TileIndex: 2
@@ -50209,7 +50227,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 28, z: 0}
     second:
       m_TileIndex: 2
@@ -50218,7 +50236,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 28, z: 0}
     second:
       m_TileIndex: 2
@@ -50227,7 +50245,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 28, z: 0}
     second:
       m_TileIndex: 2
@@ -50236,7 +50254,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 28, z: 0}
     second:
       m_TileIndex: 2
@@ -50245,7 +50263,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 28, z: 0}
     second:
       m_TileIndex: 4
@@ -50254,7 +50272,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 28, z: 0}
     second:
       m_TileIndex: 4
@@ -50263,7 +50281,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 28, z: 0}
     second:
       m_TileIndex: 4
@@ -50272,7 +50290,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 28, z: 0}
     second:
       m_TileIndex: 4
@@ -50281,7 +50299,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 29, z: 0}
     second:
       m_TileIndex: 3
@@ -50290,7 +50308,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 29, z: 0}
     second:
       m_TileIndex: 3
@@ -50299,7 +50317,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 29, z: 0}
     second:
       m_TileIndex: 3
@@ -50308,7 +50326,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 29, z: 0}
     second:
       m_TileIndex: 3
@@ -50317,7 +50335,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 29, z: 0}
     second:
       m_TileIndex: 2
@@ -50326,7 +50344,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 29, z: 0}
     second:
       m_TileIndex: 2
@@ -50335,7 +50353,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 29, z: 0}
     second:
       m_TileIndex: 4
@@ -50344,7 +50362,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 29, z: 0}
     second:
       m_TileIndex: 4
@@ -50353,7 +50371,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 30, z: 0}
     second:
       m_TileIndex: 3
@@ -50362,7 +50380,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 30, z: 0}
     second:
       m_TileIndex: 3
@@ -50371,7 +50389,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 30, z: 0}
     second:
       m_TileIndex: 3
@@ -50380,7 +50398,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 30, z: 0}
     second:
       m_TileIndex: 2
@@ -50389,7 +50407,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 30, z: 0}
     second:
       m_TileIndex: 4
@@ -50398,7 +50416,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 30, z: 0}
     second:
       m_TileIndex: 4
@@ -50407,7 +50425,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50416,7 +50434,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50425,7 +50443,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50434,7 +50452,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50443,7 +50461,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50452,7 +50470,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50461,7 +50479,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50470,7 +50488,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50479,7 +50497,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50488,7 +50506,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50497,7 +50515,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50506,7 +50524,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50515,7 +50533,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50524,7 +50542,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 31, z: 0}
     second:
       m_TileIndex: 3
@@ -50533,7 +50551,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 31, z: 0}
     second:
       m_TileIndex: 2
@@ -50542,7 +50560,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 31, z: 0}
     second:
       m_TileIndex: 4
@@ -50551,7 +50569,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 31, z: 0}
     second:
       m_TileIndex: 4
@@ -50560,7 +50578,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 32, z: 0}
     second:
       m_TileIndex: 3
@@ -50569,7 +50587,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 32, z: 0}
     second:
       m_TileIndex: 3
@@ -50578,7 +50596,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 32, z: 0}
     second:
       m_TileIndex: 3
@@ -50587,7 +50605,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 32, z: 0}
     second:
       m_TileIndex: 2
@@ -50596,7 +50614,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 32, z: 0}
     second:
       m_TileIndex: 4
@@ -50605,7 +50623,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 32, z: 0}
     second:
       m_TileIndex: 4
@@ -50614,7 +50632,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50623,7 +50641,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50632,7 +50650,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50641,7 +50659,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50650,7 +50668,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50659,7 +50677,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50668,7 +50686,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50677,7 +50695,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50686,7 +50704,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50695,7 +50713,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50704,7 +50722,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50713,7 +50731,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50722,7 +50740,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50731,7 +50749,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50740,7 +50758,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50749,7 +50767,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50758,7 +50776,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50767,7 +50785,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 33, z: 0}
     second:
       m_TileIndex: 3
@@ -50776,7 +50794,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 33, z: 0}
     second:
       m_TileIndex: 2
@@ -50785,7 +50803,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 33, z: 0}
     second:
       m_TileIndex: 2
@@ -50794,7 +50812,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 33, z: 0}
     second:
       m_TileIndex: 4
@@ -50803,7 +50821,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 33, z: 0}
     second:
       m_TileIndex: 4
@@ -50812,7 +50830,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -50821,7 +50839,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 34, z: 0}
     second:
       m_TileIndex: 3
@@ -50830,7 +50848,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -50839,7 +50857,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -50848,7 +50866,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -50857,7 +50875,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -50866,7 +50884,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -50875,7 +50893,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -50884,7 +50902,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -50893,7 +50911,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -50902,7 +50920,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -50911,7 +50929,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -50920,7 +50938,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 34, z: 0}
     second:
       m_TileIndex: 3
@@ -50929,7 +50947,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 34, z: 0}
     second:
       m_TileIndex: 3
@@ -50938,7 +50956,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -50947,7 +50965,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -50956,7 +50974,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 34, z: 0}
     second:
       m_TileIndex: 3
@@ -50965,7 +50983,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 34, z: 0}
     second:
       m_TileIndex: 3
@@ -50974,7 +50992,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -50983,7 +51001,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -50992,7 +51010,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -51001,7 +51019,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 34, z: 0}
     second:
       m_TileIndex: 2
@@ -51010,7 +51028,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -51019,7 +51037,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 34, z: 0}
     second:
       m_TileIndex: 4
@@ -51028,7 +51046,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 35, z: 0}
     second:
       m_TileIndex: 2
@@ -51037,7 +51055,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 35, z: 0}
     second:
       m_TileIndex: 3
@@ -51046,7 +51064,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 35, z: 0}
     second:
       m_TileIndex: 4
@@ -51055,7 +51073,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 35, z: 0}
     second:
       m_TileIndex: 3
@@ -51064,7 +51082,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 35, z: 0}
     second:
       m_TileIndex: 3
@@ -51073,7 +51091,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 35, z: 0}
     second:
       m_TileIndex: 2
@@ -51082,7 +51100,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 35, z: 0}
     second:
       m_TileIndex: 2
@@ -51091,7 +51109,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 35, z: 0}
     second:
       m_TileIndex: 2
@@ -51100,7 +51118,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 35, z: 0}
     second:
       m_TileIndex: 4
@@ -51109,7 +51127,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 35, z: 0}
     second:
       m_TileIndex: 4
@@ -51118,7 +51136,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 35, z: 0}
     second:
       m_TileIndex: 4
@@ -51127,7 +51145,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 35, z: 0}
     second:
       m_TileIndex: 4
@@ -51136,7 +51154,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -51145,7 +51163,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 36, z: 0}
     second:
       m_TileIndex: 3
@@ -51154,7 +51172,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 36, z: 0}
     second:
       m_TileIndex: 4
@@ -51163,7 +51181,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 36, z: 0}
     second:
       m_TileIndex: 4
@@ -51172,7 +51190,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 36, z: 0}
     second:
       m_TileIndex: 3
@@ -51181,7 +51199,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 36, z: 0}
     second:
       m_TileIndex: 3
@@ -51190,7 +51208,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -51199,7 +51217,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -51208,7 +51226,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 36, z: 0}
     second:
       m_TileIndex: 2
@@ -51217,7 +51235,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 37, z: 0}
     second:
       m_TileIndex: 2
@@ -51226,7 +51244,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 37, z: 0}
     second:
       m_TileIndex: 3
@@ -51235,7 +51253,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 37, z: 0}
     second:
       m_TileIndex: 4
@@ -51244,7 +51262,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 37, z: 0}
     second:
       m_TileIndex: 2
@@ -51253,7 +51271,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 37, z: 0}
     second:
       m_TileIndex: 3
@@ -51262,7 +51280,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 37, z: 0}
     second:
       m_TileIndex: 2
@@ -51271,7 +51289,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 37, z: 0}
     second:
       m_TileIndex: 2
@@ -51280,7 +51298,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 38, z: 0}
     second:
       m_TileIndex: 2
@@ -51289,7 +51307,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 38, z: 0}
     second:
       m_TileIndex: 3
@@ -51298,7 +51316,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 38, z: 0}
     second:
       m_TileIndex: 4
@@ -51307,7 +51325,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 38, z: 0}
     second:
       m_TileIndex: 4
@@ -51316,7 +51334,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 38, z: 0}
     second:
       m_TileIndex: 3
@@ -51325,7 +51343,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 38, z: 0}
     second:
       m_TileIndex: 3
@@ -51334,7 +51352,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 38, z: 0}
     second:
       m_TileIndex: 4
@@ -51343,7 +51361,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 38, z: 0}
     second:
       m_TileIndex: 2
@@ -51352,7 +51370,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51361,7 +51379,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 39, z: 0}
     second:
       m_TileIndex: 2
@@ -51370,7 +51388,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 39, z: 0}
     second:
       m_TileIndex: 2
@@ -51379,7 +51397,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 39, z: 0}
     second:
       m_TileIndex: 2
@@ -51388,7 +51406,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51397,7 +51415,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51406,7 +51424,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51415,7 +51433,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51424,7 +51442,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51433,7 +51451,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51442,7 +51460,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51451,7 +51469,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51460,7 +51478,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51469,7 +51487,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51478,7 +51496,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51487,7 +51505,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51496,7 +51514,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51505,7 +51523,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51514,7 +51532,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51523,7 +51541,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51532,7 +51550,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51541,7 +51559,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51550,7 +51568,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51559,7 +51577,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51568,7 +51586,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51577,7 +51595,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51586,7 +51604,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51595,7 +51613,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 39, z: 0}
     second:
       m_TileIndex: 3
@@ -51604,7 +51622,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 39, z: 0}
     second:
       m_TileIndex: 2
@@ -51613,7 +51631,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 39, z: 0}
     second:
       m_TileIndex: 2
@@ -51622,7 +51640,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51631,7 +51649,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51640,7 +51658,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51649,7 +51667,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51658,7 +51676,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51667,7 +51685,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 76, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51676,7 +51694,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 39, z: 0}
     second:
       m_TileIndex: 4
@@ -51685,7 +51703,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 40, z: 0}
     second:
       m_TileIndex: 2
@@ -51694,7 +51712,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 40, z: 0}
     second:
       m_TileIndex: 3
@@ -51703,7 +51721,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 40, z: 0}
     second:
       m_TileIndex: 3
@@ -51712,7 +51730,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 40, z: 0}
     second:
       m_TileIndex: 2
@@ -51721,7 +51739,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 40, z: 0}
     second:
       m_TileIndex: 2
@@ -51730,7 +51748,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 40, z: 0}
     second:
       m_TileIndex: 3
@@ -51739,7 +51757,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 40, z: 0}
     second:
       m_TileIndex: 2
@@ -51748,7 +51766,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 40, z: 0}
     second:
       m_TileIndex: 4
@@ -51757,7 +51775,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 40, z: 0}
     second:
       m_TileIndex: 4
@@ -51766,7 +51784,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -51775,7 +51793,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51784,7 +51802,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51793,7 +51811,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51802,7 +51820,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51811,7 +51829,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51820,7 +51838,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51829,7 +51847,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51838,7 +51856,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51847,7 +51865,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51856,7 +51874,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51865,7 +51883,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51874,7 +51892,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51883,7 +51901,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51892,7 +51910,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51901,7 +51919,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51910,7 +51928,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -51919,7 +51937,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -51928,7 +51946,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 41, z: 0}
     second:
       m_TileIndex: 2
@@ -51937,7 +51955,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51946,7 +51964,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51955,7 +51973,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51964,7 +51982,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51973,7 +51991,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51982,7 +52000,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 41, z: 0}
     second:
       m_TileIndex: 3
@@ -51991,7 +52009,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 41, z: 0}
     second:
       m_TileIndex: 4
@@ -52000,7 +52018,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 41, z: 0}
     second:
       m_TileIndex: 4
@@ -52009,7 +52027,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 42, z: 0}
     second:
       m_TileIndex: 2
@@ -52018,7 +52036,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -52027,7 +52045,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -52036,7 +52054,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -52045,7 +52063,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -52054,7 +52072,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -52063,7 +52081,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -52072,7 +52090,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -52081,7 +52099,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -52090,7 +52108,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -52099,7 +52117,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -52108,7 +52126,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 42, z: 0}
     second:
       m_TileIndex: 3
@@ -52117,7 +52135,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 42, z: 0}
     second:
       m_TileIndex: 4
@@ -52126,7 +52144,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 42, z: 0}
     second:
       m_TileIndex: 4
@@ -52135,7 +52153,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 42, z: 0}
     second:
       m_TileIndex: 4
@@ -52144,7 +52162,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 42, z: 0}
     second:
       m_TileIndex: 4
@@ -52153,7 +52171,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 42, z: 0}
     second:
       m_TileIndex: 4
@@ -52162,7 +52180,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -52171,7 +52189,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -52180,7 +52198,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -52189,7 +52207,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -52198,7 +52216,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -52207,7 +52225,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -52216,7 +52234,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 43, z: 0}
     second:
       m_TileIndex: 4
@@ -52225,7 +52243,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -52234,7 +52252,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -52243,7 +52261,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -52252,7 +52270,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 43, z: 0}
     second:
       m_TileIndex: 4
@@ -52261,7 +52279,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -52270,7 +52288,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -52279,7 +52297,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -52288,7 +52306,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 43, z: 0}
     second:
       m_TileIndex: 4
@@ -52297,7 +52315,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -52306,7 +52324,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 43, z: 0}
     second:
       m_TileIndex: 4
@@ -52315,7 +52333,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 43, z: 0}
     second:
       m_TileIndex: 2
@@ -52324,7 +52342,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 43, z: 0}
     second:
       m_TileIndex: 4
@@ -52333,7 +52351,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52342,7 +52360,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52351,7 +52369,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52360,7 +52378,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52369,7 +52387,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52378,7 +52396,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 44, z: 0}
     second:
       m_TileIndex: 3
@@ -52387,7 +52405,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 44, z: 0}
     second:
       m_TileIndex: 3
@@ -52396,7 +52414,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 44, z: 0}
     second:
       m_TileIndex: 3
@@ -52405,7 +52423,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 44, z: 0}
     second:
       m_TileIndex: 3
@@ -52414,7 +52432,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52423,7 +52441,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52432,7 +52450,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52441,7 +52459,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52450,7 +52468,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52459,7 +52477,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52468,7 +52486,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52477,7 +52495,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 44, z: 0}
     second:
       m_TileIndex: 2
@@ -52486,7 +52504,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 44, z: 0}
     second:
       m_TileIndex: 3
@@ -52495,7 +52513,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -52504,7 +52522,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -52513,7 +52531,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -52522,7 +52540,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -52531,7 +52549,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -52540,7 +52558,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -52549,7 +52567,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -52558,7 +52576,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -52567,7 +52585,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -52576,7 +52594,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -52585,7 +52603,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 44, z: 0}
     second:
       m_TileIndex: 3
@@ -52594,7 +52612,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -52603,7 +52621,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 44, z: 0}
     second:
       m_TileIndex: 4
@@ -52612,7 +52630,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -52621,7 +52639,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -52630,7 +52648,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -52639,7 +52657,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -52648,7 +52666,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -52657,7 +52675,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -52666,7 +52684,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -52675,7 +52693,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52684,7 +52702,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52693,7 +52711,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52702,7 +52720,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52711,7 +52729,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52720,7 +52738,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52729,7 +52747,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52738,7 +52756,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -52747,7 +52765,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52756,7 +52774,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52765,7 +52783,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52774,7 +52792,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52783,7 +52801,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52792,7 +52810,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -52801,7 +52819,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -52810,7 +52828,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -52819,7 +52837,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 76, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -52828,7 +52846,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -52837,7 +52855,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 45, z: 0}
     second:
       m_TileIndex: 4
@@ -52846,7 +52864,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -52855,7 +52873,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -52864,7 +52882,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -52873,7 +52891,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 46, z: 0}
     second:
       m_TileIndex: 2
@@ -52882,7 +52900,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 46, z: 0}
     second:
       m_TileIndex: 2
@@ -52891,7 +52909,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -52900,7 +52918,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -52909,7 +52927,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -52918,7 +52936,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -52927,7 +52945,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -52936,7 +52954,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 46, z: 0}
     second:
       m_TileIndex: 2
@@ -52945,7 +52963,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -52954,7 +52972,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -52963,7 +52981,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 46, z: 0}
     second:
       m_TileIndex: 2
@@ -52972,7 +52990,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -52981,7 +52999,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -52990,7 +53008,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -52999,7 +53017,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -53008,7 +53026,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -53017,7 +53035,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -53026,7 +53044,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -53035,7 +53053,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -53044,7 +53062,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 46, z: 0}
     second:
       m_TileIndex: 4
@@ -53053,7 +53071,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53062,7 +53080,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53071,7 +53089,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53080,7 +53098,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53089,7 +53107,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53098,7 +53116,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53107,7 +53125,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53116,7 +53134,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53125,7 +53143,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53134,7 +53152,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53143,7 +53161,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 47, z: 0}
     second:
       m_TileIndex: 2
@@ -53152,7 +53170,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53161,7 +53179,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53170,7 +53188,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -53179,7 +53197,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -53188,7 +53206,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -53197,7 +53215,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -53206,7 +53224,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -53215,7 +53233,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -53224,7 +53242,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 47, z: 0}
     second:
       m_TileIndex: 2
@@ -53233,7 +53251,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 47, z: 0}
     second:
       m_TileIndex: 2
@@ -53242,7 +53260,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 47, z: 0}
     second:
       m_TileIndex: 2
@@ -53251,7 +53269,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 76, y: 47, z: 0}
     second:
       m_TileIndex: 2
@@ -53260,7 +53278,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -53269,7 +53287,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -53278,7 +53296,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 47, z: 0}
     second:
       m_TileIndex: 4
@@ -53287,7 +53305,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -53296,7 +53314,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -53305,7 +53323,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -53314,7 +53332,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 48, z: 0}
     second:
       m_TileIndex: 2
@@ -53323,7 +53341,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 48, z: 0}
     second:
       m_TileIndex: 2
@@ -53332,7 +53350,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 48, z: 0}
     second:
       m_TileIndex: 2
@@ -53341,7 +53359,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 48, z: 0}
     second:
       m_TileIndex: 2
@@ -53350,7 +53368,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -53359,7 +53377,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -53368,7 +53386,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -53377,7 +53395,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -53386,7 +53404,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -53395,7 +53413,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -53404,7 +53422,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -53413,7 +53431,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -53422,7 +53440,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -53431,7 +53449,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 48, z: 0}
     second:
       m_TileIndex: 4
@@ -53440,7 +53458,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 48, z: 0}
     second:
       m_TileIndex: 2
@@ -53449,7 +53467,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -53458,7 +53476,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -53467,7 +53485,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -53476,7 +53494,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -53485,7 +53503,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -53494,7 +53512,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -53503,7 +53521,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -53512,7 +53530,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -53521,7 +53539,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -53530,7 +53548,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -53539,7 +53557,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -53548,7 +53566,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -53557,7 +53575,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -53566,7 +53584,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -53575,7 +53593,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -53584,7 +53602,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 49, z: 0}
     second:
       m_TileIndex: 4
@@ -53593,7 +53611,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 49, z: 0}
     second:
       m_TileIndex: 2
@@ -53602,7 +53620,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -53611,7 +53629,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -53620,7 +53638,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -53629,7 +53647,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -53638,7 +53656,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -53647,7 +53665,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -53656,7 +53674,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -53665,7 +53683,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -53674,7 +53692,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -53683,7 +53701,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 50, z: 0}
     second:
       m_TileIndex: 4
@@ -53692,7 +53710,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 50, z: 0}
     second:
       m_TileIndex: 4
@@ -53701,7 +53719,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 50, z: 0}
     second:
       m_TileIndex: 4
@@ -53710,7 +53728,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -53719,7 +53737,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 50, z: 0}
     second:
       m_TileIndex: 4
@@ -53728,7 +53746,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 50, z: 0}
     second:
       m_TileIndex: 4
@@ -53737,7 +53755,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 50, z: 0}
     second:
       m_TileIndex: 2
@@ -53746,7 +53764,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53755,7 +53773,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53764,7 +53782,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53773,7 +53791,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53782,7 +53800,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53791,7 +53809,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53800,7 +53818,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53809,7 +53827,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53818,7 +53836,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53827,7 +53845,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53836,7 +53854,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53845,7 +53863,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53854,7 +53872,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53863,7 +53881,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53872,7 +53890,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53881,7 +53899,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53890,7 +53908,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53899,7 +53917,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53908,7 +53926,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53917,7 +53935,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53926,7 +53944,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53935,7 +53953,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53944,7 +53962,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53953,7 +53971,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53962,7 +53980,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53971,7 +53989,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53980,7 +53998,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53989,7 +54007,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -53998,7 +54016,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -54007,7 +54025,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -54016,7 +54034,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -54025,7 +54043,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54034,7 +54052,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54043,7 +54061,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54052,7 +54070,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54061,7 +54079,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54070,7 +54088,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54079,7 +54097,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54088,7 +54106,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54097,7 +54115,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54106,7 +54124,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54115,7 +54133,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54124,7 +54142,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54133,7 +54151,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54142,7 +54160,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54151,7 +54169,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54160,7 +54178,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -54169,7 +54187,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -54178,7 +54196,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 51, z: 0}
     second:
       m_TileIndex: 3
@@ -54187,7 +54205,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54196,7 +54214,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54205,7 +54223,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54214,7 +54232,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54223,7 +54241,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54232,7 +54250,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 51, z: 0}
     second:
       m_TileIndex: 4
@@ -54241,7 +54259,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 51, z: 0}
     second:
       m_TileIndex: 2
@@ -54250,7 +54268,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 52, z: 0}
     second:
       m_TileIndex: 3
@@ -54259,7 +54277,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 52, z: 0}
     second:
       m_TileIndex: 3
@@ -54268,7 +54286,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 52, z: 0}
     second:
       m_TileIndex: 3
@@ -54277,7 +54295,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 52, z: 0}
     second:
       m_TileIndex: 4
@@ -54286,7 +54304,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 52, z: 0}
     second:
       m_TileIndex: 2
@@ -54295,7 +54313,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 53, z: 0}
     second:
       m_TileIndex: 2
@@ -54304,7 +54322,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 53, z: 0}
     second:
       m_TileIndex: 3
@@ -54313,7 +54331,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 53, z: 0}
     second:
       m_TileIndex: 2
@@ -54322,7 +54340,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 53, z: 0}
     second:
       m_TileIndex: 3
@@ -54331,7 +54349,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 53, z: 0}
     second:
       m_TileIndex: 2
@@ -54340,7 +54358,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -54349,7 +54367,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -54358,7 +54376,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -54367,7 +54385,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -54376,7 +54394,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -54385,7 +54403,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -54394,7 +54412,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -54403,7 +54421,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 54, z: 0}
     second:
       m_TileIndex: 3
@@ -54412,7 +54430,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 54, z: 0}
     second:
       m_TileIndex: 4
@@ -54421,7 +54439,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 54, z: 0}
     second:
       m_TileIndex: 2
@@ -54430,7 +54448,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54439,7 +54457,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54448,7 +54466,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54457,7 +54475,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54466,7 +54484,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54475,7 +54493,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54484,7 +54502,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54493,7 +54511,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54502,7 +54520,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54511,7 +54529,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54520,7 +54538,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54529,7 +54547,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54538,7 +54556,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54547,7 +54565,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54556,7 +54574,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54565,7 +54583,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54574,7 +54592,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54583,7 +54601,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54592,7 +54610,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54601,7 +54619,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54610,7 +54628,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54619,7 +54637,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54628,7 +54646,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54637,7 +54655,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54646,7 +54664,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54655,7 +54673,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54664,7 +54682,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54673,7 +54691,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54682,7 +54700,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54691,7 +54709,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54700,7 +54718,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54709,7 +54727,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54718,7 +54736,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54727,7 +54745,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54736,7 +54754,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54745,7 +54763,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54754,7 +54772,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54763,7 +54781,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 55, z: 0}
     second:
       m_TileIndex: 3
@@ -54772,7 +54790,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54781,7 +54799,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54790,7 +54808,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54799,7 +54817,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54808,7 +54826,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54817,7 +54835,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 55, z: 0}
     second:
       m_TileIndex: 4
@@ -54826,7 +54844,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 55, z: 0}
     second:
       m_TileIndex: 2
@@ -54835,7 +54853,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54844,7 +54862,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54853,7 +54871,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54862,7 +54880,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 56, z: 0}
     second:
       m_TileIndex: 2
@@ -54871,7 +54889,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54880,7 +54898,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 56, z: 0}
     second:
       m_TileIndex: 2
@@ -54889,7 +54907,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54898,7 +54916,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54907,7 +54925,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54916,7 +54934,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54925,7 +54943,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54934,7 +54952,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54943,7 +54961,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54952,7 +54970,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54961,7 +54979,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -54970,7 +54988,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -54979,7 +54997,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -54988,7 +55006,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -54997,7 +55015,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -55006,7 +55024,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -55015,7 +55033,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -55024,7 +55042,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -55033,7 +55051,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -55042,7 +55060,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 56, z: 0}
     second:
       m_TileIndex: 2
@@ -55051,7 +55069,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -55060,7 +55078,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 56, z: 0}
     second:
       m_TileIndex: 4
@@ -55069,7 +55087,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 56, z: 0}
     second:
       m_TileIndex: 2
@@ -55078,7 +55096,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 57, z: 0}
     second:
       m_TileIndex: 0
@@ -55087,7 +55105,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 1, y: 57, z: 0}
     second:
       m_TileIndex: 1
@@ -55096,7 +55114,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 5, y: 57, z: 0}
     second:
       m_TileIndex: 1
@@ -55105,7 +55123,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 57, z: 0}
     second:
       m_TileIndex: 0
@@ -55114,7 +55132,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -55123,7 +55141,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -55132,7 +55150,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -55141,7 +55159,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -55150,7 +55168,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -55159,7 +55177,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -55168,7 +55186,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 57, z: 0}
     second:
       m_TileIndex: 4
@@ -55177,7 +55195,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 57, z: 0}
     second:
       m_TileIndex: 2
@@ -55186,7 +55204,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 57, z: 0}
     second:
       m_TileIndex: 2
@@ -55195,7 +55213,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 57, z: 0}
     second:
       m_TileIndex: 4
@@ -55204,7 +55222,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -55213,7 +55231,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -55222,7 +55240,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -55231,7 +55249,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 57, z: 0}
     second:
       m_TileIndex: 4
@@ -55240,7 +55258,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 57, z: 0}
     second:
       m_TileIndex: 2
@@ -55249,7 +55267,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 58, z: 0}
     second:
       m_TileIndex: 1
@@ -55258,7 +55276,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 1, y: 58, z: 0}
     second:
       m_TileIndex: 0
@@ -55267,7 +55285,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 5, y: 58, z: 0}
     second:
       m_TileIndex: 0
@@ -55276,7 +55294,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 58, z: 0}
     second:
       m_TileIndex: 1
@@ -55285,7 +55303,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -55294,7 +55312,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -55303,7 +55321,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -55312,7 +55330,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -55321,7 +55339,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -55330,7 +55348,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -55339,7 +55357,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -55348,7 +55366,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -55357,7 +55375,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -55366,7 +55384,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -55375,7 +55393,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -55384,7 +55402,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -55393,7 +55411,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -55402,7 +55420,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -55411,7 +55429,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 58, z: 0}
     second:
       m_TileIndex: 2
@@ -55420,7 +55438,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -55429,7 +55447,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -55438,7 +55456,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -55447,7 +55465,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -55456,7 +55474,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 79, y: 58, z: 0}
     second:
       m_TileIndex: 4
@@ -55465,7 +55483,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 59, z: 0}
     second:
       m_TileIndex: 1
@@ -55474,7 +55492,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 59, z: 0}
     second:
       m_TileIndex: 1
@@ -55483,7 +55501,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 59, z: 0}
     second:
       m_TileIndex: 2
@@ -55492,7 +55510,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 59, z: 0}
     second:
       m_TileIndex: 2
@@ -55501,7 +55519,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 59, z: 0}
     second:
       m_TileIndex: 2
@@ -55510,7 +55528,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 59, z: 0}
     second:
       m_TileIndex: 2
@@ -55519,7 +55537,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55528,7 +55546,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55537,7 +55555,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55546,7 +55564,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55555,7 +55573,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55564,7 +55582,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55573,7 +55591,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55582,7 +55600,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55591,7 +55609,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55600,7 +55618,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55609,7 +55627,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55618,7 +55636,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -55627,7 +55645,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -55636,7 +55654,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -55645,7 +55663,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -55654,7 +55672,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55663,7 +55681,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55672,7 +55690,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55681,7 +55699,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55690,7 +55708,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55699,7 +55717,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55708,7 +55726,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55717,7 +55735,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55726,7 +55744,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55735,7 +55753,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55744,7 +55762,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55753,7 +55771,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 59, z: 0}
     second:
       m_TileIndex: 3
@@ -55762,7 +55780,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -55771,7 +55789,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 76, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -55780,7 +55798,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 77, y: 59, z: 0}
     second:
       m_TileIndex: 4
@@ -55789,7 +55807,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 60, z: 0}
     second:
       m_TileIndex: 1
@@ -55798,7 +55816,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -55807,7 +55825,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -55816,7 +55834,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -55825,7 +55843,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -55834,7 +55852,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -55843,7 +55861,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -55852,7 +55870,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -55861,7 +55879,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -55870,7 +55888,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -55879,7 +55897,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -55888,7 +55906,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -55897,7 +55915,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -55906,7 +55924,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -55915,7 +55933,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -55924,7 +55942,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -55933,7 +55951,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -55942,7 +55960,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 60, z: 0}
     second:
       m_TileIndex: 3
@@ -55951,7 +55969,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 60, z: 0}
     second:
       m_TileIndex: 4
@@ -55960,7 +55978,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 61, z: 0}
     second:
       m_TileIndex: 1
@@ -55969,7 +55987,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -55978,7 +55996,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -55987,7 +56005,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -55996,7 +56014,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -56005,7 +56023,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -56014,7 +56032,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -56023,7 +56041,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -56032,7 +56050,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -56041,7 +56059,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 61, z: 0}
     second:
       m_TileIndex: 4
@@ -56050,7 +56068,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -56059,7 +56077,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -56068,7 +56086,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 61, z: 0}
     second:
       m_TileIndex: 3
@@ -56077,7 +56095,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 61, z: 0}
     second:
       m_TileIndex: 4
@@ -56086,7 +56104,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 62, z: 0}
     second:
       m_TileIndex: 1
@@ -56095,7 +56113,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 62, z: 0}
     second:
       m_TileIndex: 1
@@ -56104,7 +56122,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 62, z: 0}
     second:
       m_TileIndex: 2
@@ -56113,7 +56131,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 62, z: 0}
     second:
       m_TileIndex: 2
@@ -56122,7 +56140,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 62, z: 0}
     second:
       m_TileIndex: 2
@@ -56131,7 +56149,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -56140,7 +56158,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -56149,7 +56167,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -56158,7 +56176,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -56167,7 +56185,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 62, z: 0}
     second:
       m_TileIndex: 4
@@ -56176,7 +56194,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 62, z: 0}
     second:
       m_TileIndex: 4
@@ -56185,7 +56203,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -56194,7 +56212,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -56203,7 +56221,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -56212,7 +56230,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -56221,7 +56239,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -56230,7 +56248,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -56239,7 +56257,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -56248,7 +56266,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 62, z: 0}
     second:
       m_TileIndex: 4
@@ -56257,7 +56275,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 63, z: 0}
     second:
       m_TileIndex: 1
@@ -56266,7 +56284,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56275,7 +56293,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56284,7 +56302,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56293,7 +56311,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56302,7 +56320,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56311,7 +56329,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56320,7 +56338,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56329,7 +56347,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56338,7 +56356,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56347,7 +56365,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56356,7 +56374,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56365,7 +56383,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56374,7 +56392,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 63, z: 0}
     second:
       m_TileIndex: 4
@@ -56383,7 +56401,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -56392,7 +56410,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -56401,7 +56419,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -56410,7 +56428,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 63, z: 0}
     second:
       m_TileIndex: 4
@@ -56419,7 +56437,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -56428,7 +56446,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -56437,7 +56455,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -56446,7 +56464,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 63, z: 0}
     second:
       m_TileIndex: 4
@@ -56455,7 +56473,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 63, z: 0}
     second:
       m_TileIndex: 4
@@ -56464,7 +56482,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56473,7 +56491,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 63, z: 0}
     second:
       m_TileIndex: 2
@@ -56482,7 +56500,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56491,7 +56509,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56500,7 +56518,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56509,7 +56527,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56518,7 +56536,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56527,7 +56545,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56536,7 +56554,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56545,7 +56563,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56554,7 +56572,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56563,7 +56581,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56572,7 +56590,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56581,7 +56599,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56590,7 +56608,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -56599,7 +56617,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 63, z: 0}
     second:
       m_TileIndex: 4
@@ -56608,7 +56626,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 64, z: 0}
     second:
       m_TileIndex: 1
@@ -56617,7 +56635,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 64, z: 0}
     second:
       m_TileIndex: 4
@@ -56626,7 +56644,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 64, z: 0}
     second:
       m_TileIndex: 4
@@ -56635,7 +56653,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 64, z: 0}
     second:
       m_TileIndex: 4
@@ -56644,7 +56662,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 64, z: 0}
     second:
       m_TileIndex: 3
@@ -56653,7 +56671,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 64, z: 0}
     second:
       m_TileIndex: 3
@@ -56662,7 +56680,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 64, z: 0}
     second:
       m_TileIndex: 4
@@ -56671,7 +56689,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 65, z: 0}
     second:
       m_TileIndex: 1
@@ -56680,7 +56698,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 65, z: 0}
     second:
       m_TileIndex: 1
@@ -56689,7 +56707,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -56698,7 +56716,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -56707,7 +56725,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -56716,7 +56734,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56725,7 +56743,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -56734,7 +56752,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -56743,7 +56761,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -56752,7 +56770,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -56761,7 +56779,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -56770,7 +56788,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -56779,7 +56797,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -56788,7 +56806,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -56797,7 +56815,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -56806,7 +56824,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -56815,7 +56833,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -56824,7 +56842,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -56833,7 +56851,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56842,7 +56860,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -56851,7 +56869,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -56860,7 +56878,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56869,7 +56887,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 55, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56878,7 +56896,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 56, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56887,7 +56905,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56896,7 +56914,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56905,7 +56923,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56914,7 +56932,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56923,7 +56941,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56932,7 +56950,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 62, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56941,7 +56959,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 63, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56950,7 +56968,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56959,7 +56977,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56968,7 +56986,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 66, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56977,7 +56995,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 67, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56986,7 +57004,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -56995,7 +57013,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -57004,7 +57022,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -57013,7 +57031,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 65, z: 0}
     second:
       m_TileIndex: 3
@@ -57022,7 +57040,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 73, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -57031,7 +57049,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 65, z: 0}
     second:
       m_TileIndex: 2
@@ -57040,7 +57058,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 75, y: 65, z: 0}
     second:
       m_TileIndex: 4
@@ -57049,7 +57067,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 66, z: 0}
     second:
       m_TileIndex: 1
@@ -57058,7 +57076,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 66, z: 0}
     second:
       m_TileIndex: 1
@@ -57067,7 +57085,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 66, z: 0}
     second:
       m_TileIndex: 2
@@ -57076,7 +57094,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 66, z: 0}
     second:
       m_TileIndex: 3
@@ -57085,7 +57103,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 66, z: 0}
     second:
       m_TileIndex: 3
@@ -57094,7 +57112,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 66, z: 0}
     second:
       m_TileIndex: 3
@@ -57103,7 +57121,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 66, z: 0}
     second:
       m_TileIndex: 3
@@ -57112,7 +57130,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 0, y: 67, z: 0}
     second:
       m_TileIndex: 0
@@ -57121,7 +57139,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 1, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -57130,7 +57148,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 2, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -57139,7 +57157,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 3, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -57148,7 +57166,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 4, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -57157,7 +57175,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 5, y: 67, z: 0}
     second:
       m_TileIndex: 1
@@ -57166,7 +57184,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 6, y: 67, z: 0}
     second:
       m_TileIndex: 0
@@ -57175,7 +57193,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 67, z: 0}
     second:
       m_TileIndex: 2
@@ -57184,7 +57202,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57193,7 +57211,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57202,7 +57220,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57211,7 +57229,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57220,7 +57238,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57229,7 +57247,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57238,7 +57256,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57247,7 +57265,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57256,7 +57274,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 29, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57265,7 +57283,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57274,7 +57292,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57283,7 +57301,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57292,7 +57310,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 33, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57301,7 +57319,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57310,7 +57328,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57319,7 +57337,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57328,7 +57346,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57337,7 +57355,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 67, z: 0}
     second:
       m_TileIndex: 2
@@ -57346,7 +57364,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 40, y: 67, z: 0}
     second:
       m_TileIndex: 2
@@ -57355,7 +57373,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 41, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57364,7 +57382,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57373,7 +57391,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57382,7 +57400,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 44, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57391,7 +57409,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 45, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57400,7 +57418,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 46, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57409,7 +57427,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 47, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57418,7 +57436,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 48, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57427,7 +57445,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 49, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57436,7 +57454,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57445,7 +57463,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57454,7 +57472,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 52, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57463,7 +57481,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 53, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57472,7 +57490,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 54, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57481,7 +57499,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57490,7 +57508,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 67, z: 0}
     second:
       m_TileIndex: 3
@@ -57499,7 +57517,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57508,7 +57526,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57517,7 +57535,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57526,7 +57544,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57535,7 +57553,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57544,7 +57562,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57553,7 +57571,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57562,7 +57580,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57571,7 +57589,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57580,7 +57598,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57589,7 +57607,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57598,7 +57616,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57607,7 +57625,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57616,7 +57634,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57625,7 +57643,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57634,7 +57652,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57643,7 +57661,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 68, z: 0}
     second:
       m_TileIndex: 3
@@ -57652,7 +57670,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -57661,7 +57679,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -57670,7 +57688,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -57679,7 +57697,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -57688,7 +57706,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -57697,7 +57715,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 69, z: 0}
     second:
       m_TileIndex: 2
@@ -57706,7 +57724,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -57715,7 +57733,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 69, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -57724,7 +57742,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 70, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -57733,7 +57751,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 71, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -57742,7 +57760,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -57751,7 +57769,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 70, z: 0}
     second:
       m_TileIndex: 0
@@ -57760,7 +57778,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 70, z: 0}
     second:
       m_TileIndex: 1
@@ -57769,7 +57787,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 70, z: 0}
     second:
       m_TileIndex: 1
@@ -57778,7 +57796,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 70, z: 0}
     second:
       m_TileIndex: 0
@@ -57787,7 +57805,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -57796,7 +57814,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -57805,7 +57823,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -57814,7 +57832,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 70, z: 0}
     second:
       m_TileIndex: 2
@@ -57823,7 +57841,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -57832,7 +57850,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -57841,7 +57859,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -57850,7 +57868,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -57859,7 +57877,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -57868,7 +57886,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 71, z: 0}
     second:
       m_TileIndex: 1
@@ -57877,7 +57895,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 71, z: 0}
     second:
       m_TileIndex: 2
@@ -57886,7 +57904,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 71, z: 0}
     second:
       m_TileIndex: 2
@@ -57895,7 +57913,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 71, z: 0}
     second:
       m_TileIndex: 2
@@ -57904,7 +57922,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 71, z: 0}
     second:
       m_TileIndex: 3
@@ -57913,7 +57931,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 71, z: 0}
     second:
       m_TileIndex: 3
@@ -57922,7 +57940,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 71, z: 0}
     second:
       m_TileIndex: 3
@@ -57931,7 +57949,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 71, z: 0}
     second:
       m_TileIndex: 2
@@ -57940,7 +57958,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 71, z: 0}
     second:
       m_TileIndex: 2
@@ -57949,7 +57967,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 71, z: 0}
     second:
       m_TileIndex: 2
@@ -57958,7 +57976,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 72, z: 0}
     second:
       m_TileIndex: 5
@@ -57967,7 +57985,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 72, z: 0}
     second:
       m_TileIndex: 5
@@ -57976,7 +57994,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -57985,7 +58003,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 72, z: 0}
     second:
       m_TileIndex: 3
@@ -57994,7 +58012,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 72, z: 0}
     second:
       m_TileIndex: 3
@@ -58003,7 +58021,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 72, z: 0}
     second:
       m_TileIndex: 3
@@ -58012,7 +58030,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 34, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -58021,7 +58039,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 35, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -58030,7 +58048,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -58039,7 +58057,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 38, y: 72, z: 0}
     second:
       m_TileIndex: 2
@@ -58048,7 +58066,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 73, z: 0}
     second:
       m_TileIndex: 1
@@ -58057,7 +58075,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -58066,7 +58084,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 23, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -58075,7 +58093,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -58084,7 +58102,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -58093,7 +58111,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -58102,7 +58120,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -58111,7 +58129,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 73, z: 0}
     second:
       m_TileIndex: 3
@@ -58120,7 +58138,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 74, z: 0}
     second:
       m_TileIndex: 5
@@ -58129,7 +58147,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 74, z: 0}
     second:
       m_TileIndex: 5
@@ -58138,7 +58156,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 74, z: 0}
     second:
       m_TileIndex: 2
@@ -58147,7 +58165,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 74, z: 0}
     second:
       m_TileIndex: 3
@@ -58156,7 +58174,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 74, z: 0}
     second:
       m_TileIndex: 3
@@ -58165,7 +58183,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 75, z: 0}
     second:
       m_TileIndex: 1
@@ -58174,7 +58192,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 75, z: 0}
     second:
       m_TileIndex: 1
@@ -58183,7 +58201,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 75, z: 0}
     second:
       m_TileIndex: 2
@@ -58192,7 +58210,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 13, y: 75, z: 0}
     second:
       m_TileIndex: 2
@@ -58201,7 +58219,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 14, y: 75, z: 0}
     second:
       m_TileIndex: 2
@@ -58210,7 +58228,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 15, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -58219,7 +58237,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 16, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -58228,7 +58246,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -58237,7 +58255,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 18, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -58246,7 +58264,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -58255,7 +58273,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -58264,7 +58282,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -58273,7 +58291,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -58282,7 +58300,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 76, z: 0}
     second:
       m_TileIndex: 0
@@ -58291,7 +58309,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 8, y: 76, z: 0}
     second:
       m_TileIndex: 1
@@ -58300,7 +58318,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 9, y: 76, z: 0}
     second:
       m_TileIndex: 5
@@ -58309,7 +58327,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 76, z: 0}
     second:
       m_TileIndex: 1
@@ -58318,7 +58336,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 11, y: 76, z: 0}
     second:
       m_TileIndex: 0
@@ -58327,7 +58345,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   m_AnimatedTiles: {}
   m_TileAssetArray:
   - m_RefCount: 24
@@ -58617,6 +58635,2167 @@ Tilemap:
     m_DirtyIndex: 0
   - serializedVersion: 1
     m_DirtyIndex: 0
+--- !u!66 &817340210
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 817340205}
+  m_Enabled: 0
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 0
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: 817340212}
+    m_ColliderPaths:
+    - - X: 120000000
+        Y: 760625024
+      - X: 110625000
+        Y: 770000000
+      - X: 100000000
+        Y: 770000000
+      - X: 100000000
+        Y: 760000000
+      - X: 110000000
+        Y: 760000000
+      - X: 110000000
+        Y: 750000000
+      - X: 120000000
+        Y: 750000000
+    - - X: 80000000
+        Y: 760000000
+      - X: 90000000
+        Y: 760000000
+      - X: 90000000
+        Y: 770000000
+      - X: 79062496
+        Y: 770000000
+      - X: 70000000
+        Y: 760937472
+      - X: 70000000
+        Y: 750000000
+      - X: 80000000
+        Y: 750000000
+    - - X: 270000000
+        Y: 720000000
+      - X: 260000000
+        Y: 720000000
+      - X: 260000000
+        Y: 680000000
+      - X: 230000000
+        Y: 680000000
+      - X: 230000000
+        Y: 730000000
+      - X: 280000000
+        Y: 730000000
+      - X: 280000000
+        Y: 720000000
+      - X: 290000000
+        Y: 720000000
+      - X: 290000000
+        Y: 740000000
+      - X: 230000000
+        Y: 740000000
+      - X: 230000000
+        Y: 760000000
+      - X: 150000000
+        Y: 760000000
+      - X: 150000000
+        Y: 740000000
+      - X: 160000000
+        Y: 740000000
+      - X: 160000000
+        Y: 750000000
+      - X: 220000000
+        Y: 750000000
+      - X: 220000000
+        Y: 670000000
+      - X: 270000000
+        Y: 670000000
+    - - X: 80000000
+        Y: 740000000
+      - X: 70000000
+        Y: 740000000
+      - X: 70000000
+        Y: 730000000
+      - X: 80000000
+        Y: 730000000
+    - - X: 160000000
+        Y: 730000000
+      - X: 150000000
+        Y: 730000000
+      - X: 150000000
+        Y: 690000000
+      - X: 90000000
+        Y: 690000000
+      - X: 90000000
+        Y: 680000000
+      - X: 160000000
+        Y: 680000000
+    - - X: 90000000
+        Y: 710000000
+      - X: 80000000
+        Y: 710000000
+      - X: 80000000
+        Y: 720000000
+      - X: 70000000
+        Y: 720000000
+      - X: 70000000
+        Y: 709062528
+      - X: 79062496
+        Y: 700000000
+      - X: 90000000
+        Y: 700000000
+    - - X: 120000000
+        Y: 709374976
+      - X: 120000000
+        Y: 720000000
+      - X: 110000000
+        Y: 720000000
+      - X: 110000000
+        Y: 710000000
+      - X: 100000000
+        Y: 710000000
+      - X: 100000000
+        Y: 700000000
+      - X: 110625000
+        Y: 700000000
+    - - X: 360000000
+        Y: 710000000
+      - X: 340000000
+        Y: 710000000
+      - X: 340000000
+        Y: 700000000
+      - X: 360000000
+        Y: 700000000
+    - - X: 390000000
+        Y: 710000000
+      - X: 370000000
+        Y: 710000000
+      - X: 370000000
+        Y: 700000000
+      - X: 390000000
+        Y: 700000000
+    - - X: 690000000
+        Y: 690000000
+      - X: 720000000
+        Y: 690000000
+      - X: 720000000
+        Y: 660000000
+      - X: 700000000
+        Y: 660000000
+      - X: 700000000
+        Y: 650000000
+      - X: 730000000
+        Y: 650000000
+      - X: 730000000
+        Y: 700000000
+      - X: 680000000
+        Y: 700000000
+      - X: 680000000
+        Y: 660000000
+      - X: 540000000
+        Y: 660000000
+      - X: 540000000
+        Y: 650000000
+      - X: 690000000
+        Y: 650000000
+    - - X: 200000000
+        Y: 670000000
+      - X: 210000000
+        Y: 670000000
+      - X: 210000000
+        Y: 680000000
+      - X: 200000000
+        Y: 680000000
+      - X: 200000000
+        Y: 690000000
+      - X: 170000000
+        Y: 690000000
+      - X: 170000000
+        Y: 680000000
+      - X: 190000000
+        Y: 680000000
+      - X: 190000000
+        Y: 650000000
+      - X: 200000000
+        Y: 650000000
+    - - X: 360000000
+        Y: 680000000
+      - X: 350000000
+        Y: 680000000
+      - X: 350000000
+        Y: 690000000
+      - X: 340000000
+        Y: 690000000
+      - X: 340000000
+        Y: 680000000
+      - X: 290000000
+        Y: 680000000
+      - X: 290000000
+        Y: 690000000
+      - X: 280000000
+        Y: 690000000
+      - X: 280000000
+        Y: 670000000
+      - X: 360000000
+        Y: 670000000
+    - - X: 390000000
+        Y: 690000000
+      - X: 380000000
+        Y: 690000000
+      - X: 380000000
+        Y: 680000000
+      - X: 370000000
+        Y: 680000000
+      - X: 370000000
+        Y: 670000000
+      - X: 390000000
+        Y: 670000000
+    - - X: 20000000
+        Y: 580625024
+      - X: 10625000
+        Y: 590000000
+      - X: 10000000
+        Y: 590000000
+      - X: 10000000
+        Y: 670000000
+      - X: 60000000
+        Y: 670000000
+      - X: 60000000
+        Y: 650000000
+      - X: 70000000
+        Y: 650000000
+      - X: 70000000
+        Y: 670625024
+      - X: 60625000
+        Y: 680000000
+      - X: 9062500
+        Y: 680000000
+      - X: 0
+        Y: 670937472
+      - X: 0
+        Y: 579062528
+      - X: 9062500
+        Y: 570000000
+      - X: 20000000
+        Y: 570000000
+    - - X: 530000000
+        Y: 630000000
+      - X: 500000000
+        Y: 630000000
+      - X: 500000000
+        Y: 670000000
+      - X: 550000000
+        Y: 670000000
+      - X: 550000000
+        Y: 680000000
+      - X: 410000000
+        Y: 680000000
+      - X: 410000000
+        Y: 670000000
+      - X: 490000000
+        Y: 670000000
+      - X: 490000000
+        Y: 620000000
+      - X: 530000000
+        Y: 620000000
+    - - X: 760000000
+        Y: 590000000
+      - X: 770000000
+        Y: 590000000
+      - X: 770000000
+        Y: 580000000
+      - X: 790000000
+        Y: 580000000
+      - X: 790000000
+        Y: 570000000
+      - X: 800000000
+        Y: 570000000
+      - X: 800000000
+        Y: 590000000
+      - X: 780000000
+        Y: 590000000
+      - X: 780000000
+        Y: 600000000
+      - X: 760000000
+        Y: 600000000
+      - X: 760000000
+        Y: 660000000
+      - X: 750000000
+        Y: 660000000
+      - X: 750000000
+        Y: 560000000
+      - X: 720000000
+        Y: 560000000
+      - X: 720000000
+        Y: 550000000
+      - X: 750000000
+        Y: 550000000
+      - X: 750000000
+        Y: 540000000
+      - X: 760000000
+        Y: 540000000
+    - - X: 480000000
+        Y: 560000000
+      - X: 510000000
+        Y: 560000000
+      - X: 510000000
+        Y: 550000000
+      - X: 530000000
+        Y: 550000000
+      - X: 530000000
+        Y: 610000000
+      - X: 480000000
+        Y: 610000000
+      - X: 480000000
+        Y: 660000000
+      - X: 360000000
+        Y: 660000000
+      - X: 360000000
+        Y: 620000000
+      - X: 370000000
+        Y: 620000000
+      - X: 370000000
+        Y: 650000000
+      - X: 400000000
+        Y: 650000000
+      - X: 400000000
+        Y: 630000000
+      - X: 410000000
+        Y: 630000000
+      - X: 410000000
+        Y: 650000000
+      - X: 440000000
+        Y: 650000000
+      - X: 440000000
+        Y: 630000000
+      - X: 450000000
+        Y: 630000000
+      - X: 450000000
+        Y: 650000000
+      - X: 470000000
+        Y: 650000000
+      - X: 470000000
+        Y: 580000000
+      - X: 490000000
+        Y: 580000000
+      - X: 490000000
+        Y: 600000000
+      - X: 520000000
+        Y: 600000000
+      - X: 520000000
+        Y: 570000000
+      - X: 470000000
+        Y: 570000000
+      - X: 470000000
+        Y: 560000000
+      - X: 410000000
+        Y: 560000000
+      - X: 410000000
+        Y: 550000000
+      - X: 480000000
+        Y: 550000000
+    - - X: 230000000
+        Y: 550000000
+      - X: 240000000
+        Y: 550000000
+      - X: 240000000
+        Y: 560000000
+      - X: 230000000
+        Y: 560000000
+      - X: 230000000
+        Y: 630000000
+      - X: 250000000
+        Y: 630000000
+      - X: 250000000
+        Y: 610000000
+      - X: 240000000
+        Y: 610000000
+      - X: 240000000
+        Y: 600000000
+      - X: 260000000
+        Y: 600000000
+      - X: 260000000
+        Y: 630000000
+      - X: 280000000
+        Y: 630000000
+      - X: 280000000
+        Y: 610000000
+      - X: 270000000
+        Y: 610000000
+      - X: 270000000
+        Y: 600000000
+      - X: 290000000
+        Y: 600000000
+      - X: 290000000
+        Y: 630000000
+      - X: 340000000
+        Y: 630000000
+      - X: 340000000
+        Y: 640000000
+      - X: 220000000
+        Y: 640000000
+      - X: 220000000
+        Y: 530000000
+      - X: 230000000
+        Y: 530000000
+    - - X: 700000000
+        Y: 560000000
+      - X: 680000000
+        Y: 560000000
+      - X: 680000000
+        Y: 640000000
+      - X: 630000000
+        Y: 640000000
+      - X: 630000000
+        Y: 630000000
+      - X: 670000000
+        Y: 630000000
+      - X: 670000000
+        Y: 600000000
+      - X: 630000000
+        Y: 600000000
+      - X: 630000000
+        Y: 590000000
+      - X: 670000000
+        Y: 590000000
+      - X: 670000000
+        Y: 560000000
+      - X: 620000000
+        Y: 560000000
+      - X: 620000000
+        Y: 550000000
+      - X: 700000000
+        Y: 550000000
+    - - X: 600000000
+        Y: 560000000
+      - X: 550000000
+        Y: 560000000
+      - X: 550000000
+        Y: 590000000
+      - X: 590000000
+        Y: 590000000
+      - X: 590000000
+        Y: 600000000
+      - X: 550000000
+        Y: 600000000
+      - X: 550000000
+        Y: 630000000
+      - X: 610000000
+        Y: 630000000
+      - X: 610000000
+        Y: 600000000
+      - X: 600000000
+        Y: 600000000
+      - X: 600000000
+        Y: 590000000
+      - X: 620000000
+        Y: 590000000
+      - X: 620000000
+        Y: 640000000
+      - X: 540000000
+        Y: 640000000
+      - X: 540000000
+        Y: 550000000
+      - X: 600000000
+        Y: 550000000
+    - - X: 210000000
+        Y: 570000000
+      - X: 200000000
+        Y: 570000000
+      - X: 200000000
+        Y: 630000000
+      - X: 190000000
+        Y: 630000000
+      - X: 190000000
+        Y: 600000000
+      - X: 110000000
+        Y: 600000000
+      - X: 110000000
+        Y: 590000000
+      - X: 190000000
+        Y: 590000000
+      - X: 190000000
+        Y: 570000000
+      - X: 160000000
+        Y: 570000000
+      - X: 160000000
+        Y: 560000000
+      - X: 210000000
+        Y: 560000000
+    - - X: 70000000
+        Y: 630000000
+      - X: 60000000
+        Y: 630000000
+      - X: 60000000
+        Y: 620000000
+      - X: 70000000
+        Y: 620000000
+    - - X: 340000000
+        Y: 620000000
+      - X: 300000000
+        Y: 620000000
+      - X: 300000000
+        Y: 600000000
+      - X: 310000000
+        Y: 600000000
+      - X: 310000000
+        Y: 610000000
+      - X: 330000000
+        Y: 610000000
+      - X: 330000000
+        Y: 590000000
+      - X: 300000000
+        Y: 590000000
+      - X: 300000000
+        Y: 570000000
+      - X: 310000000
+        Y: 570000000
+      - X: 310000000
+        Y: 580000000
+      - X: 330000000
+        Y: 580000000
+      - X: 330000000
+        Y: 560000000
+      - X: 290000000
+        Y: 560000000
+      - X: 290000000
+        Y: 590000000
+      - X: 270000000
+        Y: 590000000
+      - X: 270000000
+        Y: 580000000
+      - X: 280000000
+        Y: 580000000
+      - X: 280000000
+        Y: 560000000
+      - X: 260000000
+        Y: 560000000
+      - X: 260000000
+        Y: 590000000
+      - X: 250000000
+        Y: 590000000
+      - X: 250000000
+        Y: 550000000
+      - X: 340000000
+        Y: 550000000
+    - - X: 400000000
+        Y: 560000000
+      - X: 370000000
+        Y: 560000000
+      - X: 370000000
+        Y: 600000000
+      - X: 360000000
+        Y: 600000000
+      - X: 360000000
+        Y: 560000000
+      - X: 350000000
+        Y: 560000000
+      - X: 350000000
+        Y: 550000000
+      - X: 400000000
+        Y: 550000000
+    - - X: 70000000
+        Y: 579374976
+      - X: 70000000
+        Y: 600000000
+      - X: 60000000
+        Y: 600000000
+      - X: 60000000
+        Y: 590000000
+      - X: 59062500
+        Y: 590000000
+      - X: 50000000
+        Y: 580937472
+      - X: 50000000
+        Y: 570000000
+      - X: 60625000
+        Y: 570000000
+    - - X: 150000000
+        Y: 570000000
+      - X: 140000000
+        Y: 570000000
+      - X: 140000000
+        Y: 560000000
+      - X: 150000000
+        Y: 560000000
+    - - X: 120000000
+        Y: 550000000
+      - X: 110000000
+        Y: 550000000
+      - X: 110000000
+        Y: 560000000
+      - X: 130000000
+        Y: 560000000
+      - X: 130000000
+        Y: 570000000
+      - X: 100000000
+        Y: 570000000
+      - X: 100000000
+        Y: 540000000
+      - X: 120000000
+        Y: 540000000
+    - - X: 240000000
+        Y: 400000000
+      - X: 230000000
+        Y: 400000000
+      - X: 230000000
+        Y: 480000000
+      - X: 170000000
+        Y: 480000000
+      - X: 170000000
+        Y: 510000000
+      - X: 180000000
+        Y: 510000000
+      - X: 180000000
+        Y: 490000000
+      - X: 190000000
+        Y: 490000000
+      - X: 190000000
+        Y: 510000000
+      - X: 200000000
+        Y: 510000000
+      - X: 200000000
+        Y: 490000000
+      - X: 210000000
+        Y: 490000000
+      - X: 210000000
+        Y: 510000000
+      - X: 220000000
+        Y: 510000000
+      - X: 220000000
+        Y: 490000000
+      - X: 230000000
+        Y: 490000000
+      - X: 230000000
+        Y: 520000000
+      - X: 170000000
+        Y: 520000000
+      - X: 170000000
+        Y: 540000000
+      - X: 210000000
+        Y: 540000000
+      - X: 210000000
+        Y: 550000000
+      - X: 160000000
+        Y: 550000000
+      - X: 160000000
+        Y: 520000000
+      - X: 120000000
+        Y: 520000000
+      - X: 120000000
+        Y: 530000000
+      - X: 100000000
+        Y: 530000000
+      - X: 100000000
+        Y: 520000000
+      - X: 110000000
+        Y: 520000000
+      - X: 110000000
+        Y: 510000000
+      - X: 160000000
+        Y: 510000000
+      - X: 160000000
+        Y: 470000000
+      - X: 220000000
+        Y: 470000000
+      - X: 220000000
+        Y: 390000000
+      - X: 240000000
+        Y: 390000000
+    - - X: 780000000
+        Y: 420000000
+      - X: 810000000
+        Y: 420000000
+      - X: 810000000
+        Y: 470000000
+      - X: 800000000
+        Y: 470000000
+      - X: 800000000
+        Y: 490000000
+      - X: 790000000
+        Y: 490000000
+      - X: 790000000
+        Y: 480000000
+      - X: 770000000
+        Y: 480000000
+      - X: 770000000
+        Y: 460000000
+      - X: 800000000
+        Y: 460000000
+      - X: 800000000
+        Y: 430000000
+      - X: 770000000
+        Y: 430000000
+      - X: 770000000
+        Y: 400000000
+      - X: 720000000
+        Y: 400000000
+      - X: 720000000
+        Y: 510000000
+      - X: 760000000
+        Y: 510000000
+      - X: 760000000
+        Y: 530000000
+      - X: 750000000
+        Y: 530000000
+      - X: 750000000
+        Y: 520000000
+      - X: 680000000
+        Y: 520000000
+      - X: 680000000
+        Y: 510000000
+      - X: 700000000
+        Y: 510000000
+      - X: 700000000
+        Y: 460000000
+      - X: 670000000
+        Y: 460000000
+      - X: 670000000
+        Y: 520000000
+      - X: 660000000
+        Y: 520000000
+      - X: 660000000
+        Y: 420000000
+      - X: 650000000
+        Y: 420000000
+      - X: 650000000
+        Y: 410000000
+      - X: 670000000
+        Y: 410000000
+      - X: 670000000
+        Y: 450000000
+      - X: 710000000
+        Y: 450000000
+      - X: 710000000
+        Y: 390000000
+      - X: 780000000
+        Y: 390000000
+    - - X: 570000000
+        Y: 470000000
+      - X: 550000000
+        Y: 470000000
+      - X: 550000000
+        Y: 450000000
+      - X: 530000000
+        Y: 450000000
+      - X: 530000000
+        Y: 460000000
+      - X: 520000000
+        Y: 460000000
+      - X: 520000000
+        Y: 480000000
+      - X: 530000000
+        Y: 480000000
+      - X: 530000000
+        Y: 490000000
+      - X: 550000000
+        Y: 490000000
+      - X: 550000000
+        Y: 480000000
+      - X: 560000000
+        Y: 480000000
+      - X: 560000000
+        Y: 510000000
+      - X: 590000000
+        Y: 510000000
+      - X: 590000000
+        Y: 520000000
+      - X: 490000000
+        Y: 520000000
+      - X: 490000000
+        Y: 440000000
+      - X: 560000000
+        Y: 440000000
+      - X: 560000000
+        Y: 430000000
+      - X: 570000000
+        Y: 430000000
+    - - X: 650000000
+        Y: 520000000
+      - X: 600000000
+        Y: 520000000
+      - X: 600000000
+        Y: 510000000
+      - X: 640000000
+        Y: 510000000
+      - X: 640000000
+        Y: 500000000
+      - X: 650000000
+        Y: 500000000
+    - - X: 360000000
+        Y: 510000000
+      - X: 410000000
+        Y: 510000000
+      - X: 410000000
+        Y: 470000000
+      - X: 420000000
+        Y: 470000000
+      - X: 420000000
+        Y: 510000000
+      - X: 450000000
+        Y: 510000000
+      - X: 450000000
+        Y: 490000000
+      - X: 460000000
+        Y: 490000000
+      - X: 460000000
+        Y: 520000000
+      - X: 350000000
+        Y: 520000000
+      - X: 350000000
+        Y: 470000000
+      - X: 360000000
+        Y: 470000000
+    - - X: 340000000
+        Y: 520000000
+      - X: 260000000
+        Y: 520000000
+      - X: 260000000
+        Y: 500000000
+      - X: 270000000
+        Y: 500000000
+      - X: 270000000
+        Y: 510000000
+      - X: 330000000
+        Y: 510000000
+      - X: 330000000
+        Y: 430000000
+      - X: 340000000
+        Y: 430000000
+    - - X: 500000000
+        Y: 450000000
+      - X: 500000000
+        Y: 510000000
+      - X: 550000000
+        Y: 510000000
+      - X: 550000000
+        Y: 500000000
+      - X: 520000000
+        Y: 500000000
+      - X: 520000000
+        Y: 490000000
+      - X: 510000000
+        Y: 490000000
+      - X: 510000000
+        Y: 450000000
+    - - X: 650000000
+        Y: 490000000
+      - X: 640000000
+        Y: 490000000
+      - X: 640000000
+        Y: 470000000
+      - X: 630000000
+        Y: 470000000
+      - X: 630000000
+        Y: 460000000
+      - X: 640000000
+        Y: 460000000
+      - X: 640000000
+        Y: 430000000
+      - X: 650000000
+        Y: 430000000
+    - - X: 340000000
+        Y: 420000000
+      - X: 270000000
+        Y: 420000000
+      - X: 270000000
+        Y: 480000000
+      - X: 260000000
+        Y: 480000000
+      - X: 260000000
+        Y: 410000000
+      - X: 340000000
+        Y: 410000000
+    - - X: 460000000
+        Y: 480000000
+      - X: 450000000
+        Y: 480000000
+      - X: 450000000
+        Y: 410000000
+      - X: 460000000
+        Y: 410000000
+    - - X: 610000000
+        Y: 470000000
+      - X: 590000000
+        Y: 470000000
+      - X: 590000000
+        Y: 460000000
+      - X: 600000000
+        Y: 460000000
+      - X: 600000000
+        Y: 430000000
+      - X: 610000000
+        Y: 430000000
+    - - X: 360000000
+        Y: 340000000
+      - X: 430000000
+        Y: 340000000
+      - X: 430000000
+        Y: 350000000
+      - X: 360000000
+        Y: 350000000
+      - X: 360000000
+        Y: 390000000
+      - X: 450000000
+        Y: 390000000
+      - X: 450000000
+        Y: 380000000
+      - X: 460000000
+        Y: 380000000
+      - X: 460000000
+        Y: 400000000
+      - X: 360000000
+        Y: 400000000
+      - X: 360000000
+        Y: 460000000
+      - X: 350000000
+        Y: 460000000
+      - X: 350000000
+        Y: 330000000
+      - X: 360000000
+        Y: 330000000
+    - - X: 500000000
+        Y: 420000000
+      - X: 540000000
+        Y: 420000000
+      - X: 540000000
+        Y: 410000000
+      - X: 570000000
+        Y: 410000000
+      - X: 570000000
+        Y: 420000000
+      - X: 550000000
+        Y: 420000000
+      - X: 550000000
+        Y: 430000000
+      - X: 490000000
+        Y: 430000000
+      - X: 490000000
+        Y: 410000000
+      - X: 500000000
+        Y: 410000000
+    - - X: 620000000
+        Y: 410000000
+      - X: 640000000
+        Y: 410000000
+      - X: 640000000
+        Y: 420000000
+      - X: 600000000
+        Y: 420000000
+      - X: 600000000
+        Y: 410000000
+      - X: 610000000
+        Y: 410000000
+      - X: 610000000
+        Y: 360000000
+      - X: 620000000
+        Y: 360000000
+    - - X: 340000000
+        Y: 400000000
+      - X: 250000000
+        Y: 400000000
+      - X: 250000000
+        Y: 390000000
+      - X: 330000000
+        Y: 390000000
+      - X: 330000000
+        Y: 340000000
+      - X: 240000000
+        Y: 340000000
+      - X: 240000000
+        Y: 330000000
+      - X: 340000000
+        Y: 330000000
+    - - X: 180000000
+        Y: 400000000
+      - X: 170000000
+        Y: 400000000
+      - X: 170000000
+        Y: 390000000
+      - X: 180000000
+        Y: 390000000
+    - - X: 500000000
+        Y: 400000000
+      - X: 490000000
+        Y: 400000000
+      - X: 490000000
+        Y: 380000000
+      - X: 500000000
+        Y: 380000000
+    - - X: 640000000
+        Y: 390000000
+      - X: 630000000
+        Y: 390000000
+      - X: 630000000
+        Y: 380000000
+      - X: 640000000
+        Y: 380000000
+    - - X: 500000000
+        Y: 370000000
+      - X: 490000000
+        Y: 370000000
+      - X: 490000000
+        Y: 340000000
+      - X: 500000000
+        Y: 340000000
+    - - X: 460000000
+        Y: 370000000
+      - X: 450000000
+        Y: 370000000
+      - X: 450000000
+        Y: 340000000
+      - X: 460000000
+        Y: 340000000
+    - - X: 750000000
+        Y: 280000000
+      - X: 760000000
+        Y: 280000000
+      - X: 760000000
+        Y: 360000000
+      - X: 740000000
+        Y: 360000000
+      - X: 740000000
+        Y: 350000000
+      - X: 750000000
+        Y: 350000000
+      - X: 750000000
+        Y: 290000000
+      - X: 740000000
+        Y: 290000000
+      - X: 740000000
+        Y: 280000000
+      - X: 730000000
+        Y: 280000000
+      - X: 730000000
+        Y: 290000000
+      - X: 720000000
+        Y: 290000000
+      - X: 720000000
+        Y: 350000000
+      - X: 730000000
+        Y: 350000000
+      - X: 730000000
+        Y: 360000000
+      - X: 710000000
+        Y: 360000000
+      - X: 710000000
+        Y: 280000000
+      - X: 720000000
+        Y: 280000000
+      - X: 720000000
+        Y: 270000000
+      - X: 750000000
+        Y: 270000000
+    - - X: 540000000
+        Y: 350000000
+      - X: 520000000
+        Y: 350000000
+      - X: 520000000
+        Y: 340000000
+      - X: 530000000
+        Y: 340000000
+      - X: 530000000
+        Y: 310000000
+      - X: 540000000
+        Y: 310000000
+    - - X: 330000000
+        Y: 320000000
+      - X: 230000000
+        Y: 320000000
+      - X: 230000000
+        Y: 340000000
+      - X: 170000000
+        Y: 340000000
+      - X: 170000000
+        Y: 330000000
+      - X: 220000000
+        Y: 330000000
+      - X: 220000000
+        Y: 310000000
+      - X: 320000000
+        Y: 310000000
+      - X: 320000000
+        Y: 260000000
+      - X: 280000000
+        Y: 260000000
+      - X: 280000000
+        Y: 250000000
+      - X: 330000000
+        Y: 250000000
+    - - X: 460000000
+        Y: 230000000
+      - X: 420000000
+        Y: 230000000
+      - X: 420000000
+        Y: 330000000
+      - X: 410000000
+        Y: 330000000
+      - X: 410000000
+        Y: 230000000
+      - X: 380000000
+        Y: 230000000
+      - X: 380000000
+        Y: 220000000
+      - X: 460000000
+        Y: 220000000
+    - - X: 380000000
+        Y: 160000000
+      - X: 390000000
+        Y: 160000000
+      - X: 390000000
+        Y: 170000000
+      - X: 380000000
+        Y: 170000000
+      - X: 380000000
+        Y: 200000000
+      - X: 390000000
+        Y: 200000000
+      - X: 390000000
+        Y: 210000000
+      - X: 370000000
+        Y: 210000000
+      - X: 370000000
+        Y: 230000000
+      - X: 360000000
+        Y: 230000000
+      - X: 360000000
+        Y: 320000000
+      - X: 350000000
+        Y: 320000000
+      - X: 350000000
+        Y: 240000000
+      - X: 280000000
+        Y: 240000000
+      - X: 280000000
+        Y: 230000000
+      - X: 350000000
+        Y: 230000000
+      - X: 350000000
+        Y: 220000000
+      - X: 360000000
+        Y: 220000000
+      - X: 360000000
+        Y: 200000000
+      - X: 370000000
+        Y: 200000000
+      - X: 370000000
+        Y: 130000000
+      - X: 380000000
+        Y: 130000000
+    - - X: 540000000
+        Y: 300000000
+      - X: 530000000
+        Y: 300000000
+      - X: 530000000
+        Y: 290000000
+      - X: 540000000
+        Y: 290000000
+    - - X: 600000000
+        Y: 250000000
+      - X: 570000000
+        Y: 250000000
+      - X: 570000000
+        Y: 240000000
+      - X: 600000000
+        Y: 240000000
+    - - X: 540000000
+        Y: 250000000
+      - X: 530000000
+        Y: 250000000
+      - X: 530000000
+        Y: 240000000
+      - X: 540000000
+        Y: 240000000
+    - - X: 560000000
+        Y: 250000000
+      - X: 550000000
+        Y: 250000000
+      - X: 550000000
+        Y: 240000000
+      - X: 560000000
+        Y: 240000000
+    - - X: 520000000
+        Y: 230000000
+      - X: 500000000
+        Y: 230000000
+      - X: 500000000
+        Y: 210000000
+      - X: 520000000
+        Y: 210000000
+    - - X: 540000000
+        Y: 230000000
+      - X: 530000000
+        Y: 230000000
+      - X: 530000000
+        Y: 220000000
+      - X: 540000000
+        Y: 220000000
+    - - X: 560000000
+        Y: 230000000
+      - X: 550000000
+        Y: 230000000
+      - X: 550000000
+        Y: 220000000
+      - X: 560000000
+        Y: 220000000
+    - - X: 600000000
+        Y: 230000000
+      - X: 570000000
+        Y: 230000000
+      - X: 570000000
+        Y: 220000000
+      - X: 600000000
+        Y: 220000000
+    - - X: 440000000
+        Y: 170000000
+      - X: 460000000
+        Y: 170000000
+      - X: 460000000
+        Y: 210000000
+      - X: 400000000
+        Y: 210000000
+      - X: 400000000
+        Y: 200000000
+      - X: 410000000
+        Y: 200000000
+      - X: 410000000
+        Y: 190000000
+      - X: 420000000
+        Y: 190000000
+      - X: 420000000
+        Y: 200000000
+      - X: 450000000
+        Y: 200000000
+      - X: 450000000
+        Y: 180000000
+      - X: 430000000
+        Y: 180000000
+      - X: 430000000
+        Y: 170000000
+      - X: 420000000
+        Y: 170000000
+      - X: 420000000
+        Y: 180000000
+      - X: 410000000
+        Y: 180000000
+      - X: 410000000
+        Y: 170000000
+      - X: 400000000
+        Y: 170000000
+      - X: 400000000
+        Y: 160000000
+      - X: 430000000
+        Y: 160000000
+      - X: 430000000
+        Y: 150000000
+      - X: 440000000
+        Y: 150000000
+    - - X: 530000000
+        Y: 190000000
+      - X: 500000000
+        Y: 190000000
+      - X: 500000000
+        Y: 170000000
+      - X: 520000000
+        Y: 170000000
+      - X: 520000000
+        Y: 150000000
+      - X: 530000000
+        Y: 150000000
+    - - X: 430000000
+        Y: 100000000
+      - X: 440000000
+        Y: 100000000
+      - X: 440000000
+        Y: 110000000
+      - X: 389062496
+        Y: 110000000
+      - X: 380000000
+        Y: 100937504
+      - X: 380000000
+        Y: 100000000
+      - X: 370000000
+        Y: 100000000
+      - X: 370000000
+        Y: 90000000
+      - X: 390000000
+        Y: 90000000
+      - X: 390000000
+        Y: 100000000
+      - X: 420000000
+        Y: 100000000
+      - X: 420000000
+        Y: 80000000
+      - X: 430000000
+        Y: 80000000
+    - - X: 460000000
+        Y: 110000000
+      - X: 450000000
+        Y: 110000000
+      - X: 450000000
+        Y: 100000000
+      - X: 460000000
+        Y: 100000000
+    - - X: 490000000
+        Y: 110000000
+      - X: 480000000
+        Y: 110000000
+      - X: 480000000
+        Y: 100000000
+      - X: 490000000
+        Y: 100000000
+    - - X: 510000000
+        Y: 110000000
+      - X: 500000000
+        Y: 110000000
+      - X: 500000000
+        Y: 60000000
+      - X: 510000000
+        Y: 60000000
+    - - X: 550000000
+        Y: 90000000
+      - X: 580000000
+        Y: 90000000
+      - X: 580000000
+        Y: 89062496
+      - X: 589062528
+        Y: 80000000
+      - X: 600000000
+        Y: 80000000
+      - X: 600000000
+        Y: 90000000
+      - X: 590000000
+        Y: 90000000
+      - X: 590000000
+        Y: 90625000
+      - X: 580625024
+        Y: 100000000
+      - X: 550000000
+        Y: 100000000
+      - X: 550000000
+        Y: 100625000
+      - X: 540625024
+        Y: 110000000
+      - X: 520000000
+        Y: 110000000
+      - X: 520000000
+        Y: 100000000
+      - X: 540000000
+        Y: 100000000
+      - X: 540000000
+        Y: 60000000
+      - X: 550000000
+        Y: 60000000
+    - - X: 430000000
+        Y: 70000000
+      - X: 420000000
+        Y: 70000000
+      - X: 420000000
+        Y: 60000000
+      - X: 390000000
+        Y: 60000000
+      - X: 390000000
+        Y: 50000000
+      - X: 430000000
+        Y: 50000000
+    - - X: 550000000
+        Y: 9375000
+      - X: 550000000
+        Y: 10000000
+      - X: 580625024
+        Y: 10000000
+      - X: 590000000
+        Y: 19375000
+      - X: 590000000
+        Y: 20000000
+      - X: 600000000
+        Y: 20000000
+      - X: 600000000
+        Y: 30000000
+      - X: 589062528
+        Y: 30000000
+      - X: 580000000
+        Y: 20937500
+      - X: 580000000
+        Y: 20000000
+      - X: 550000000
+        Y: 20000000
+      - X: 550000000
+        Y: 50000000
+      - X: 540000000
+        Y: 50000000
+      - X: 540000000
+        Y: 10000000
+      - X: 500000000
+        Y: 10000000
+      - X: 500000000
+        Y: 0
+      - X: 540625024
+        Y: 0
+    - - X: 460000000
+        Y: 10000000
+      - X: 390000000
+        Y: 10000000
+      - X: 390000000
+        Y: 20000000
+      - X: 370000000
+        Y: 20000000
+      - X: 370000000
+        Y: 10000000
+      - X: 380000000
+        Y: 10000000
+      - X: 380000000
+        Y: 9062500
+      - X: 389062496
+        Y: 0
+      - X: 460000000
+        Y: 0
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 12, y: 76.0625}
+      - {x: 11.0625, y: 77}
+      - {x: 10, y: 77}
+      - {x: 10, y: 76}
+      - {x: 11, y: 76}
+      - {x: 11, y: 75}
+      - {x: 12, y: 75}
+    - - {x: 8, y: 76}
+      - {x: 9, y: 76}
+      - {x: 9, y: 77}
+      - {x: 7.9062495, y: 77}
+      - {x: 7, y: 76.09375}
+      - {x: 7, y: 75}
+      - {x: 8, y: 75}
+    - - {x: 27, y: 72}
+      - {x: 26, y: 72}
+      - {x: 26, y: 68}
+      - {x: 23, y: 68}
+      - {x: 23, y: 73}
+      - {x: 28, y: 73}
+      - {x: 28, y: 72}
+      - {x: 29, y: 72}
+      - {x: 29, y: 74}
+      - {x: 23, y: 74}
+      - {x: 23, y: 76}
+      - {x: 15, y: 76}
+      - {x: 15, y: 74}
+      - {x: 16, y: 74}
+      - {x: 16, y: 75}
+      - {x: 22, y: 75}
+      - {x: 22, y: 67}
+      - {x: 27, y: 67}
+    - - {x: 8, y: 74}
+      - {x: 7, y: 74}
+      - {x: 7, y: 73}
+      - {x: 8, y: 73}
+    - - {x: 16, y: 73}
+      - {x: 15, y: 73}
+      - {x: 15, y: 69}
+      - {x: 9, y: 69}
+      - {x: 9, y: 68}
+      - {x: 16, y: 68}
+    - - {x: 9, y: 71}
+      - {x: 8, y: 71}
+      - {x: 8, y: 72}
+      - {x: 7, y: 72}
+      - {x: 7, y: 70.90625}
+      - {x: 7.9062495, y: 70}
+      - {x: 9, y: 70}
+    - - {x: 12, y: 70.9375}
+      - {x: 12, y: 72}
+      - {x: 11, y: 72}
+      - {x: 11, y: 71}
+      - {x: 10, y: 71}
+      - {x: 10, y: 70}
+      - {x: 11.0625, y: 70}
+    - - {x: 36, y: 71}
+      - {x: 34, y: 71}
+      - {x: 34, y: 70}
+      - {x: 36, y: 70}
+    - - {x: 39, y: 71}
+      - {x: 37, y: 71}
+      - {x: 37, y: 70}
+      - {x: 39, y: 70}
+    - - {x: 69, y: 69}
+      - {x: 72, y: 69}
+      - {x: 72, y: 66}
+      - {x: 70, y: 66}
+      - {x: 70, y: 65}
+      - {x: 73, y: 65}
+      - {x: 73, y: 70}
+      - {x: 68, y: 70}
+      - {x: 68, y: 66}
+      - {x: 54, y: 66}
+      - {x: 54, y: 65}
+      - {x: 69, y: 65}
+    - - {x: 39, y: 69}
+      - {x: 38, y: 69}
+      - {x: 38, y: 68}
+      - {x: 37, y: 68}
+      - {x: 37, y: 67}
+      - {x: 39, y: 67}
+    - - {x: 36, y: 68}
+      - {x: 35, y: 68}
+      - {x: 35, y: 69}
+      - {x: 34, y: 69}
+      - {x: 34, y: 68}
+      - {x: 29, y: 68}
+      - {x: 29, y: 69}
+      - {x: 28, y: 69}
+      - {x: 28, y: 67}
+      - {x: 36, y: 67}
+    - - {x: 20, y: 67}
+      - {x: 21, y: 67}
+      - {x: 21, y: 68}
+      - {x: 20, y: 68}
+      - {x: 20, y: 69}
+      - {x: 17, y: 69}
+      - {x: 17, y: 68}
+      - {x: 19, y: 68}
+      - {x: 19, y: 65}
+      - {x: 20, y: 65}
+    - - {x: 2, y: 58.062504}
+      - {x: 1.0625, y: 59}
+      - {x: 1, y: 59}
+      - {x: 1, y: 67}
+      - {x: 6, y: 67}
+      - {x: 6, y: 65}
+      - {x: 7, y: 65}
+      - {x: 7, y: 67.0625}
+      - {x: 6.0625, y: 68}
+      - {x: 0.90625, y: 68}
+      - {x: 0, y: 67.09375}
+      - {x: 0, y: 57.906254}
+      - {x: 0.90625, y: 57}
+      - {x: 2, y: 57}
+    - - {x: 53, y: 63}
+      - {x: 50, y: 63}
+      - {x: 50, y: 67}
+      - {x: 55, y: 67}
+      - {x: 55, y: 68}
+      - {x: 41, y: 68}
+      - {x: 41, y: 67}
+      - {x: 49, y: 67}
+      - {x: 49, y: 62}
+      - {x: 53, y: 62}
+    - - {x: 76, y: 59}
+      - {x: 77, y: 59}
+      - {x: 77, y: 58}
+      - {x: 79, y: 58}
+      - {x: 79, y: 57}
+      - {x: 80, y: 57}
+      - {x: 80, y: 59}
+      - {x: 78, y: 59}
+      - {x: 78, y: 60}
+      - {x: 76, y: 60}
+      - {x: 76, y: 66}
+      - {x: 75, y: 66}
+      - {x: 75, y: 56}
+      - {x: 72, y: 56}
+      - {x: 72, y: 55}
+      - {x: 75, y: 55}
+      - {x: 75, y: 54}
+      - {x: 76, y: 54}
+    - - {x: 48, y: 56}
+      - {x: 51, y: 56}
+      - {x: 51, y: 55}
+      - {x: 53, y: 55}
+      - {x: 53, y: 61}
+      - {x: 48, y: 61}
+      - {x: 48, y: 66}
+      - {x: 36, y: 66}
+      - {x: 36, y: 62}
+      - {x: 37, y: 62}
+      - {x: 37, y: 65}
+      - {x: 40, y: 65}
+      - {x: 40, y: 63}
+      - {x: 41, y: 63}
+      - {x: 41, y: 65}
+      - {x: 44, y: 65}
+      - {x: 44, y: 63}
+      - {x: 45, y: 63}
+      - {x: 45, y: 65}
+      - {x: 47, y: 65}
+      - {x: 47, y: 58}
+      - {x: 49, y: 58}
+      - {x: 49, y: 60}
+      - {x: 52, y: 60}
+      - {x: 52, y: 57}
+      - {x: 47, y: 57}
+      - {x: 47, y: 56}
+      - {x: 41, y: 56}
+      - {x: 41, y: 55}
+      - {x: 48, y: 55}
+    - - {x: 60, y: 56}
+      - {x: 55, y: 56}
+      - {x: 55, y: 59}
+      - {x: 59, y: 59}
+      - {x: 59, y: 60}
+      - {x: 55, y: 60}
+      - {x: 55, y: 63}
+      - {x: 61, y: 63}
+      - {x: 61, y: 60}
+      - {x: 60, y: 60}
+      - {x: 60, y: 59}
+      - {x: 62, y: 59}
+      - {x: 62, y: 64}
+      - {x: 54, y: 64}
+      - {x: 54, y: 55}
+      - {x: 60, y: 55}
+    - - {x: 70, y: 56}
+      - {x: 68, y: 56}
+      - {x: 68, y: 64}
+      - {x: 63, y: 64}
+      - {x: 63, y: 63}
+      - {x: 67, y: 63}
+      - {x: 67, y: 60}
+      - {x: 63, y: 60}
+      - {x: 63, y: 59}
+      - {x: 67, y: 59}
+      - {x: 67, y: 56}
+      - {x: 62, y: 56}
+      - {x: 62, y: 55}
+      - {x: 70, y: 55}
+    - - {x: 23, y: 55}
+      - {x: 24, y: 55}
+      - {x: 24, y: 56}
+      - {x: 23, y: 56}
+      - {x: 23, y: 63}
+      - {x: 25, y: 63}
+      - {x: 25, y: 61}
+      - {x: 24, y: 61}
+      - {x: 24, y: 60}
+      - {x: 26, y: 60}
+      - {x: 26, y: 63}
+      - {x: 28, y: 63}
+      - {x: 28, y: 61}
+      - {x: 27, y: 61}
+      - {x: 27, y: 60}
+      - {x: 29, y: 60}
+      - {x: 29, y: 63}
+      - {x: 34, y: 63}
+      - {x: 34, y: 64}
+      - {x: 22, y: 64}
+      - {x: 22, y: 53}
+      - {x: 23, y: 53}
+    - - {x: 7, y: 63}
+      - {x: 6, y: 63}
+      - {x: 6, y: 62}
+      - {x: 7, y: 62}
+    - - {x: 21, y: 57}
+      - {x: 20, y: 57}
+      - {x: 20, y: 63}
+      - {x: 19, y: 63}
+      - {x: 19, y: 60}
+      - {x: 11, y: 60}
+      - {x: 11, y: 59}
+      - {x: 19, y: 59}
+      - {x: 19, y: 57}
+      - {x: 16, y: 57}
+      - {x: 16, y: 56}
+      - {x: 21, y: 56}
+    - - {x: 34, y: 62}
+      - {x: 30, y: 62}
+      - {x: 30, y: 60}
+      - {x: 31, y: 60}
+      - {x: 31, y: 61}
+      - {x: 33, y: 61}
+      - {x: 33, y: 59}
+      - {x: 30, y: 59}
+      - {x: 30, y: 57}
+      - {x: 31, y: 57}
+      - {x: 31, y: 58}
+      - {x: 33, y: 58}
+      - {x: 33, y: 56}
+      - {x: 29, y: 56}
+      - {x: 29, y: 59}
+      - {x: 27, y: 59}
+      - {x: 27, y: 58}
+      - {x: 28, y: 58}
+      - {x: 28, y: 56}
+      - {x: 26, y: 56}
+      - {x: 26, y: 59}
+      - {x: 25, y: 59}
+      - {x: 25, y: 55}
+      - {x: 34, y: 55}
+    - - {x: 40, y: 56}
+      - {x: 37, y: 56}
+      - {x: 37, y: 60}
+      - {x: 36, y: 60}
+      - {x: 36, y: 56}
+      - {x: 35, y: 56}
+      - {x: 35, y: 55}
+      - {x: 40, y: 55}
+    - - {x: 7, y: 57.9375}
+      - {x: 7, y: 60}
+      - {x: 6, y: 60}
+      - {x: 6, y: 59}
+      - {x: 5.90625, y: 59}
+      - {x: 5, y: 58.093746}
+      - {x: 5, y: 57}
+      - {x: 6.0625, y: 57}
+    - - {x: 15, y: 57}
+      - {x: 14, y: 57}
+      - {x: 14, y: 56}
+      - {x: 15, y: 56}
+    - - {x: 12, y: 55}
+      - {x: 11, y: 55}
+      - {x: 11, y: 56}
+      - {x: 13, y: 56}
+      - {x: 13, y: 57}
+      - {x: 10, y: 57}
+      - {x: 10, y: 54}
+      - {x: 12, y: 54}
+    - - {x: 24, y: 40}
+      - {x: 23, y: 40}
+      - {x: 23, y: 48}
+      - {x: 17, y: 48}
+      - {x: 17, y: 51}
+      - {x: 18, y: 51}
+      - {x: 18, y: 49}
+      - {x: 19, y: 49}
+      - {x: 19, y: 51}
+      - {x: 20, y: 51}
+      - {x: 20, y: 49}
+      - {x: 21, y: 49}
+      - {x: 21, y: 51}
+      - {x: 22, y: 51}
+      - {x: 22, y: 49}
+      - {x: 23, y: 49}
+      - {x: 23, y: 52}
+      - {x: 17, y: 52}
+      - {x: 17, y: 54}
+      - {x: 21, y: 54}
+      - {x: 21, y: 55}
+      - {x: 16, y: 55}
+      - {x: 16, y: 52}
+      - {x: 12, y: 52}
+      - {x: 12, y: 53}
+      - {x: 10, y: 53}
+      - {x: 10, y: 52}
+      - {x: 11, y: 52}
+      - {x: 11, y: 51}
+      - {x: 16, y: 51}
+      - {x: 16, y: 47}
+      - {x: 22, y: 47}
+      - {x: 22, y: 39}
+      - {x: 24, y: 39}
+    - - {x: 78, y: 42}
+      - {x: 81, y: 42}
+      - {x: 81, y: 47}
+      - {x: 80, y: 47}
+      - {x: 80, y: 49}
+      - {x: 79, y: 49}
+      - {x: 79, y: 48}
+      - {x: 77, y: 48}
+      - {x: 77, y: 46}
+      - {x: 80, y: 46}
+      - {x: 80, y: 43}
+      - {x: 77, y: 43}
+      - {x: 77, y: 40}
+      - {x: 72, y: 40}
+      - {x: 72, y: 51}
+      - {x: 76, y: 51}
+      - {x: 76, y: 53}
+      - {x: 75, y: 53}
+      - {x: 75, y: 52}
+      - {x: 68, y: 52}
+      - {x: 68, y: 51}
+      - {x: 70, y: 51}
+      - {x: 70, y: 46}
+      - {x: 67, y: 46}
+      - {x: 67, y: 52}
+      - {x: 66, y: 52}
+      - {x: 66, y: 42}
+      - {x: 65, y: 42}
+      - {x: 65, y: 41}
+      - {x: 67, y: 41}
+      - {x: 67, y: 45}
+      - {x: 71, y: 45}
+      - {x: 71, y: 39}
+      - {x: 78, y: 39}
+    - - {x: 34, y: 52}
+      - {x: 26, y: 52}
+      - {x: 26, y: 50}
+      - {x: 27, y: 50}
+      - {x: 27, y: 51}
+      - {x: 33, y: 51}
+      - {x: 33, y: 43}
+      - {x: 34, y: 43}
+    - - {x: 36, y: 51}
+      - {x: 41, y: 51}
+      - {x: 41, y: 47}
+      - {x: 42, y: 47}
+      - {x: 42, y: 51}
+      - {x: 45, y: 51}
+      - {x: 45, y: 49}
+      - {x: 46, y: 49}
+      - {x: 46, y: 52}
+      - {x: 35, y: 52}
+      - {x: 35, y: 47}
+      - {x: 36, y: 47}
+    - - {x: 65, y: 52}
+      - {x: 60, y: 52}
+      - {x: 60, y: 51}
+      - {x: 64, y: 51}
+      - {x: 64, y: 50}
+      - {x: 65, y: 50}
+    - - {x: 57, y: 47}
+      - {x: 55, y: 47}
+      - {x: 55, y: 45}
+      - {x: 53, y: 45}
+      - {x: 53, y: 46}
+      - {x: 52, y: 46}
+      - {x: 52, y: 48}
+      - {x: 53, y: 48}
+      - {x: 53, y: 49}
+      - {x: 55, y: 49}
+      - {x: 55, y: 48}
+      - {x: 56, y: 48}
+      - {x: 56, y: 51}
+      - {x: 59, y: 51}
+      - {x: 59, y: 52}
+      - {x: 49, y: 52}
+      - {x: 49, y: 44}
+      - {x: 56, y: 44}
+      - {x: 56, y: 43}
+      - {x: 57, y: 43}
+    - - {x: 50, y: 45}
+      - {x: 50, y: 51}
+      - {x: 55, y: 51}
+      - {x: 55, y: 50}
+      - {x: 52, y: 50}
+      - {x: 52, y: 49}
+      - {x: 51, y: 49}
+      - {x: 51, y: 45}
+    - - {x: 65, y: 49}
+      - {x: 64, y: 49}
+      - {x: 64, y: 47}
+      - {x: 63, y: 47}
+      - {x: 63, y: 46}
+      - {x: 64, y: 46}
+      - {x: 64, y: 43}
+      - {x: 65, y: 43}
+    - - {x: 34, y: 42}
+      - {x: 27, y: 42}
+      - {x: 27, y: 48}
+      - {x: 26, y: 48}
+      - {x: 26, y: 41}
+      - {x: 34, y: 41}
+    - - {x: 46, y: 48}
+      - {x: 45, y: 48}
+      - {x: 45, y: 41}
+      - {x: 46, y: 41}
+    - - {x: 61, y: 47}
+      - {x: 59, y: 47}
+      - {x: 59, y: 46}
+      - {x: 60, y: 46}
+      - {x: 60, y: 43}
+      - {x: 61, y: 43}
+    - - {x: 36, y: 34}
+      - {x: 43, y: 34}
+      - {x: 43, y: 35}
+      - {x: 36, y: 35}
+      - {x: 36, y: 39}
+      - {x: 45, y: 39}
+      - {x: 45, y: 38}
+      - {x: 46, y: 38}
+      - {x: 46, y: 40}
+      - {x: 36, y: 40}
+      - {x: 36, y: 46}
+      - {x: 35, y: 46}
+      - {x: 35, y: 33}
+      - {x: 36, y: 33}
+    - - {x: 50, y: 42}
+      - {x: 54, y: 42}
+      - {x: 54, y: 41}
+      - {x: 57, y: 41}
+      - {x: 57, y: 42}
+      - {x: 55, y: 42}
+      - {x: 55, y: 43}
+      - {x: 49, y: 43}
+      - {x: 49, y: 41}
+      - {x: 50, y: 41}
+    - - {x: 62, y: 41}
+      - {x: 64, y: 41}
+      - {x: 64, y: 42}
+      - {x: 60, y: 42}
+      - {x: 60, y: 41}
+      - {x: 61, y: 41}
+      - {x: 61, y: 36}
+      - {x: 62, y: 36}
+    - - {x: 34, y: 40}
+      - {x: 25, y: 40}
+      - {x: 25, y: 39}
+      - {x: 33, y: 39}
+      - {x: 33, y: 34}
+      - {x: 24, y: 34}
+      - {x: 24, y: 33}
+      - {x: 34, y: 33}
+    - - {x: 18, y: 40}
+      - {x: 17, y: 40}
+      - {x: 17, y: 39}
+      - {x: 18, y: 39}
+    - - {x: 50, y: 40}
+      - {x: 49, y: 40}
+      - {x: 49, y: 38}
+      - {x: 50, y: 38}
+    - - {x: 64, y: 39}
+      - {x: 63, y: 39}
+      - {x: 63, y: 38}
+      - {x: 64, y: 38}
+    - - {x: 46, y: 37}
+      - {x: 45, y: 37}
+      - {x: 45, y: 34}
+      - {x: 46, y: 34}
+    - - {x: 50, y: 37}
+      - {x: 49, y: 37}
+      - {x: 49, y: 34}
+      - {x: 50, y: 34}
+    - - {x: 75, y: 28}
+      - {x: 76, y: 28}
+      - {x: 76, y: 36}
+      - {x: 74, y: 36}
+      - {x: 74, y: 35}
+      - {x: 75, y: 35}
+      - {x: 75, y: 29}
+      - {x: 74, y: 29}
+      - {x: 74, y: 28}
+      - {x: 73, y: 28}
+      - {x: 73, y: 29}
+      - {x: 72, y: 29}
+      - {x: 72, y: 35}
+      - {x: 73, y: 35}
+      - {x: 73, y: 36}
+      - {x: 71, y: 36}
+      - {x: 71, y: 28}
+      - {x: 72, y: 28}
+      - {x: 72, y: 27}
+      - {x: 75, y: 27}
+    - - {x: 54, y: 35}
+      - {x: 52, y: 35}
+      - {x: 52, y: 34}
+      - {x: 53, y: 34}
+      - {x: 53, y: 31}
+      - {x: 54, y: 31}
+    - - {x: 33, y: 32}
+      - {x: 23, y: 32}
+      - {x: 23, y: 34}
+      - {x: 17, y: 34}
+      - {x: 17, y: 33}
+      - {x: 22, y: 33}
+      - {x: 22, y: 31}
+      - {x: 32, y: 31}
+      - {x: 32, y: 26}
+      - {x: 28, y: 26}
+      - {x: 28, y: 25}
+      - {x: 33, y: 25}
+    - - {x: 46, y: 23}
+      - {x: 42, y: 23}
+      - {x: 42, y: 33}
+      - {x: 41, y: 33}
+      - {x: 41, y: 23}
+      - {x: 38, y: 23}
+      - {x: 38, y: 22}
+      - {x: 46, y: 22}
+    - - {x: 38, y: 16}
+      - {x: 39, y: 16}
+      - {x: 39, y: 17}
+      - {x: 38, y: 17}
+      - {x: 38, y: 20}
+      - {x: 39, y: 20}
+      - {x: 39, y: 21}
+      - {x: 37, y: 21}
+      - {x: 37, y: 23}
+      - {x: 36, y: 23}
+      - {x: 36, y: 32}
+      - {x: 35, y: 32}
+      - {x: 35, y: 24}
+      - {x: 28, y: 24}
+      - {x: 28, y: 23}
+      - {x: 35, y: 23}
+      - {x: 35, y: 22}
+      - {x: 36, y: 22}
+      - {x: 36, y: 20}
+      - {x: 37, y: 20}
+      - {x: 37, y: 13}
+      - {x: 38, y: 13}
+    - - {x: 54, y: 30}
+      - {x: 53, y: 30}
+      - {x: 53, y: 29}
+      - {x: 54, y: 29}
+    - - {x: 56, y: 25}
+      - {x: 55, y: 25}
+      - {x: 55, y: 24}
+      - {x: 56, y: 24}
+    - - {x: 54, y: 25}
+      - {x: 53, y: 25}
+      - {x: 53, y: 24}
+      - {x: 54, y: 24}
+    - - {x: 60, y: 25}
+      - {x: 57, y: 25}
+      - {x: 57, y: 24}
+      - {x: 60, y: 24}
+    - - {x: 52, y: 23}
+      - {x: 50, y: 23}
+      - {x: 50, y: 21}
+      - {x: 52, y: 21}
+    - - {x: 54, y: 23}
+      - {x: 53, y: 23}
+      - {x: 53, y: 22}
+      - {x: 54, y: 22}
+    - - {x: 56, y: 23}
+      - {x: 55, y: 23}
+      - {x: 55, y: 22}
+      - {x: 56, y: 22}
+    - - {x: 60, y: 23}
+      - {x: 57, y: 23}
+      - {x: 57, y: 22}
+      - {x: 60, y: 22}
+    - - {x: 44, y: 17}
+      - {x: 46, y: 17}
+      - {x: 46, y: 21}
+      - {x: 40, y: 21}
+      - {x: 40, y: 20}
+      - {x: 41, y: 20}
+      - {x: 41, y: 19}
+      - {x: 42, y: 19}
+      - {x: 42, y: 20}
+      - {x: 45, y: 20}
+      - {x: 45, y: 18}
+      - {x: 43, y: 18}
+      - {x: 43, y: 17}
+      - {x: 42, y: 17}
+      - {x: 42, y: 18}
+      - {x: 41, y: 18}
+      - {x: 41, y: 17}
+      - {x: 40, y: 17}
+      - {x: 40, y: 16}
+      - {x: 43, y: 16}
+      - {x: 43, y: 15}
+      - {x: 44, y: 15}
+    - - {x: 53, y: 19}
+      - {x: 50, y: 19}
+      - {x: 50, y: 17}
+      - {x: 52, y: 17}
+      - {x: 52, y: 15}
+      - {x: 53, y: 15}
+    - - {x: 55, y: 9}
+      - {x: 58, y: 9}
+      - {x: 58, y: 8.90625}
+      - {x: 58.906254, y: 8}
+      - {x: 60, y: 8}
+      - {x: 60, y: 9}
+      - {x: 59, y: 9}
+      - {x: 59, y: 9.0625}
+      - {x: 58.062504, y: 10}
+      - {x: 55, y: 10}
+      - {x: 55, y: 10.0625}
+      - {x: 54.062504, y: 11}
+      - {x: 52, y: 11}
+      - {x: 52, y: 10}
+      - {x: 54, y: 10}
+      - {x: 54, y: 6}
+      - {x: 55, y: 6}
+    - - {x: 51, y: 11}
+      - {x: 50, y: 11}
+      - {x: 50, y: 6}
+      - {x: 51, y: 6}
+    - - {x: 49, y: 11}
+      - {x: 48, y: 11}
+      - {x: 48, y: 10}
+      - {x: 49, y: 10}
+    - - {x: 46, y: 11}
+      - {x: 45, y: 11}
+      - {x: 45, y: 10}
+      - {x: 46, y: 10}
+    - - {x: 43, y: 10}
+      - {x: 44, y: 10}
+      - {x: 44, y: 11}
+      - {x: 38.90625, y: 11}
+      - {x: 38, y: 10.093751}
+      - {x: 38, y: 10}
+      - {x: 37, y: 10}
+      - {x: 37, y: 9}
+      - {x: 39, y: 9}
+      - {x: 39, y: 10}
+      - {x: 42, y: 10}
+      - {x: 42, y: 8}
+      - {x: 43, y: 8}
+    - - {x: 43, y: 7}
+      - {x: 42, y: 7}
+      - {x: 42, y: 6}
+      - {x: 39, y: 6}
+      - {x: 39, y: 5}
+      - {x: 43, y: 5}
+    - - {x: 55, y: 0.9375}
+      - {x: 55, y: 1}
+      - {x: 58.062504, y: 1}
+      - {x: 59, y: 1.9375}
+      - {x: 59, y: 2}
+      - {x: 60, y: 2}
+      - {x: 60, y: 3}
+      - {x: 58.906254, y: 3}
+      - {x: 58, y: 2.09375}
+      - {x: 58, y: 2}
+      - {x: 55, y: 2}
+      - {x: 55, y: 5}
+      - {x: 54, y: 5}
+      - {x: 54, y: 1}
+      - {x: 50, y: 1}
+      - {x: 50, y: 0}
+      - {x: 54.062504, y: 0}
+    - - {x: 46, y: 1}
+      - {x: 39, y: 1}
+      - {x: 39, y: 2}
+      - {x: 37, y: 2}
+      - {x: 37, y: 1}
+      - {x: 38, y: 1}
+      - {x: 38, y: 0.90625}
+      - {x: 38.90625, y: 0}
+      - {x: 46, y: 0}
+  m_VertexDistance: 0.0005
+--- !u!50 &817340211
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 817340205}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!19719996 &817340212
+TilemapCollider2D:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 817340205}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: 0, y: 0}
 --- !u!1001 &821815468
 Prefab:
   m_ObjectHideFlags: 0
@@ -61913,7 +64092,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 1, z: 0}
     second:
       m_TileIndex: 3
@@ -61931,7 +64110,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 2, z: 0}
     second:
       m_TileIndex: 3
@@ -61949,7 +64128,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 50, y: 3, z: 0}
     second:
       m_TileIndex: 0
@@ -61958,7 +64137,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 51, y: 3, z: 0}
     second:
       m_TileIndex: 0
@@ -61967,7 +64146,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 3, z: 0}
     second:
       m_TileIndex: 0
@@ -61976,7 +64155,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 3, z: 0}
     second:
       m_TileIndex: 3
@@ -62048,7 +64227,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 4, z: 0}
     second:
       m_TileIndex: 3
@@ -62084,7 +64263,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 5, z: 0}
     second:
       m_TileIndex: 3
@@ -62228,7 +64407,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 7, z: 0}
     second:
       m_TileIndex: 3
@@ -62264,7 +64443,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 9, z: 0}
     second:
       m_TileIndex: 3
@@ -62570,7 +64749,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 14, z: 0}
     second:
       m_TileIndex: 1
@@ -62579,7 +64758,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 14, z: 0}
     second:
       m_TileIndex: 3
@@ -62705,7 +64884,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 20, y: 18, z: 0}
     second:
       m_TileIndex: 3
@@ -63308,7 +65487,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 19, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -63317,7 +65496,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 21, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -63326,7 +65505,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 22, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -63335,7 +65514,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 24, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -63344,7 +65523,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 25, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -63353,7 +65532,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 26, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -63362,7 +65541,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 27, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -63371,7 +65550,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -63380,7 +65559,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 30, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -63389,7 +65568,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -63398,7 +65577,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 34, z: 0}
     second:
       m_TileIndex: 1
@@ -63407,7 +65586,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 34, z: 0}
     second:
       m_TileIndex: 3
@@ -63605,7 +65784,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 65, y: 38, z: 0}
     second:
       m_TileIndex: 3
@@ -63749,7 +65928,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 43, z: 0}
     second:
       m_TileIndex: 3
@@ -63947,7 +66126,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 31, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -63956,7 +66135,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -63983,7 +66162,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 43, y: 45, z: 0}
     second:
       m_TileIndex: 2
@@ -63992,7 +66171,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 45, z: 0}
     second:
       m_TileIndex: 3
@@ -64046,7 +66225,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -64073,7 +66252,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 57, y: 46, z: 0}
     second:
       m_TileIndex: 3
@@ -64100,7 +66279,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 39, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -64118,7 +66297,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 72, y: 47, z: 0}
     second:
       m_TileIndex: 3
@@ -64163,7 +66342,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 36, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -64208,7 +66387,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 59, y: 48, z: 0}
     second:
       m_TileIndex: 0
@@ -64217,7 +66396,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 60, y: 48, z: 0}
     second:
       m_TileIndex: 0
@@ -64226,7 +66405,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 61, y: 48, z: 0}
     second:
       m_TileIndex: 0
@@ -64235,7 +66414,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 48, z: 0}
     second:
       m_TileIndex: 3
@@ -64253,7 +66432,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 49, z: 0}
     second:
       m_TileIndex: 2
@@ -64262,7 +66441,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 49, z: 0}
     second:
       m_TileIndex: 3
@@ -64280,7 +66459,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 32, y: 50, z: 0}
     second:
       m_TileIndex: 0
@@ -64289,7 +66468,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 42, y: 50, z: 0}
     second:
       m_TileIndex: 2
@@ -64298,7 +66477,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 50, z: 0}
     second:
       m_TileIndex: 3
@@ -64406,7 +66585,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 56, z: 0}
     second:
       m_TileIndex: 3
@@ -64442,7 +66621,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 57, z: 0}
     second:
       m_TileIndex: 2
@@ -64451,7 +66630,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 78, y: 57, z: 0}
     second:
       m_TileIndex: 2
@@ -64460,7 +66639,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 80, y: 57, z: 0}
     second:
       m_TileIndex: 3
@@ -64478,7 +66657,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 58, y: 58, z: 0}
     second:
       m_TileIndex: 3
@@ -64532,7 +66711,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 17, y: 60, z: 0}
     second:
       m_TileIndex: 0
@@ -64541,7 +66720,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 60, z: 0}
     second:
       m_TileIndex: 2
@@ -64550,7 +66729,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 61, z: 0}
     second:
       m_TileIndex: 2
@@ -64559,7 +66738,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 7, y: 62, z: 0}
     second:
       m_TileIndex: 3
@@ -64595,7 +66774,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 64, y: 62, z: 0}
     second:
       m_TileIndex: 0
@@ -64604,7 +66783,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 68, y: 62, z: 0}
     second:
       m_TileIndex: 2
@@ -64613,7 +66792,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 74, y: 62, z: 0}
     second:
       m_TileIndex: 2
@@ -64622,7 +66801,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 37, y: 63, z: 0}
     second:
       m_TileIndex: 3
@@ -64820,7 +66999,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 69, z: 0}
     second:
       m_TileIndex: 3
@@ -64874,7 +67053,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 28, y: 70, z: 0}
     second:
       m_TileIndex: 3
@@ -65099,7 +67278,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 10, y: 75, z: 0}
     second:
       m_TileIndex: 2
@@ -65108,7 +67287,7 @@ Tilemap:
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 3
-      m_ColliderType: 0
+      m_ColliderType: 1
   - first: {x: 12, y: 75, z: 0}
     second:
       m_TileIndex: 3
@@ -70719,6 +72898,21 @@ Transform:
   m_PrefabParentObject: {fileID: 4699640297835872, guid: fa26dc8a7e76973489beed18bc59d792,
     type: 2}
   m_PrefabInternal: {fileID: 1247669318}
+--- !u!1 &1248790741
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 1955758325}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1955758326}
+  m_Layer: 0
+  m_Name: Missing Prefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1001 &1250956675
 Prefab:
   m_ObjectHideFlags: 0
@@ -78048,6 +80242,34 @@ Transform:
   m_PrefabParentObject: {fileID: 4000012824533570, guid: 6123044d3e1847569dcc23e34dd3d3f5,
     type: 2}
   m_PrefabInternal: {fileID: 1581630210}
+--- !u!1 &1586355968
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 2122784268}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1586355969}
+  m_Layer: 0
+  m_Name: Missing Prefab (Dummy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1586355969
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 2122784268}
+  m_GameObject: {fileID: 1586355968}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2122784269}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1588710253
 Prefab:
   m_ObjectHideFlags: 0
@@ -79656,6 +81878,7 @@ Transform:
   - {fileID: 713042692}
   - {fileID: 789472104}
   - {fileID: 386446121}
+  - {fileID: 1955758326}
   - {fileID: 74127855}
   - {fileID: 1811799762}
   - {fileID: 1532783699}
@@ -79686,7 +81909,6 @@ Transform:
   - {fileID: 1571814115}
   - {fileID: 590200520}
   - {fileID: 947005209}
-  - {fileID: 1955758326}
   - {fileID: 95174702}
   - {fileID: 10476669}
   - {fileID: 1062502924}
@@ -80268,10 +82490,10 @@ Transform:
   - {fileID: 1551170057}
   - {fileID: 1689666959}
   - {fileID: 1820068395}
-  - {fileID: 547526927}
-  - {fileID: 1003096352}
   - {fileID: 204201114}
+  - {fileID: 547526927}
   - {fileID: 16282239}
+  - {fileID: 1003096352}
   - {fileID: 2053288197}
   m_Father: {fileID: 169189433}
   m_RootOrder: 1
@@ -100326,10 +102548,20 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: e7b65a2b345c046db8268576a2e8a388, type: 2}
   m_IsPrefabParent: 0
---- !u!4 &1955758326 stripped
+--- !u!4 &1955758326
 Transform:
+  m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 1955758325}
+  m_GameObject: {fileID: 1248790741}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2071699599}
+  m_Father: {fileID: 1658452411}
+  m_RootOrder: 219
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1955888221
 Prefab:
   m_ObjectHideFlags: 0
@@ -103309,6 +105541,34 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2071699598
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 1955758325}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2071699599}
+  m_Layer: 0
+  m_Name: Missing Prefab (Dummy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2071699599
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 1955758325}
+  m_GameObject: {fileID: 2071699598}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1955758326}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2082628453
 Prefab:
   m_ObjectHideFlags: 0
@@ -104143,10 +106403,20 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: e7b65a2b345c046db8268576a2e8a388, type: 2}
   m_IsPrefabParent: 0
---- !u!4 &2122784269 stripped
+--- !u!4 &2122784269
 Transform:
+  m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 2122784268}
+  m_GameObject: {fileID: 375452728}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1586355969}
+  m_Father: {fileID: 1658452411}
+  m_RootOrder: 194
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2132138678
 Prefab:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Tilemaps/Scripts/Tiles/ConnectedTile.cs
+++ b/UnityProject/Assets/Tilemaps/Scripts/Tiles/ConnectedTile.cs
@@ -94,7 +94,7 @@ namespace Tilemaps.Scripts.Tiles
             {
                 tileData.sprite = sprites[i];
                 tileData.flags = TileFlags.LockAll;
-				// create collider
+				// create collider for
 				tileData.colliderType = Tile.ColliderType.Sprite;
             }
         }

--- a/UnityProject/Assets/Tilemaps/Scripts/Tiles/ConnectedTile.cs
+++ b/UnityProject/Assets/Tilemaps/Scripts/Tiles/ConnectedTile.cs
@@ -94,7 +94,7 @@ namespace Tilemaps.Scripts.Tiles
             {
                 tileData.sprite = sprites[i];
                 tileData.flags = TileFlags.LockAll;
-				// create collider for
+				// create collider for tiles, None, Sprite or Grid
 				tileData.colliderType = Tile.ColliderType.Sprite;
             }
         }

--- a/UnityProject/Assets/Tilemaps/Scripts/Tiles/ConnectedTile.cs
+++ b/UnityProject/Assets/Tilemaps/Scripts/Tiles/ConnectedTile.cs
@@ -94,7 +94,8 @@ namespace Tilemaps.Scripts.Tiles
             {
                 tileData.sprite = sprites[i];
                 tileData.flags = TileFlags.LockAll;
-                tileData.colliderType = Tile.ColliderType.None;
+				// create collider
+				tileData.colliderType = Tile.ColliderType.Sprite;
             }
         }
 

--- a/UnityProject/Assets/UI/Fonts/Font_Awesome_4.7.0/Resources/FontAwesome.meta
+++ b/UnityProject/Assets/UI/Fonts/Font_Awesome_4.7.0/Resources/FontAwesome.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 262977eb415bc984ab55a4f54196ed70
+folderAsset: yes
+timeCreated: 1512548594
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
The Tilemap walls had no collider for what unity is concerned, this sucked because FOV and bullets depend on it.

### Approach
I turned the damn thing on, moved structure to layer "walls" and added the needed components to structure

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors
- [X]  This PR does not include scenes without specific need to do so.

### Notes:
FOV still has some slight QOL issues, but it works now too.
There also seems an issue that it doesn't load the collider grid unless ConnectedTile.cs gets reloaded, but I don't know if thats always the case or just when adding components.

The old Deathmatch maps seems to have another issue with FOV or it's switched off


### In case of feature: How to use the feature: