### PR TITLE
moved station by (0.5, 0.5) to align with the spawn points and FoV

### DIFF
--- a/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
+++ b/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
@@ -393,19 +393,19 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4913963894797502, guid: 74b0c48298b6e4d1489fa0aaadd8187b, type: 2}
       propertyPath: m_LocalPosition.x
-      value: 47.5
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 4913963894797502, guid: 74b0c48298b6e4d1489fa0aaadd8187b, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 25.5
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 4579866980362802, guid: 74b0c48298b6e4d1489fa0aaadd8187b, type: 2}
       propertyPath: m_LocalPosition.x
-      value: 15.5
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 4579866980362802, guid: 74b0c48298b6e4d1489fa0aaadd8187b, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 63.5
+      value: 63
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 74b0c48298b6e4d1489fa0aaadd8187b, type: 2}
@@ -1396,7 +1396,7 @@ Transform:
   - {fileID: 388090548}
   - {fileID: 830870708}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &74127854
 Prefab:
@@ -44296,7 +44296,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 639849607}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 27.5, y: 35.5, z: 0}
+  m_LocalPosition: {x: 27, y: 35, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 16282239}
@@ -46081,12 +46081,12 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 710173749}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0.5, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 169189433}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &713042670
 Prefab:
@@ -48341,7 +48341,7 @@ Tilemap:
   - first: {x: 37, y: 1, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 86
+      m_TileSpriteIndex: 101
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -48350,7 +48350,7 @@ Tilemap:
   - first: {x: 38, y: 1, z: 0}
     second:
       m_TileIndex: 1
-      m_TileSpriteIndex: 107
+      m_TileSpriteIndex: 96
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -48368,7 +48368,7 @@ Tilemap:
   - first: {x: 54, y: 1, z: 0}
     second:
       m_TileIndex: 1
-      m_TileSpriteIndex: 91
+      m_TileSpriteIndex: 107
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -48440,7 +48440,7 @@ Tilemap:
   - first: {x: 59, y: 2, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 71
+      m_TileSpriteIndex: 82
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -48656,7 +48656,7 @@ Tilemap:
   - first: {x: 59, y: 8, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 71
+      m_TileSpriteIndex: 82
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -48665,7 +48665,7 @@ Tilemap:
   - first: {x: 37, y: 9, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 86
+      m_TileSpriteIndex: 101
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -48701,7 +48701,7 @@ Tilemap:
   - first: {x: 54, y: 9, z: 0}
     second:
       m_TileIndex: 1
-      m_TileSpriteIndex: 91
+      m_TileSpriteIndex: 107
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -48737,7 +48737,7 @@ Tilemap:
   - first: {x: 58, y: 9, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 84
+      m_TileSpriteIndex: 91
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -48863,7 +48863,7 @@ Tilemap:
   - first: {x: 54, y: 10, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 84
+      m_TileSpriteIndex: 91
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -49817,7 +49817,7 @@ Tilemap:
   - first: {x: 59, y: 22, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 71
+      m_TileSpriteIndex: 82
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -49970,7 +49970,7 @@ Tilemap:
   - first: {x: 59, y: 24, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 71
+      m_TileSpriteIndex: 82
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -53048,7 +53048,7 @@ Tilemap:
   - first: {x: 78, y: 46, z: 0}
     second:
       m_TileIndex: 4
-      m_TileSpriteIndex: 85
+      m_TileSpriteIndex: 86
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -54569,7 +54569,7 @@ Tilemap:
   - first: {x: 36, y: 55, z: 0}
     second:
       m_TileIndex: 4
-      m_TileSpriteIndex: 83
+      m_TileSpriteIndex: 85
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -55100,7 +55100,7 @@ Tilemap:
   - first: {x: 0, y: 57, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 101
+      m_TileSpriteIndex: 84
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -55109,7 +55109,7 @@ Tilemap:
   - first: {x: 1, y: 57, z: 0}
     second:
       m_TileIndex: 1
-      m_TileSpriteIndex: 96
+      m_TileSpriteIndex: 83
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -55118,7 +55118,7 @@ Tilemap:
   - first: {x: 5, y: 57, z: 0}
     second:
       m_TileIndex: 1
-      m_TileSpriteIndex: 82
+      m_TileSpriteIndex: 81
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -55127,7 +55127,7 @@ Tilemap:
   - first: {x: 6, y: 57, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 81
+      m_TileSpriteIndex: 80
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -55271,7 +55271,7 @@ Tilemap:
   - first: {x: 0, y: 58, z: 0}
     second:
       m_TileIndex: 1
-      m_TileSpriteIndex: 80
+      m_TileSpriteIndex: 79
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -55280,7 +55280,7 @@ Tilemap:
   - first: {x: 1, y: 58, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 103
+      m_TileSpriteIndex: 78
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -55289,7 +55289,7 @@ Tilemap:
   - first: {x: 5, y: 58, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 79
+      m_TileSpriteIndex: 73
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -55298,7 +55298,7 @@ Tilemap:
   - first: {x: 6, y: 58, z: 0}
     second:
       m_TileIndex: 1
-      m_TileSpriteIndex: 78
+      m_TileSpriteIndex: 71
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -55406,7 +55406,7 @@ Tilemap:
   - first: {x: 48, y: 58, z: 0}
     second:
       m_TileIndex: 4
-      m_TileSpriteIndex: 73
+      m_TileSpriteIndex: 103
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -57188,7 +57188,7 @@ Tilemap:
   - first: {x: 6, y: 67, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 84
+      m_TileSpriteIndex: 91
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -58340,7 +58340,7 @@ Tilemap:
   - first: {x: 11, y: 76, z: 0}
     second:
       m_TileIndex: 0
-      m_TileSpriteIndex: 84
+      m_TileSpriteIndex: 91
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_ObjectToInstantiate: {fileID: 0}
@@ -58503,12 +58503,12 @@ Tilemap:
     m_Data: {fileID: 21300000, guid: 261c95d16b34285488152c60387e4bb1, type: 3}
   - m_RefCount: 3
     m_Data: {fileID: 21300028, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
-  - m_RefCount: 4
-    m_Data: {fileID: 21300006, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300050, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
   - m_RefCount: 4
     m_Data: {fileID: 21300000, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300040, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
+    m_Data: {fileID: 21300036, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 2
     m_Data: {fileID: 21300050, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 3
@@ -58518,23 +58518,23 @@ Tilemap:
   - m_RefCount: 2
     m_Data: {fileID: 21300048, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300050, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 21300036, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
+    m_Data: {fileID: 21300038, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300044, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300040, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300034, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
+  - m_RefCount: 4
+    m_Data: {fileID: 21300006, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300040, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300034, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300030, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
-  - m_RefCount: 4
-    m_Data: {fileID: 21300016, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300088, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
-  - m_RefCount: 2
-    m_Data: {fileID: 21300002, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 3
     m_Data: {fileID: 21300018, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 1
@@ -58543,8 +58543,8 @@ Tilemap:
     m_Data: {fileID: 21300018, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300032, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
-  - m_RefCount: 2
-    m_Data: {fileID: 21300024, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
+  - m_RefCount: 4
+    m_Data: {fileID: 21300016, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 4
     m_Data: {fileID: 21300014, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 1
@@ -58554,7 +58554,7 @@ Tilemap:
   - m_RefCount: 2
     m_Data: {fileID: 21300034, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300040, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
+    m_Data: {fileID: 21300016, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300000, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 2
@@ -58563,20 +58563,20 @@ Tilemap:
     m_Data: {fileID: 21300052, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 2
     m_Data: {fileID: 21300036, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 21300034, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
+  - m_RefCount: 2
+    m_Data: {fileID: 21300002, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300084, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300038, guid: 0ffb0ee13d246494fa84e652fd102e98, type: 3}
+    m_Data: {fileID: 21300040, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300088, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300028, guid: 261c95d16b34285488152c60387e4bb1, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300026, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 21300016, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
+  - m_RefCount: 2
+    m_Data: {fileID: 21300024, guid: 0a0f91b9c43ff9743a56ea9ef270abbd, type: 3}
   m_TileMatrixArray:
   - m_RefCount: 1129
     m_Data:
@@ -58624,7 +58624,7 @@ Tilemap:
     e33: 1
   m_TileRefreshArray:
   - serializedVersion: 1
-    m_DirtyIndex: 0
+    m_DirtyIndex: 4
   - serializedVersion: 1
     m_DirtyIndex: 0
   - serializedVersion: 1
@@ -58858,6 +58858,26 @@ CompositeCollider2D:
         Y: 670000000
       - X: 390000000
         Y: 670000000
+    - - X: 530000000
+        Y: 630000000
+      - X: 500000000
+        Y: 630000000
+      - X: 500000000
+        Y: 670000000
+      - X: 550000000
+        Y: 670000000
+      - X: 550000000
+        Y: 680000000
+      - X: 410000000
+        Y: 680000000
+      - X: 410000000
+        Y: 670000000
+      - X: 490000000
+        Y: 670000000
+      - X: 490000000
+        Y: 620000000
+      - X: 530000000
+        Y: 620000000
     - - X: 20000000
         Y: 580625024
       - X: 10625000
@@ -58886,26 +58906,6 @@ CompositeCollider2D:
         Y: 570000000
       - X: 20000000
         Y: 570000000
-    - - X: 530000000
-        Y: 630000000
-      - X: 500000000
-        Y: 630000000
-      - X: 500000000
-        Y: 670000000
-      - X: 550000000
-        Y: 670000000
-      - X: 550000000
-        Y: 680000000
-      - X: 410000000
-        Y: 680000000
-      - X: 410000000
-        Y: 670000000
-      - X: 490000000
-        Y: 670000000
-      - X: 490000000
-        Y: 620000000
-      - X: 530000000
-        Y: 620000000
     - - X: 760000000
         Y: 590000000
       - X: 770000000
@@ -59002,50 +59002,6 @@ CompositeCollider2D:
         Y: 550000000
       - X: 480000000
         Y: 550000000
-    - - X: 230000000
-        Y: 550000000
-      - X: 240000000
-        Y: 550000000
-      - X: 240000000
-        Y: 560000000
-      - X: 230000000
-        Y: 560000000
-      - X: 230000000
-        Y: 630000000
-      - X: 250000000
-        Y: 630000000
-      - X: 250000000
-        Y: 610000000
-      - X: 240000000
-        Y: 610000000
-      - X: 240000000
-        Y: 600000000
-      - X: 260000000
-        Y: 600000000
-      - X: 260000000
-        Y: 630000000
-      - X: 280000000
-        Y: 630000000
-      - X: 280000000
-        Y: 610000000
-      - X: 270000000
-        Y: 610000000
-      - X: 270000000
-        Y: 600000000
-      - X: 290000000
-        Y: 600000000
-      - X: 290000000
-        Y: 630000000
-      - X: 340000000
-        Y: 630000000
-      - X: 340000000
-        Y: 640000000
-      - X: 220000000
-        Y: 640000000
-      - X: 220000000
-        Y: 530000000
-      - X: 230000000
-        Y: 530000000
     - - X: 700000000
         Y: 560000000
       - X: 680000000
@@ -59106,6 +59062,58 @@ CompositeCollider2D:
         Y: 550000000
       - X: 600000000
         Y: 550000000
+    - - X: 230000000
+        Y: 550000000
+      - X: 240000000
+        Y: 550000000
+      - X: 240000000
+        Y: 560000000
+      - X: 230000000
+        Y: 560000000
+      - X: 230000000
+        Y: 630000000
+      - X: 250000000
+        Y: 630000000
+      - X: 250000000
+        Y: 610000000
+      - X: 240000000
+        Y: 610000000
+      - X: 240000000
+        Y: 600000000
+      - X: 260000000
+        Y: 600000000
+      - X: 260000000
+        Y: 630000000
+      - X: 280000000
+        Y: 630000000
+      - X: 280000000
+        Y: 610000000
+      - X: 270000000
+        Y: 610000000
+      - X: 270000000
+        Y: 600000000
+      - X: 290000000
+        Y: 600000000
+      - X: 290000000
+        Y: 630000000
+      - X: 340000000
+        Y: 630000000
+      - X: 340000000
+        Y: 640000000
+      - X: 220000000
+        Y: 640000000
+      - X: 220000000
+        Y: 530000000
+      - X: 230000000
+        Y: 530000000
+    - - X: 70000000
+        Y: 630000000
+      - X: 60000000
+        Y: 630000000
+      - X: 60000000
+        Y: 620000000
+      - X: 70000000
+        Y: 620000000
     - - X: 210000000
         Y: 570000000
       - X: 200000000
@@ -59130,14 +59138,6 @@ CompositeCollider2D:
         Y: 560000000
       - X: 210000000
         Y: 560000000
-    - - X: 70000000
-        Y: 630000000
-      - X: 60000000
-        Y: 630000000
-      - X: 60000000
-        Y: 620000000
-      - X: 70000000
-        Y: 620000000
     - - X: 340000000
         Y: 620000000
       - X: 300000000
@@ -59186,22 +59186,6 @@ CompositeCollider2D:
         Y: 550000000
       - X: 340000000
         Y: 550000000
-    - - X: 400000000
-        Y: 560000000
-      - X: 370000000
-        Y: 560000000
-      - X: 370000000
-        Y: 600000000
-      - X: 360000000
-        Y: 600000000
-      - X: 360000000
-        Y: 560000000
-      - X: 350000000
-        Y: 560000000
-      - X: 350000000
-        Y: 550000000
-      - X: 400000000
-        Y: 550000000
     - - X: 70000000
         Y: 579374976
       - X: 70000000
@@ -59218,14 +59202,22 @@ CompositeCollider2D:
         Y: 570000000
       - X: 60625000
         Y: 570000000
-    - - X: 150000000
-        Y: 570000000
-      - X: 140000000
-        Y: 570000000
-      - X: 140000000
+    - - X: 400000000
         Y: 560000000
-      - X: 150000000
+      - X: 370000000
         Y: 560000000
+      - X: 370000000
+        Y: 600000000
+      - X: 360000000
+        Y: 600000000
+      - X: 360000000
+        Y: 560000000
+      - X: 350000000
+        Y: 560000000
+      - X: 350000000
+        Y: 550000000
+      - X: 400000000
+        Y: 550000000
     - - X: 120000000
         Y: 550000000
       - X: 110000000
@@ -59242,6 +59234,14 @@ CompositeCollider2D:
         Y: 540000000
       - X: 120000000
         Y: 540000000
+    - - X: 150000000
+        Y: 570000000
+      - X: 140000000
+        Y: 570000000
+      - X: 140000000
+        Y: 560000000
+      - X: 150000000
+        Y: 560000000
     - - X: 240000000
         Y: 400000000
       - X: 230000000
@@ -59378,6 +59378,34 @@ CompositeCollider2D:
         Y: 390000000
       - X: 780000000
         Y: 390000000
+    - - X: 340000000
+        Y: 520000000
+      - X: 260000000
+        Y: 520000000
+      - X: 260000000
+        Y: 500000000
+      - X: 270000000
+        Y: 500000000
+      - X: 270000000
+        Y: 510000000
+      - X: 330000000
+        Y: 510000000
+      - X: 330000000
+        Y: 430000000
+      - X: 340000000
+        Y: 430000000
+    - - X: 650000000
+        Y: 520000000
+      - X: 600000000
+        Y: 520000000
+      - X: 600000000
+        Y: 510000000
+      - X: 640000000
+        Y: 510000000
+      - X: 640000000
+        Y: 500000000
+      - X: 650000000
+        Y: 500000000
     - - X: 570000000
         Y: 470000000
       - X: 550000000
@@ -59418,18 +59446,6 @@ CompositeCollider2D:
         Y: 430000000
       - X: 570000000
         Y: 430000000
-    - - X: 650000000
-        Y: 520000000
-      - X: 600000000
-        Y: 520000000
-      - X: 600000000
-        Y: 510000000
-      - X: 640000000
-        Y: 510000000
-      - X: 640000000
-        Y: 500000000
-      - X: 650000000
-        Y: 500000000
     - - X: 360000000
         Y: 510000000
       - X: 410000000
@@ -59454,22 +59470,6 @@ CompositeCollider2D:
         Y: 470000000
       - X: 360000000
         Y: 470000000
-    - - X: 340000000
-        Y: 520000000
-      - X: 260000000
-        Y: 520000000
-      - X: 260000000
-        Y: 500000000
-      - X: 270000000
-        Y: 500000000
-      - X: 270000000
-        Y: 510000000
-      - X: 330000000
-        Y: 510000000
-      - X: 330000000
-        Y: 430000000
-      - X: 340000000
-        Y: 430000000
     - - X: 500000000
         Y: 450000000
       - X: 500000000
@@ -59502,6 +59502,14 @@ CompositeCollider2D:
         Y: 430000000
       - X: 650000000
         Y: 430000000
+    - - X: 460000000
+        Y: 480000000
+      - X: 450000000
+        Y: 480000000
+      - X: 450000000
+        Y: 410000000
+      - X: 460000000
+        Y: 410000000
     - - X: 340000000
         Y: 420000000
       - X: 270000000
@@ -59513,14 +59521,6 @@ CompositeCollider2D:
       - X: 260000000
         Y: 410000000
       - X: 340000000
-        Y: 410000000
-    - - X: 460000000
-        Y: 480000000
-      - X: 450000000
-        Y: 480000000
-      - X: 450000000
-        Y: 410000000
-      - X: 460000000
         Y: 410000000
     - - X: 610000000
         Y: 470000000
@@ -59614,14 +59614,6 @@ CompositeCollider2D:
         Y: 330000000
       - X: 340000000
         Y: 330000000
-    - - X: 180000000
-        Y: 400000000
-      - X: 170000000
-        Y: 400000000
-      - X: 170000000
-        Y: 390000000
-      - X: 180000000
-        Y: 390000000
     - - X: 500000000
         Y: 400000000
       - X: 490000000
@@ -59630,6 +59622,14 @@ CompositeCollider2D:
         Y: 380000000
       - X: 500000000
         Y: 380000000
+    - - X: 180000000
+        Y: 400000000
+      - X: 170000000
+        Y: 400000000
+      - X: 170000000
+        Y: 390000000
+      - X: 180000000
+        Y: 390000000
     - - X: 640000000
         Y: 390000000
       - X: 630000000
@@ -59798,13 +59798,13 @@ CompositeCollider2D:
         Y: 290000000
       - X: 540000000
         Y: 290000000
-    - - X: 600000000
+    - - X: 560000000
         Y: 250000000
-      - X: 570000000
+      - X: 550000000
         Y: 250000000
-      - X: 570000000
+      - X: 550000000
         Y: 240000000
-      - X: 600000000
+      - X: 560000000
         Y: 240000000
     - - X: 540000000
         Y: 250000000
@@ -59814,14 +59814,30 @@ CompositeCollider2D:
         Y: 240000000
       - X: 540000000
         Y: 240000000
+    - - X: 600000000
+        Y: 250000000
+      - X: 570000000
+        Y: 250000000
+      - X: 570000000
+        Y: 240000000
+      - X: 600000000
+        Y: 240000000
     - - X: 560000000
-        Y: 250000000
+        Y: 230000000
       - X: 550000000
-        Y: 250000000
+        Y: 230000000
       - X: 550000000
-        Y: 240000000
+        Y: 220000000
       - X: 560000000
-        Y: 240000000
+        Y: 220000000
+    - - X: 600000000
+        Y: 230000000
+      - X: 570000000
+        Y: 230000000
+      - X: 570000000
+        Y: 220000000
+      - X: 600000000
+        Y: 220000000
     - - X: 520000000
         Y: 230000000
       - X: 500000000
@@ -59837,22 +59853,6 @@ CompositeCollider2D:
       - X: 530000000
         Y: 220000000
       - X: 540000000
-        Y: 220000000
-    - - X: 560000000
-        Y: 230000000
-      - X: 550000000
-        Y: 230000000
-      - X: 550000000
-        Y: 220000000
-      - X: 560000000
-        Y: 220000000
-    - - X: 600000000
-        Y: 230000000
-      - X: 570000000
-        Y: 230000000
-      - X: 570000000
-        Y: 220000000
-      - X: 600000000
         Y: 220000000
     - - X: 440000000
         Y: 170000000
@@ -59910,6 +59910,48 @@ CompositeCollider2D:
         Y: 150000000
       - X: 530000000
         Y: 150000000
+    - - X: 490000000
+        Y: 110000000
+      - X: 480000000
+        Y: 110000000
+      - X: 480000000
+        Y: 100000000
+      - X: 490000000
+        Y: 100000000
+    - - X: 550000000
+        Y: 90000000
+      - X: 580000000
+        Y: 90000000
+      - X: 580000000
+        Y: 89062496
+      - X: 589062528
+        Y: 80000000
+      - X: 600000000
+        Y: 80000000
+      - X: 600000000
+        Y: 90000000
+      - X: 590000000
+        Y: 90000000
+      - X: 590000000
+        Y: 90625000
+      - X: 580625024
+        Y: 100000000
+      - X: 550000000
+        Y: 100000000
+      - X: 550000000
+        Y: 100625000
+      - X: 540625024
+        Y: 110000000
+      - X: 520000000
+        Y: 110000000
+      - X: 520000000
+        Y: 100000000
+      - X: 540000000
+        Y: 100000000
+      - X: 540000000
+        Y: 60000000
+      - X: 550000000
+        Y: 60000000
     - - X: 430000000
         Y: 100000000
       - X: 440000000
@@ -59944,14 +59986,6 @@ CompositeCollider2D:
         Y: 100000000
       - X: 460000000
         Y: 100000000
-    - - X: 490000000
-        Y: 110000000
-      - X: 480000000
-        Y: 110000000
-      - X: 480000000
-        Y: 100000000
-      - X: 490000000
-        Y: 100000000
     - - X: 510000000
         Y: 110000000
       - X: 500000000
@@ -59959,40 +59993,6 @@ CompositeCollider2D:
       - X: 500000000
         Y: 60000000
       - X: 510000000
-        Y: 60000000
-    - - X: 550000000
-        Y: 90000000
-      - X: 580000000
-        Y: 90000000
-      - X: 580000000
-        Y: 89062496
-      - X: 589062528
-        Y: 80000000
-      - X: 600000000
-        Y: 80000000
-      - X: 600000000
-        Y: 90000000
-      - X: 590000000
-        Y: 90000000
-      - X: 590000000
-        Y: 90625000
-      - X: 580625024
-        Y: 100000000
-      - X: 550000000
-        Y: 100000000
-      - X: 550000000
-        Y: 100625000
-      - X: 540625024
-        Y: 110000000
-      - X: 520000000
-        Y: 110000000
-      - X: 520000000
-        Y: 100000000
-      - X: 540000000
-        Y: 100000000
-      - X: 540000000
-        Y: 60000000
-      - X: 550000000
         Y: 60000000
     - - X: 430000000
         Y: 70000000
@@ -60136,22 +60136,6 @@ CompositeCollider2D:
       - {x: 54, y: 66}
       - {x: 54, y: 65}
       - {x: 69, y: 65}
-    - - {x: 39, y: 69}
-      - {x: 38, y: 69}
-      - {x: 38, y: 68}
-      - {x: 37, y: 68}
-      - {x: 37, y: 67}
-      - {x: 39, y: 67}
-    - - {x: 36, y: 68}
-      - {x: 35, y: 68}
-      - {x: 35, y: 69}
-      - {x: 34, y: 69}
-      - {x: 34, y: 68}
-      - {x: 29, y: 68}
-      - {x: 29, y: 69}
-      - {x: 28, y: 69}
-      - {x: 28, y: 67}
-      - {x: 36, y: 67}
     - - {x: 20, y: 67}
       - {x: 21, y: 67}
       - {x: 21, y: 68}
@@ -60162,6 +60146,32 @@ CompositeCollider2D:
       - {x: 19, y: 68}
       - {x: 19, y: 65}
       - {x: 20, y: 65}
+    - - {x: 36, y: 68}
+      - {x: 35, y: 68}
+      - {x: 35, y: 69}
+      - {x: 34, y: 69}
+      - {x: 34, y: 68}
+      - {x: 29, y: 68}
+      - {x: 29, y: 69}
+      - {x: 28, y: 69}
+      - {x: 28, y: 67}
+      - {x: 36, y: 67}
+    - - {x: 39, y: 69}
+      - {x: 38, y: 69}
+      - {x: 38, y: 68}
+      - {x: 37, y: 68}
+      - {x: 37, y: 67}
+      - {x: 39, y: 67}
+    - - {x: 53, y: 63}
+      - {x: 50, y: 63}
+      - {x: 50, y: 67}
+      - {x: 55, y: 67}
+      - {x: 55, y: 68}
+      - {x: 41, y: 68}
+      - {x: 41, y: 67}
+      - {x: 49, y: 67}
+      - {x: 49, y: 62}
+      - {x: 53, y: 62}
     - - {x: 2, y: 58.062504}
       - {x: 1.0625, y: 59}
       - {x: 1, y: 59}
@@ -60176,16 +60186,6 @@ CompositeCollider2D:
       - {x: 0, y: 57.906254}
       - {x: 0.90625, y: 57}
       - {x: 2, y: 57}
-    - - {x: 53, y: 63}
-      - {x: 50, y: 63}
-      - {x: 50, y: 67}
-      - {x: 55, y: 67}
-      - {x: 55, y: 68}
-      - {x: 41, y: 68}
-      - {x: 41, y: 67}
-      - {x: 49, y: 67}
-      - {x: 49, y: 62}
-      - {x: 53, y: 62}
     - - {x: 76, y: 59}
       - {x: 77, y: 59}
       - {x: 77, y: 58}
@@ -60234,6 +60234,20 @@ CompositeCollider2D:
       - {x: 41, y: 56}
       - {x: 41, y: 55}
       - {x: 48, y: 55}
+    - - {x: 70, y: 56}
+      - {x: 68, y: 56}
+      - {x: 68, y: 64}
+      - {x: 63, y: 64}
+      - {x: 63, y: 63}
+      - {x: 67, y: 63}
+      - {x: 67, y: 60}
+      - {x: 63, y: 60}
+      - {x: 63, y: 59}
+      - {x: 67, y: 59}
+      - {x: 67, y: 56}
+      - {x: 62, y: 56}
+      - {x: 62, y: 55}
+      - {x: 70, y: 55}
     - - {x: 60, y: 56}
       - {x: 55, y: 56}
       - {x: 55, y: 59}
@@ -60250,20 +60264,6 @@ CompositeCollider2D:
       - {x: 54, y: 64}
       - {x: 54, y: 55}
       - {x: 60, y: 55}
-    - - {x: 70, y: 56}
-      - {x: 68, y: 56}
-      - {x: 68, y: 64}
-      - {x: 63, y: 64}
-      - {x: 63, y: 63}
-      - {x: 67, y: 63}
-      - {x: 67, y: 60}
-      - {x: 63, y: 60}
-      - {x: 63, y: 59}
-      - {x: 67, y: 59}
-      - {x: 67, y: 56}
-      - {x: 62, y: 56}
-      - {x: 62, y: 55}
-      - {x: 70, y: 55}
     - - {x: 23, y: 55}
       - {x: 24, y: 55}
       - {x: 24, y: 56}
@@ -60326,14 +60326,6 @@ CompositeCollider2D:
       - {x: 25, y: 59}
       - {x: 25, y: 55}
       - {x: 34, y: 55}
-    - - {x: 40, y: 56}
-      - {x: 37, y: 56}
-      - {x: 37, y: 60}
-      - {x: 36, y: 60}
-      - {x: 36, y: 56}
-      - {x: 35, y: 56}
-      - {x: 35, y: 55}
-      - {x: 40, y: 55}
     - - {x: 7, y: 57.9375}
       - {x: 7, y: 60}
       - {x: 6, y: 60}
@@ -60342,10 +60334,14 @@ CompositeCollider2D:
       - {x: 5, y: 58.093746}
       - {x: 5, y: 57}
       - {x: 6.0625, y: 57}
-    - - {x: 15, y: 57}
-      - {x: 14, y: 57}
-      - {x: 14, y: 56}
-      - {x: 15, y: 56}
+    - - {x: 40, y: 56}
+      - {x: 37, y: 56}
+      - {x: 37, y: 60}
+      - {x: 36, y: 60}
+      - {x: 36, y: 56}
+      - {x: 35, y: 56}
+      - {x: 35, y: 55}
+      - {x: 40, y: 55}
     - - {x: 12, y: 55}
       - {x: 11, y: 55}
       - {x: 11, y: 56}
@@ -60354,6 +60350,10 @@ CompositeCollider2D:
       - {x: 10, y: 57}
       - {x: 10, y: 54}
       - {x: 12, y: 54}
+    - - {x: 15, y: 57}
+      - {x: 14, y: 57}
+      - {x: 14, y: 56}
+      - {x: 15, y: 56}
     - - {x: 24, y: 40}
       - {x: 23, y: 40}
       - {x: 23, y: 48}
@@ -60430,18 +60430,6 @@ CompositeCollider2D:
       - {x: 33, y: 51}
       - {x: 33, y: 43}
       - {x: 34, y: 43}
-    - - {x: 36, y: 51}
-      - {x: 41, y: 51}
-      - {x: 41, y: 47}
-      - {x: 42, y: 47}
-      - {x: 42, y: 51}
-      - {x: 45, y: 51}
-      - {x: 45, y: 49}
-      - {x: 46, y: 49}
-      - {x: 46, y: 52}
-      - {x: 35, y: 52}
-      - {x: 35, y: 47}
-      - {x: 36, y: 47}
     - - {x: 65, y: 52}
       - {x: 60, y: 52}
       - {x: 60, y: 51}
@@ -60468,6 +60456,18 @@ CompositeCollider2D:
       - {x: 56, y: 44}
       - {x: 56, y: 43}
       - {x: 57, y: 43}
+    - - {x: 36, y: 51}
+      - {x: 41, y: 51}
+      - {x: 41, y: 47}
+      - {x: 42, y: 47}
+      - {x: 42, y: 51}
+      - {x: 45, y: 51}
+      - {x: 45, y: 49}
+      - {x: 46, y: 49}
+      - {x: 46, y: 52}
+      - {x: 35, y: 52}
+      - {x: 35, y: 47}
+      - {x: 36, y: 47}
     - - {x: 50, y: 45}
       - {x: 50, y: 51}
       - {x: 55, y: 51}
@@ -60540,26 +60540,26 @@ CompositeCollider2D:
       - {x: 24, y: 34}
       - {x: 24, y: 33}
       - {x: 34, y: 33}
-    - - {x: 18, y: 40}
-      - {x: 17, y: 40}
-      - {x: 17, y: 39}
-      - {x: 18, y: 39}
     - - {x: 50, y: 40}
       - {x: 49, y: 40}
       - {x: 49, y: 38}
       - {x: 50, y: 38}
+    - - {x: 18, y: 40}
+      - {x: 17, y: 40}
+      - {x: 17, y: 39}
+      - {x: 18, y: 39}
     - - {x: 64, y: 39}
       - {x: 63, y: 39}
       - {x: 63, y: 38}
       - {x: 64, y: 38}
-    - - {x: 46, y: 37}
-      - {x: 45, y: 37}
-      - {x: 45, y: 34}
-      - {x: 46, y: 34}
     - - {x: 50, y: 37}
       - {x: 49, y: 37}
       - {x: 49, y: 34}
       - {x: 50, y: 34}
+    - - {x: 46, y: 37}
+      - {x: 45, y: 37}
+      - {x: 45, y: 34}
+      - {x: 46, y: 34}
     - - {x: 75, y: 28}
       - {x: 76, y: 28}
       - {x: 76, y: 36}
@@ -60644,14 +60644,6 @@ CompositeCollider2D:
       - {x: 57, y: 25}
       - {x: 57, y: 24}
       - {x: 60, y: 24}
-    - - {x: 52, y: 23}
-      - {x: 50, y: 23}
-      - {x: 50, y: 21}
-      - {x: 52, y: 21}
-    - - {x: 54, y: 23}
-      - {x: 53, y: 23}
-      - {x: 53, y: 22}
-      - {x: 54, y: 22}
     - - {x: 56, y: 23}
       - {x: 55, y: 23}
       - {x: 55, y: 22}
@@ -60660,6 +60652,14 @@ CompositeCollider2D:
       - {x: 57, y: 23}
       - {x: 57, y: 22}
       - {x: 60, y: 22}
+    - - {x: 52, y: 23}
+      - {x: 50, y: 23}
+      - {x: 50, y: 21}
+      - {x: 52, y: 21}
+    - - {x: 54, y: 23}
+      - {x: 53, y: 23}
+      - {x: 53, y: 22}
+      - {x: 54, y: 22}
     - - {x: 44, y: 17}
       - {x: 46, y: 17}
       - {x: 46, y: 21}
@@ -60688,6 +60688,10 @@ CompositeCollider2D:
       - {x: 52, y: 17}
       - {x: 52, y: 15}
       - {x: 53, y: 15}
+    - - {x: 49, y: 11}
+      - {x: 48, y: 11}
+      - {x: 48, y: 10}
+      - {x: 49, y: 10}
     - - {x: 55, y: 9}
       - {x: 58, y: 9}
       - {x: 58, y: 8.90625}
@@ -60705,18 +60709,6 @@ CompositeCollider2D:
       - {x: 54, y: 10}
       - {x: 54, y: 6}
       - {x: 55, y: 6}
-    - - {x: 51, y: 11}
-      - {x: 50, y: 11}
-      - {x: 50, y: 6}
-      - {x: 51, y: 6}
-    - - {x: 49, y: 11}
-      - {x: 48, y: 11}
-      - {x: 48, y: 10}
-      - {x: 49, y: 10}
-    - - {x: 46, y: 11}
-      - {x: 45, y: 11}
-      - {x: 45, y: 10}
-      - {x: 46, y: 10}
     - - {x: 43, y: 10}
       - {x: 44, y: 10}
       - {x: 44, y: 11}
@@ -60730,6 +60722,14 @@ CompositeCollider2D:
       - {x: 42, y: 10}
       - {x: 42, y: 8}
       - {x: 43, y: 8}
+    - - {x: 46, y: 11}
+      - {x: 45, y: 11}
+      - {x: 45, y: 10}
+      - {x: 46, y: 10}
+    - - {x: 51, y: 11}
+      - {x: 50, y: 11}
+      - {x: 50, y: 6}
+      - {x: 51, y: 6}
     - - {x: 43, y: 7}
       - {x: 42, y: 7}
       - {x: 42, y: 6}
@@ -63819,7 +63819,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &966670980
 Prefab:
@@ -78998,7 +78998,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1532744587}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 76.5, y: 50.5, z: 0}
+  m_LocalPosition: {x: 77, y: 51, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 16282239}
@@ -104499,46 +104499,6 @@ Transform:
   m_PrefabParentObject: {fileID: 4905743905385754, guid: 281a9627782b7bd4a9ad7283af0300ce,
     type: 2}
   m_PrefabInternal: {fileID: 2033313958}
---- !u!1 &2037514279
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 2037514280}
-  - component: {fileID: 2037514281}
-  m_Layer: 0
-  m_Name: LobbySpawn
-  m_TagString: Untagged
-  m_Icon: {fileID: -964228994112308473, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2037514280
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2037514279}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1976.03, y: 1143.03, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2071673250}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2037514281
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2037514279}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -1050975500, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &2037675138
 Prefab:
   m_ObjectHideFlags: 0
@@ -105510,37 +105470,6 @@ Transform:
   m_PrefabParentObject: {fileID: 4000014280643290, guid: 78c5c1682869400f88094a093ea097b8,
     type: 2}
   m_PrefabInternal: {fileID: 2070792754}
---- !u!1 &2071673249
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1336196336489452, guid: 0fe8c7195fc924e17bd58d3b908840de,
-    type: 2}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 2071673250}
-  m_Layer: 0
-  m_Name: SpawnPoints
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2071673250
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4543065463001936, guid: 0fe8c7195fc924e17bd58d3b908840de,
-    type: 2}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2071673249}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2037514280}
-  m_Father: {fileID: 0}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2071699598
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Purpose
Putting the station at 0, 0 causes lots of problems, since the tms works with 0.5, 0.5 offset tiles.

### Approach
offsetting the station by 0.5, 0.5 seems to fix most issues with other offset stuff (e.g. FoV and spawn points)

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.