### PR TITLE
Closet drop fix

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons_Melee/Resources/Knife.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons_Melee/Resources/Knife.prefab
@@ -38,7 +38,6 @@ GameObject:
   - component: {fileID: 61000012096311666}
   - component: {fileID: 114112083421409656}
   - component: {fileID: 114196360688232010}
-  - component: {fileID: 50000013026031628}
   - component: {fileID: 114000012876358140}
   - component: {fileID: 114186698601475536}
   - component: {fileID: 114457471827933586}
@@ -69,34 +68,14 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000011622113908}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -3, y: -2, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0.00000014901144, w: 1}
+  m_LocalPosition: {x: 40, y: 29, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4000011569130768}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!50 &50000013026031628
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011622113908}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_Interpolate: 1
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 4
 --- !u!61 &61000012096311666
 BoxCollider2D:
   m_ObjectHideFlags: 1
@@ -134,16 +113,16 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   cloth: 0
+  clothingReference: -1
   hierarchy: 
-  itemName: kitchen knife
+  inHandReferenceLeft: 564
+  inHandReferenceRight: 576
   itemDescription: A general purpose Chef's Knife made by SpaceCook Incorporated.
     Guaranteed to stay sharp for years to come.
+  itemName: kitchen knife
+  size: 0
   spriteType: 0
   type: 15
-  inHandReferenceRight: 576
-  inHandReferenceLeft: 564
-  clothingReference: -1
-  size: 0
 --- !u!114 &114112083421409656
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -198,7 +177,7 @@ MonoBehaviour:
   m_Script: {fileID: -1768714887, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_TransformSyncMode: 2
+  m_TransformSyncMode: 1
   m_SendInterval: 0.1
   m_SyncRotationAxis: 3
   m_RotationSyncCompression: 0
@@ -231,18 +210,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  visibleState: 1
   isPlayer: 0
   registerTile: {fileID: 0}
-  moveSpeed: 7
+  visibleState: 1
   allowedToMove: 1
+  currentPos: {x: 0, y: 0, z: 0}
   isPushable: 0
+  moveSpeed: 7
   pulledBy: {fileID: 0}
-  pushTarget: {x: 0, y: 0, z: 0}
   pushing: 0
+  pushTarget: {x: 0, y: 0, z: 0}
   serverLittleLag: 0
   serverPos: {x: 0, y: 0, z: 0}
-  currentPos: {x: 0, y: 0, z: 0}
   timeInPush: 0
 --- !u!212 &212000011121867930
 SpriteRenderer:

--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -99,6 +99,7 @@ namespace Cupboards
 
         private void OpenClose(bool isClosed)
         {
+            IsClosed = isClosed;
             if (isClosed)
             {
                 Close();
@@ -111,6 +112,7 @@ namespace Cupboards
 
         private void LockUnlock(bool lockIt)
         {
+            IsLocked = lockIt;
             if (lockLight == null)
             {
                 return;
@@ -162,12 +164,12 @@ namespace Cupboards
                     return;
                 }
 
-                GameObject item = UIManager.Hands.CurrentSlot.Clear();
+                GameObject item = UIManager.Hands.CurrentSlot.Item;
                 if (item != null)
                 {
                     Vector3 targetPosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
                     targetPosition.z = 0f;
-                    PlayerManager.LocalPlayerScript.playerNetworkActions.PlaceItem(
+                    PlayerManager.LocalPlayerScript.playerNetworkActions.CmdPlaceItem(
                         UIManager.Hands.CurrentSlot.eventName, transform.position, null);
 
                     item.BroadcastMessage("OnRemoveFromInventory", null, SendMessageOptions.DontRequireReceiver);

--- a/UnityProject/Assets/Scripts/Health/Machines/ClosetHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Machines/ClosetHealthBehaviour.cs
@@ -1,4 +1,5 @@
-﻿using Cupboards;
+﻿using System;
+using Cupboards;
 using Tilemaps.Scripts.Behaviours.Objects;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -25,6 +26,14 @@ namespace Objects
             if (isServer)
             {
                 ServerDeathActions();
+            }
+        }
+
+        public override void OnMouseDown()
+        {
+            if (closetControl.IsClosed)
+            {
+                base.OnMouseDown();
             }
         }
 

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/Triggers/TableTrigger.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/Triggers/TableTrigger.cs
@@ -52,7 +52,7 @@ public class TableTrigger : InputTrigger
         }
         Vector3 targetPosition = gameObject.transform.position; //Camera.main.ScreenToWorldPoint(Input.mousePosition);
         targetPosition.z = -0.2f;
-        ps.playerNetworkActions.PlaceItem(hand, targetPosition, gameObject);
+        ps.playerNetworkActions.CmdPlaceItem(hand, targetPosition, gameObject);
         item.BroadcastMessage("OnRemoveFromInventory", null, SendMessageOptions.DontRequireReceiver);
 
         return true;

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.PushPull.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.PushPull.cs
@@ -80,12 +80,12 @@ public partial class PlayerNetworkActions : NetworkBehaviour
     }
 
     [Command]
-    public void CmdTryPush(GameObject obj, Vector3 pos)
+    public void CmdTryPush(GameObject obj, Vector3 startLocalPos, Vector3 targetPos)
     {
         PushPull pushed = obj.GetComponent<PushPull>();
         if (pushed != null)
         {
-            pushed.serverPos = pos;
+           pushed.RpcPushSync(startLocalPos,targetPos);
         }
     }
 }

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
@@ -244,8 +244,8 @@ public partial class PlayerNetworkActions : NetworkBehaviour
         EquipmentPool.DisposeOfObject(gameObject, obj);
     }
 
-    [Server]
-    public void PlaceItem(string slotName, Vector3 pos, GameObject newParent)
+    [Command]
+    public void CmdPlaceItem(string slotName, Vector3 pos, GameObject newParent)
     {
         if (!SlotNotEmpty(slotName))
         {

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Interaction/TableInteraction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Interaction/TableInteraction.cs
@@ -33,7 +33,7 @@ namespace Tilemaps.Scripts.Behaviours.Interaction
 
             Vector3 targetPosition = position;
             targetPosition.z = -0.2f;
-            ps.playerNetworkActions.PlaceItem(hand, targetPosition, gameObject);
+            ps.playerNetworkActions.CmdPlaceItem(hand, targetPosition, gameObject);
 
             item.BroadcastMessage("OnRemoveFromInventory", null, SendMessageOptions.DontRequireReceiver);
         }

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
@@ -148,7 +148,6 @@ namespace UI
 
         public bool CheckItemFit(GameObject item)
         {
-            
             ItemAttributes attributes = item.GetComponent<ItemAttributes>();
            
             if(!allowAllItems) 
@@ -164,9 +163,7 @@ namespace UI
             Debug.Log("Item is too big!");
             return false;
             }
-            Debug.Log("end of script");
             return allowAllItems || allowedItemTypes.Contains(attributes.type);
-
         }
     }
 }


### PR DESCRIPTION
### Purpose
- Fixes #664 
- Fixes unreliable object pushing over network

### Approach
#664:
The PNA commands were turned into server commands making the interaction between client and server impossible. 

Fixes:
- Adjusted Server method to a Cmd method (client was trying to call a Server method)
- Placed a check on ClosetHealth to check if the closet it is open before allowing the closet to be stabbed to death. This fixed a UI slot clearing bug with the knife
- Removed a debug log from a previous commt on UI slot

Unreliable Pushing:
Push was unreliable as it was based off faulty logic and a SyncVar with hook. Also edge cases would arise from the object being pushed not being at the exact starting pos of every client instance and on the server resulting in unintended results.

Fixes:
- Server now calls an Rpc on the object being pushed instead of syncing a var with hook
- Removed MoveTowards and implemented a Vector3.Lerp instead
- Added a starting position to be synced as well
- Cleaned up the wait logic that determines when the player can push again (waits for server to be done)

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.

### Notes:
Tested it heavily over MP