### PR TITLE
Fixes problems with energyweapons

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Energy/Resources/LaserGun.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Energy/Resources/LaserGun.prefab
@@ -156,10 +156,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   AmmoType: FusionCells
+  SpawnsCaseing: 0
   CurrentRecoilVariance: 0
   FireCountDown: 0
   FireingSound: ShootLaser
-  SpawnsCaseing: 0
   FireRate: 5
   InAutomaticAction: 0
   MaxRecoilVariance: 0
@@ -261,7 +261,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 63ad07f389034e49893bdd6e79303e4d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Energy/Resources/LaserPistol.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Energy/Resources/LaserPistol.prefab
@@ -160,10 +160,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   AmmoType: FusionCells
+  SpawnsCaseing: 0
   CurrentRecoilVariance: 0
   FireCountDown: 0
   FireingSound: ShootLaser
-  SpawnsCaseing: 0
   FireRate: 5
   InAutomaticAction: 0
   MaxRecoilVariance: 0
@@ -261,7 +261,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 63ad07f389034e49893bdd6e79303e4d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Energy/Resources/Tazer.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Energy/Resources/Tazer.prefab
@@ -114,6 +114,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114155970044334132
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -188,12 +190,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 0
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
   closetHandlerCache: {fileID: 0}
 --- !u!114 &114758040345321802
 MonoBehaviour:
@@ -212,12 +211,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
   closetHandlerCache: {fileID: 0}
 --- !u!114 &114958751264410972
 MonoBehaviour:
@@ -265,7 +261,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 63ad07f389034e49893bdd6e79303e4d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0


### PR DESCRIPTION
### Purpose
The Energy weapons where NOT tested by @DooblyNoobly as promised. They where missing sprite-pixelsnap. This causes a huge issue with lockers.

@lquinn2015 Please next time: Actually copy what we already have and edit it to fit your goals. Don't try to reinvent the wheel and make some prefabs from scratch. Also: Test all interaction of new objects the world. Including tables, creates and Lockers

### Approach
Places sprite pixelsnap on them

### Open Questions and Pre-Merge TODOs

- [X]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes:
