### PR TITLE
Only (de)equip item on left click

### DIFF
--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSwap.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSwap.cs
@@ -9,8 +9,11 @@ namespace UI
 
 		public void OnPointerClick(PointerEventData eventData)
 		{
-			SoundManager.Play("Click01");
-			UIManager.Hands.SwapItem(itemSlot);
+			if (eventData.button == PointerEventData.InputButton.Left)
+			{
+				SoundManager.Play("Click01");
+				UIManager.Hands.SwapItem(itemSlot);
+			}
 		}
 
 		private void Start()


### PR DESCRIPTION
### Purpose
Items could be (de)equiped by multiple mousebuttons, this would lead to issues when those buttons where assigned to do other actions.

### Approach
After the event trigger, I placed an If to only execute the (de)equip when LMB is used.

### Open Questions and Pre-Merge TODOs

- [X]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes:
Fixes #510 