### PR TITLE
Prevents the clothing menu from being blocked

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/Managers.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/Managers.prefab
@@ -12513,7 +12513,7 @@ MonoBehaviour:
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 2100000, guid: 63ad07f389034e49893bdd6e79303e4d, type: 2}
+  m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:

--- a/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
+++ b/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
@@ -69959,11 +69959,6 @@ Prefab:
       propertyPath: m_UseSimulator
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 224723082631607132, guid: 829f4ca992b848d6bb4d007fb9c112e1,
-        type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 2
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 829f4ca992b848d6bb4d007fb9c112e1, type: 2}
   m_IsPrefabParent: 0

--- a/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
+++ b/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
@@ -69959,6 +69959,11 @@ Prefab:
       propertyPath: m_UseSimulator
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 224723082631607132, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 829f4ca992b848d6bb4d007fb9c112e1, type: 2}
   m_IsPrefabParent: 0


### PR DESCRIPTION
### Purpose
Fixes #689 
Prevents the damage overlay from blocking the equipment button.

### Approach
The Z value of the equipment button was increased so that it would be on top of the crit overlay.

### Open Questions and Pre-Merge TODOs

- [X]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code(Not relevant)
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes:
First time working with Unity and git, hoping I got it right.