### PR TITLE
Disabled BreakPull, Disabled bullet damage on shooter

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -132,6 +132,9 @@ public class PushPull : VisibleBehaviour
 
 	public void BreakPull()
 	{
+		Debug.Log("Doobles is currently working on pull fixes");
+		//FIXME: Pulling is a WIP
+		return;
 		PlayerScript player = PlayerManager.LocalPlayerScript;
 		if (!player.playerSync) //FIXME: this doesn't exist on the client sometimes
 		{

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
@@ -37,7 +37,7 @@ public abstract class BulletBehaviour : MonoBehaviour
 	private void OnTriggerEnter2D(Collider2D coll)
 	{
 		HealthBehaviour damageable = coll.GetComponent<HealthBehaviour>();
-		if (damageable == null || damageable.IsDead )
+		if (damageable == null || damageable.IsDead || coll.gameObject == shooter)
 		{
 			return;
 		}


### PR DESCRIPTION
### Purpose
- Fix NREs on server due to exploding cansiters and faulty pull code
- Turn off bullet damage for shooter

### Approach
- BreakPull method is disabled for time being until I can look at the pull code
- Made sure shooter cannot be damaged by the bullets. Suicide by shooting should be handled without expelling a bullet. It should cause the SFX, spawn casing, cause damage and remove a bullet from ammo count but it should not spawn a bullet

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
tested mp all scenarios