### PR TITLE
Fix items not going into containers

### DIFF
--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -169,7 +169,6 @@ namespace Cupboards
                     PlayerManager.LocalPlayerScript.playerNetworkActions.PlaceItem(UIManager.Hands.CurrentSlot.eventName, transform.position, null);
 
                     item.BroadcastMessage("OnRemoveFromInventory", null, SendMessageOptions.DontRequireReceiver);
-                    //
                 }
                 else
                 {
@@ -195,12 +194,15 @@ namespace Cupboards
 
         private void SetItemsAliveState(bool on)
         {
-            if (!on)
-                heldItems = matrix.Get<ObjectBehaviour>(registerTile.Position, ObjectType.Item);
+			if (!on)
+			{
+				heldItems = matrix.Get<ObjectBehaviour>(registerTile.Position, ObjectType.Item);
+			}
             foreach (var item in heldItems)
             {
-                if (on)
-                { item.transform.position = transform.position; }
+                if (on) {
+					item.transform.position = transform.position;
+				}
 
                 item.visibleState = on;
             }
@@ -209,7 +211,9 @@ namespace Cupboards
         private void SetPlayersAliveState(bool on)
         {
             if (!on)
-                heldPlayers = matrix.Get<ObjectBehaviour>(registerTile.Position, ObjectType.Player);
+			{
+				heldPlayers = matrix.Get<ObjectBehaviour>(registerTile.Position, ObjectType.Player);
+			}
 
             foreach (var player in heldPlayers)
             {

--- a/UnityProject/Assets/Scripts/Equipment/EquipmentPool.cs
+++ b/UnityProject/Assets/Scripts/Equipment/EquipmentPool.cs
@@ -81,7 +81,9 @@ namespace Equipment
         public static void DropGameObject(GameObject player, GameObject gObj, Vector3 pos)
         {
             var playerName = player.name;
-            if (!Instance.equipPools.ContainsKey(playerName)) return;
+			if (!Instance.equipPools.ContainsKey(playerName)) {
+				return;
+			}
             Instance.equipPools[playerName].DropGameObject(gObj, pos);
             gObj.BroadcastMessage("OnRemoveFromPool", null, SendMessageOptions.DontRequireReceiver);
             //			Debug.LogFormat("{0}: removed {1}({2}) from pool. size={3} ", 

--- a/UnityProject/Assets/Scripts/Equipment/ObjectPool.cs
+++ b/UnityProject/Assets/Scripts/Equipment/ObjectPool.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEngine.Networking;
 using Items;
 using UI;
+using Tilemaps.Scripts.Behaviours.Objects;
 
 namespace Equipment
 {
@@ -55,7 +56,8 @@ namespace Equipment
                     DropNow(o, dropPos);
                 }
                 currentObjects.Remove(id);
-            }
+				gObj.GetComponent<RegisterTile>().UpdatePosition();
+			}
         }
 
         private static void DropNow(GameObject gObj, Vector3 dropPos)

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
@@ -244,7 +244,11 @@ public partial class PlayerNetworkActions : NetworkBehaviour
     [Server]
     public void PlaceItem(string slotName, Vector3 pos, GameObject newParent)
     {
-        if (!SlotNotEmpty(slotName)) return;
+		if (!SlotNotEmpty(slotName))
+		{
+			return;
+		}
+
         GameObject item = _inventory[slotName];
         EquipmentPool.DropGameObject(gameObject, _inventory[slotName], pos);
         ClearInventorySlot(slotName);


### PR DESCRIPTION
### Purpose
Fixes the bug where items could not be placed into containers during play

### Approach
Dropped items did not get their position updated in RegisterTile. This has been fixed.

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.