### PR TITLE
Closet fix

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Accessories/Resources/Space Cigarettes.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Accessories/Resources/Space Cigarettes.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1645856876941636}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 183.24207, y: 38.653076, z: -0.2}
+  m_LocalPosition: {x: 183.24207, y: 38.653076, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4915420850159430}

--- a/UnityProject/Assets/Prefabs/Items/Food/Resources/Meat Steak.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Resources/Meat Steak.prefab
@@ -69,7 +69,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1110193000772614}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -7, y: 8, z: -0.2}
+  m_LocalPosition: {x: -7, y: 8, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4207712374710558}

--- a/UnityProject/Assets/Prefabs/Items/Food/Resources/Meat.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Resources/Meat.prefab
@@ -69,7 +69,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1970759932574268}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -8, y: 8, z: -0.2}
+  m_LocalPosition: {x: -8, y: 8, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4206167326584234}

--- a/UnityProject/Assets/Prefabs/Items/IDs/Resources/ID.prefab
+++ b/UnityProject/Assets/Prefabs/Items/IDs/Resources/ID.prefab
@@ -57,7 +57,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1748120534729806}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 182.24207, y: 38.653076, z: -0.2}
+  m_LocalPosition: {x: 182.24207, y: 38.653076, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4871409285900632}

--- a/UnityProject/Assets/Prefabs/Items/Kitchen/Resources/Pepper Shaker.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Kitchen/Resources/Pepper Shaker.prefab
@@ -69,7 +69,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1651733465195328}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -11, y: 5, z: -0.2}
+  m_LocalPosition: {x: -11, y: 5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4117772871168058}

--- a/UnityProject/Assets/Prefabs/Items/Kitchen/Resources/RollingPin.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Kitchen/Resources/RollingPin.prefab
@@ -69,7 +69,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000012939332086}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1, y: 6, z: -0.2}
+  m_LocalPosition: {x: -1, y: 6, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4000013350538200}

--- a/UnityProject/Assets/Prefabs/Items/Kitchen/Resources/Salt Shaker.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Kitchen/Resources/Salt Shaker.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1036141445992816}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3, y: 2, z: -0.2}
+  m_LocalPosition: {x: 3, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4950178486404574}

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_12mm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_12mm.prefab
@@ -42,7 +42,6 @@ GameObject:
   - component: {fileID: 114604252264824848}
   - component: {fileID: 114477551015379840}
   - component: {fileID: 114401754672532888}
-  - component: {fileID: 114841785088974726}
   - component: {fileID: 114151640759957448}
   m_Layer: 10
   m_Name: Magazine_12mm
@@ -194,30 +193,6 @@ MonoBehaviour:
   inHandReferenceLeft: 0
   clothingReference: -1
   size: 0
---- !u!114 &114841785088974726
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1837689547681116}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visibleState: 1
-  isPlayer: 0
-  registerTile: {fileID: 0}
-  moveSpeed: 7
-  allowedToMove: 1
-  isPushable: 1
-  pulledBy: {fileID: 0}
-  pushTarget: {x: 0, y: 0, z: 0}
-  pushing: 0
-  serverLittleLag: 0
-  serverPos: {x: 0, y: 0, z: 0}
-  currentPos: {x: 0, y: 0, z: 0}
-  timeInPush: 0
 --- !u!114 &114902950977177642
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_38.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_38.prefab
@@ -26,7 +26,6 @@ GameObject:
   - component: {fileID: 114462994006981904}
   - component: {fileID: 114673342454476188}
   - component: {fileID: 114726631009728650}
-  - component: {fileID: 114554720864615500}
   - component: {fileID: 114595661855791112}
   m_Layer: 10
   m_Name: Magazine_38
@@ -177,30 +176,6 @@ MonoBehaviour:
   inHandReferenceLeft: 0
   clothingReference: -1
   size: 0
---- !u!114 &114554720864615500
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1887694972930660}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visibleState: 1
-  isPlayer: 0
-  registerTile: {fileID: 0}
-  moveSpeed: 7
-  allowedToMove: 1
-  isPushable: 0
-  pulledBy: {fileID: 0}
-  pushTarget: {x: 0, y: 0, z: 0}
-  pushing: 0
-  serverLittleLag: 0
-  serverPos: {x: 0, y: 0, z: 0}
-  currentPos: {x: 0, y: 0, z: 0}
-  timeInPush: 0
 --- !u!114 &114595661855791112
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_46x30mmtT.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_46x30mmtT.prefab
@@ -42,7 +42,6 @@ GameObject:
   - component: {fileID: 114788448572266270}
   - component: {fileID: 114831615385714540}
   - component: {fileID: 114851554163762622}
-  - component: {fileID: 114689155521477348}
   - component: {fileID: 114905923286005146}
   m_Layer: 10
   m_Name: Magazine_46x30mmtT
@@ -156,30 +155,6 @@ MonoBehaviour:
     i15: 59
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114689155521477348
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1976442409144630}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visibleState: 1
-  isPlayer: 0
-  registerTile: {fileID: 0}
-  moveSpeed: 7
-  allowedToMove: 1
-  isPushable: 1
-  pulledBy: {fileID: 0}
-  pushTarget: {x: 0, y: 0, z: 0}
-  pushing: 0
-  serverLittleLag: 0
-  serverPos: {x: 0, y: 0, z: 0}
-  currentPos: {x: 0, y: 0, z: 0}
-  timeInPush: 0
 --- !u!114 &114788448572266270
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_5.56m.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_5.56m.prefab
@@ -42,7 +42,6 @@ GameObject:
   - component: {fileID: 114201985098492696}
   - component: {fileID: 114692482863562414}
   - component: {fileID: 114469684380555384}
-  - component: {fileID: 114061128006195780}
   - component: {fileID: 114030497333023434}
   m_Layer: 10
   m_Name: Magazine_5.56m
@@ -115,30 +114,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 0
---- !u!114 &114061128006195780
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1777791374362824}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visibleState: 1
-  isPlayer: 0
-  registerTile: {fileID: 0}
-  moveSpeed: 7
-  allowedToMove: 1
-  isPushable: 1
-  pulledBy: {fileID: 0}
-  pushTarget: {x: 0, y: 0, z: 0}
-  pushing: 0
-  serverLittleLag: 0
-  serverPos: {x: 0, y: 0, z: 0}
-  currentPos: {x: 0, y: 0, z: 0}
-  timeInPush: 0
 --- !u!114 &114117670336802206
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_50mm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_50mm.prefab
@@ -26,7 +26,6 @@ GameObject:
   - component: {fileID: 114360322155976810}
   - component: {fileID: 114154442812104440}
   - component: {fileID: 114953782875578298}
-  - component: {fileID: 114513991921966578}
   - component: {fileID: 114017665477135202}
   m_Layer: 10
   m_Name: Magazine_50mm
@@ -175,30 +174,6 @@ MonoBehaviour:
   inHandReferenceLeft: 0
   clothingReference: -1
   size: 0
---- !u!114 &114513991921966578
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1141452593325796}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visibleState: 1
-  isPlayer: 0
-  registerTile: {fileID: 0}
-  moveSpeed: 7
-  allowedToMove: 1
-  isPushable: 1
-  pulledBy: {fileID: 0}
-  pushTarget: {x: 0, y: 0, z: 0}
-  pushing: 0
-  serverLittleLag: 0
-  serverPos: {x: 0, y: 0, z: 0}
-  currentPos: {x: 0, y: 0, z: 0}
-  timeInPush: 0
 --- !u!114 &114601128805409166
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_9mm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_9mm.prefab
@@ -42,7 +42,6 @@ GameObject:
   - component: {fileID: 114319963738854120}
   - component: {fileID: 114797802676123676}
   - component: {fileID: 114656900756177718}
-  - component: {fileID: 114668510444507766}
   - component: {fileID: 114541784541101990}
   m_Layer: 10
   m_Name: Magazine_9mm
@@ -224,30 +223,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &114668510444507766
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1570589854574774}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visibleState: 1
-  isPlayer: 0
-  registerTile: {fileID: 0}
-  moveSpeed: 7
-  allowedToMove: 1
-  isPushable: 1
-  pulledBy: {fileID: 0}
-  pushTarget: {x: 0, y: 0, z: 0}
-  pushing: 0
-  serverLittleLag: 0
-  serverPos: {x: 0, y: 0, z: 0}
-  currentPos: {x: 0, y: 0, z: 0}
-  timeInPush: 0
 --- !u!114 &114797802676123676
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_Slug.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_Slug.prefab
@@ -42,7 +42,6 @@ GameObject:
   - component: {fileID: 114106706923861624}
   - component: {fileID: 114268989769706622}
   - component: {fileID: 114052493599766462}
-  - component: {fileID: 114465251844701374}
   - component: {fileID: 114112538034184592}
   m_Layer: 10
   m_Name: Magazine_Slug
@@ -211,30 +210,6 @@ MonoBehaviour:
   moveSpeed: 7
   allowedToMove: 1
   isPushable: 0
-  pulledBy: {fileID: 0}
-  pushTarget: {x: 0, y: 0, z: 0}
-  pushing: 0
-  serverLittleLag: 0
-  serverPos: {x: 0, y: 0, z: 0}
-  currentPos: {x: 0, y: 0, z: 0}
-  timeInPush: 0
---- !u!114 &114465251844701374
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1560639281521250}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visibleState: 1
-  isPlayer: 0
-  registerTile: {fileID: 0}
-  moveSpeed: 7
-  allowedToMove: 1
-  isPushable: 1
   pulledBy: {fileID: 0}
   pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_Syringe.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_Syringe.prefab
@@ -42,7 +42,6 @@ GameObject:
   - component: {fileID: 114319963738854120}
   - component: {fileID: 114797802676123676}
   - component: {fileID: 114656900756177718}
-  - component: {fileID: 114668510444507766}
   - component: {fileID: 114541784541101990}
   m_Layer: 10
   m_Name: Magazine_Syringe
@@ -224,30 +223,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &114668510444507766
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1570589854574774}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visibleState: 1
-  isPlayer: 0
-  registerTile: {fileID: 0}
-  moveSpeed: 7
-  allowedToMove: 1
-  isPushable: 1
-  pulledBy: {fileID: 0}
-  pushTarget: {x: 0, y: 0, z: 0}
-  pushing: 0
-  serverLittleLag: 0
-  serverPos: {x: 0, y: 0, z: 0}
-  currentPos: {x: 0, y: 0, z: 0}
-  timeInPush: 0
 --- !u!114 &114797802676123676
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_a762.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_a762.prefab
@@ -26,7 +26,6 @@ GameObject:
   - component: {fileID: 114110166021715606}
   - component: {fileID: 114496109277905418}
   - component: {fileID: 114129525222004082}
-  - component: {fileID: 114549149174987832}
   - component: {fileID: 114045955017882788}
   m_Layer: 10
   m_Name: Magazine_a762
@@ -215,30 +214,6 @@ MonoBehaviour:
   magazineSize: 100
   Usable: 1
   ammoRemains: 50
---- !u!114 &114549149174987832
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1505511589050458}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visibleState: 1
-  isPlayer: 0
-  registerTile: {fileID: 0}
-  moveSpeed: 7
-  allowedToMove: 1
-  isPushable: 1
-  pulledBy: {fileID: 0}
-  pushTarget: {x: 0, y: 0, z: 0}
-  pushing: 0
-  serverLittleLag: 0
-  serverPos: {x: 0, y: 0, z: 0}
-  currentPos: {x: 0, y: 0, z: 0}
-  timeInPush: 0
 --- !u!114 &114631740818005732
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_smg9mm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_smg9mm.prefab
@@ -42,7 +42,6 @@ GameObject:
   - component: {fileID: 114704218100228718}
   - component: {fileID: 114589406112588394}
   - component: {fileID: 114479092072498442}
-  - component: {fileID: 114017371362694180}
   - component: {fileID: 114942314213274562}
   m_Layer: 10
   m_Name: Magazine_smg9mm
@@ -103,30 +102,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!114 &114017371362694180
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1549444462283266}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visibleState: 1
-  isPlayer: 0
-  registerTile: {fileID: 0}
-  moveSpeed: 7
-  allowedToMove: 1
-  isPushable: 1
-  pulledBy: {fileID: 0}
-  pushTarget: {x: 0, y: 0, z: 0}
-  pushing: 0
-  serverLittleLag: 0
-  serverPos: {x: 0, y: 0, z: 0}
-  currentPos: {x: 0, y: 0, z: 0}
-  timeInPush: 0
 --- !u!114 &114395108806851474
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_uzi9mm.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Magazines/Resources/Rifles/Magazine_uzi9mm.prefab
@@ -26,7 +26,6 @@ GameObject:
   - component: {fileID: 114162752830568772}
   - component: {fileID: 114015820852929730}
   - component: {fileID: 114607729733656858}
-  - component: {fileID: 114644331076306408}
   - component: {fileID: 114908791848257368}
   m_Layer: 10
   m_Name: Magazine_uzi9mm
@@ -171,30 +170,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &114644331076306408
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1249881654656566}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  visibleState: 1
-  isPlayer: 0
-  registerTile: {fileID: 0}
-  moveSpeed: 7
-  allowedToMove: 1
-  isPushable: 1
-  pulledBy: {fileID: 0}
-  pushTarget: {x: 0, y: 0, z: 0}
-  pushing: 0
-  serverLittleLag: 0
-  serverPos: {x: 0, y: 0, z: 0}
-  currentPos: {x: 0, y: 0, z: 0}
-  timeInPush: 0
 --- !u!114 &114714776944677938
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/C20rSMG_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/C20rSMG_Ballistic.prefab
@@ -69,7 +69,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1296620499762930}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 23, y: 9, z: -0.2}
+  m_LocalPosition: {x: 23, y: 9, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4006978410657130}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Cshotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Cshotgun_Ballistic.prefab
@@ -69,7 +69,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1968992119088728}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4672361745207960}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Detective_Gold_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Detective_Gold_Ballistic.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1946347799520078}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4955741579806508}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Detective_Peacemaker.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Detective_Peacemaker.prefab
@@ -69,7 +69,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1831002801606018}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4246299840989830}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/ERT_Gun_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/ERT_Gun_Ballistic.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1167865368234136}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4511954284235312}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Handgun_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Handgun_Ballistic.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1557459482202932}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4867358543139262}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Heirloom_Handgun_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Heirloom_Handgun_Ballistic.prefab
@@ -69,7 +69,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1269203658156660}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4105064929275890}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Improved_Syringegun_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Improved_Syringegun_Ballistic.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1528286794630592}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4973050677802726}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/L6SAW_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/L6SAW_Ballistic.prefab
@@ -69,7 +69,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1228446059428988}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 30, y: 20, z: -0.2}
+  m_LocalPosition: {x: 30, y: 20, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4410983592697660}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/M90_ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/M90_ballistic.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1860654956334788}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4268731059555766}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/P90_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/P90_Ballistic.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1273261371329586}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4970655005589142}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Revolver_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Revolver_Ballistic.prefab
@@ -69,7 +69,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1863058284462694}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4740587549331180}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Revolver_Detective_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Revolver_Detective_Ballistic.prefab
@@ -69,7 +69,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1589781730870112}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 47, y: 28, z: -0.2}
+  m_LocalPosition: {x: 47, y: 28, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4065992223828830}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Saber_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Saber_Ballistic.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1404025141166736}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4498185969065612}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Sawn_Shotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Sawn_Shotgun_Ballistic.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1869071035267636}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4696591045778554}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Shotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Shotgun_Ballistic.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1436741001650206}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4908946227389686}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Syringegun_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Syringegun_Ballistic.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1858738269464528}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4507131070642596}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Tactical_Handgun_ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Tactical_Handgun_ballistic.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1713052969755012}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4296879798429268}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Uzi_Ballistic.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Ballistics/Resources/Uzi_Ballistic.prefab
@@ -56,7 +56,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1397937101809150}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.2}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4988721424920578}

--- a/UnityProject/Assets/Prefabs/Items/Weapons_Melee/Resources/Knife.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons_Melee/Resources/Knife.prefab
@@ -70,7 +70,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000011622113908}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -3, y: -2, z: -0.2}
+  m_LocalPosition: {x: -3, y: -2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4000011569130768}

--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -165,7 +165,7 @@ namespace Cupboards
                 if (item != null)
                 {
                     var targetPosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
-                    targetPosition.z = -0.2f;
+                    targetPosition.z = 0f;
                     PlayerManager.LocalPlayerScript.playerNetworkActions.PlaceItem(UIManager.Hands.CurrentSlot.eventName, transform.position, null);
 
                     item.BroadcastMessage("OnRemoveFromInventory", null, SendMessageOptions.DontRequireReceiver);
@@ -197,11 +197,11 @@ namespace Cupboards
         {
             if (!on)
                 heldItems = matrix.Get<ObjectBehaviour>(registerTile.Position, ObjectType.Item);
-
             foreach (var item in heldItems)
             {
                 if (on)
-                    item.transform.position = transform.position;
+                { item.transform.position = transform.position; }
+
                 item.visibleState = on;
             }
         }


### PR DESCRIPTION
### Purpose
- Some objects where not in containers on start
- No objects could be put into containers

### Approach
It seemed to be a cascade of 3 problems:
* Some Items where put on an location of z-0.2, which prevented them from being catched by the closet script, which read the items at closet location
* Items where put into closets at z-0.2, which prevented them from being catched by the closet script on close after being put into the closet.
* Some magazines had double object behaviour scripts

So I removed the z-0.2 cases and replaced them with 0f
The object behaviour duplicates where removed

Now everything runs fine.

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors
- [X]  This PR does not include scenes without specific need to do so.

### Notes:
#Fixes #631 

### In case of feature: How to use the feature: