### PR TITLE
temporary fix to get Death working again on headless

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/PlayerHealth.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/PlayerHealth.cs
@@ -217,6 +217,8 @@ namespace PlayGroup
 		{
 			if (CustomNetworkManager.Instance._isServer)
 			{
+				PlayerNetworkActions pna = gameObject.GetComponent<PlayerNetworkActions>();
+				PlayerMove pm = gameObject.GetComponent<PlayerMove>();
 				string killerName = "stressfull work";
 				if (LastDamagedBy != null)
 				{
@@ -264,22 +266,22 @@ namespace PlayGroup
 					//Combat demo killfeed
 					//PostToChatMessage.Send(killerName + " has killed " + gameObject.name, ChatChannel.System);
 				}
-				playerNetworkActions.ValidateDropItem("rightHand", true, transform.position);
-				playerNetworkActions.ValidateDropItem("leftHand", true, transform.position);
+				pna.ValidateDropItem("rightHand", true, transform.position);
+				pna.ValidateDropItem("leftHand", true, transform.position);
 
 				if (isServer)
 				{
 					EffectsFactory.Instance.BloodSplat(transform.position, BloodSplatSize.large);
 				}
 
-				playerNetworkActions.RpcSpawnGhost();
-				playerMove.isGhost = true;
-				playerMove.allowInput = true;
+				pna.RpcSpawnGhost();
+				pm.isGhost = true;
+				pm.allowInput = true;
 				RpcPassBullets(gameObject);
 				PlayerDeathMessage.Send(gameObject);
 
 				//FIXME Remove for next demo
-				playerNetworkActions.RespawnPlayer(10);
+				pna.RespawnPlayer(10);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Health/Living/PlayerHealth.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/PlayerHealth.cs
@@ -219,6 +219,11 @@ namespace PlayGroup
 			{
 				PlayerNetworkActions pna = gameObject.GetComponent<PlayerNetworkActions>();
 				PlayerMove pm = gameObject.GetComponent<PlayerMove>();
+				
+				// FIXME
+				// reenable killfeed once the systemmessages are fixed
+				
+				/*
 				string killerName = "stressfull work";
 				if (LastDamagedBy != null)
 				{
@@ -265,7 +270,7 @@ namespace PlayGroup
 
 					//Combat demo killfeed
 					//PostToChatMessage.Send(killerName + " has killed " + gameObject.name, ChatChannel.System);
-				}
+				}*/
 				pna.ValidateDropItem("rightHand", true, transform.position);
 				pna.ValidateDropItem("leftHand", true, transform.position);
 


### PR DESCRIPTION
### Purpose
The last death actions including ghost, the ghost UI hide and the killfeed wouldn't work

### Approach
It seems the killfeed was the culprid. The killfeed is executed by the server (which has no localplayer) and send as a client message based chat message. later on it relies on localplayerscript to define some chat parameters which the server (again) doesn;t have.

The whole "Server sending client message" thing shouldn't exist in the first place, or at least wouldn't rely on client-only scripts being available to the server.

It would require a significant change to the way the killfeed is working and I rater have a missing QOL feature than a gamebreaking bug. Thus i Disabled the killfeed till @Em3rgencyLT or someone else can fix the killfeed.

### Open Questions and Pre-Merge TODOs

- [X]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes:
Fixes #768
Fixes #767 