### PR TITLE
Set overlaycrits to death locally on death

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
@@ -436,6 +436,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
         if (PlayerManager.LocalPlayer == gameObject)
         {
             SoundManager.Stop("Critstate");
+            UIManager.PlayerHealthUI.heartMonitor.overlayCrits.SetState(OverlayState.death);
             Camera2DFollow.followControl.target = playerScript.ghost.transform;
             FieldOfView fovScript = GetComponent<FieldOfView>();
             if (fovScript != null)


### PR DESCRIPTION
- This makes sure the overlay crit is set to death when the player dies instead of waiting for HealthReporting

### Purpose
- Because healthreporting is turned off when the player dies sometimes the last UI update is cut short. This now sets the overlay crit status to death from the death rpc on PNA

### Approach
- Added a death crit update from the death action on PNA

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.

### Notes:

### In case of feature: How to use the feature:
- Start mp, kill someone really fast, UI crit sets to death as it should (actually set to normal as we haven't implemented a full death ui overlay yet)