### PR TITLE
Fix fire ext not working

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/FireExtinguisherCabinet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/FireExtinguisherCabinet.prefab
@@ -86,7 +86,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -1, y: 0}
+  m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}


### PR DESCRIPTION
### Purpose
Fireext cabinet was not working due to offset on the trigger collider

### Approach
Set the offset to zero.

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors
- [X]  This PR does not include scenes without specific need to do so.

### Notes:


### In case of feature: How to use the feature: