### PR TITLE
ServerCache isGhost check

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.cs
@@ -280,7 +280,13 @@ namespace PlayGroup
         private void CmdAction(PlayerAction action)
         {
             serverState = NextState(serverState, action);
-            serverStateCache = serverState;
+            //Do not cache the position if the player is a ghost
+            //or else new players will sync the deadbody with the last pos
+            //of the gost:
+            if (!playerMove.isGhost)
+            {
+                serverStateCache = serverState;
+            }
             RpcOnServerStateChange(serverState);
         }
 


### PR DESCRIPTION
### Purpose
- The server cache for the players body was being updated even though the player was moving around as a ghost

### Approach
- Added a check to make sure the cache isn't updated if the player is a ghost
- Cache will update if the body is dragged though

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.

### Notes:
- tested with 1 server(host) and 2 clients
- This fixes #667