### PR TITLE
Added department selection to Occupation Roster

### DIFF
--- a/UnityProject/Assets/Scripts/Jobs/JobDepartments.cs
+++ b/UnityProject/Assets/Scripts/Jobs/JobDepartments.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// See \code\__DEFINES\jobs.dm
+public enum JobDepartment
+{
+    Graytide,
+    Medical,
+    Engineering,
+    Security,
+    Research,
+    Personal,
+}

--- a/UnityProject/Assets/Scripts/Jobs/JobDepartments.cs.meta
+++ b/UnityProject/Assets/Scripts/Jobs/JobDepartments.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1acc21b5686bf42368b45def00747f6d
+timeCreated: 1498499039
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Jobs/OccupationRoster.cs
+++ b/UnityProject/Assets/Scripts/Jobs/OccupationRoster.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class OccupationRoster : MonoBehaviour
 {
     public JobType Type;
+    public JobDepartment department;
     public int limit;
     public int priority = 99;
     public GameObject outfit;


### PR DESCRIPTION
### Purpose
Added departments to the Occupation rooster, for use in the team deathmatch system

### Approach
A player now not only has a job, but also a department this job belongs too.

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors
- [X]  This PR does not include scenes without specific need to do so.

### Notes:
This can be used for the TDM statistics and or spawn


### In case of feature: How to use the feature:
