### PR TITLE
Spawn file tiles on matrix locally

### DIFF
--- a/UnityProject/Assets/Scripts/Factories/EffectsFactory.cs
+++ b/UnityProject/Assets/Scripts/Factories/EffectsFactory.cs
@@ -41,10 +41,13 @@ public class EffectsFactory : NetworkBehaviour
     }
 
     //FileTiles are client side effects only, no need for network sync (triggered by same event on all clients/server)
-    public void SpawnFileTile(float fuelAmt, Vector3 position)
+    public void SpawnFileTileLocal(float fuelAmt, Vector3 localPosition, Transform parent)
     {
         //ClientSide pool spawn
-        GameObject fireObj = PoolManager.Instance.PoolClientInstantiate(fireTile, position, Quaternion.identity);
+        GameObject fireObj = PoolManager.Instance.PoolClientInstantiate(fireTile, Vector3.zero, Quaternion.identity);
+        //Spawn tiles need to be placed in a local matrix:
+        fireObj.transform.parent = parent;
+        fireObj.transform.localPosition = localPosition;
         FireTile fT = fireObj.GetComponent<FireTile>();
         fT.StartFire(fuelAmt);
     }

--- a/UnityProject/Assets/Scripts/Objects/ExplodeWhenShot.cs
+++ b/UnityProject/Assets/Scripts/Objects/ExplodeWhenShot.cs
@@ -37,6 +37,7 @@ public class ExplodeWhenShot : NetworkBehaviour
 
         _registerTile = GetComponent<RegisterTile>();
         _matrix = Matrix.GetMatrix(this);
+        
     }
 
     //#if !ENABLE_PLAYMODE_TESTS_RUNNER
@@ -186,8 +187,8 @@ public class ExplodeWhenShot : NetworkBehaviour
         int maxNumOfFire = 4;
         int cLength = 3;
         int rHeight = 3;
-        Vector3Int pos = Vector3Int.RoundToInt(transform.position);
-        EffectsFactory.Instance.SpawnFileTile(Random.Range(0.4f, 1f), pos);
+        Vector3Int pos = Vector3Int.RoundToInt(transform.localPosition);
+        EffectsFactory.Instance.SpawnFileTileLocal(Random.Range(0.4f, 1f), pos, transform.parent);
         pos.x--;
         pos.y++;
 
@@ -199,15 +200,11 @@ public class ExplodeWhenShot : NetworkBehaviour
                 {
                     continue;
                 }
-
+                
                 Vector3Int checkPos = new Vector3Int(pos.x + i, pos.y - j, 0);
-
-                _matrix.IsPassableAt(checkPos);
-
-
                 if (_matrix.IsPassableAt(checkPos)) // || MatrixOld.Matrix.At(checkPos).IsPlayer())
                 {
-                    EffectsFactory.Instance.SpawnFileTile(Random.Range(0.4f, 1f), checkPos);
+                    EffectsFactory.Instance.SpawnFileTileLocal(Random.Range(0.4f, 1f), checkPos, transform.parent);
                     maxNumOfFire--;
                 }
                 if (maxNumOfFire <= 0)


### PR DESCRIPTION
- The fire tiles were spawning using world positions. Force them to spawn locally to the matrix. This ensures the tiles are correctly placed (not in walls etc)

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.
