### PR TITLE
Move Pushing Behaviour to CNT

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -148,7 +148,16 @@ public class PushPull : VisibleBehaviour
 	private void Update()
 	{
 		if(pushing){
-			if(transform.localPosition == pushTarget && !customNetTransform.isPushing){
+			if(customNetTransform.predictivePushing){
+				//Wait for the server to catch up to the pushtarget if predictivePushing is true
+				if(currentPos == pushTarget){
+					//if it is then set it to false, this ensures that the player cannot keep pushing if
+					//he is experiencing high lag by waiting for the server position to match up
+					customNetTransform.predictivePushing = false;
+				}
+			}
+
+			if(transform.localPosition == pushTarget && !customNetTransform.isPushing && !customNetTransform.predictivePushing){
 				pushing = false;
 			}
 		}

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -12,23 +12,14 @@ public class PushPull : VisibleBehaviour
 	[SyncVar] public Vector3 currentPos;
 	public bool isPushable = true;
 
-	//cache
-	private float journeyLength;
-
 	private Matrix matrix;
-	public float moveSpeed = 7f;
+	private CustomNetTransform customNetTransform;
 
 	[SyncVar] public GameObject pulledBy;
-	private Vector3 pushFrom;
 
 	public bool pushing;
-	private float pushStep;
 
 	public Vector3 pushTarget;
-	public bool serverLittleLag;
-
-	//A check to make sure there are no network errors
-	public float timeInPush;
 
 	public GameObject pusher { get; private set; }
 
@@ -42,16 +33,15 @@ public class PushPull : VisibleBehaviour
 	private IEnumerator WaitForLoad()
 	{
 		yield return new WaitForSeconds(2f);
-//        if (currentPos != Vector3.zero)
-//        {
+
 		if (registerTile == null)
 		{
 			registerTile = GetComponent<RegisterTile>();
 		}
-//            transform.localPosition = RoundedPos(currentPos);
+
 		registerTile.UpdatePosition();
 		matrix = Matrix.GetMatrix(this);
-//        }
+		customNetTransform = GetComponent<CustomNetTransform>();
 	}
 
 	public virtual void OnMouseDown()
@@ -87,13 +77,14 @@ public class PushPull : VisibleBehaviour
 		PlayerManager.LocalPlayerScript.playerSync.PullReset(gameObject.GetComponent<NetworkIdentity>().netId);
 	}
 
-	public void TryPush(GameObject pushedBy, float pusherSpeed, Vector2 pushDir)
+	public void TryPush(GameObject pushedBy, Vector2 pushDir)
 	{
 		if (pushDir != Vector2.up && pushDir != Vector2.right && pushDir != Vector2.down && pushDir != Vector2.left)
 		{
 			return;
 		}
-		if (pushing || !isPushable)
+		if (pushing || !isPushable || customNetTransform.isPushing
+		    || customNetTransform.predictivePushing)
 		{
 			return;
 		}
@@ -116,30 +107,19 @@ public class PushPull : VisibleBehaviour
 			}
 		}
 
-		moveSpeed = pusherSpeed;
 		Vector3Int newPos = Vector3Int.RoundToInt(transform.localPosition + (Vector3) pushDir);
-		//newPos.z = transform.localPosition.z;
-
 
 		if (matrix.IsPassableAt(newPos) || matrix.ContainsAt(newPos, gameObject))
 		{
 			//Start the push on the client, then start on the server, the server then tells all other clients to start the push also
 			pusher = pushedBy;
-			if (pusher == PlayerManager.LocalPlayer)
-			{
-				PlayerManager.LocalPlayerScript.playerMove.IsPushing = true;
-			}
-
 			pushTarget = newPos;
-			pushFrom = transform.localPosition;
-			pushStep = 0f;
-			journeyLength = Vector3.Distance(transform.localPosition, newPos) + 0.2f;
-			timeInPush = 0f;
-			pushing = true;
 			//Start command to push on server
 			if (pusher == PlayerManager.LocalPlayer)
 			{
-				PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryPush(gameObject, transform.localPosition, pushTarget);
+				//pushing for local player is set to true from CNT, to make sure prediction isn't overwhelmed
+				customNetTransform.PushToPosition(pushTarget,PlayerManager.LocalPlayerScript.playerMove.speed, this);
+				PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryPush(gameObject, transform.localPosition, pushTarget, PlayerManager.LocalPlayerScript.playerMove.speed);
 			}
 		}
 	}
@@ -167,22 +147,8 @@ public class PushPull : VisibleBehaviour
 
 	private void Update()
 	{
-		if (pushing && transform.localPosition != pushTarget)
-		{
-			PushTowards();
-		}
-		//This is a back up incase things go wrong as playerMove is important
-		if (pusher != null)
-		{
-			timeInPush += Time.deltaTime;
-			if (timeInPush > 3f)
-			{
-				if (pusher == PlayerManager.LocalPlayer)
-				{
-					PlayerManager.LocalPlayerScript.playerMove.IsPushing = false;
-				}
-				pusher = null;
-				serverLittleLag = false;
+		if(pushing){
+			if(transform.localPosition == pushTarget && !customNetTransform.isPushing){
 				pushing = false;
 			}
 		}
@@ -198,62 +164,5 @@ public class PushPull : VisibleBehaviour
 				currentPos = transform.localPosition;
 			}
 		}
-	}
-
-	private void PushTowards()
-	{
-		pushStep += Time.deltaTime * moveSpeed / journeyLength;
-		transform.localPosition = Vector3.Lerp(pushFrom, pushTarget, pushStep);
-
-		if (transform.localPosition == pushTarget)
-		{
-			registerTile.UpdatePosition();
-			if (pusher == PlayerManager.LocalPlayer)
-			{
-				StartCoroutine(PushFinishWait());
-			}
-			pushing = false;
-		}
-	}
-
-	private IEnumerator PushFinishWait()
-	{
-		yield return new WaitForSeconds(0.05f);
-		if (serverLittleLag)
-		{
-			pusher = null;
-			PlayerManager.LocalPlayerScript.playerMove.IsPushing = false;
-		}
-		else
-		{
-			//Server is a bit behind, wait before allowing to push again
-			//TODO: Determine how far behind the server actual is and use that to wait
-			yield return new WaitForSeconds(0.4f);
-			pusher = null;
-			PlayerManager.LocalPlayerScript.playerMove.IsPushing = false;
-		}
-	}
-
-	[ClientRpc]
-	public void RpcPushSync(Vector3 startLocalPos, Vector3 targetPos)
-	{
-		if (pusher == PlayerManager.LocalPlayer || transform.localPosition == targetPos)
-		{
-			//Rpc happened on the pushee before he was finished
-			//this means there is very little lag so allow him to move straight away after it's done
-			if (pushing)
-			{
-				serverLittleLag = true;
-			}
-			//No need to push if it is already at the position or is the one initiating the push
-			return;
-		}
-
-		pushFrom = startLocalPos;
-		pushTarget = targetPos;
-		pushStep = 0f;
-		journeyLength = Vector3.Distance(transform.localPosition, targetPos) + 0.2f;
-		timeInPush = 0f;
-		pushing = true;
 	}
 }

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerMove.cs
@@ -217,7 +217,7 @@ namespace PlayGroup
 			{
 				if (pushPulls[i] && pushPulls[i].gameObject != gameObject)
 				{
-					pushPulls[i].TryPush(gameObject, speed, direction);
+					pushPulls[i].TryPush(gameObject, direction);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.PushPull.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.PushPull.cs
@@ -84,14 +84,13 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	}
 
 	[Command]
-	public void CmdTryPush(GameObject obj, Vector3 startLocalPos, Vector3 targetPos)
+	public void CmdTryPush(GameObject obj, Vector3 startLocalPos, Vector3 targetPos, float speed)
 	{
 		PushPull pushed = obj.GetComponent<PushPull>();
 		if (pushed != null)
 		{
-			pushed.RpcPushSync(startLocalPos, targetPos);
 			var netTransform = obj.GetComponent<CustomNetTransform>();
-			netTransform.SetPosition(targetPos);
+			netTransform.SetPosition(targetPos, true, speed, true);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.cs
@@ -245,8 +245,9 @@ namespace PlayGroup
 			else
 			{
 				PlayerState state = isLocalPlayer ? predictedState : serverState;
-				playerScript.ghost.transform.localPosition =
-					Vector3.MoveTowards(playerScript.ghost.transform.localPosition, state.Position, playerMove.speed * Time.deltaTime);
+					playerScript.ghost.transform.localPosition =
+						Vector3.MoveTowards(playerScript.ghost.transform.localPosition, state.Position, playerMove.speed * Time.deltaTime);
+				
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
@@ -52,6 +52,11 @@ public class CustomNetTransform : ManagedNetworkBehaviour //see UpdateManager
 
 	public TransformState State => serverTransformState;
 
+	[SyncVar(hook="UpdatePushing")]
+	public bool isPushing;
+	public bool predictivePushing = false;
+	public bool serverRegisteredPush = false;
+
 	private void Start()
 	{
 		registerTile = GetComponent<RegisterTile>();
@@ -71,6 +76,8 @@ public class CustomNetTransform : ManagedNetworkBehaviour //see UpdateManager
 			return;
 		}
 
+		isPushing = false;
+
 		serverTransformState.Speed = SpeedMultiplier;
 		if (transform.localPosition.Equals(Vector3.zero))
 		{
@@ -88,11 +95,33 @@ public class CustomNetTransform : ManagedNetworkBehaviour //see UpdateManager
 
 	/// Manually set an item to a specific position. Use localPosition!
 	[Server]
-	public void SetPosition(Vector3 pos, bool notify = true)
+	public void SetPosition(Vector3 pos, bool notify = true, float speed = 4f, bool _isPushing = false)
 	{
+		//Only allow one movement at a time if it is currently being pushed
+		if(isPushing || predictivePushing){
+			if(predictivePushing && _isPushing){
+				//This is if the server player is pushing because the predictive flag
+				//will be set early we still need to notify the players so call it here:
+				UpdateServerTransformState(pos, notify, speed);
+				//And then set the isPushing flag:
+				isPushing = true;
+			}
+			return;
+		}
+		UpdateServerTransformState(pos, notify, speed);
+
+		//Set it to being pushed if it is a push net action
+		if(_isPushing){
+			//This is synced via syncvar with all players
+			isPushing = true;
+		}
+	}
+
+	[Server]
+	private void UpdateServerTransformState(Vector3 pos, bool notify = true, float speed = 4f){
+		serverTransformState.Speed = speed;
 		serverTransformState.localPos = pos;
-		if (notify)
-		{
+		if (notify) {
 			NotifyPlayers();
 		}
 	}
@@ -191,6 +220,49 @@ public class CustomNetTransform : ManagedNetworkBehaviour //see UpdateManager
 		updateActiveStatus();
 	}
 
+	/// <summary>
+	/// Client side prediction for pushing
+	/// This allows instant pushing reaction to a pushing event
+	/// on the client who instigated it. The server then validates
+	/// the transform position and returns it if it is illegal
+	/// </summary>
+	public void PushToPosition(Vector3 pos, float speed, PushPull pushComponent)
+	{
+		if(pushComponent.pushing || predictivePushing){
+			return;
+		}
+		TransformState newState = new TransformState();
+		newState.Active = true;
+		newState.Speed = speed;
+		newState.localPos = pos;
+		UpdateClientState(newState);
+		predictivePushing = true;
+		pushComponent.pushing = true;
+	}
+
+	//Used with the syncvar as a hook
+	private void UpdatePushing(bool _isPushing){
+		isPushing = _isPushing;
+		if(isServer){
+			return;
+		}
+		//Client use only. Mainly to prevent more pushing in high lag clients
+		if (predictivePushing && !serverRegisteredPush) {
+			//This means the syncvar has caught up
+			if (isPushing) {
+				serverRegisteredPush = true;
+			}
+		}
+
+		if (predictivePushing && serverRegisteredPush && !isPushing) {
+			//Now we can turn off predictivepush for clients as the server has stopped
+			//pushing:
+			RegisterObjects();
+			predictivePushing = false;
+			serverRegisteredPush = false;
+		}
+	}
+
 	public void UpdateClientState(TransformState newState)
 	{
 		//Don't lerp (instantly change pos) if active state was changed or speed is zero
@@ -267,7 +339,16 @@ public class CustomNetTransform : ManagedNetworkBehaviour //see UpdateManager
 		if (isServer)
 		{
 			CheckSpaceDrift();
-		}
+			//Sync the pushing state to all players
+			//this makes sure that players with high pings cannot get too
+			//far with prediction
+			if(isPushing){
+				if(transformState.localPos == transform.localPosition){
+					isPushing = false;
+					predictivePushing = false;
+				}
+			}
+		} 
 
 		if (IsFloating())
 		{
@@ -280,7 +361,7 @@ public class CustomNetTransform : ManagedNetworkBehaviour //see UpdateManager
 		}
 
 		//Registering
-		if (registerTilePos() != Vector3Int.RoundToInt(transformState.localPos))
+		if (registerTilePos() != Vector3Int.RoundToInt(transformState.localPos) && !isPushing && !predictivePushing)
 		{
 //			Debug.LogFormat($"registerTile updating {localToWorld(registerTilePos())}->{localToWorld(Vector3Int.RoundToInt(transform.localPosition))}, " +
 //			                $"ts={localToWorld(Vector3Int.RoundToInt(transformState.localPos))}");

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
@@ -52,10 +52,9 @@ public class CustomNetTransform : ManagedNetworkBehaviour //see UpdateManager
 
 	public TransformState State => serverTransformState;
 
-	[SyncVar(hook="UpdatePushing")]
+	[SyncVar]
 	public bool isPushing;
 	public bool predictivePushing = false;
-	public bool serverRegisteredPush = false;
 
 	private void Start()
 	{
@@ -240,28 +239,28 @@ public class CustomNetTransform : ManagedNetworkBehaviour //see UpdateManager
 		pushComponent.pushing = true;
 	}
 
-	//Used with the syncvar as a hook
-	private void UpdatePushing(bool _isPushing){
-		isPushing = _isPushing;
-		if(isServer){
-			return;
-		}
-		//Client use only. Mainly to prevent more pushing in high lag clients
-		if (predictivePushing && !serverRegisteredPush) {
-			//This means the syncvar has caught up
-			if (isPushing) {
-				serverRegisteredPush = true;
-			}
-		}
+	////Used with the syncvar as a hook
+	//private void UpdatePushing(bool _isPushing){
+	//	isPushing = _isPushing;
+	//	if(isServer){
+	//		return;
+	//	}
+	//	//Client use only. Mainly to prevent more pushing in high lag clients
+	//	if (predictivePushing && !serverRegisteredPush) {
+	//		//This means the syncvar has caught up
+	//		if (isPushing) {
+	//			serverRegisteredPush = true;
+	//		}
+	//	}
 
-		if (predictivePushing && serverRegisteredPush && !isPushing) {
-			//Now we can turn off predictivepush for clients as the server has stopped
-			//pushing:
-			RegisterObjects();
-			predictivePushing = false;
-			serverRegisteredPush = false;
-		}
-	}
+	//	if (predictivePushing && serverRegisteredPush && !isPushing) {
+	//		//Now we can turn off predictivepush for clients as the server has stopped
+	//		//pushing:
+	//		RegisterObjects();
+	//		predictivePushing = false;
+	//		serverRegisteredPush = false;
+	//	}
+	//}
 
 	public void UpdateClientState(TransformState newState)
 	{

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
@@ -239,29 +239,6 @@ public class CustomNetTransform : ManagedNetworkBehaviour //see UpdateManager
 		pushComponent.pushing = true;
 	}
 
-	////Used with the syncvar as a hook
-	//private void UpdatePushing(bool _isPushing){
-	//	isPushing = _isPushing;
-	//	if(isServer){
-	//		return;
-	//	}
-	//	//Client use only. Mainly to prevent more pushing in high lag clients
-	//	if (predictivePushing && !serverRegisteredPush) {
-	//		//This means the syncvar has caught up
-	//		if (isPushing) {
-	//			serverRegisteredPush = true;
-	//		}
-	//	}
-
-	//	if (predictivePushing && serverRegisteredPush && !isPushing) {
-	//		//Now we can turn off predictivepush for clients as the server has stopped
-	//		//pushing:
-	//		RegisterObjects();
-	//		predictivePushing = false;
-	//		serverRegisteredPush = false;
-	//	}
-	//}
-
 	public void UpdateClientState(TransformState newState)
 	{
 		//Don't lerp (instantly change pos) if active state was changed or speed is zero


### PR DESCRIPTION
### Purpose
- This moves the pushing behaviour to be based off the new CNT component
- It uses the lerp, predictive methods and registertile functions of CNT instead of its own
- Ensures that push behaviour is robust for all players even at very high ping rates
- Gives the client 1 predictive move. Meaning there will be instant reaction to moving an object before it waits for the server to catch up

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
I have tested at extremely high ping rates in mp (over 1500ms). Anything over 1000ms will show the rare bug of the player sometimes lerping into the pushing object. Other players in visible range will not see the player do this and it only happens on the lagging client. It also does not break anything. Suspect the issue might now be with PlayerSync lag as I have made sure the pushable object only registers on the client once it has synced with the server pos. This is why I suspect it might be a PlayerSync issue as the server state could be further ahead where the register tile allowed the server to move forward 1 tile in the 1 - 2 seconds it took to receive the update. In any case it is probably not an issue as the player will probably be dropped at that very high ping rate