### PR TITLE
RegisterTile WaitForServer register

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -1,4 +1,5 @@
-﻿using Tilemaps.Scripts.Behaviours.Layers;
+﻿using System.Collections;
+using Tilemaps.Scripts.Behaviours.Layers;
 using UnityEngine;
 
 namespace Tilemaps.Scripts.Behaviours.Objects
@@ -46,11 +47,29 @@ namespace Tilemaps.Scripts.Behaviours.Objects
                 }
                 else
                 {
-                    Debug.LogError("GameObject: " + gameObject.name + " could not find the matrix");
+                    //Matrix could not be found, this client is lagging so matrix will still be loading:
+                    StartCoroutine(WaitForServer());
+                    return;
+                    //     Debug.LogError("GameObject: " + gameObject.name + " could not find the matrix");
                 }
                 layer = transform.GetComponentInParent<ObjectLayer>();
             }
 
+            Register();
+        }
+
+        //Wait for the matrix to initialize (high lag situation)
+        IEnumerator WaitForServer()
+        {
+            yield return new WaitForEndOfFrame();
+            GameObject tempParent = GameObject.FindGameObjectWithTag("SpawnParent");
+            while (tempParent == null)
+            {
+                yield return new WaitForSeconds(0.1f);
+            }
+            yield return new WaitForEndOfFrame();
+            transform.parent = tempParent.transform;
+            layer = transform.GetComponentInParent<ObjectLayer>();
             Register();
         }
 


### PR DESCRIPTION

### Purpose
Fixes: #673 
Items were not being correctly registered on the matrix in high ping situation, this was because the client did not wait for the matrix to be initialized and instead just threw a LogError. 

### Approach
Created a coroutine that waits for the matrix to be ready

### Open Questions and Pre-Merge TODOs

- [x]  The issue solved or feature added is still open/missing in the branch you PR to.
- [x]  This fix is tested on the branch it is PR'ed to.
- [x]  This PR is checked for side effects and it has none
- [x]  This PR does not bring up any new compile errors
- [x]  This PR does not include scenes without specific need to do so.
