### PR TITLE
fixed doors closing with player inside

### DIFF
--- a/UnityProject/Assets/Tilemaps/Scripts/Behaviours/Layers/ObjectLayer.cs
+++ b/UnityProject/Assets/Tilemaps/Scripts/Behaviours/Layers/ObjectLayer.cs
@@ -65,15 +65,9 @@ namespace Tilemaps.Scripts.Behaviours.Layers
 
         public override bool IsPassableAt(Vector3Int position)
         {
-            var obj = Objects.GetFirst<RegisterObject>(position);
-
-            if (obj)
-            {
-                return obj.IsPassable();
-            }
-
-            var player = Objects.GetFirst<RegisterPlayer>(position);
-            return player ? player.IsPassable() : base.IsPassableAt(position);
+            var objects = Objects.Get<RegisterTile>(position);
+            
+            return objects.All(x => x.IsPassable()) && base.IsPassableAt(position);
         }
 
         public override bool IsAtmosPassableAt(Vector3Int position)


### PR DESCRIPTION
### Purpose
door were closing even if a player was standing inside.

### Approach
fixed by checking on the objectlayer of the tms for all objects. (Before it only check the first one it found)

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.

### Notes:
fixes #575