### PR TITLE
GameObject() method removal from UISlot

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
@@ -243,9 +243,9 @@ namespace PlayGroups.Input
 
 		private bool InteractHands()
 		{
-			if (UIManager.Hands.CurrentSlot.GameObject() != null && objectBehaviour.visibleState)
+			if (UIManager.Hands.CurrentSlot.Item != null && objectBehaviour.visibleState)
 			{
-				InputTrigger inputTrigger = UIManager.Hands.CurrentSlot.GameObject().GetComponent<InputTrigger>();
+				InputTrigger inputTrigger = UIManager.Hands.CurrentSlot.Item.GetComponent<InputTrigger>();
 				if (inputTrigger != null)
 				{
 					inputTrigger.Trigger();

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
@@ -102,15 +102,6 @@ namespace UI
 		}
 
 		/// <summary>
-		///     returnes the current item from the slot
-		/// </summary>
-		/// <returns></returns>
-		public GameObject GameObject()
-		{
-			return Item;
-		}
-
-		/// <summary>
 		///     Clientside check for dropping/placing objects from inventory slot
 		/// </summary>
 		public bool CanPlaceItem()

--- a/UnityProject/Assets/Scripts/Weapons/Weapon.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Weapon.cs
@@ -234,7 +234,7 @@ namespace Weapons
 				return;
 			}
 			//shoot gun interation if its in hand
-			if (gameObject == UIManager.Hands.CurrentSlot.GameObject())
+			if (gameObject == UIManager.Hands.CurrentSlot.Item)
 			{
 				AttemptToFireWeapon();
 			}


### PR DESCRIPTION
- Item is already a property and you do not need another method to return the gameobject of the Item property
- Removing this method and getting the gObj directly from Item property has fixed #685

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
Tested in high ping MP (800ms avg) and tested with 4 different types of ballistic weapons. All now work when spamming the trigger