### PR TITLE
Fixed all system messages and restart issues

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/PlayerHealth.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/PlayerHealth.cs
@@ -220,10 +220,6 @@ namespace PlayGroup
 				PlayerNetworkActions pna = gameObject.GetComponent<PlayerNetworkActions>();
 				PlayerMove pm = gameObject.GetComponent<PlayerMove>();
 				
-				// FIXME
-				// reenable killfeed once the systemmessages are fixed
-				
-				/*
 				string killerName = "stressfull work";
 				if (LastDamagedBy != null)
 				{
@@ -270,7 +266,7 @@ namespace PlayGroup
 
 					//Combat demo killfeed
 					//PostToChatMessage.Send(killerName + " has killed " + gameObject.name, ChatChannel.System);
-				}*/
+				}
 				pna.ValidateDropItem("rightHand", true, transform.position);
 				pna.ValidateDropItem("leftHand", true, transform.position);
 

--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -140,7 +140,7 @@ public class GameData : MonoBehaviour
 
 	private IEnumerator WaitToStartServer()
 	{
-		yield return new WaitForSeconds(5f);
+		yield return new WaitForSeconds(0.1f);
 		CustomNetworkManager.Instance.StartHost();
 	}
 

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -9,7 +9,7 @@ using UnityEngine.Rendering;
 public class GameManager : MonoBehaviour
 {
 	public static GameManager Instance;
-	private readonly float cacheTime = 60f;
+	private readonly float cacheTime = 480f;
 	public bool counting;
 	public List<GameObject> Occupations = new List<GameObject>();
 	public float restartTime = 10f;
@@ -19,7 +19,7 @@ public class GameManager : MonoBehaviour
 	public GameObject StandardOutfit;
 	public bool waitForRestart;
 
-	public float GetRoundTime { get; private set; } = 60f;
+	public float GetRoundTime { get; private set; } = 480f;
 
 	private void Awake()
 	{

--- a/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs
@@ -1,5 +1,6 @@
 ﻿using PlayGroup;
 using UnityEngine.Networking;
+using UnityEngine;
 
 public abstract class ClientMessage : GameMessageBase
 {
@@ -7,9 +8,13 @@ public abstract class ClientMessage : GameMessageBase
 
 	public void Send()
 	{
-		SentBy = LocalPlayerId();
+		if (PlayerManager.LocalPlayer)
+		{
+			SentBy = LocalPlayerId();
+		}
+
 		CustomNetworkManager.Instance.client.connection.Send(GetMessageType(), this);
-		//		Debug.LogFormat("Sent {0}", this);
+		Debug.LogFormat("Sent {0}", this);
 	}
 
 	public void SendUnreliable()
@@ -20,6 +25,7 @@ public abstract class ClientMessage : GameMessageBase
 
 	private static NetworkInstanceId LocalPlayerId()
 	{
+		
 		return PlayerManager.LocalPlayer.GetComponent<NetworkIdentity>().netId;
 	}
 

--- a/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs
@@ -15,12 +15,19 @@ public class PostToChatMessage : ClientMessage
 	public override IEnumerator Process()
 	{
 		yield return WaitFor(SentBy);
-
-		GameObject player = NetworkObject;
-		if (ValidRequest(player))
+		if (NetworkObject)
 		{
-			ChatModifier modifiers = player.GetComponent<PlayerScript>().GetCurrentChatModifiers();
-			ChatEvent chatEvent = new ChatEvent(ChatMessageText, player.name, Channels, modifiers);
+			GameObject player = NetworkObject;
+			if (ValidRequest(player))
+			{
+				ChatModifier modifiers = player.GetComponent<PlayerScript>().GetCurrentChatModifiers();
+				ChatEvent chatEvent = new ChatEvent(ChatMessageText, player.name, Channels, modifiers);
+				ChatRelay.Instance.AddToChatLogServer(chatEvent);
+			}
+		}
+		else
+		{
+			ChatEvent chatEvent = new ChatEvent(ChatMessageText, Channels);
 			ChatRelay.Instance.AddToChatLogServer(chatEvent);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateRoundTimeMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateRoundTimeMessage.cs
@@ -14,7 +14,7 @@ public class UpdateRoundTimeMessage : ServerMessage
 	{
 		yield return WaitFor(Subject);
 
-		GameManager.Instance.SyncTimendResetCounter(Time);
+		GameManager.Instance.SyncTime(Time);
 	}
 
 	public static UpdateRoundTimeMessage Send(float time)

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
@@ -244,17 +244,20 @@ namespace PlayGroup
 
 		public ChatModifier GetCurrentChatModifiers()
 		{
+			ChatModifier modifiers = ChatModifier.None;
 			if (playerMove.isGhost)
 			{
 				return ChatModifier.None;
 			}
 
 			//TODO add missing modifiers
-			ChatModifier modifiers = ChatModifier.Drunk;
+			//TODO add if for being drunk
+			//ChatModifier modifiers = ChatModifier.Drunk;
 
 			if (JobType == JobType.CLOWN)
 			{
 				modifiers |= ChatModifier.Clown;
+				
 			}
 
 			return modifiers;


### PR DESCRIPTION
### Purpose
- Restart freaked out sometimes.
- All system messages where broken on headless server (Killfeed and end-of-round messages)

### Approach
1. Restart was behaving strangly, due to many issues with the round-time-update message. It was causing circumstantial loops all over the place. I put some extra checks in place to prevent those.

2. All system messages where broken, because it requered a sent-by network identity. I made sure it wouldn't be required throughout the whole chain while still preserving the option to use it if needed.

### Open Questions and Pre-Merge TODOs

- [X]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes:
fixes #783