### PR TITLE
Fix ghost visibility on outpostdeathmatch

### DIFF
--- a/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
+++ b/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
@@ -64449,6 +64449,11 @@ Prefab:
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 20680082919460720, guid: bdc8c5eacef3f4b2a90445083973323d,
+        type: 2}
+      propertyPath: m_CullingMask.m_Bits
+      value: 2132803583
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: bdc8c5eacef3f4b2a90445083973323d, type: 2}
   m_IsPrefabParent: 0


### PR DESCRIPTION
### Purpose
The living could see the dead. That's bad, mkay?

### Approach
The main camera had ghosts unculled on start.

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.
