### PR TITLE
Improving server CPU usage by over 90% and limiting client updates

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -117,6 +117,8 @@ public class GameData : MonoBehaviour
 		//Check if running in batchmode (headless server)
 		if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null || Instance.testServer)
 		{
+			float calcFrameRate =  1f / Time.fixedDeltaTime;
+			Application.targetFrameRate = (int) calcFrameRate;
 			Debug.Log("START SERVER HEADLESS MODE");
 			IsHeadlessServer = true;
 			StartCoroutine(WaitToStartServer());

--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -114,6 +114,12 @@ public class GameData : MonoBehaviour
 			}
 			return;
 		}
+		//force vsync when not-headless
+		if (SystemInfo.graphicsDeviceType != GraphicsDeviceType.Null && !Instance.testServer && !IsHeadlessServer)
+		{
+			Application.targetFrameRate = 60;
+			QualitySettings.vSyncCount = 1;
+		}
 		//Check if running in batchmode (headless server)
 		if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null || Instance.testServer)
 		{


### PR DESCRIPTION
### Purpose
Server CPU was maxing out when running and multiple clients on one pc ate more resource than needed.

### Approach
It seems the server was doing to update() function so many times per second till it maxxed out CPU when running headless, because there was no GPU to limit the update() execution.
I limited execution of update() when running headless to fixeddeltatime

Also it seems vsync was not enforced on clients, which leads to multiple clients on one pc eating more resources than needed, due to too many updates being executed.

### Open Questions and Pre-Merge TODOs

- [X]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes:
This PR is also uploaded to the test server, but clients can still use 0.2.2A1 as it doesn't change client execution.