### PR TITLE
Add restriction to cupboard interaction

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
@@ -48,6 +48,8 @@ namespace PlayGroups.Input
 
         private void Update()
         {
+			//Needs to be rewritted to be server authoritative
+			//Clients can currently ignore most intaract limitations (other than reach)
             CheckHandSwitch();
             CheckClick();
             CheckAltClick();
@@ -231,9 +233,9 @@ namespace PlayGroups.Input
                         inputTrigger.Trigger();
                         return true;
                     }
-                    //Allow interact with all cupboards because you may be in one!
+                    //Allow interact with cupboards we are inside of!
                     ClosetControl cCtrl = inputTrigger.GetComponent<ClosetControl>();
-                    if (cCtrl)
+                    if (cCtrl && cCtrl.transform.position == PlayerManager.LocalPlayerScript.transform.position)
                     {
                         inputTrigger.Trigger();
                         return true;


### PR DESCRIPTION
### Purpose
Fixes #497 

### Approach
The base Interact() method in InputController was allowing all interactions with cupboards all the time.
Added restriction to check if we're inside one.

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.

### Notes:
This fix brings to light another issue - clients ignore most restrictions in Interact(), as they're not server authoritative. Only the reach check is, which continues to be enforced. Clients can still interact with objects (not just lockers!) while inside a locker. Interact handling needs to be rewritten.
