### PR TITLE
Finish adding uniHeadSet and re-enable chat limitations based on headset

### DIFF
--- a/UnityProject/Assets/Scripts/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Equipment/Equipment.cs
@@ -157,17 +157,13 @@ namespace Equipment
 
             foreach (KeyValuePair<string, string> gearItem in gear)
             {
-				if (gearItem.Value.Contains("cloth"))
+				if (gearItem.Value.Contains(ClothFactory.ClothingHierIdentifier) ||
+					gearItem.Value.Contains(ClothFactory.HeadsetHierIdentifier))
 				{
 					GameObject obj = ClothFactory.Instance.CreateCloth(gearItem.Value, Vector3.zero);
 					ItemAttributes itemAtts = obj.GetComponent<ItemAttributes>();
 					SetItem(GetLoadOutEventName(gearItem.Key), itemAtts.gameObject);
-				} else if (gearItem.Value.Contains("headset")) {
-					GameObject obj = ClothFactory.Instance.CreateCloth(gearItem.Value, Vector3.zero);
-					ItemAttributes itemAtts = obj.GetComponent<ItemAttributes>();
-					SetItem(GetLoadOutEventName(gearItem.Key), itemAtts.gameObject);
-					obj.AddComponent<Headset>();
-				} else {
+				} else if (!String.IsNullOrEmpty(gearItem.Value)) {
 					Debug.Log(gearItem.Value + " creation not implemented yet.");
 				}
             }

--- a/UnityProject/Assets/Scripts/Factories/ClothFactory.cs
+++ b/UnityProject/Assets/Scripts/Factories/ClothFactory.cs
@@ -8,6 +8,9 @@ public class ClothFactory : NetworkBehaviour
 {
     public static ClothFactory Instance;
 
+	public static string ClothingHierIdentifier = "cloth";
+	public static string HeadsetHierIdentifier = "headset";
+
     private GameObject uniCloth { get; set; }
     private GameObject uniHeadSet { get; set; }
 
@@ -23,7 +26,8 @@ public class ClothFactory : NetworkBehaviour
     {
         //Do init stuff
         uniCloth = Resources.Load("UniCloth") as GameObject;
-    }
+		uniHeadSet = Resources.Load("UniHeadSet") as GameObject;
+	}
 
     public void PreLoadCloth(int preLoads)
     {
@@ -37,12 +41,35 @@ public class ClothFactory : NetworkBehaviour
     public GameObject CreateCloth(string hierString, Vector3 spawnPos)
     {
         if (!CustomNetworkManager.Instance._isServer)
-            return null;
+		{
+			return null;
+		}
 
-        //PoolManager handles networkspawn
-        GameObject clothObj = PoolManager.Instance.PoolNetworkInstantiate(uniCloth, spawnPos, Quaternion.identity);
+		//PoolManager handles networkspawn
+		GameObject uniItem = pickClothObject(hierString);
+		GameObject clothObj = PoolManager.Instance.PoolNetworkInstantiate(uniItem, spawnPos, Quaternion.identity);
         ItemAttributes i = clothObj.GetComponent<ItemAttributes>();
         i.hierarchy = hierString;
+		if(uniItem == uniHeadSet)
+		{
+			Headset headset = clothObj.GetComponent<Headset>();
+			headset.init();
+		}
         return clothObj;
     }
+
+	private GameObject pickClothObject(string hierarchy)
+	{
+		if(hierarchy.Contains(ClothingHierIdentifier))
+		{
+			return uniCloth;
+		} else if (hierarchy.Contains(HeadsetHierIdentifier))
+		{
+			return uniHeadSet;
+		} else
+		{
+			Debug.LogError("Clot factory could not pick uni item. Falling back to uniCloth");
+			return uniCloth;
+		}
+	}
 }

--- a/UnityProject/Assets/Scripts/Items/Headset.cs
+++ b/UnityProject/Assets/Scripts/Items/Headset.cs
@@ -8,9 +8,10 @@ using UnityEngine.Networking;
 /// </summary>
 public class Headset : NetworkBehaviour
 {
+	[SyncVar]
 	public EncryptionKeyType EncryptionKey;
 
-	private void Start()
+	public void init()
 	{
 		getEncryptionTypeFromHier();
 	}

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
@@ -12,7 +12,7 @@ namespace PlayGroup
         // the maximum distance the player needs to be to an object to interact with it
 		//1.75 is the optimal distance to now have any direction click too far
 		//NOTE FOR ANYONE EDITING THIS IN THE FUTURE: Character's head is slightly below the top of the tile
-		//hence top reach is slightly lowered than bottom reach, where the legs go exactly to the bottom of the tile.
+		//hence top reach is slightly lower than bottom reach, where the legs go exactly to the bottom of the tile.
         public const float interactionDistance = 1.75f;
 
         public PlayerNetworkActions playerNetworkActions { get; set; }
@@ -215,11 +215,11 @@ namespace PlayGroup
             //TODO: Checks if player can speak (is not gagged, unconcious, has no mouth)
             ChatChannel transmitChannels = ChatChannel.OOC | ChatChannel.Local;
 
-            /*GameObject headset = UIManager.InventorySlots.EarSlot.Item;
+            GameObject headset = UIManager.InventorySlots.EarSlot.Item;
             if(headset) {
                 EncryptionKeyType key = headset.GetComponent<Headset>().EncryptionKey;
                 transmitChannels = transmitChannels | EncryptionKey.Permissions[key];
-            }*/
+            }
             ChatChannel receiveChannels = (ChatChannel.Examine | ChatChannel.System);
 
             if (transmitOnly)


### PR DESCRIPTION
### Purpose
Headsets are fully in.
Chat channels now depend entirely on headset.

### Approach
Updated clothfactory to differentiate between uniCloth and uniHeadset and spawn the new type accordingly.

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.

### Notes:
uniAnything is the future! I really like this best of both worlds approach. With some cleanup, simplification and unification refactoring to Equipment.cs this can be a really powerful system.