### PR TITLE
Heavy code cleanup 2.5

### DIFF
--- a/UnityProject/Assets/Scripts/Editor/Doors/DoorAnimatorEditor.cs
+++ b/UnityProject/Assets/Scripts/Editor/Doors/DoorAnimatorEditor.cs
@@ -32,12 +32,12 @@ namespace Doors
                 {
                     dTarget.LoadSprites();
                 }
-                if (dTarget.doorBaseSprites.Length == null || dTarget.overlaySprites.Length == null
-                    || dTarget.overlayLights.Length == null)
-                {
-                    EditorGUILayout.HelpBox("No sprites loaded into the arrays yet. Please press" +
-                                            "'Auto Load Sprites' button.", MessageType.Info);
-                }
+//               if (dTarget.doorBaseSprites.Length == null || dTarget.overlaySprites.Length == null
+//                   || dTarget.overlayLights.Length == null)
+//               {
+//                  EditorGUILayout.HelpBox("No sprites loaded into the arrays yet. Please press" +
+//                                          "'Auto Load Sprites' button.", MessageType.Info);
+//                }
                 else
                 {
                     EditorGUILayout.HelpBox("All Sprites Loaded. You can always refresh them again by pressing " +

--- a/UnityProject/Assets/Scripts/Editor/Sprite2PrefabChild_Ammo.cs
+++ b/UnityProject/Assets/Scripts/Editor/Sprite2PrefabChild_Ammo.cs
@@ -30,13 +30,13 @@ public class Sprite2PrefabChild_Ammo_MenuItem
             }
 
             GameObject parent = new GameObject();
-            BoxCollider2D boxCollider = parent.AddComponent<BoxCollider2D>();
-            NetworkIdentity networkIdentiy = parent.AddComponent<NetworkIdentity>();
-            NetworkTransform networkTransform = parent.AddComponent<NetworkTransform>();
-            ItemAttributes itemAttributes = parent.AddComponent<ItemAttributes>();
-            MagazineBehaviour magazineBehaviour = parent.AddComponent<MagazineBehaviour>();
-            ObjectBehaviour objectBehaviour = parent.AddComponent<ObjectBehaviour>();
-            RegisterItem registerItem = parent.AddComponent<RegisterItem>();
+            parent.AddComponent<BoxCollider2D>();
+            parent.AddComponent<NetworkIdentity>();
+            parent.AddComponent<NetworkTransform>();
+            parent.AddComponent<ItemAttributes>();
+            parent.AddComponent<MagazineBehaviour>();
+            parent.AddComponent<ObjectBehaviour>();
+            parent.AddComponent<RegisterItem>();
             GameObject spriteObject = new GameObject();
             SpriteRenderer spriteRenderer = spriteObject.AddComponent<SpriteRenderer>();
             Material spriteMaterial = Resources.Load("Sprite-PixelSnap", typeof(Material)) as Material;

--- a/UnityProject/Assets/Scripts/Editor/Sprite2PrefabChild_Gun.cs
+++ b/UnityProject/Assets/Scripts/Editor/Sprite2PrefabChild_Gun.cs
@@ -31,13 +31,13 @@ public class Sprite2PrefabChild_Gun_MenuItem
             }
 
             GameObject parent = new GameObject();
-            BoxCollider2D boxCollider = parent.AddComponent<BoxCollider2D>();
-            NetworkIdentity networkIdentiy = parent.AddComponent<NetworkIdentity>();
-            NetworkTransform networkTransform = parent.AddComponent<NetworkTransform>();
-            ItemAttributes itemAttributes = parent.AddComponent<ItemAttributes>();
-            Weapon weapon = parent.AddComponent<Weapon>();
-            ObjectBehaviour objectBehaviour = parent.AddComponent<ObjectBehaviour>();
-            RegisterItem registerItem = parent.AddComponent<RegisterItem>();
+            parent.AddComponent<BoxCollider2D>();
+            parent.AddComponent<NetworkIdentity>();
+            parent.AddComponent<NetworkTransform>();
+            parent.AddComponent<ItemAttributes>();
+            parent.AddComponent<Weapon>();
+            parent.AddComponent<ObjectBehaviour>();
+            parent.AddComponent<RegisterItem>();
             GameObject spriteObject = new GameObject();
             SpriteRenderer spriteRenderer = spriteObject.AddComponent<SpriteRenderer>();
             Material spriteMaterial = Resources.Load("Sprite-PixelSnap", typeof(Material)) as Material;

--- a/UnityProject/Assets/Scripts/Editor/Sprite2PrefabChild_Object.cs
+++ b/UnityProject/Assets/Scripts/Editor/Sprite2PrefabChild_Object.cs
@@ -29,9 +29,9 @@ public class Sprite2PrefabChild_Object_MenuItem
             }
 
             GameObject parent = new GameObject();
-            BoxCollider2D boxCollider = parent.AddComponent<BoxCollider2D>();
-            EditModeControl editModeControl = parent.AddComponent<EditModeControl>();
-            RegisterObject registerObject = parent.AddComponent<RegisterObject>();
+            parent.AddComponent<BoxCollider2D>();
+            parent.AddComponent<EditModeControl>();
+            parent.AddComponent<RegisterObject>();
             GameObject spriteObject = new GameObject();
             SpriteRenderer spriteRenderer = spriteObject.AddComponent<SpriteRenderer>();
             Material spriteMaterial = Resources.Load("Sprite-PixelSnap", typeof(Material)) as Material;


### PR DESCRIPTION
### Purpose
There where some compile warnings and that is ugly

### Approach
most where caused by an error of mine in sprite2prefabchild, those where fixed
the last where due to an commented out part being referred too in an ifstatement in dooranimationeditor, so i commented that one out too.

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors
- [X]  This PR does not include scenes without specific need to do so.

### Notes:


### In case of feature: How to use the feature:
