### PR TITLE
Added  ClosetHandlerMessage

### DIFF
--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -226,6 +226,13 @@ namespace Cupboards
 					player.transform.position = transform.position;
 				}
 				player.visibleState = on;
+
+				if (!on)
+				{
+					//Make sure a ClosetPlayerHandler is created on the client to monitor 
+					//the players input inside the storage. The handler also controls the camera follow targets:
+					ClosetHandlerMessage.Send(player.gameObject, this.gameObject);
+				}
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Closets/ClosetPlayerHandler.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetPlayerHandler.cs
@@ -16,20 +16,14 @@ namespace Cupboards
 	/// </summary>
 	public class ClosetPlayerHandler : MonoBehaviour
 	{
-		private RegisterTile _registerTile;
 		private ClosetControl closetControl;
 		private bool monitor;
 
-		private void Start()
+		public void Init(ClosetControl closetCtrl)
 		{
-			_registerTile = GetComponent<RegisterTile>();
-			//Closets have healthbehaviours on them, search through the list for the cupboard you are in
-
+			closetControl = closetCtrl;
+			
 			Matrix matrix = Matrix.GetMatrix(this);
-			ClosetControl[] closetControls = matrix.Get<ClosetControl>(_registerTile.Position).ToArray();
-
-			closetControl = closetControls[0];
-			//Set the camera to follow the closet
 			Camera2DFollow.followControl.target = closetControl.transform;
 			Camera2DFollow.followControl.damping = 0.2f;
 

--- a/UnityProject/Assets/Scripts/Messages/Server/ClosetHandlerMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/ClosetHandlerMessage.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using PlayGroup;
+using UnityEngine;
+using UnityEngine.Networking;
+using Cupboards;
+
+/// <summary>
+/// This Server to Client message is sent when a player is stored inside a closet or crate.
+/// It makes sure the relevant ClosetHandler is created on the client to monitor the players actions while the
+/// player is being hidden inside
+/// </summary>
+public class ClosetHandlerMessage : ServerMessage<ClosetHandlerMessage> {
+
+	public NetworkInstanceId Recipient;
+	public GameObject Closet;
+
+	public override IEnumerator Process()
+	{
+		yield return WaitFor(Recipient);
+			//Add the local player ClosetPlayerHandler (controls camera and interaction when closet is moving)
+			//Also monitors players movement inside the cupboard and tries to break them out
+			ObjectBehaviour playerBehaviour = PlayerManager.LocalPlayer.GetComponent<ObjectBehaviour>();
+			playerBehaviour.closetHandlerCache = PlayerManager.LocalPlayer.AddComponent<ClosetPlayerHandler>();
+			ClosetControl closetCtrl = Closet.GetComponent<ClosetControl>();
+			playerBehaviour.closetHandlerCache.Init(closetCtrl);
+	}
+
+	public static ClosetHandlerMessage Send(GameObject recipient, GameObject closet)
+	{
+		ClosetHandlerMessage msg = new ClosetHandlerMessage {
+			Recipient = recipient.GetComponent<NetworkIdentity>().netId,
+			Closet = closet
+		};
+		msg.SendTo(recipient);
+		return msg;
+	}
+
+	public override string ToString()
+	{
+		return string.Format("[ClosetHandlerMessage Recipient={0} Closet={1}]", Recipient, Closet);
+	}
+}

--- a/UnityProject/Assets/Scripts/Messages/Server/ClosetHandlerMessage.cs.meta
+++ b/UnityProject/Assets/Scripts/Messages/Server/ClosetHandlerMessage.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 8122e90c19a7a4e42bf8f698ccd17c79
+timeCreated: 1513915460
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/ObjectBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Objects/ObjectBehaviour.cs
@@ -10,7 +10,8 @@ using UnityEngine;
 /// </summary>
 public class ObjectBehaviour : PushPull
 {
-	private ClosetPlayerHandler closetHandlerCache;
+	[HideInInspector]
+	public ClosetPlayerHandler closetHandlerCache;
 
 	//Inspector is controlled by ObjectBehaviourEditor
 	//Please expose any properties you need in there
@@ -53,12 +54,7 @@ public class ObjectBehaviour : PushPull
 				//itself if not needed
 				//TODO turn the ClosetPlayerHandler into a more generic component to handle disposals bin,
 				//coffins etc
-				if (!state)
-				{
-					StartCoroutine(AddHiddenHandler());
-				}
-				else
-				{
+				if(state){
 					if (closetHandlerCache)
 					{
 						//Set the camera to follow the player again
@@ -69,13 +65,5 @@ public class ObjectBehaviour : PushPull
 				}
 			}
 		}
-	}
-
-	private IEnumerator AddHiddenHandler()
-	{
-		//wait for all the components to be disabled on the 
-		//player before adding the handler
-		yield return new WaitForEndOfFrame();
-		closetHandlerCache = playerScript.gameObject.AddComponent<ClosetPlayerHandler>();
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/VisibleBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Objects/VisibleBehaviour.cs
@@ -18,6 +18,7 @@ public class VisibleBehaviour : NetworkBehaviour
 	private const string regTile = "RegisterTile";
 	private const string inputController = "InputController";
 	private const string playerSync = "PlayerSync";
+	private const string closetHandler = "ClosetPlayerHandler";
 
 	public bool isPlayer;
 	public RegisterTile registerTile;
@@ -56,6 +57,7 @@ public class VisibleBehaviour : NetworkBehaviour
 
 	private void UpdateState(bool _aliveState)
 	{
+		visibleState = _aliveState;
 		OnVisibilityChange(_aliveState);
 
 		MonoBehaviour[] scripts = GetComponentsInChildren<MonoBehaviour>(true);
@@ -64,7 +66,8 @@ public class VisibleBehaviour : NetworkBehaviour
 		for (int i = 0; i < scripts.Length; i++)
 		{
 			if (scripts[i].GetType().Name != networkId && scripts[i].GetType().Name != networkT && scripts[i].GetType().Name != objectBehaviour &&
-			    scripts[i].GetType().Name != regTile && scripts[i].GetType().Name != inputController && scripts[i].GetType().Name != playerSync)
+			    scripts[i].GetType().Name != regTile && scripts[i].GetType().Name != inputController && scripts[i].GetType().Name != playerSync
+			    && scripts[i].GetType().Name != closetHandler)
 			{
 				scripts[i].enabled = _aliveState;
 			}


### PR DESCRIPTION
### Purpose
Current approach to adding the ClosetHandler was flawed and could be easily broken. Created a more robust way to determine when to add the closethandler and to ensure all dependencies are provided on creation. It is now based off a ServerMessage that controls the behaviour

### Approach
- Added a server message that tells the client to create a ClosetHandler to monitor the players input and to control the camera targets when inside the storage of a closet/crate etc
- Fixes: #699 

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
Tested in high lag MP