### PR TITLE
Restart fix

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -108,7 +108,7 @@ public class GameData : MonoBehaviour
 			{
 				IsHeadlessServer = true;
 			}
-			if (GameManager.Instance != null && CustomNetworkManager.Instance._isServer)
+			if (IsInGame && GameManager.Instance != null && CustomNetworkManager.Instance._isServer)
 			{
 				GameManager.Instance.ResetRoundTime();
 			}
@@ -133,7 +133,7 @@ public class GameData : MonoBehaviour
 
 	private IEnumerator WaitToStartServer()
 	{
-		yield return new WaitForSeconds(0.1f);
+		yield return new WaitForSeconds(5f);
 		CustomNetworkManager.Instance.StartHost();
 	}
 

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -52,10 +52,7 @@ public class GameManager : MonoBehaviour
 
 	private void OnLevelFinishedLoading(Scene scene, LoadSceneMode mode)
 	{
-		if (scene.name == "DeathMatch" || scene.name == "OutpostDeathmatch")
-		{
-			counting = true;
-		}
+
 	}
 
 	public void SyncTime(float currentTime)
@@ -84,29 +81,35 @@ public class GameManager : MonoBehaviour
 			restartTime -= Time.deltaTime;
 			if (restartTime <= 0f)
 			{
+				restartTime = 0;
 				waitForRestart = false;
 				RestartRound();
 			}
 		}
 
-		if (counting)
+		else if (counting)
 		{
 			GetRoundTime -= Time.deltaTime;
 			roundTimer.text = Mathf.Floor(GetRoundTime / 60).ToString("00") + ":" +
 			                  (GetRoundTime % 60).ToString("00");
 			if (GetRoundTime <= 0f)
 			{
+				GetRoundTime = 0;
 				counting = false;
 				roundTimer.text = "GameOver";
 				SoundManager.Play("ApcDestroyed", 0.3f, 1f, 0f);
 
 				if (CustomNetworkManager.Instance._isServer)
 				{
-					PlayerList.Instance.ReportScores();
 					waitForRestart = true;
+					// FIXME 
+					// This again lets the server execute a chat, which wont work as intended
+					//	PlayerList.Instance.ReportScores();
+
 				}
 			}
 		}
+
 	}
 
 	public int GetOccupationsCount(JobType jobType)


### PR DESCRIPTION
### Purpose
Restart was completely broken

### Approach
Somehow it seems someone added a second counter start boolean, that would execute before the timer got reset. Got rid of that one.
Also made very sure Counter and WaitingForRestart, wouldn't be able to both execute by using an else-if and made sure both counters and with a zero instead of zero or lower

Besides that the round end message is commented out, due to #783 

### Open Questions and Pre-Merge TODOs

- [X]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes:
Fixes #778 