### PR TITLE
Fixed issue #709

### DIFF
--- a/UnityProject/Assets/Scripts/Doors/DoorController.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorController.cs
@@ -224,7 +224,7 @@ namespace Doors
         {
             if (Door.GetComponent<AccessRestrictions>() != null)
             {
-                if (Door.GetComponent<AccessRestrictions>().checkAccess(Originator, Door))
+                if (Door.GetComponent<AccessRestrictions>().CheckAccess(Originator, Door))
                 {
                     CmdTryOpen(Originator);
                 }

--- a/UnityProject/Assets/Scripts/Doors/DoorTrigger.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorTrigger.cs
@@ -22,11 +22,11 @@ namespace Doors
 
         public override void Interact(GameObject originator, Vector3 position, string hand)
         {
-            
+            PlayerNetworkActions pna = PlayerManager.LocalPlayer.GetComponent<PlayerNetworkActions>();
             // Close the door if it's open
             if(doorController.IsOpened && allowInput)
             {
-                PlayerManager.LocalPlayer.GetComponent<PlayerNetworkActions>().CmdTryCloseDoor(gameObject);
+                pna.CmdTryCloseDoor(gameObject);
 
                 allowInput = false;
                 StartCoroutine(DoorInputCoolDown());
@@ -35,7 +35,7 @@ namespace Doors
             // Attempt to open if it's closed
             if (doorController != null && allowInput)
             {
-                PlayerManager.LocalPlayer.GetComponent<PlayerNetworkActions>().CmdCheckDoorPermissions(gameObject, PlayerManager.LocalPlayerScript.gameObject);
+                pna.CmdCheckDoorPermissions(gameObject, PlayerManager.LocalPlayerScript.gameObject);
 
                 allowInput = false;
                 StartCoroutine(DoorInputCoolDown());

--- a/UnityProject/Assets/Scripts/Doors/DoorTrigger.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorTrigger.cs
@@ -22,7 +22,6 @@ namespace Doors
 
         public override void Interact(GameObject originator, Vector3 position, string hand)
         {
-            AccessRestrictions AR = GetComponent<AccessRestrictions>();
             
             // Close the door if it's open
             if(doorController.IsOpened && allowInput)

--- a/UnityProject/Assets/Scripts/Doors/DoorTrigger.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorTrigger.cs
@@ -24,14 +24,19 @@ namespace Doors
         {
             AccessRestrictions AR = GetComponent<AccessRestrictions>();
             
-            if(doorController.IsOpened)
+            // Close the door if it's open
+            if(doorController.IsOpened && allowInput)
             {
-                doorController.CmdTryClose();
+                PlayerManager.LocalPlayer.GetComponent<PlayerNetworkActions>().CmdTryCloseDoor(gameObject);
+
+                allowInput = false;
+                StartCoroutine(DoorInputCoolDown());
             }
 
+            // Attempt to open if it's closed
             if (doorController != null && allowInput)
             {
-                doorController.CmdCheckDoorPermissions(this.gameObject, originator);
+                PlayerManager.LocalPlayer.GetComponent<PlayerNetworkActions>().CmdCheckDoorPermissions(gameObject, PlayerManager.LocalPlayerScript.gameObject);
 
                 allowInput = false;
                 StartCoroutine(DoorInputCoolDown());

--- a/UnityProject/Assets/Scripts/Jobs/AccessRestrictions.cs
+++ b/UnityProject/Assets/Scripts/Jobs/AccessRestrictions.cs
@@ -13,15 +13,14 @@ public class AccessRestrictions : MonoBehaviour
 {
     public Access restriction;
 
-    public bool checkAccess(GameObject Player)
+    public bool CheckAccess(GameObject Player)
     {
-        return checkAccess(Player, this.gameObject);
+        return CheckAccess(Player, gameObject);
     }
 
-    public bool checkAccess(GameObject Player, GameObject Object)
+    public bool CheckAccess(GameObject Player, GameObject Object)
     {
         IDCard card;
-        UIManager playerUIManager = Player.GetComponent<UIManager>();
         PlayerNetworkActions PNA = Player.GetComponent<PlayerNetworkActions>();
 
         // Check for an ID card

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
@@ -518,6 +518,15 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		door.GetComponent<DoorController>().CmdTryDenied();
 	}
 
+    [Command]
+    public void CmdCheckDoorPermissions(GameObject door, GameObject player)
+    {
+        if(door.GetComponent<DoorController>() != null)
+        {
+            door.GetComponent<DoorController>().CmdCheckDoorPermissions(door, player);
+        }
+    }
+
 	//FOOD
 	[Command]
 	public void CmdEatFood(GameObject food, string fromSlot)


### PR DESCRIPTION
### Purpose
Fixed issue #709

### Approach
I added Debug.Logs and looked at the client's log file. It turns out that the client cannot access commands of another object, thus requiring the door commands to be routed through the PNA.

### Open Questions and Pre-Merge TODOs

- X ]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes:
None