### PR TITLE
Rework of access system and fix of bug #675

### DIFF
--- a/UnityProject/Assets/Prefabs/Doors/Resources/AirLock.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/AirLock.prefab
@@ -25,6 +25,7 @@ GameObject:
   - component: {fileID: 114990158330489740}
   - component: {fileID: 114298626141523242}
   - component: {fileID: 114897681876509866}
+  - component: {fileID: 114997946200806902}
   m_Layer: 18
   m_Name: AirLock
   m_TagString: Untagged
@@ -482,22 +483,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 13
-  restriction: 34
-  isWindowedDoor: 1
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 49
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114298626141523242}
-  openSFX: {fileID: 82346760648337948}
   closeSFX: {fileID: 82771154139725662}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114298626141523242}
+  DoorCoverSpriteOffset: 49
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 13
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 1
+  maxTimeOpen: 5
+  openSFX: {fileID: 82346760648337948}
   oppeningDirection: 1
+  restriction: 34
+  spriteRenderer: {fileID: 0}
 --- !u!114 &114298626141523242
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -510,8 +511,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114232321497863980}
-  overlay_Lights: {fileID: 212106163674931676}
-  overlay_Glass: {fileID: 212000010235302174}
+  animSize: 6
   doorbase: {fileID: 212270947609497162}
   doorBaseSprites:
   - {fileID: 21300000, guid: 349b9f3d6c6bf4c3083aa8a79a42ec7e, type: 3}
@@ -544,88 +544,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: 349b9f3d6c6bf4c3083aa8a79a42ec7e, type: 3}
   - {fileID: 21300056, guid: 349b9f3d6c6bf4c3083aa8a79a42ec7e, type: 3}
   - {fileID: 21300058, guid: 349b9f3d6c6bf4c3083aa8a79a42ec7e, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300002, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300004, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300006, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300008, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300010, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300012, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300014, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300016, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300018, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300020, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300022, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300024, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300026, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300028, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300030, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300032, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300034, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300036, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300038, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300040, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300042, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300044, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300046, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300048, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300050, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300052, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300054, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300056, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300058, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300060, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300062, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300064, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300066, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300068, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300070, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300072, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300074, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300076, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300078, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300080, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300082, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300084, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300086, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300088, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300090, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300092, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300094, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300096, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300098, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300100, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300102, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300104, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300106, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300108, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300110, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300112, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300114, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300116, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300118, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300120, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300122, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300124, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300126, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300128, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300130, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300132, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300134, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300136, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300138, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300140, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300142, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300144, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300146, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300148, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300150, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300152, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300154, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300156, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300158, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  - {fileID: 21300160, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  overlay_Glass: {fileID: 212000010235302174}
+  overlay_Lights: {fileID: 212106163674931676}
   overlayLights:
   - {fileID: 21300000, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
   - {fileID: 21300002, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
@@ -708,7 +628,88 @@ MonoBehaviour:
   - {fileID: 21300156, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
   - {fileID: 21300158, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
   - {fileID: 21300160, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300002, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300004, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300006, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300008, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300010, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300012, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300014, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300016, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300018, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300020, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300022, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300024, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300026, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300028, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300030, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300032, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300034, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300036, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300038, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300040, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300042, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300044, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300046, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300048, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300050, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300052, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300054, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300056, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300058, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300060, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300062, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300064, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300066, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300068, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300070, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300072, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300074, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300076, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300078, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300080, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300082, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300084, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300086, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300088, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300090, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300092, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300094, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300096, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300098, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300100, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300102, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300104, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300106, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300108, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300110, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300112, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300114, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300116, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300118, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300120, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300122, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300124, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300126, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300128, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300130, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300132, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300134, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300136, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300138, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300140, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300142, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300144, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300146, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300148, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300150, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300152, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300154, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300156, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300158, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
+  - {fileID: 21300160, guid: 2e0e4fceb7237430a8aa55fb53d0944a, type: 3}
 --- !u!114 &114897681876509866
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -721,11 +722,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!114 &114956925939094640
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -770,6 +771,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   allowInput: 1
+--- !u!114 &114997946200806902
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011462531918}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 0
 --- !u!212 &212000010235302174
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/AtmosDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/AtmosDoor.prefab
@@ -88,6 +88,7 @@ GameObject:
   - component: {fileID: 114955538477622776}
   - component: {fileID: 114796983354351306}
   - component: {fileID: 114984589981480830}
+  - component: {fileID: 114828729200829102}
   m_Layer: 17
   m_Name: AtmosDoor
   m_TagString: Untagged
@@ -480,22 +481,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 0
-  restriction: 4
-  isWindowedDoor: 0
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 17
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114796983354351306}
-  openSFX: {fileID: 82155393946766332}
   closeSFX: {fileID: 82478818841260734}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114796983354351306}
+  DoorCoverSpriteOffset: 17
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 0
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 0
+  maxTimeOpen: 5
+  openSFX: {fileID: 82155393946766332}
   oppeningDirection: 0
+  restriction: 4
+  spriteRenderer: {fileID: 0}
 --- !u!114 &114471071171978832
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -540,8 +541,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114201876269245600}
-  overlay_Lights: {fileID: 212341596637452762}
-  overlay_Glass: {fileID: 212357709635985620}
+  animSize: 6
   doorbase: {fileID: 212387133501380760}
   doorBaseSprites:
   - {fileID: 21300000, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
@@ -574,37 +574,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
   - {fileID: 21300056, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
   - {fileID: 21300058, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300002, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300004, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300006, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300008, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300010, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300012, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300014, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300016, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300018, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300020, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300022, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300024, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300026, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300028, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300030, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300032, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300034, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300036, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300038, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300040, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300042, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300044, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300046, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300048, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300050, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300052, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300054, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300056, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
-  - {fileID: 21300058, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  overlay_Glass: {fileID: 212357709635985620}
+  overlay_Lights: {fileID: 212341596637452762}
   overlayLights:
   - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
@@ -706,7 +677,49 @@ MonoBehaviour:
   - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300002, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300004, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300006, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300008, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300010, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300012, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300014, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300016, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300018, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300020, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300022, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300024, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300026, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300028, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300030, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300032, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300034, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300036, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300038, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300040, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300042, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300044, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300046, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300048, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300050, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300052, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300054, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300056, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+  - {fileID: 21300058, guid: 972b5464ef5654c99bb13c8b6b2983a4, type: 3}
+--- !u!114 &114828729200829102
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1457523303891292}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 4
 --- !u!114 &114955538477622776
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -731,11 +744,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!212 &212341596637452762
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/CommandDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/CommandDoor.prefab
@@ -40,6 +40,7 @@ GameObject:
   - component: {fileID: 114136653046911712}
   - component: {fileID: 114134813779297148}
   - component: {fileID: 114341371726771256}
+  - component: {fileID: 114208438911392292}
   m_Layer: 17
   m_Name: CommandDoor
   m_TagString: Untagged
@@ -481,8 +482,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114389256914724986}
-  overlay_Lights: {fileID: 212393307592725592}
-  overlay_Glass: {fileID: 212014735325414666}
+  animSize: 6
   doorbase: {fileID: 212398477298658288}
   doorBaseSprites:
   - {fileID: 21300000, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
@@ -515,37 +515,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
   - {fileID: 21300056, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
   - {fileID: 21300058, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300002, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300004, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300006, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300008, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300010, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300012, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300014, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300016, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300018, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300020, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300022, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300024, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300026, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300028, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300030, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300032, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300034, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300036, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300038, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300040, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300042, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300044, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300046, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300048, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300050, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300052, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300054, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300056, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
-  - {fileID: 21300058, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  overlay_Glass: {fileID: 212014735325414666}
+  overlay_Lights: {fileID: 212393307592725592}
   overlayLights:
   - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
@@ -647,7 +618,37 @@ MonoBehaviour:
   - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300002, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300004, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300006, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300008, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300010, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300012, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300014, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300016, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300018, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300020, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300022, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300024, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300026, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300028, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300030, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300032, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300034, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300036, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300038, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300040, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300042, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300044, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300046, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300048, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300050, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300052, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300054, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300056, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
+  - {fileID: 21300058, guid: 774c1913632e84715a61a1948840b4e3, type: 3}
 --- !u!114 &114136653046911712
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -660,6 +661,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   allowInput: 1
+--- !u!114 &114208438911392292
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1069162904971260}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 38
 --- !u!114 &114341371726771256
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -672,11 +685,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!114 &114389256914724986
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -688,22 +701,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 1
-  restriction: 38
-  isWindowedDoor: 0
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 17
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114134813779297148}
-  openSFX: {fileID: 82352768117769496}
   closeSFX: {fileID: 82705712073591644}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114134813779297148}
+  DoorCoverSpriteOffset: 17
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 1
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 0
+  maxTimeOpen: 5
+  openSFX: {fileID: 82352768117769496}
   oppeningDirection: 0
+  restriction: 38
+  spriteRenderer: {fileID: 0}
 --- !u!114 &114594704414043054
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/EngineeringDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/EngineeringDoor.prefab
@@ -104,6 +104,7 @@ GameObject:
   - component: {fileID: 114566587194028974}
   - component: {fileID: 114030775671006844}
   - component: {fileID: 114602670746664174}
+  - component: {fileID: 114216704812953892}
   m_Layer: 17
   m_Name: EngineeringDoor
   m_TagString: Untagged
@@ -481,8 +482,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114059249025983974}
-  overlay_Lights: {fileID: 212050190612633776}
-  overlay_Glass: {fileID: 212541320661430270}
+  animSize: 6
   doorbase: {fileID: 212665150722991628}
   doorBaseSprites:
   - {fileID: 21300000, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
@@ -515,37 +515,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
   - {fileID: 21300056, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
   - {fileID: 21300058, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300002, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300004, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300006, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300008, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300010, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300012, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300014, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300016, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300018, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300020, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300022, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300024, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300026, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300028, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300030, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300032, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300034, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300036, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300038, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300040, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300042, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300044, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300046, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300048, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300050, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300052, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300054, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300056, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
-  - {fileID: 21300058, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  overlay_Glass: {fileID: 212541320661430270}
+  overlay_Lights: {fileID: 212050190612633776}
   overlayLights:
   - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
@@ -647,7 +618,37 @@ MonoBehaviour:
   - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300002, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300004, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300006, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300008, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300010, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300012, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300014, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300016, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300018, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300020, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300022, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300024, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300026, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300028, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300030, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300032, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300034, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300036, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300038, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300040, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300042, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300044, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300046, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300048, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300050, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300052, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300054, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300056, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
+  - {fileID: 21300058, guid: 0a5217928a1af4657803729ce32a1649, type: 3}
 --- !u!114 &114059249025983974
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -659,22 +660,34 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 2
-  restriction: 32
-  isWindowedDoor: 0
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 17
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114030775671006844}
-  openSFX: {fileID: 82119343689486036}
   closeSFX: {fileID: 82465022889846938}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114030775671006844}
+  DoorCoverSpriteOffset: 17
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 2
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 0
+  maxTimeOpen: 5
+  openSFX: {fileID: 82119343689486036}
   oppeningDirection: 0
+  restriction: 32
+  spriteRenderer: {fileID: 0}
+--- !u!114 &114216704812953892
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1636844411894304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 32
 --- !u!114 &114390321638166826
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -731,11 +744,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!212 &212050190612633776
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/MaintDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/MaintDoor.prefab
@@ -25,6 +25,7 @@ GameObject:
   - component: {fileID: 114898495208177878}
   - component: {fileID: 114989240748267380}
   - component: {fileID: 114976444947845894}
+  - component: {fileID: 114456309332343076}
   m_Layer: 17
   m_Name: MaintDoor
   m_TagString: Untagged
@@ -480,22 +481,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 3
-  restriction: 49
-  isWindowedDoor: 0
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 17
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114989240748267380}
-  openSFX: {fileID: 82377813942762574}
   closeSFX: {fileID: 82698941018732718}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114989240748267380}
+  DoorCoverSpriteOffset: 17
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 3
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 0
+  maxTimeOpen: 5
+  openSFX: {fileID: 82377813942762574}
   oppeningDirection: 0
+  restriction: 49
+  spriteRenderer: {fileID: 0}
 --- !u!114 &114079267586071556
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -528,6 +529,18 @@ MonoBehaviour:
     i15: 217
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
+--- !u!114 &114456309332343076
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1006244272141468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 49
 --- !u!114 &114898495208177878
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -552,11 +565,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!114 &114989240748267380
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -569,8 +582,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114052080359656786}
-  overlay_Lights: {fileID: 212637019369820934}
-  overlay_Glass: {fileID: 212582583605288990}
+  animSize: 6
   doorbase: {fileID: 212682416317525988}
   doorBaseSprites:
   - {fileID: 21300000, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
@@ -603,37 +615,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
   - {fileID: 21300056, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
   - {fileID: 21300058, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300002, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300004, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300006, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300008, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300010, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300012, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300014, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300016, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300018, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300020, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300022, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300024, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300026, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300028, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300030, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300032, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300034, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300036, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300038, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300040, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300042, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300044, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300046, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300048, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300050, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300052, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300054, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300056, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
-  - {fileID: 21300058, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  overlay_Glass: {fileID: 212582583605288990}
+  overlay_Lights: {fileID: 212637019369820934}
   overlayLights:
   - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
@@ -735,7 +718,37 @@ MonoBehaviour:
   - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300002, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300004, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300006, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300008, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300010, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300012, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300014, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300016, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300018, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300020, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300022, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300024, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300026, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300028, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300030, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300032, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300034, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300036, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300038, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300040, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300042, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300044, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300046, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300048, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300050, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300052, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300054, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300056, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
+  - {fileID: 21300058, guid: c08e6d7f218e543b3a2cd700d05ecfe3, type: 3}
 --- !u!212 &212582583605288990
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/MedBayDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/MedBayDoor.prefab
@@ -25,6 +25,7 @@ GameObject:
   - component: {fileID: 114203827934596338}
   - component: {fileID: 114416454276806238}
   - component: {fileID: 114244929954303746}
+  - component: {fileID: 114745468428679086}
   m_Layer: 17
   m_Name: MedBayDoor
   m_TagString: Untagged
@@ -525,11 +526,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!114 &114416454276806238
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -542,8 +543,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114813765941142440}
-  overlay_Lights: {fileID: 212945465059047480}
-  overlay_Glass: {fileID: 212682667343390072}
+  animSize: 6
   doorbase: {fileID: 212763884745741634}
   doorBaseSprites:
   - {fileID: 21300000, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
@@ -576,37 +576,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
   - {fileID: 21300056, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
   - {fileID: 21300058, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300002, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300004, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300006, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300008, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300010, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300012, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300014, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300016, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300018, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300020, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300022, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300024, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300026, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300028, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300030, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300032, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300034, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300036, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300038, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300040, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300042, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300044, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300046, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300048, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300050, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300052, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300054, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300056, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
-  - {fileID: 21300058, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  overlay_Glass: {fileID: 212682667343390072}
+  overlay_Lights: {fileID: 212945465059047480}
   overlayLights:
   - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
@@ -708,7 +679,49 @@ MonoBehaviour:
   - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300002, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300004, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300006, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300008, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300010, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300012, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300014, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300016, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300018, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300020, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300022, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300024, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300026, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300028, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300030, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300032, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300034, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300036, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300038, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300040, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300042, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300044, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300046, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300048, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300050, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300052, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300054, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300056, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+  - {fileID: 21300058, guid: 43c31dff620ca409d8144d3a062dedca, type: 3}
+--- !u!114 &114745468428679086
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1033492078376264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 51
 --- !u!114 &114813765941142440
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -720,22 +733,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 4
-  restriction: 51
-  isWindowedDoor: 0
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 17
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114416454276806238}
-  openSFX: {fileID: 82424364662987246}
   closeSFX: {fileID: 82734786462398976}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114416454276806238}
+  DoorCoverSpriteOffset: 17
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 4
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 0
+  maxTimeOpen: 5
+  openSFX: {fileID: 82424364662987246}
   oppeningDirection: 0
+  restriction: 51
+  spriteRenderer: {fileID: 0}
 --- !u!212 &212682667343390072
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/MiningDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/MiningDoor.prefab
@@ -89,6 +89,7 @@ GameObject:
   - component: {fileID: 114968749450346888}
   - component: {fileID: 114996715703636540}
   - component: {fileID: 114426269936519498}
+  - component: {fileID: 114719513637198392}
   m_Layer: 17
   m_Name: MiningDoor
   m_TagString: Untagged
@@ -480,22 +481,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 5
-  restriction: 53
-  isWindowedDoor: 0
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 17
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114996715703636540}
-  openSFX: {fileID: 82338390985291098}
   closeSFX: {fileID: 82235433271380022}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114996715703636540}
+  DoorCoverSpriteOffset: 17
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 5
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 0
+  maxTimeOpen: 5
+  openSFX: {fileID: 82338390985291098}
   oppeningDirection: 0
+  restriction: 53
+  spriteRenderer: {fileID: 0}
 --- !u!114 &114426269936519498
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -508,11 +509,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!114 &114717910890541562
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -545,6 +546,18 @@ MonoBehaviour:
     i15: 61
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
+--- !u!114 &114719513637198392
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1649904137728258}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 53
 --- !u!114 &114968749450346888
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -569,8 +582,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114349135786929062}
-  overlay_Lights: {fileID: 212679880435605806}
-  overlay_Glass: {fileID: 212253482956949698}
+  animSize: 6
   doorbase: {fileID: 212412880872180760}
   doorBaseSprites:
   - {fileID: 21300000, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
@@ -603,37 +615,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
   - {fileID: 21300056, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
   - {fileID: 21300058, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300002, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300004, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300006, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300008, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300010, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300012, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300014, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300016, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300018, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300020, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300022, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300024, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300026, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300028, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300030, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300032, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300034, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300036, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300038, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300040, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300042, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300044, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300046, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300048, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300050, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300052, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300054, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300056, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
-  - {fileID: 21300058, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  overlay_Glass: {fileID: 212253482956949698}
+  overlay_Lights: {fileID: 212679880435605806}
   overlayLights:
   - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
@@ -735,7 +718,37 @@ MonoBehaviour:
   - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300002, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300004, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300006, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300008, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300010, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300012, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300014, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300016, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300018, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300020, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300022, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300024, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300026, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300028, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300030, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300032, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300034, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300036, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300038, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300040, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300042, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300044, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300046, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300048, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300050, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300052, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300054, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300056, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
+  - {fileID: 21300058, guid: bfd2f2c31af534302b05001adb7e8429, type: 3}
 --- !u!212 &212253482956949698
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/PublicDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/PublicDoor.prefab
@@ -73,6 +73,7 @@ GameObject:
   - component: {fileID: 114287951213915578}
   - component: {fileID: 114647979991530576}
   - component: {fileID: 114129184533949936}
+  - component: {fileID: 114506160011368158}
   m_Layer: 18
   m_Name: PublicDoor
   m_TagString: Untagged
@@ -480,22 +481,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 7
-  restriction: 0
-  isWindowedDoor: 1
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 61
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114647979991530576}
-  openSFX: {fileID: 82241881426066012}
   closeSFX: {fileID: 82491796335204434}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114647979991530576}
+  DoorCoverSpriteOffset: 61
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 7
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 1
+  maxTimeOpen: 5
+  openSFX: {fileID: 82241881426066012}
   oppeningDirection: 0
+  restriction: 0
+  spriteRenderer: {fileID: 0}
 --- !u!114 &114129184533949936
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -508,11 +509,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!114 &114287951213915578
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -525,6 +526,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   allowInput: 1
+--- !u!114 &114506160011368158
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013208201100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 0
 --- !u!114 &114647979991530576
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -537,8 +550,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114000012557435128}
-  overlay_Lights: {fileID: 212000011195497998}
-  overlay_Glass: {fileID: 212000011330282726}
+  animSize: 6
   doorbase: {fileID: 212000011125170888}
   doorBaseSprites:
   - {fileID: 21300000, guid: b8db0726da03749cf9fbc0e3f8fd7dba, type: 3}
@@ -571,107 +583,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: b8db0726da03749cf9fbc0e3f8fd7dba, type: 3}
   - {fileID: 21300056, guid: b8db0726da03749cf9fbc0e3f8fd7dba, type: 3}
   - {fileID: 21300058, guid: b8db0726da03749cf9fbc0e3f8fd7dba, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300004, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300006, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300008, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300010, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300012, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300014, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300016, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300018, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300020, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300022, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300024, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300026, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300028, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300030, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300032, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300034, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300036, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300038, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300040, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300042, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300044, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300046, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300048, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300050, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300052, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300054, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300056, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300058, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300060, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300062, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300064, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300066, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300068, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300070, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300072, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300074, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300076, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300078, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300080, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300082, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300084, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300086, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300088, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300090, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300092, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300094, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300096, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300098, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300100, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300102, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300104, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300106, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300108, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300110, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300112, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300114, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300116, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300118, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300120, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300122, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300124, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300126, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300128, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300130, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300132, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300134, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300136, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300138, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300140, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300142, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300144, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300146, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300148, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300150, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300152, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300154, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300156, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300158, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300160, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300162, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300164, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300166, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300168, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300170, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300172, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300174, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300176, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300178, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300180, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300182, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300184, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300186, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300188, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300190, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300192, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  overlay_Glass: {fileID: 212000011330282726}
+  overlay_Lights: {fileID: 212000011195497998}
   overlayLights:
   - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
@@ -773,7 +686,107 @@ MonoBehaviour:
   - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300004, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300006, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300008, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300010, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300012, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300014, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300016, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300018, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300020, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300022, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300024, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300026, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300028, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300030, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300032, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300034, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300036, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300038, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300040, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300042, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300044, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300046, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300048, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300050, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300052, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300054, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300056, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300058, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300060, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300062, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300064, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300066, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300068, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300070, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300072, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300074, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300076, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300078, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300080, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300082, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300084, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300086, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300088, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300090, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300092, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300094, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300096, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300098, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300100, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300102, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300104, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300106, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300108, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300110, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300112, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300114, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300116, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300118, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300120, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300122, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300124, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300126, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300128, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300130, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300132, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300134, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300136, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300138, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300140, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300142, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300144, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300146, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300148, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300150, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300152, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300154, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300156, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300158, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300160, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300162, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300164, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300166, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300168, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300170, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300172, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300174, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300176, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300178, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300180, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300182, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300184, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300186, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300188, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300190, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300192, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
+  - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
 --- !u!114 &114752899670656194
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/ResearchDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/ResearchDoor.prefab
@@ -104,6 +104,7 @@ GameObject:
   - component: {fileID: 114071899722853512}
   - component: {fileID: 114740141523933832}
   - component: {fileID: 114513430624311320}
+  - component: {fileID: 114347167898776186}
   m_Layer: 17
   m_Name: ResearchDoor
   m_TagString: Untagged
@@ -481,6 +482,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   allowInput: 1
+--- !u!114 &114347167898776186
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1471265584270754}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 63
 --- !u!114 &114513430624311320
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -493,11 +506,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!114 &114527851460587104
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -509,22 +522,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 8
-  restriction: 63
-  isWindowedDoor: 0
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 17
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114740141523933832}
-  openSFX: {fileID: 82646497274377664}
   closeSFX: {fileID: 82737520476845884}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114740141523933832}
+  DoorCoverSpriteOffset: 17
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 8
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 0
+  maxTimeOpen: 5
+  openSFX: {fileID: 82646497274377664}
   oppeningDirection: 0
+  restriction: 63
+  spriteRenderer: {fileID: 0}
 --- !u!114 &114628297871027656
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -569,8 +582,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114527851460587104}
-  overlay_Lights: {fileID: 212274409604352804}
-  overlay_Glass: {fileID: 212993425797920958}
+  animSize: 6
   doorbase: {fileID: 212488587135522660}
   doorBaseSprites:
   - {fileID: 21300000, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
@@ -603,37 +615,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
   - {fileID: 21300056, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
   - {fileID: 21300058, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300002, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300004, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300006, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300008, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300010, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300012, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300014, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300016, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300018, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300020, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300022, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300024, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300026, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300028, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300030, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300032, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300034, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300036, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300038, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300040, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300042, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300044, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300046, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300048, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300050, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300052, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300054, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300056, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
-  - {fileID: 21300058, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  overlay_Glass: {fileID: 212993425797920958}
+  overlay_Lights: {fileID: 212274409604352804}
   overlayLights:
   - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
@@ -735,7 +718,37 @@ MonoBehaviour:
   - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300002, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300004, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300006, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300008, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300010, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300012, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300014, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300016, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300018, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300020, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300022, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300024, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300026, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300028, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300030, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300032, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300034, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300036, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300038, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300040, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300042, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300044, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300046, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300048, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300050, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300052, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300054, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300056, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
+  - {fileID: 21300058, guid: 303196ad4eff84bcf9d0fa7bfbd3e651, type: 3}
 --- !u!212 &212274409604352804
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/ScienceDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/ScienceDoor.prefab
@@ -88,6 +88,7 @@ GameObject:
   - component: {fileID: 114636056436692218}
   - component: {fileID: 114746668465746426}
   - component: {fileID: 114487638215291910}
+  - component: {fileID: 114340590407541506}
   m_Layer: 17
   m_Name: ScienceDoor
   m_TagString: Untagged
@@ -480,22 +481,34 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 9
-  restriction: 63
-  isWindowedDoor: 0
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 17
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114746668465746426}
-  openSFX: {fileID: 82585580305196082}
   closeSFX: {fileID: 82137359379656950}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114746668465746426}
+  DoorCoverSpriteOffset: 17
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 9
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 0
+  maxTimeOpen: 5
+  openSFX: {fileID: 82585580305196082}
   oppeningDirection: 0
+  restriction: 63
+  spriteRenderer: {fileID: 0}
+--- !u!114 &114340590407541506
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1703130924713270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 63
 --- !u!114 &114487638215291910
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -508,11 +521,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!114 &114636056436692218
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -537,8 +550,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114116368055496416}
-  overlay_Lights: {fileID: 212694625464252988}
-  overlay_Glass: {fileID: 212821258253684330}
+  animSize: 6
   doorbase: {fileID: 212189348538616740}
   doorBaseSprites:
   - {fileID: 21300000, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
@@ -571,37 +583,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
   - {fileID: 21300056, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
   - {fileID: 21300058, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300002, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300004, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300006, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300008, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300010, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300012, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300014, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300016, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300018, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300020, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300022, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300024, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300026, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300028, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300030, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300032, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300034, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300036, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300038, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300040, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300042, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300044, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300046, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300048, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300050, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300052, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300054, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300056, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
-  - {fileID: 21300058, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  overlay_Glass: {fileID: 212821258253684330}
+  overlay_Lights: {fileID: 212694625464252988}
   overlayLights:
   - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
@@ -703,7 +686,37 @@ MonoBehaviour:
   - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300002, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300004, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300006, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300008, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300010, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300012, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300014, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300016, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300018, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300020, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300022, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300024, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300026, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300028, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300030, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300032, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300034, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300036, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300038, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300040, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300042, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300044, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300046, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300048, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300050, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300052, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300054, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300056, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
+  - {fileID: 21300058, guid: d236100e17fe04863bf5d32c42f495f3, type: 3}
 --- !u!114 &114915423448367456
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/SecDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/SecDoor.prefab
@@ -88,6 +88,7 @@ GameObject:
   - component: {fileID: 114776570776623186}
   - component: {fileID: 114063757892050276}
   - component: {fileID: 114224470283974914}
+  - component: {fileID: 114124758183691526}
   m_Layer: 17
   m_Name: SecDoor
   m_TagString: Untagged
@@ -481,8 +482,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114716872036012102}
-  overlay_Lights: {fileID: 212750581741884302}
-  overlay_Glass: {fileID: 212134995205660142}
+  animSize: 6
   doorbase: {fileID: 212354931256592704}
   doorBaseSprites:
   - {fileID: 21300000, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
@@ -515,37 +515,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
   - {fileID: 21300056, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
   - {fileID: 21300058, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300002, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300004, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300006, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300008, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300010, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300012, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300014, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300016, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300018, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300020, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300022, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300024, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300026, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300028, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300030, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300032, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300034, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300036, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300038, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300040, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300042, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300044, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300046, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300048, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300050, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300052, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300054, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300056, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
-  - {fileID: 21300058, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  overlay_Glass: {fileID: 212134995205660142}
+  overlay_Lights: {fileID: 212750581741884302}
   overlayLights:
   - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
@@ -647,7 +618,49 @@ MonoBehaviour:
   - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300002, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300004, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300006, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300008, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300010, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300012, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300014, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300016, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300018, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300020, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300022, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300024, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300026, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300028, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300030, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300032, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300034, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300036, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300038, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300040, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300042, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300044, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300046, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300048, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300050, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300052, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300054, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300056, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+  - {fileID: 21300058, guid: fec1a0841196d47cbbbf2dcfd4d846bd, type: 3}
+--- !u!114 &114124758183691526
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1488470923909840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 68
 --- !u!114 &114224470283974914
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -660,11 +673,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!114 &114716872036012102
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -676,22 +689,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 10
-  restriction: 68
-  isWindowedDoor: 0
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 17
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114063757892050276}
-  openSFX: {fileID: 82426556019595742}
   closeSFX: {fileID: 82079168272760752}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114063757892050276}
+  DoorCoverSpriteOffset: 17
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 10
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 0
+  maxTimeOpen: 5
+  openSFX: {fileID: 82426556019595742}
   oppeningDirection: 0
+  restriction: 68
+  spriteRenderer: {fileID: 0}
 --- !u!114 &114773857305252160
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/SpaceshipDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/SpaceshipDoor.prefab
@@ -25,6 +25,7 @@ GameObject:
   - component: {fileID: 114082268845705964}
   - component: {fileID: 114555128303457534}
   - component: {fileID: 114934665753762238}
+  - component: {fileID: 114783260291918140}
   m_Layer: 18
   m_Name: SpaceshipDoor
   m_TagString: Untagged
@@ -492,22 +493,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 12
-  restriction: 0
-  isWindowedDoor: 0
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 17
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114555128303457534}
-  openSFX: {fileID: 82121942072772510}
   closeSFX: {fileID: 82020299355121634}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114555128303457534}
+  DoorCoverSpriteOffset: 17
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 12
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 0
+  maxTimeOpen: 5
+  openSFX: {fileID: 82121942072772510}
   oppeningDirection: 0
+  restriction: 0
+  spriteRenderer: {fileID: 0}
 --- !u!114 &114489728062938340
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -552,8 +553,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114459946896903996}
-  overlay_Lights: {fileID: 212742844654875348}
-  overlay_Glass: {fileID: 212860882851672800}
+  animSize: 6
   doorbase: {fileID: 212254836695897932}
   doorBaseSprites:
   - {fileID: 21300000, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
@@ -586,37 +586,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
   - {fileID: 21300056, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
   - {fileID: 21300058, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300002, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300004, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300006, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300008, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300010, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300012, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300014, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300016, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300018, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300020, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300022, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300024, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300026, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300028, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300030, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300032, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300034, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300036, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300038, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300040, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300042, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300044, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300046, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300048, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300050, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300052, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300054, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300056, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
-  - {fileID: 21300058, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  overlay_Glass: {fileID: 212860882851672800}
+  overlay_Lights: {fileID: 212742844654875348}
   overlayLights:
   - {fileID: 21300000, guid: cfe50577f2e1047679a52b943cb1123f, type: 3}
   - {fileID: 21300002, guid: cfe50577f2e1047679a52b943cb1123f, type: 3}
@@ -708,7 +679,49 @@ MonoBehaviour:
   - {fileID: 21300174, guid: cfe50577f2e1047679a52b943cb1123f, type: 3}
   - {fileID: 21300176, guid: cfe50577f2e1047679a52b943cb1123f, type: 3}
   - {fileID: 21300178, guid: cfe50577f2e1047679a52b943cb1123f, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300002, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300004, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300006, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300008, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300010, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300012, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300014, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300016, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300018, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300020, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300022, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300024, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300026, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300028, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300030, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300032, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300034, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300036, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300038, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300040, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300042, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300044, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300046, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300048, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300050, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300052, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300054, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300056, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+  - {fileID: 21300058, guid: d3aab064d302f4b53bf232a50e6814ca, type: 3}
+--- !u!114 &114783260291918140
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1067917369029206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 0
 --- !u!114 &114934665753762238
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -721,11 +734,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!212 &212254836695897932
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/Virology.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/Virology.prefab
@@ -72,6 +72,7 @@ GameObject:
   - component: {fileID: 114235526540606744}
   - component: {fileID: 114072467774251574}
   - component: {fileID: 114823388259431498}
+  - component: {fileID: 114249863671345724}
   m_Layer: 17
   m_Name: Virology
   m_TagString: Untagged
@@ -481,8 +482,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114767970609396208}
-  overlay_Lights: {fileID: 212043546246156924}
-  overlay_Glass: {fileID: 212705240095914254}
+  animSize: 6
   doorbase: {fileID: 212560484114377812}
   doorBaseSprites:
   - {fileID: 21300000, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
@@ -515,37 +515,8 @@ MonoBehaviour:
   - {fileID: 21300054, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
   - {fileID: 21300056, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
   - {fileID: 21300058, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300002, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300004, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300006, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300008, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300010, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300012, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300014, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300016, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300018, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300020, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300022, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300024, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300026, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300028, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300030, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300032, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300034, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300036, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300038, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300040, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300042, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300044, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300046, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300048, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300050, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300052, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300054, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300056, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
-  - {fileID: 21300058, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  overlay_Glass: {fileID: 212705240095914254}
+  overlay_Lights: {fileID: 212043546246156924}
   overlayLights:
   - {fileID: 21300000, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300002, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
@@ -647,7 +618,37 @@ MonoBehaviour:
   - {fileID: 21300194, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300196, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   - {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300002, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300004, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300006, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300008, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300010, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300012, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300014, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300016, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300018, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300020, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300022, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300024, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300026, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300028, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300030, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300032, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300034, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300036, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300038, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300040, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300042, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300044, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300046, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300048, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300050, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300052, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300054, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300056, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
+  - {fileID: 21300058, guid: dcc76c55f951944c083fe6080f9b6a8e, type: 3}
 --- !u!114 &114235526540606744
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -660,6 +661,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   allowInput: 1
+--- !u!114 &114249863671345724
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1807313548142900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 78
 --- !u!114 &114338759738806540
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -703,22 +716,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 11
-  restriction: 78
-  isWindowedDoor: 0
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 17
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114072467774251574}
-  openSFX: {fileID: 82420744150140008}
   closeSFX: {fileID: 82586256685024074}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114072467774251574}
+  DoorCoverSpriteOffset: 17
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 11
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 0
+  maxTimeOpen: 5
+  openSFX: {fileID: 82420744150140008}
   oppeningDirection: 0
+  restriction: 78
+  spriteRenderer: {fileID: 0}
 --- !u!114 &114823388259431498
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -731,11 +744,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!212 &212043546246156924
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/WhiteServiceDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/WhiteServiceDoor.prefab
@@ -57,6 +57,7 @@ GameObject:
   - component: {fileID: 114672552748689518}
   - component: {fileID: 114644895939695836}
   - component: {fileID: 114937751941926332}
+  - component: {fileID: 114823252709214448}
   m_Layer: 18
   m_Name: WhiteServiceDoor
   m_TagString: Untagged
@@ -480,22 +481,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 14
-  restriction: 0
-  isWindowedDoor: 1
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 58
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 5
-  doorAnimator: {fileID: 114644895939695836}
-  openSFX: {fileID: 82034696694369034}
   closeSFX: {fileID: 82262653965746812}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114644895939695836}
+  DoorCoverSpriteOffset: 58
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 14
   FullDoor: 1
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 1
+  maxTimeOpen: 5
+  openSFX: {fileID: 82034696694369034}
   oppeningDirection: 0
+  restriction: 0
+  spriteRenderer: {fileID: 0}
 --- !u!114 &114229922813896132
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -540,8 +541,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   doorController: {fileID: 114000011089653234}
-  overlay_Lights: {fileID: 212000011445080960}
-  overlay_Glass: {fileID: 212000011094967888}
+  animSize: 6
   doorbase: {fileID: 212000011262533386}
   doorBaseSprites:
   - {fileID: 21300000, guid: 63b7011f0f41a4a86b02c7a6eec1de98, type: 3}
@@ -560,97 +560,8 @@ MonoBehaviour:
   - {fileID: 21300026, guid: 63b7011f0f41a4a86b02c7a6eec1de98, type: 3}
   - {fileID: 21300028, guid: 63b7011f0f41a4a86b02c7a6eec1de98, type: 3}
   - {fileID: 21300030, guid: 63b7011f0f41a4a86b02c7a6eec1de98, type: 3}
-  overlaySprites:
-  - {fileID: 21300000, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300002, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300004, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300006, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300008, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300010, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300012, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300014, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300016, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300018, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300020, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300022, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300024, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300026, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300028, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300030, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300032, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300034, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300036, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300038, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300040, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300042, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300044, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300046, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300048, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300050, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300052, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300054, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300056, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300058, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300060, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300062, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300064, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300066, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300068, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300070, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300072, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300074, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300076, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300078, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300080, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300082, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300084, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300086, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300088, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300090, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300092, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300094, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300096, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300098, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300100, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300102, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300104, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300106, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300108, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300110, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300112, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300114, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300116, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300118, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300120, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300122, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300124, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300126, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300128, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300130, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300132, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300134, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300136, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300138, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300140, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300142, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300144, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300146, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300148, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300150, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300152, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300154, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300156, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300158, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300160, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300162, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300164, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300166, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300168, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300170, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300172, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300174, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300176, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  - {fileID: 21300178, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  overlay_Glass: {fileID: 212000011094967888}
+  overlay_Lights: {fileID: 212000011445080960}
   overlayLights:
   - {fileID: 21300000, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
   - {fileID: 21300002, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
@@ -742,7 +653,97 @@ MonoBehaviour:
   - {fileID: 21300174, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
   - {fileID: 21300176, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
   - {fileID: 21300178, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
-  animSize: 6
+  overlaySprites:
+  - {fileID: 21300000, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300002, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300004, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300006, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300008, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300010, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300012, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300014, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300016, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300018, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300020, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300022, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300024, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300026, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300028, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300030, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300032, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300034, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300036, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300038, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300040, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300042, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300044, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300046, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300048, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300050, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300052, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300054, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300056, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300058, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300060, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300062, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300064, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300066, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300068, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300070, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300072, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300074, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300076, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300078, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300080, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300082, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300084, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300086, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300088, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300090, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300092, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300094, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300096, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300098, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300100, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300102, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300104, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300106, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300108, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300110, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300112, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300114, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300116, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300118, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300120, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300122, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300124, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300126, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300128, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300130, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300132, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300134, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300136, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300138, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300140, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300142, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300144, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300146, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300148, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300150, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300152, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300154, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300156, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300158, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300160, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300162, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300164, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300166, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300168, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300170, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300172, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300174, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300176, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
+  - {fileID: 21300178, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
 --- !u!114 &114672552748689518
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -755,6 +756,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   allowInput: 1
+--- !u!114 &114823252709214448
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013430947772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 0
 --- !u!114 &114937751941926332
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -767,11 +780,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 0
   IsClosed: 1
+  OneDirectionRestricted: 0
 --- !u!212 &212000011094967888
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Prefabs/Doors/Resources/WinDoor.prefab
+++ b/UnityProject/Assets/Prefabs/Doors/Resources/WinDoor.prefab
@@ -73,6 +73,7 @@ GameObject:
   - component: {fileID: 114029210237443714}
   - component: {fileID: 114719229024385200}
   - component: {fileID: 114476203546729768}
+  - component: {fileID: 114531569165117964}
   m_Layer: 17
   m_Name: WinDoor
   m_TagString: Untagged
@@ -420,22 +421,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: abede496a2014828a4bdb14c65ffd675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  doorType: 15
-  restriction: 0
-  isWindowedDoor: 1
-  doorAnimationSize: 6
-  DoorSpriteOffset: 2
-  DoorLightSpriteOffset: 0
-  DoorCoverSpriteOffset: 17
-  isPerformingAction: 0
-  spriteRenderer: {fileID: 0}
-  maxTimeOpen: 2
-  doorAnimator: {fileID: 114719229024385200}
-  openSFX: {fileID: 82779476563424656}
   closeSFX: {fileID: 82801123418606930}
-  IsOpened: 0
+  doorAnimationSize: 6
+  doorAnimator: {fileID: 114719229024385200}
+  DoorCoverSpriteOffset: 17
+  DoorLightSpriteOffset: 0
+  DoorSpriteOffset: 2
+  doorType: 15
   FullDoor: 0
+  IsOpened: 0
+  isPerformingAction: 0
+  isWindowedDoor: 1
+  maxTimeOpen: 2
+  openSFX: {fileID: 82779476563424656}
   oppeningDirection: 0
+  restriction: 0
+  spriteRenderer: {fileID: 0}
 --- !u!114 &114412479674324666
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -492,11 +493,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ObjectType: 1
+  AtmosPassable: 0
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  AtmosPassable: 0
-  OneDirectionRestricted: 1
   IsClosed: 1
+  OneDirectionRestricted: 1
+--- !u!114 &114531569165117964
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1797280918088156}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  restriction: 0
 --- !u!114 &114719229024385200
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Scripts/Doors/DoorController.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorController.cs
@@ -219,7 +219,28 @@ namespace Doors
 			}
 		}
 
-		private void ResetWaiting()
+        // How the client attempts to open the door. If there is no AccessRestrictions component, it returns an error and everything goes about its business.
+        [Command]
+        public void CmdCheckDoorPermissions(GameObject Door, GameObject Originator)
+        {
+            if (Door.GetComponent<AccessRestrictions>() != null)
+            {
+                if (Door.GetComponent<AccessRestrictions>().checkAccess(Originator, Door))
+                {
+                    CmdTryOpen(Originator);
+                }
+                else
+                {
+                    CmdTryDenied();
+                }
+            }
+            else
+            {
+                Debug.LogError("Door lacks access restriction component!");
+            }
+        }
+
+        private void ResetWaiting()
 		{
 			if (coWaitOpened != null)
 			{

--- a/UnityProject/Assets/Scripts/Doors/DoorTrigger.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorTrigger.cs
@@ -20,90 +20,23 @@ namespace Doors
 			doorController = GetComponent<DoorController>();
 		}
 
-		public override void Interact(GameObject originator, Vector3 position, string hand)
-		{
-			if (doorController != null && allowInput)
-			{
-				if ((int) doorController.restriction > 0)
-				{
-					if (UIManager.InventorySlots.IDSlot.IsFull &&
-					    UIManager.InventorySlots.IDSlot.Item.GetComponent<IDCard>() != null)
-					{
-						CheckDoorAccess(UIManager.InventorySlots.IDSlot.Item.GetComponent<IDCard>(), doorController, originator);
-					}
-					else if (UIManager.Hands.CurrentSlot.IsFull &&
-					         UIManager.Hands.CurrentSlot.Item.GetComponent<IDCard>() != null)
-					{
-						CheckDoorAccess(UIManager.Hands.CurrentSlot.Item.GetComponent<IDCard>(), doorController, originator);
-					}
-					else
-					{
-						allowInput = false;
-						StartCoroutine(DoorInputCoolDown());
-						PlayerManager.LocalPlayerScript.playerNetworkActions
-							.CmdRestrictDoorDenied(gameObject);
-					}
-				}
-				else
-				{
-					Debug.Log("no restriction required");
-					allowInput = false;
-					if (CustomNetworkManager.Instance._isServer)
-					{
-						if (!doorController.IsOpened)
-						{
-							doorController.CmdTryOpen(originator);
-						}
-						else
-						{
-							doorController.CmdTryClose();
-						}
-					}
-					else
-					{
-						//for mouse click opening when not server
-						if (!doorController.IsOpened)
-						{
-							PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryOpenDoor(gameObject, originator);
-						}
-						else
-						{
-							PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryCloseDoor(gameObject);
-						}
-					}
-					StartCoroutine(DoorInputCoolDown());
-				}
-			}
-		}
+        public override void Interact(GameObject originator, Vector3 position, string hand)
+        {
+            AccessRestrictions AR = GetComponent<AccessRestrictions>();
+            
+            if(doorController.IsOpened)
+            {
+                doorController.CmdTryClose();
+            }
 
-		private void CheckDoorAccess(IDCard cardID, DoorController doorController, GameObject originator)
-		{
-			Debug.Log("been here!");
-			if (cardID.accessSyncList.Contains((int) doorController.restriction))
-			{
-// has access
-				allowInput = false;
-				if (!doorController.IsOpened)
-				{
-					PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryOpenDoor(gameObject, originator);
-				}
-				else
-				{
-					PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryCloseDoor(gameObject);
-				}
+            if (doorController != null && allowInput)
+            {
+                doorController.CmdCheckDoorPermissions(this.gameObject, originator);
 
-				Debug.Log(doorController.restriction + " access granted");
-				StartCoroutine(DoorInputCoolDown());
-			}
-			else
-			{
-// does not have access
-				Debug.Log(doorController.restriction + " no access");
-				allowInput = false;
-				StartCoroutine(DoorInputCoolDown());
-				PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRestrictDoorDenied(gameObject);
-			}
-		}
+                allowInput = false;
+                StartCoroutine(DoorInputCoolDown());
+            }
+        }
 
 		private IEnumerator DoorInputCoolDown()
 		{

--- a/UnityProject/Assets/Scripts/Jobs/AccessRestrictions.cs
+++ b/UnityProject/Assets/Scripts/Jobs/AccessRestrictions.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections;
+using AccessType;
+using Sprites;
+using Tilemaps.Scripts;
+using Tilemaps.Scripts.Behaviours.Objects;
+using UI;
+using UnityEngine;
+using UnityEngine.Networking;
+
+
+// This manages access via ID cards. 
+public class AccessRestrictions : MonoBehaviour
+{
+    public Access restriction;
+
+    public bool checkAccess(GameObject Player)
+    {
+        return checkAccess(Player, this.gameObject);
+    }
+
+    public bool checkAccess(GameObject Player, GameObject Object)
+    {
+        IDCard card;
+        UIManager playerUIManager = Player.GetComponent<UIManager>();
+        PlayerNetworkActions PNA = Player.GetComponent<PlayerNetworkActions>();
+
+        // Check for an ID card
+        if(PNA.Inventory["id"] != null &&
+            PNA.Inventory["id"].GetComponent<IDCard>() != null)
+        {
+            card = PNA.Inventory["id"].GetComponent<IDCard>();
+        }
+        else if(PNA.Inventory[PNA.activeHand + "Hand"] != null &&
+            PNA.Inventory[PNA.activeHand + "Hand"].GetComponent<IDCard>() != null)
+        {
+            card = PNA.Inventory[PNA.activeHand + "Hand"].GetComponent<IDCard>();
+        }
+        else
+        {
+            // If there isn't one, see if we even need one
+            if ((int)restriction == 0)
+            {
+                return true;
+            }
+            // If there isn't one and we don't need one, we don't open the door
+            return false;
+        }
+
+        // If we have an ID, make sure we have access
+        if ((int)restriction == 0)
+        {
+            return true;
+        }
+        else if (card.accessSyncList.Contains((int)restriction))
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+}

--- a/UnityProject/Assets/Scripts/Jobs/AccessRestrictions.cs.meta
+++ b/UnityProject/Assets/Scripts/Jobs/AccessRestrictions.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 91b1f6111eb8ac243b137dc8a7e36d1a
+timeCreated: 1513797949
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
@@ -22,6 +22,11 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		"suitStorage"
 	};
 
+    // For access checking. Must be nonserialized.
+    // This has to be added because using the UIManager at client gets the server's UIManager. So instead I just had it send the active hand to be cached at server.
+    [System.NonSerialized]
+    public string activeHand = "right";
+
 	private ChatIcon chatIcon;
 
 	private Equipment.Equipment equipment;
@@ -539,4 +544,11 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		Inventory[fromSlot] = null;
 		equipment.ClearItemSprite(fromSlot);
 	}
+
+    [Command]
+    public void CmdSetActiveHand(string hand)
+    {
+        activeHand = hand;
+    }
+    
 }

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
@@ -48,12 +48,14 @@ namespace UI
 			{
 				CurrentSlot = Slots.RightHandSlot;
 				OtherSlot = Slots.LeftHandSlot;
+                PlayerManager.LocalPlayerScript.playerNetworkActions.CmdSetActiveHand("right");
 			}
 			else
 			{
 				CurrentSlot = Slots.LeftHandSlot;
 				OtherSlot = Slots.RightHandSlot;
-			}
+                PlayerManager.LocalPlayerScript.playerNetworkActions.CmdSetActiveHand("left");
+            }
 
 			IsRight = right;
 			selector.position = CurrentSlot.transform.position;


### PR DESCRIPTION
### Purpose
Reworks access system to reduce unnecessary code redundancy.
Fixes bug #675 

### Approach
I followed the code until I found that the client's check for access. At this point I noticed (With the help of Doobly) that it was using the server's ID instead of the client's. In looking for a fix, I found a rework of the whole system.
### Open Questions and Pre-Merge TODOs

- [X]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes:
The new component can be applied to department cabinets, consoles, etc.

All checks for access are now serverside.