### PR TITLE
forgot to add spritesheet offset back

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
@@ -176,8 +176,8 @@ namespace PlayGroups.Input
                     var x = hitPosition.y * Mathf.Sin(angle) - hitPosition.x * Mathf.Cos(angle);
                     var y = hitPosition.y * Mathf.Cos(angle) - hitPosition.x * Mathf.Sin(angle);
                     
-                    var texPosX = Mathf.RoundToInt((x / scale.x - offset.x % 1) * pixelsPerUnit + sprite.rect.width * 0.5f);
-                    var texPosY = Mathf.RoundToInt((y / scale.y - offset.y % 1) * pixelsPerUnit + sprite.rect.height * 0.5f);
+                    var texPosX = Mathf.RoundToInt(sprite.rect.x + (x / scale.x - offset.x % 1) * pixelsPerUnit + sprite.rect.width * 0.5f);
+                    var texPosY = Mathf.RoundToInt(sprite.rect.y + (y / scale.y - offset.y % 1) * pixelsPerUnit + sprite.rect.height * 0.5f);
 
                     var pixelColor = sprite.texture.GetPixel(texPosX, texPosY);
                     if (pixelColor.a > 0)


### PR DESCRIPTION
### Purpose
interaction with closets, doors, etc. wasnt possible due to missing spritesheet offset. The bug was introduced through PR #622

### Approach
added offset back in.

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.