### PR TITLE
Player start fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Equipment/Equipment.cs
@@ -184,6 +184,11 @@ namespace Equipment
                     gearItem.Value.Contains(ClothFactory.HeadsetHierIdentifier))
                 {
                     GameObject obj = ClothFactory.Instance.CreateCloth(gearItem.Value, Vector3.zero);
+                    //if ClothFactory does not return an object then move on to the next clothing item
+                    if (!obj){
+                        Debug.LogWarning("Trying to instantiate clothing item "+ gearItem.Value+" failed!");
+                        continue;
+                    }
                     ItemAttributes itemAtts = obj.GetComponent<ItemAttributes>();
                     SetItem(GetLoadOutEventName(gearItem.Key), itemAtts.gameObject);
                 }

--- a/UnityProject/Assets/Scripts/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Equipment/Equipment.cs
@@ -69,8 +69,10 @@ namespace Equipment
             isInit = true;
             //Player sprite offset:
             clothingSlots[10].Reference = 33;
-
-            StartCoroutine(SetPlayerLoadOuts());
+            if (isServer)
+            {
+                StartCoroutine(SetPlayerLoadOuts());
+            }
         }
 
         public void SyncSprites(SyncList<int>.Operation op, int index)

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateConnectedPlayersMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateConnectedPlayersMessage.cs
@@ -29,12 +29,19 @@ public class UpdateConnectedPlayersMessage : ServerMessage<UpdateConnectedPlayer
         }
 
         //Remove players that are stored locally, but not on server. Unless its us.
+        //foreach does not allow mutations on the dictionary collection while it is iterating over it
+        //Store names to be removed and do it after
+        List<string> playersToRemove = new List<string>();
         foreach (KeyValuePair<string, GameObject> entry in connectedPlayers)
         {
             if (!Players.Contains(entry.Value) && entry.Key != PlayerManager.LocalPlayerScript.playerName)
             {
-                connectedPlayers.Remove(entry.Key);
+                playersToRemove.Add(entry.Key);
             }
+        }
+        for (int i = 0; i < playersToRemove.Count; i++)
+        {
+            connectedPlayers.Remove(playersToRemove[i]);
         }
     }
 


### PR DESCRIPTION
### Purpose
First exception: UpdateConnectPlayersMessage.cs:32
InvalidOperationException: Collection was modified; enumeration operation may not execute.

Cause: The dictionary was being modified while it was being iterated through. 

Second Exception: Equipment.cs SetPlayerLoadOut NRE's

Cause: The player load out was being called on the client also, this is only meant to be called on the server 

### Approach
1st Fix: Collected all of the changes and performed them at the end
2nd Fix: Forced load out to be called on server only

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.
