### PR TITLE
Adding windows and linux to travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 # do not install anything extra onto the image
 language: generic
 
@@ -11,12 +12,14 @@ os: osx
 cache:
   timeout: 1000
   directories:
-  - $HOME/Applications/Unity
+  - /Applications/Unity
+  - /Users/Travis/Library/Unity
+  - /Users/Travis/Library/Preferences/Unity
 
 # only run builds on pushes to the master branch
 branches:
   only:
-  - develop
+  - Develop
   - TravisCI
 
 # send email notifications when the build changes from succeeding to broken
@@ -29,19 +32,15 @@ notifications:
 #before_install:
 #- openssl aes-256-cbc -k "$KEYFILE_PASS" -in "${UPLOAD_KEYPATH}.enc" -out "${UPLOAD_KEYPATH}" -d
 
-# run the script to download and install Unity editor to cache
-#install: travis_wait 30 sh ./Travis/upgrade.sh
+# run the script to download and install Unity editor
+install: travis_wait 30 sudo -E sh ./Travis/upgrade.sh
 
 jobs:
   include:
     - stage: Testing
-      script: travis_wait 45 sudo -E sh ./Travis/build.sh
-    - # stage name not required, will continue to use `test`
-      script: travis_wait 45 sudo -E sh ./Travis/buildOSX.sh
+      script: travis_wait 45 sudo -E sh ./Travis/blank.sh
 #    - # stage name not required, will continue to use `test`
-#      script: travis_wait 45 sudo -E sh ./Travis/buildWindows.sh
-#    - # stage name not required, will continue to use `test`
-#      script: travis_wait 45 sudo -E sh ./Travis/buildLinux.sh
+#      script: travis_wait 45 sudo -E sh ./Travis/buildOther.sh
 #    - stage: deploy
 #      script: sudo -E sh ./Travis/post_build.sh
 

--- a/Travis/build.sh
+++ b/Travis/build.sh
@@ -1,3 +1,4 @@
+
 #! /bin/sh
 
 # NOTE the command args below make the assumption that your Unity project folder is
@@ -7,7 +8,7 @@
 
 ## Run the editor unit tests
 echo "Running editor unit tests for ${UNITYCI_PROJECT_NAME}"
-/Users/travis/Applications/Unity/Unity.app/Contents/MacOS/Unity \
+/Applications/Unity/Unity.app/Contents/MacOS/Unity \
 	-batchmode \
 	-nographics \
 	-silent-crashes \
@@ -18,7 +19,25 @@ echo "Running editor unit tests for ${UNITYCI_PROJECT_NAME}"
 	-quit
 
 rc0=$?
+
 echo "Unit test logs"
 cat $(pwd)/test.xml
 # exit if tests failed
 if [ $rc0 -ne 0 ]; then { echo "Failed unit tests"; exit $rc0; } fi
+
+echo "Attempting build of ${UNITYCI_PROJECT_NAME} for OSX"
+/Applications/Unity/Unity.app/Contents/MacOS/Unity \
+	-batchmode \
+	-nographics \
+	-silent-crashes \
+	-logFile $(pwd)/unity.log \
+	-projectPath "$(pwd)/${UNITYCI_PROJECT_NAME}" \
+	-buildOSXUniversalPlayer "$(pwd)/Build/osx/${UNITYCI_PROJECT_NAME}.app" \
+	-quit
+
+ls -l $(pwd)/Build/osx/
+rc1=$?
+echo "Build logs (OSX)"
+cat $(pwd)/unity.log
+
+exit $(($rc1))

--- a/Travis/buildLinux.sh
+++ b/Travis/buildLinux.sh
@@ -1,9 +1,5 @@
-
 ## Make the builds
 # Recall from install.sh that a separate module was needed for Windows build support
-echo "Installing UnitySetup-Linux-Support-for-Editor"
-sudo installer -dumplog -package "UnitySetup-Linux-Support-for-Editor-$VERSION.pkg" -target /
-
 echo "Attempting build of ${UNITYCI_PROJECT_NAME} for Linux"
 /Applications/Unity/Unity.app/Contents/MacOS/Unity \
 	-batchmode \

--- a/Travis/buildOther.sh
+++ b/Travis/buildOther.sh
@@ -1,0 +1,36 @@
+## Make the builds
+# Recall from install.sh that a separate module was needed for Windows build support
+echo "Attempting build of ${UNITYCI_PROJECT_NAME} for Windows"
+/Applications/Unity/Unity.app/Contents/MacOS/Unity \
+	-batchmode \
+	-nographics \
+	-silent-crashes \
+	-logFile $(pwd)/unity.log \
+	-projectPath "$(pwd)/${UNITYCI_PROJECT_NAME}" \
+	-buildWindows64Player "$(pwd)/Build/windows/${UNITYCI_PROJECT_NAME}.exe" \
+	-quit
+
+ls -l $(pwd)/Build/windows/
+rc2=$?
+echo "Build logs (Windows)"
+cat $(pwd)/unity.log
+
+## Make the builds
+# Recall from install.sh that a separate module was needed for Linux build support
+echo "Attempting build of ${UNITYCI_PROJECT_NAME} for Linux"
+/Applications/Unity/Unity.app/Contents/MacOS/Unity \
+	-batchmode \
+	-nographics \
+	-silent-crashes \
+	-logFile $(pwd)/unity.log \
+	-projectPath "$(pwd)/${UNITYCI_PROJECT_NAME}" \
+	-buildLinuxUniversalPlayer  "$(pwd)/Build/linux/${UNITYCI_PROJECT_NAME}.bin" \
+	-quit
+
+ls -l $(pwd)/Build/linux/
+
+rc3=$?
+echo "Build logs (Linux)"
+cat $(pwd)/unity.log
+
+exit $(($rc2|$rc3))

--- a/Travis/buildWindows.sh
+++ b/Travis/buildWindows.sh
@@ -1,9 +1,7 @@
 ## Make the builds
 # Recall from install.sh that a separate module was needed for Windows build support
-echo "Installing UnitySetup-Windows-Support-for-Editor-$VERSION"
-sudo installer -dumplog -package "UnitySetup-Windows-Support-for-Editor-$VERSION.pkg" -target /
 echo "Attempting build of ${UNITYCI_PROJECT_NAME} for Windows"
-/Applications/Unity/Unity.app/Contents/MacOS/Unity \
+/Users/travis/Applications/Unity/Unity.app/Contents/MacOS/Unity \
 	-batchmode \
 	-nographics \
 	-silent-crashes \

--- a/Travis/upgrade.sh
+++ b/Travis/upgrade.sh
@@ -17,13 +17,20 @@ install() {
   download "$package"
 
   echo "Installing "`basename "$package"`
-  installer -dumplog -package `basename "$package"` -target CurrentUserHomeDirectory
+  sudo installer -dumplog -package `basename "$package"` -target /
 }
 
 # See $BASE_URL/$HASH/unity-$VERSION-$PLATFORM.ini for complete list
 # of available packages, where PLATFORM is `osx` or `win`
 
 install "MacEditorInstaller/Unity-$VERSION.pkg"
-#install "MacEditorTargetInstaller/UnitySetup-Windows-Support-for-Editor-$VERSION.pkg"
+install "MacEditorTargetInstaller/UnitySetup-Windows-Support-for-Editor-$VERSION.pkg"
 #install "MacEditorTargetInstaller/UnitySetup-Mac-Support-for-Editor-$VERSION.pkg"
-#install "MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-$VERSION.pkg"
+install "MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-$VERSION.pkg"
+
+
+sudo chmod -R 777 /Applications/Unity
+ls /Applications/Unity
+ls /Applications/Unity/PlaybackEngines
+ls /Users/Travis/Library/Unity
+ls /Users/Travis/Library/Preferences/Unity


### PR DESCRIPTION
### Purpose
Travis was not building Linux and Windows Binaries and if configured to do so it was inefficient

### Approach
Added windows and linux packages, cached them and put those into a seperate parallel job.

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors
- [X]  This PR does not include scenes without specific need to do so.

### Notes:
First of two PR's, this one is needed to generate cache.


### In case of feature: How to use the feature: