### PR TITLE
 fixed problem when spawning bullets, and players couldnt get hurt

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/PoolManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/PoolManager.cs
@@ -33,17 +33,15 @@ public class PoolManager : NetworkBehaviour
 	[Server]
 	public GameObject PoolNetworkInstantiate(GameObject prefab, Vector2 position, Quaternion rotation, Transform parent=null)
 	{
-		GameObject tempObject = PoolClientInstantiate(prefab, position, rotation, parent);
+		GameObject tempObject = PoolClientInstantiate(prefab, position, rotation, parent, true);
 		
-		NetworkServer.Spawn(tempObject);
-
 		return tempObject;
 	}
 
 	/// <summary>
 	///     For non network stuff only! (e.g. bullets)
 	/// </summary>
-	public GameObject PoolClientInstantiate(GameObject prefab, Vector2 position, Quaternion rotation, Transform parent=null)
+	public GameObject PoolClientInstantiate(GameObject prefab, Vector2 position, Quaternion rotation, Transform parent=null, bool netSpawn=false)
 	{
 		GameObject tempObject = null;
 		if (pools.ContainsKey(prefab))
@@ -55,7 +53,13 @@ public class PoolManager : NetworkBehaviour
 				tempObject = pools[prefab][index];
 				pools[prefab].RemoveAt(index);
 				tempObject.SetActive(true);
-				tempObject.GetComponent<ObjectBehaviour>().visibleState = true;
+
+				ObjectBehaviour objBehaviour = tempObject.GetComponent<ObjectBehaviour>();
+				if (objBehaviour)
+				{
+					objBehaviour.visibleState = true;
+				}
+
 				tempObject.transform.position = position;
 				tempObject.transform.rotation = rotation;
 				tempObject.transform.localScale = prefab.transform.localScale;
@@ -67,6 +71,12 @@ public class PoolManager : NetworkBehaviour
 
 		tempObject = Instantiate(prefab, position, rotation, parent);
 		tempObject.AddComponent<PoolPrefabTracker>().myPrefab = prefab;
+
+		if (netSpawn)
+		{
+			NetworkServer.Spawn(tempObject);
+		}
+		
 		return tempObject;
 	}
 

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
@@ -37,9 +37,7 @@ public abstract class BulletBehaviour : MonoBehaviour
 	private void OnTriggerEnter2D(Collider2D coll)
 	{
 		HealthBehaviour damageable = coll.GetComponent<HealthBehaviour>();
-		if (damageable == null ||
-		    damageable.IsDead ||
-		    damageable.gameObject.name.Equals(shooter.name))
+		if (damageable == null || damageable.IsDead )
 		{
 			return;
 		}


### PR DESCRIPTION
### Purpose
1. Bullets weren't spawned and were leading to Exceptions
2. Players with the same name couldn't hurt each other

### Approach
1. included a check in PoolManager to avoid the Exception
2. removed bullet check if shooter had the same name as target.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer