### PR TITLE
Fixes door access control in multiplayer

### DIFF
--- a/UnityProject/Assets/Scripts/Doors/DoorTrigger.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorTrigger.cs
@@ -29,12 +29,12 @@ namespace Doors
                     if (UIManager.InventorySlots.IDSlot.IsFull &&
                         UIManager.InventorySlots.IDSlot.Item.GetComponent<IDCard>() != null)
                     {
-                        CheckDoorAccess(UIManager.InventorySlots.IDSlot.Item.GetComponent<IDCard>(), doorController);
+                        CheckDoorAccess(UIManager.InventorySlots.IDSlot.Item.GetComponent<IDCard>(), doorController, originator);
                     }
                     else if (UIManager.Hands.CurrentSlot.IsFull &&
                              UIManager.Hands.CurrentSlot.Item.GetComponent<IDCard>() != null)
                     {
-                        CheckDoorAccess(UIManager.Hands.CurrentSlot.Item.GetComponent<IDCard>(), doorController);
+                        CheckDoorAccess(UIManager.Hands.CurrentSlot.Item.GetComponent<IDCard>(), doorController, originator);
                     }
                     else
                     {
@@ -46,12 +46,13 @@ namespace Doors
                 }
                 else
                 {
+                    Debug.Log("no restriction required");
                     allowInput = false;
                     if (CustomNetworkManager.Instance._isServer)
                     {
                         if (!doorController.IsOpened)
                         {
-                            doorController.CmdTryOpen(gameObject);
+                            doorController.CmdTryOpen(originator);
                         }
                         else
                         {
@@ -63,7 +64,7 @@ namespace Doors
                         //for mouse click opening when not server
                         if (!doorController.IsOpened)
                         {
-                            PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryOpenDoor(gameObject);
+                            PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryOpenDoor(gameObject, originator);
                         }
                         else
                         {
@@ -75,7 +76,7 @@ namespace Doors
             }
         }
 
-        private void CheckDoorAccess(IDCard cardID, DoorController doorController)
+        private void CheckDoorAccess(IDCard cardID, DoorController doorController, GameObject originator)
         {
             Debug.Log("been here!");
             if (cardID.accessSyncList.Contains((int) doorController.restriction))
@@ -84,7 +85,7 @@ namespace Doors
                 allowInput = false;
                 if (!doorController.IsOpened)
                 {
-                    PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryOpenDoor(gameObject);
+                    PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryOpenDoor(gameObject, originator);
                 }
                 else
                 {

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
@@ -501,9 +501,9 @@ public partial class PlayerNetworkActions : NetworkBehaviour
     }
 
     [Command]
-    public void CmdTryOpenDoor(GameObject door)
+    public void CmdTryOpenDoor(GameObject door, GameObject originator)
     {
-        door.GetComponent<DoorController>().CmdTryOpen(gameObject);
+        door.GetComponent<DoorController>().CmdTryOpen(originator);
     }
 
     [Command]


### PR DESCRIPTION
### Purpose
Door access by clients in multiplayer was not being consistent

### Approach
It seems DoorTrigger was passing the wrong arguments, because no one ever cared to test their code. SMITE

### Open Questions and Pre-Merge TODOs

- [X]  The issue solved or feature added is still open/missing in the branch you PR to.
- [X]  This fix is tested on the branch it is PR'ed to.
- [X]  This PR is checked for side effects and it has none
- [X]  This PR does not bring up any new compile errors
- [X]  This PR does not include scenes without specific need to do so.

### Notes:
It literally states you are sending the wrong argument in doorcontroller btw >.<
Fixes #649 


### In case of feature: How to use the feature:
