### PR TITLE
UI health display fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/PlayerHealthReporting.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/PlayerHealthReporting.cs
@@ -14,6 +14,7 @@ namespace PlayGroup
     {
         private int bloodLevelCache;
         private float BloodPercentage = 100f;
+        private PlayerMove playerMove;
 
         //server only caches
         private int healthServerCache;
@@ -34,6 +35,7 @@ namespace PlayGroup
             {
                 healthServerCache = playerHealth.Health;
                 bloodLevelCache = playerHealth.BloodLevel;
+                playerMove = GetComponent<PlayerMove>();
                 UpdateManager.Instance.regularUpdate.Add(this);
                 StartCoroutine(WaitForLoad());
             }
@@ -67,7 +69,11 @@ namespace PlayGroup
         {
             //Add other damage methods here like burning, 
             //suffication, etc
-
+            
+            //If already dead then do not check the status of the body anymore
+            if (playerMove.isGhost)
+                return;
+            
             //Blood calcs:
             if (bloodLevelCache != playerHealth.BloodLevel)
             {

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
@@ -530,8 +530,12 @@ public partial class PlayerNetworkActions : NetworkBehaviour
         FoodBehaviour baseFood = food.GetComponent<FoodBehaviour>();
         soundNetworkActions.CmdPlaySoundAtPlayerPos("EatFood");
         PlayerHealth playerHealth = GetComponent<PlayerHealth>();
-
+        
+        //FIXME: remove health and blood changes after TDM
+        //and use this Cmd for healing hunger and applying 
+        //food related attributes instead:
         playerHealth.AddHealth(baseFood.healAmount);
+        playerHealth.BloodLevel += baseFood.healAmount;
         playerHealth.StopBleeding();
 
         PoolManager.Instance.PoolNetworkDestroy(food);

--- a/UnityProject/Assets/Scripts/UI/UI_HeartMonitor.cs
+++ b/UnityProject/Assets/Scripts/UI/UI_HeartMonitor.cs
@@ -119,7 +119,7 @@ namespace UI
         {
             //PlayGroup.PlayerManager.PlayerScript.playerNetworkActions.CmdSendAlertMessage("mHealth: " + cHealth, true);
             //Debug.Log("PlayerHealth: " + PlayGroup.PlayerManager.PlayerScript.playerHealth.Health);
-            if (cHealth >= 100
+            if (cHealth >= 90
                 && spriteStart != fullHealthStart)
             {
                 SoundManager.Stop("Critstate");
@@ -127,7 +127,7 @@ namespace UI
                 pulseImg.sprite = sprites[spriteStart];
                 overlayCrits.SetState(OverlayState.normal);
             }
-            if (cHealth < 100
+            if (cHealth < 90
                 && cHealth > 80
                 && spriteStart != minorDmgStart)
             {


### PR DESCRIPTION
- Now updates the UI correctly by ensuring the data of the PlayerHealth monitor is accurate
- Also adjusted the threshold for a healthy UI display
- Also added more blood to the players blood level when eating for TDM

Network fixes:
- Checks if player is a ghost before doing any calculations and network updates. This stops messages being sent to a players body that is no longer controlled

### Purpose
- Before UI changes weren't happening as expected
- When you respawned your old body was still trying to send UI updates from the carcass

### Approach
- Added blood to the blood levels
- Move the threshold for a healthy UI from 100% to 90%

- Added a check to HealthReporting to see if the player has turned into a ghost to stop updating UI

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.

### Notes:
Its gud


### In case of feature: How to use the feature:
- Stab yourself, eat meat and see that crit overlay goes back to normal (note the health doll doesn't update fully to green, thats another issue)

- Die and respawn, no netmsg errors! yay
