### PR TITLE
PropagateChatToClients chat message fix

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Managers/ChatRelay.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using PlayGroup;
 using UI;
+using UnityEngine;
 using UnityEngine.Networking;
 
 public class ChatRelay : NetworkBehaviour
@@ -72,10 +73,15 @@ public class ChatRelay : NetworkBehaviour
     {
         PlayerScript[] players = FindObjectsOfType<PlayerScript>();
 
-        foreach (PlayerScript player in players)
+        for (int i = 0; i < players.Length; i++)
         {
-            ChatChannel channels = player.GetAvailableChannels(false) & chatEvent.channels;
-            UpdateChatMessage.Send(player.gameObject, channels, chatEvent.message);
+            //First check if the players object is owned by a client
+            //by checking if the inputController is enabled:
+            if (players[i].inputController.enabled)
+            {
+                ChatChannel channels = players[i].GetAvailableChannels(false) & chatEvent.channels;
+                UpdateChatMessage.Send(players[i].gameObject, channels, chatEvent.message);
+            }
         }
     }
 


### PR DESCRIPTION
- PropagateChatToClients() collects all playerscripts in the scene but does not check if they are dead bodies or not. Added a check to see if the inputController is enabled and if it is then it means this object is owned by a client and can now be included in the UpdateChatMessage
- This fixes the Server error of object not being in the connected players list

### Purpose
See above

### Approach
See above. Perm fix

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.
