### PR TITLE
Print more info if the message times out while waiting

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs
+++ b/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs
@@ -9,6 +9,12 @@ public abstract class GameMessageBase : MessageBase
 
 	protected IEnumerator WaitFor(NetworkInstanceId id)
 	{
+		if (id.IsEmpty()) 
+		{
+			Debug.LogError($"{this} tried to wait on an empty (0) id");
+			yield break;
+		}
+
 		int tries = 0;
 		while ((NetworkObject = ClientScene.FindLocalObject(id)) == null)
 		{

--- a/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs
+++ b/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs
@@ -14,7 +14,7 @@ public abstract class GameMessageBase : MessageBase
 		{
 			if (tries++ > 10)
 			{
-				Debug.LogWarning("GameMessageBase could not find object with id " + id);
+				Debug.LogWarning($"{this} could not find object with id {id}");
 				yield break;
 			}
 


### PR DESCRIPTION
### Purpose
If a net message times out, you have no idea which one did or what it was waiting for. This helps people piece it together.

### Approach
Prints the message label instead of just "GameMessageBase".

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer
