### PR TITLE
Add env switch to enable test server

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -43,6 +43,13 @@ public class GameData : MonoBehaviour
 		}
 
 		Environment.SetEnvironmentVariable("MONO_REFLECTION_SERIALIZER", "yes");
+
+		string testServerEnv = Environment.GetEnvironmentVariable("TEST_SERVER");
+		if (!string.IsNullOrEmpty(testServerEnv))
+		{
+			testServer = Convert.ToBoolean(testServerEnv);
+		}
+
 		LoadData();
 	}
 


### PR DESCRIPTION
### Purpose
Instead of toggling the GameData "testServer" checkbox in the inspector, you can enable it with an environment switch.

### Approach

Windows
```bash
set TEST_SERVER=True && build.exe
```

OSX
```bash
TEST_SERVER=True open -n build.app/
```

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer
