### PR TITLE
Clientside DropItem prediction 

### DIFF
--- a/UnityProject/Assets/Scripts/Equipment/EquipmentPool.cs
+++ b/UnityProject/Assets/Scripts/Equipment/EquipmentPool.cs
@@ -81,6 +81,12 @@ namespace Equipment
 			DropGameObject(player, gObj, PlayerList.Instance.connectedPlayers[player.name].transform.position);
 		}
 
+		///When dropping items etc, remove them from the player equipment pool and place in scene
+		public static void DropGameObjectAtPos(GameObject player, GameObject gObj, Vector3 dropAtWorldPos)
+		{
+			DropGameObject(player, gObj, dropAtWorldPos);
+		}
+
 		//When placing items at a position etc also removes them from the player equipment pool and places it in scene
 		public static void DropGameObject(GameObject player, GameObject gObj, Vector3 pos)
 		{

--- a/UnityProject/Assets/Scripts/Health/Living/PlayerHealth.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/PlayerHealth.cs
@@ -264,8 +264,8 @@ namespace PlayGroup
 					//Combat demo killfeed
 					//PostToChatMessage.Send(killerName + " has killed " + gameObject.name, ChatChannel.System);
 				}
-				playerNetworkActions.ValidateDropItem("rightHand", true);
-				playerNetworkActions.ValidateDropItem("leftHand", true);
+				playerNetworkActions.ValidateDropItem("rightHand", true, transform.position);
+				playerNetworkActions.ValidateDropItem("leftHand", true, transform.position);
 
 				if (isServer)
 				{

--- a/UnityProject/Assets/Scripts/Managers/UpdateManager/ManagedNetworkBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Managers/UpdateManager/ManagedNetworkBehaviour.cs
@@ -11,6 +11,11 @@ public class ManagedNetworkBehaviour : NetworkBehaviour
 		UpdateManager.Instance.Add(this);
 	}
 
+	protected virtual void OnDisable()
+	{
+		UpdateManager.Instance.Remove(this);
+	}
+
 	/// <summary>
 	///     If your class uses the Awake function, please use  protected override void Awake() instead.
 	///     Also don't forget to call ManagedNetworkBehaviour.Awake(); first.

--- a/UnityProject/Assets/Scripts/Managers/UpdateManager/ManagedNetworkBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Managers/UpdateManager/ManagedNetworkBehaviour.cs
@@ -13,7 +13,9 @@ public class ManagedNetworkBehaviour : NetworkBehaviour
 
 	protected virtual void OnDisable()
 	{
-		UpdateManager.Instance.Remove(this);
+		if (UpdateManager.Instance != null) {
+			UpdateManager.Instance.Remove(this);
+		}
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
@@ -36,7 +36,9 @@ public class UpdateManager : MonoBehaviour
 
 	public void Remove(ManagedNetworkBehaviour updatable)
 	{
-		regularUpdate.Remove(updatable);
+		if (regularUpdate.Contains(updatable)) {
+			regularUpdate.Remove(updatable);
+		}
 	}
 
 	private void OnEnable()

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerMove.cs
@@ -51,7 +51,7 @@ namespace PlayGroup
 			playerSprites = gameObject.GetComponent<PlayerSprites>();
 			playerSync = GetComponent<PlayerSync>();
 			pushPull = GetComponent<PushPull>();
-			pna = PlayerManager.LocalPlayer.GetComponent<PlayerNetworkActions>();
+			pna = GetComponent<PlayerNetworkActions>();
 		}
 
 		public PlayerAction SendAction()

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -66,6 +66,7 @@ namespace Tilemaps.Scripts.Behaviours.Objects
 			while (tempParent == null)
 			{
 				yield return new WaitForSeconds(0.1f);
+				tempParent = GameObject.FindGameObjectWithTag("SpawnParent");
 			}
 			yield return new WaitForEndOfFrame();
 			transform.parent = tempParent.transform;

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
@@ -64,11 +64,6 @@ public class CustomNetTransform : ManagedNetworkBehaviour //see UpdateManager
 		base.OnStartServer();
 	}
 
-	protected override void OnEnable()
-	{
-		base.OnEnable();
-	}
-
 	private void InitServerState()
 	{
 		if (!isServer)

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
@@ -187,6 +187,7 @@ public class CustomNetTransform : ManagedNetworkBehaviour //see UpdateManager
 	{
 		transformState.Active = true;
 		transformState.position = pos;
+		transform.localPosition = pos + deOffset;
 		updateActiveStatus();
 	}
 

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
@@ -72,10 +72,14 @@ namespace UI
 			//            else
 			//            {
 			//Only clear slot(while moving, as prediction is shit in this situation)
+			GameObject dropObj = currentSlot.Item;
+			CustomNetTransform cnt = dropObj.GetComponent<CustomNetTransform>();
+			//It is converted to LocalPos in transformstate struct
+			cnt.AppearAtPosition(PlayerManager.LocalPlayer.transform.position);
 			currentSlot.Clear();
 			//            }
 			//Message
-			lps.playerNetworkActions.RequestDropItem(currentSlot.eventName);
+			lps.playerNetworkActions.RequestDropItem(currentSlot.eventName, PlayerManager.LocalPlayer.transform.position ,false);
 			SoundManager.Play("Click01");
 			Debug.Log("Drop Button");
 		}

--- a/UnityProject/Assets/Scripts/UI/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/UIManager.cs
@@ -99,7 +99,7 @@ namespace UI
 			{
 				return false;
 			}
-			InventoryInteractMessage.Send(slotInfo.Slot, slotInfo.SlotContents, true);
+			InventoryInteractMessage.Send(slotInfo.Slot, slotInfo.SlotContents, true, Vector3.zero);
 			UpdateSlot(slotInfo);
 			return true;
 		}


### PR DESCRIPTION
### Purpose
- Added the prediction logic for client side prediction
- Fixed up PNA referencing on PlayerMove
- Added an OnDisable to ManagedNetworkBehaviour to remove the component from the UpdateManager when it is disabled or destroyed.
- Fixed the RegisterTile while loop when waiting for the Matrix Parent to be active
- Removed an unnecessary OnEnable override from CNT

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
Tested in high ping MP