### PR TITLE
forcing items to be placed under the objects game object

### DIFF
--- a/UnityProject/Assets/Scripts/Equipment/ObjectPool.cs
+++ b/UnityProject/Assets/Scripts/Equipment/ObjectPool.cs
@@ -60,7 +60,7 @@ namespace Equipment
 
         private static void DropNow(GameObject gObj, Vector3 dropPos)
         {
-            gObj.transform.parent = null;
+            gObj.transform.parent = GameObject.FindGameObjectWithTag("SpawnParent").transform;
             gObj.transform.position = dropPos;
         }
     }

--- a/UnityProject/Assets/Tilemaps/Scripts/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Tilemaps/Scripts/Behaviours/Objects/RegisterTile.cs
@@ -35,7 +35,13 @@ namespace Tilemaps.Scripts.Behaviours.Objects
         public void Start()
         {
             layer = transform.GetComponentInParent<ObjectLayer>();
-
+            
+            if (layer == null)
+            {
+                transform.parent = GameObject.FindGameObjectWithTag("SpawnParent").transform;
+                layer = transform.parent.GetComponentInParent<ObjectLayer>();
+            }
+            
             Register();
         }
 


### PR DESCRIPTION
### Purpose
Items didn't get placed under the Objects gameobject, which lead to problems, e.g. when trying to pull.

### Approach
Similar to Matrix.GetMatrix(....), the items will be placed under Objects.

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.

### Notes:
This is a temporary fix as it won't work with multi matrices.