### PR TITLE
Fixed reload shortcut and magazines pickup error

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_5.56mm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_5.56mm.prefab
@@ -27,7 +27,7 @@ GameObject:
   - component: {fileID: 114293222903219424}
   - component: {fileID: 114615447094342146}
   - component: {fileID: 114310753133130846}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: Magazine_5.56mm
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -43,7 +43,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4275761417540930}
   - component: {fileID: 212130450539007782}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: sprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Weapons/Weapon.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Weapon.cs
@@ -133,7 +133,7 @@ namespace Weapons
             }
 
             //Check if magazine in opposite hand or if unloading
-            if (Input.GetKeyDown(KeyCode.E))
+            if (Input.GetKeyDown(KeyCode.R))
             {
                 //PlaceHolder for click UI
                 GameObject currentHandItem = UIManager.Hands.CurrentSlot.Item;


### PR DESCRIPTION
### Purpose
Reload didn't work on the shortcut-key E.
Also big mags could not be picked up, fixed that too.

### Approach
E gets used for more than just reloads. I replaced E with R (the standard FPS reload key) and it works now (with a higher chance to keep working)
Big magazines where on the wrong layer, put them back on items and they are yet again functional.

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors
- [X]  This PR does not include scenes without specific need to do so.

### Notes:
Fixes #565 


### In case of feature: How to use the feature: