### PR TITLE
Fix pickup on headless

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/Input/Triggers/PickUpTrigger.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/Triggers/PickUpTrigger.cs
@@ -80,7 +80,7 @@ namespace Items
 
 		private static bool SlotUnavailable(PlayerScript ps, string slotName)
 		{
-			return PlayerManager.PlayerScript == null
+			return ps == null
 			       || !ps.playerNetworkActions.Inventory.ContainsKey(slotName)
 			       || ps.playerNetworkActions.SlotNotEmpty(slotName);
 		}


### PR DESCRIPTION
### Purpose
You couldn't pick up items on headless

### Approach
Well after hours of tracing, it seems someone made a terrible mistake that you wouldn't notice unless you run headless. Because as long as the server has a player associated, PNA on the server would be true. But when te server has no player, it would trigger an pickup validation error.

### Open Questions and Pre-Merge TODOs

- [X]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes:
fixes #762