### PR TITLE
FoV wait for Camera target ready

### DIFF
--- a/UnityProject/Assets/Scripts/Camera/FieldOfViewTiled.cs
+++ b/UnityProject/Assets/Scripts/Camera/FieldOfViewTiled.cs
@@ -254,6 +254,16 @@ public class FieldOfViewTiled : ThreadedBehaviour
 
 	private void RayCastQueue(Vector2 endPos, Vector2 offsetPos)
 	{
+		if(Camera2DFollow.followControl != null){
+			if(Camera2DFollow.followControl.target == null){
+				Debug.LogWarning("Client player not ready yet for the FOV - Possibly due to lag");
+				return;
+			}
+		} else {
+			//Just incase for any reason the Camera instance is not yet set
+			return;
+		}
+
 		RaycastHit2D hit = Physics2D.Linecast(Camera2DFollow.followControl.target.position, endPos, _layerMask);
 		// If it hits a wall we should enable the shroud
 		//		Debug.DrawLine(GetPlayerSource().transform.position, endPos,Color.red);


### PR DESCRIPTION
### Purpose
- This makes sure the Camera target is ready starting the raycast. Sometimes it is not ready due to lag and then it throws an NRE breaking the FoV

### Approach
Added null checks for the Camera Follow instance and the target

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer


### Notes:
it may fix fov bug #805 monitor for a few days to make sure
 Fixes #805 