### PR TITLE
Removed closet health, as it adds nothing but trouble.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114793968027197088}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114332551563909192}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -251,12 +235,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -301,6 +282,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Green.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114597010362170592}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114615101260203070}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -235,12 +219,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114597010362170592
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -253,6 +234,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114615101260203070
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Pink.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Pink.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114419139457667244}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114523646684726672}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -230,6 +214,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -247,12 +233,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114523646684726672
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Red_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Red_Plain.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114192154473191574}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114170089691885322}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114170089691885322
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -229,6 +213,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -263,12 +249,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Red_Stripe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Red_Stripe.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114599001885558102}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114622615258334520}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -235,12 +219,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114599001885558102
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -253,6 +234,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114622615258334520
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Black.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Black.prefab
@@ -24,7 +24,6 @@ GameObject:
   - component: {fileID: 114563119404815312}
   - component: {fileID: 114334495745331238}
   - component: {fileID: 114310759356319872}
-  - component: {fileID: 114291343940822994}
   - component: {fileID: 114097153114912920}
   - component: {fileID: 114590671685477684}
   m_Layer: 11
@@ -203,27 +202,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
---- !u!114 &114291343940822994
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000522475151462}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114310759356319872
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -253,6 +234,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114563119404815312
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Blue.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114809995071011442}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114480465103792078}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -251,12 +235,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -301,6 +282,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Bomb.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Bomb.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114949813296282442}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114559887282967898}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -235,12 +219,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114559887282967898
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -301,6 +282,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Brown.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Brown.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114731756476040546}
   - component: {fileID: 114178227343361656}
   - component: {fileID: 114226188280779116}
-  - component: {fileID: 114380320722249372}
   - component: {fileID: 114973538546967054}
   - component: {fileID: 114137355759862740}
   m_Layer: 11
@@ -214,6 +213,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114226188280779116
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -231,21 +232,6 @@ MonoBehaviour:
   items: {fileID: 1522744671779814}
   lockLight: {fileID: 0}
   spriteRenderer: {fileID: 212585266423504292}
---- !u!114 &114380320722249372
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1326196951998806}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114731756476040546
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -295,12 +281,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!212 &212585266423504292
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Electricity.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Electricity.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114368139429836270}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114544474243738448}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -230,6 +214,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -247,12 +233,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114544474243738448
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Enginering.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Enginering.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114098053694904296}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114235402911808258}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114098053694904296
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -213,6 +197,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114235402911808258
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -263,12 +249,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Fire_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Fire_Red.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114394553509429574}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114440515152274470}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -230,6 +214,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114440515152274470
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -263,12 +249,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Fire_Yellow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Fire_Yellow.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114811604509801888}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114817056745690750}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -235,12 +219,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -285,6 +266,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114817056745690750
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Green.prefab
@@ -71,7 +71,6 @@ GameObject:
   - component: {fileID: 114477434517256044}
   - component: {fileID: 114501655910360080}
   - component: {fileID: 114672394582474368}
-  - component: {fileID: 114092640990397102}
   - component: {fileID: 114034944277787380}
   - component: {fileID: 114471672769914432}
   m_Layer: 11
@@ -203,27 +202,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
---- !u!114 &114092640990397102
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1992679967695770}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114471672769914432
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -284,6 +265,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114672394582474368
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Grey.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Grey.prefab
@@ -55,7 +55,6 @@ GameObject:
   - component: {fileID: 114107365703837954}
   - component: {fileID: 114881239354733470}
   - component: {fileID: 114859863419137498}
-  - component: {fileID: 114064175606115938}
   - component: {fileID: 114092793192366008}
   - component: {fileID: 114407287186085312}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.83569336, y: 0.9217529}
   m_EdgeRadius: 0
---- !u!114 &114064175606115938
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1180280463732794}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114092793192366008
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -218,12 +202,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114107365703837954
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -301,6 +282,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!212 &212172245744083514
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_HOS.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_HOS.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114013243339958884}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114086862237097484}
   m_Layer: 11
@@ -198,21 +197,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114086862237097484
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -263,12 +249,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_HOS1.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_HOS1.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114309583552779882}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114770503305342756}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -230,6 +214,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -247,12 +233,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Blue.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114204169222423732}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114644364860119310}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114204169222423732
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_CE.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_CE.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114460486150970724}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114248233175949198}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -246,6 +230,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -263,12 +249,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_CMO.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_CMO.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114819687656175812}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114649345137454126}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -235,12 +219,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114649345137454126
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -301,6 +282,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Captain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Captain.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114892240168144284}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114935263454225050}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Enginering.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Enginering.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114024170624231532}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114812631774233812}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114024170624231532
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -213,6 +197,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -247,12 +233,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Green.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114007936688419140}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114896337446882410}
   m_Layer: 11
@@ -200,21 +199,6 @@ MonoBehaviour:
   SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_HOP.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_HOP.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114065163849066438}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114582121561473138}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114065163849066438
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_HOS2.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_HOS2.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114444741572267014}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114689190573812974}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -230,6 +214,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -247,12 +233,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Medical_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Medical_Blue.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114325376994497856}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114731592007980676}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -230,6 +214,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -247,12 +233,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Medical_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Medical_Red.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114850073692931946}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114693708255967736}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -235,12 +219,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -301,6 +282,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Plain.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114380468365835130}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114892200674845614}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -230,6 +214,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -247,12 +233,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Purple.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Purple.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114297601676347656}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114038549829774776}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114038549829774776
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_RD.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_RD.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114360195284987434}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114281463853194846}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -246,6 +230,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -263,12 +249,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Security.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Security.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114836660138393894}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114605337504269064}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -235,12 +219,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114605337504269064
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -301,6 +282,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Warden.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Warden.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114014101349316756}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114922293611875512}
   m_Layer: 11
@@ -198,21 +197,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -247,12 +233,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Yellow_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Yellow_Blue.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114519431623713784}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114002540538224682}
   m_Layer: 11
@@ -202,21 +201,6 @@ MonoBehaviour:
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
   IsClosed: 1
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -251,12 +235,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114519431623713784
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -269,6 +250,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Yellow_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Yellow_Green.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114183100861501246}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114934066705055290}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114183100861501246
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -213,6 +197,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -247,12 +233,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Yellow_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Yellow_Red.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114167712126867458}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114322238352018174}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114167712126867458
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -213,6 +197,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -263,12 +249,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_mining.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_mining.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114026821851648828}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114159567590582482}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114026821851648828
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -213,6 +197,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114159567590582482
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -263,12 +249,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Nuclear.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Nuclear.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114547321624010300}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114636999251767984}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -235,12 +219,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114547321624010300
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -253,6 +234,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114636999251767984
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Oxygen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Oxygen.prefab
@@ -24,7 +24,6 @@ GameObject:
   - component: {fileID: 114473011698291292}
   - component: {fileID: 114836981699317108}
   - component: {fileID: 114325905384881024}
-  - component: {fileID: 114634621835178574}
   - component: {fileID: 114456479662004144}
   - component: {fileID: 114195129605414080}
   m_Layer: 11
@@ -236,12 +235,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114473011698291292
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -274,21 +270,6 @@ MonoBehaviour:
     i15: 139
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114634621835178574
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1146263997293372}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114836981699317108
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -301,6 +282,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!212 &212309241971002690
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Pink_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Pink_Plain.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114840521567148940}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114411567513637418}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -251,12 +235,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -301,6 +282,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Purple.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Purple.prefab
@@ -71,7 +71,6 @@ GameObject:
   - component: {fileID: 114465697400450480}
   - component: {fileID: 114569148275177306}
   - component: {fileID: 114835786064520692}
-  - component: {fileID: 114546295996061072}
   - component: {fileID: 114008606363410360}
   - component: {fileID: 114092939811341892}
   m_Layer: 11
@@ -203,12 +202,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114092939811341892
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -257,21 +253,6 @@ MonoBehaviour:
     i15: 118
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114546295996061072
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1967120683374944}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114569148275177306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -284,6 +265,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114835786064520692
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Red.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114110721192159654}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114098930696084046}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114098930696084046
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -229,6 +213,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -263,12 +249,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Red_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Red_Plain.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114181166744408970}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114789322306219058}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114181166744408970
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -213,6 +197,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -247,12 +233,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_YellowBlue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_YellowBlue.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114678338651277788}
   - component: {fileID: 114300286672676254}
   - component: {fileID: 114239634461430000}
-  - component: {fileID: 114014262675263028}
   - component: {fileID: 114485734239509306}
   - component: {fileID: 114212272870360996}
   m_Layer: 11
@@ -186,21 +185,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5410156, y: 0.8852539}
   m_EdgeRadius: 0
---- !u!114 &114014262675263028
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 400
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114212272870360996
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -246,6 +230,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -263,12 +249,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_25.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_25.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114195364431647472}
   - component: {fileID: 114312187167322552}
   - component: {fileID: 114624201496929774}
-  - component: {fileID: 114555570991743912}
   - component: {fileID: 114728862151555782}
   - component: {fileID: 114503017526061194}
   m_Layer: 11
@@ -230,6 +229,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114503017526061194
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -246,21 +247,6 @@ MonoBehaviour:
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
   IsClosed: 1
---- !u!114 &114555570991743912
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1501407896951118}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114624201496929774
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -295,12 +281,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!212 &212346375950534824
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_27.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_27.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114924782040466904}
   - component: {fileID: 114502689129448986}
   - component: {fileID: 114041722743958658}
-  - component: {fileID: 114181663698198348}
   - component: {fileID: 114300212432654210}
   - component: {fileID: 114712611594111156}
   m_Layer: 11
@@ -203,21 +202,6 @@ MonoBehaviour:
   items: {fileID: 1782405127851724}
   lockLight: {fileID: 0}
   spriteRenderer: {fileID: 212453103544694556}
---- !u!114 &114181663698198348
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1523863081027030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114300212432654210
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -235,12 +219,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114502689129448986
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -253,6 +234,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114712611594111156
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_29.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_29.prefab
@@ -56,7 +56,6 @@ GameObject:
   - component: {fileID: 114295723265879730}
   - component: {fileID: 114680917774830940}
   - component: {fileID: 114909173354328112}
-  - component: {fileID: 114833423137625402}
   - component: {fileID: 114537669086459234}
   - component: {fileID: 114472020371701898}
   m_Layer: 11
@@ -252,12 +251,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114680917774830940
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -270,21 +266,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
---- !u!114 &114833423137625402
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1476871417342792}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114909173354328112
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_31.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_31.prefab
@@ -56,7 +56,6 @@ GameObject:
   - component: {fileID: 114181612573510762}
   - component: {fileID: 114203660061737976}
   - component: {fileID: 114727864889730296}
-  - component: {fileID: 114011427433938242}
   - component: {fileID: 114146171702453404}
   - component: {fileID: 114017635886564424}
   m_Layer: 11
@@ -187,21 +186,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.85, y: 0.85}
   m_EdgeRadius: 0
---- !u!114 &114011427433938242
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1930016640541606}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114017635886564424
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -235,12 +219,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114181612573510762
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -285,6 +266,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114727864889730296
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_33.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_33.prefab
@@ -24,7 +24,6 @@ GameObject:
   - component: {fileID: 114341401985723400}
   - component: {fileID: 114451849879818634}
   - component: {fileID: 114687776773198576}
-  - component: {fileID: 114412503303399214}
   - component: {fileID: 114755658481990444}
   - component: {fileID: 114769490943460672}
   m_Layer: 11
@@ -219,21 +218,6 @@ MonoBehaviour:
     i15: 156
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114412503303399214
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1172562073016694}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114451849879818634
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -246,6 +230,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114687776773198576
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -280,12 +266,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114769490943460672
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_35.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_35.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114057550863274524}
   - component: {fileID: 114471373235078564}
   - component: {fileID: 114792840174579722}
-  - component: {fileID: 114178378261359144}
   - component: {fileID: 114212963560835634}
   - component: {fileID: 114770697319524486}
   m_Layer: 11
@@ -219,21 +218,6 @@ MonoBehaviour:
     i15: 172
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114178378261359144
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1725541231692740}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114212963560835634
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -251,12 +235,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114471373235078564
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -269,6 +250,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114770697319524486
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_37.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_37.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114330726669758060}
   - component: {fileID: 114033159393086184}
   - component: {fileID: 114095274155442226}
-  - component: {fileID: 114528670149905996}
   - component: {fileID: 114826408582836528}
   - component: {fileID: 114789974186404946}
   m_Layer: 11
@@ -199,6 +198,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114095274155442226
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -248,21 +249,6 @@ MonoBehaviour:
     i15: 162
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114528670149905996
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1623680258428568}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114789974186404946
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -296,12 +282,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!212 &212190977598804058
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_39.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_39.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114757676526798440}
   - component: {fileID: 114297742929761050}
   - component: {fileID: 114071782524652884}
-  - component: {fileID: 114248124126117508}
   - component: {fileID: 114215584145867606}
   - component: {fileID: 114228922600464636}
   m_Layer: 11
@@ -221,12 +220,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114228922600464636
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -243,21 +239,6 @@ MonoBehaviour:
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
   IsClosed: 1
---- !u!114 &114248124126117508
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1171324585748574}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114297742929761050
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -270,6 +251,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114757676526798440
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_41.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_41.prefab
@@ -72,7 +72,6 @@ GameObject:
   - component: {fileID: 114067817207725090}
   - component: {fileID: 114871415670409854}
   - component: {fileID: 114005325939491094}
-  - component: {fileID: 114088367131421412}
   - component: {fileID: 114332086181728130}
   - component: {fileID: 114249522964518044}
   m_Layer: 11
@@ -236,21 +235,6 @@ MonoBehaviour:
     i15: 152
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114088367131421412
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1924829694925096}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114249522964518044
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -284,12 +268,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114871415670409854
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -302,6 +283,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!212 &212188871185799970
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_43.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_43.prefab
@@ -71,7 +71,6 @@ GameObject:
   - component: {fileID: 114053175267134406}
   - component: {fileID: 114172041256659066}
   - component: {fileID: 114997183691469382}
-  - component: {fileID: 114868399001644080}
   - component: {fileID: 114870341870814934}
   - component: {fileID: 114204757990214010}
   m_Layer: 11
@@ -205,6 +204,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114204757990214010
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -221,21 +222,6 @@ MonoBehaviour:
   Offset: {x: 0, y: 0, z: 0}
   Passable: 0
   IsClosed: 1
---- !u!114 &114868399001644080
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1969509301568012}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114870341870814934
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -253,12 +239,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114997183691469382
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_45.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_45.prefab
@@ -40,7 +40,6 @@ GameObject:
   - component: {fileID: 114578137437934688}
   - component: {fileID: 114439906662283016}
   - component: {fileID: 114168612985768984}
-  - component: {fileID: 114474239767170154}
   - component: {fileID: 114161560780868246}
   - component: {fileID: 114602900905777840}
   m_Layer: 11
@@ -204,12 +203,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114168612985768984
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -239,21 +235,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
---- !u!114 &114474239767170154
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1502243171082208}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114578137437934688
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_47.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_47.prefab
@@ -56,7 +56,6 @@ GameObject:
   - component: {fileID: 114155333831734132}
   - component: {fileID: 114388335254351326}
   - component: {fileID: 114294527913026106}
-  - component: {fileID: 114619145373609976}
   - component: {fileID: 114860650845099624}
   - component: {fileID: 114167406021928690}
   m_Layer: 11
@@ -264,21 +263,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
---- !u!114 &114619145373609976
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1478563989471078}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114860650845099624
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -296,12 +282,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!212 &212237543671680568
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_49.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_49.prefab
@@ -72,7 +72,6 @@ GameObject:
   - component: {fileID: 114268464882101760}
   - component: {fileID: 114798688265202516}
   - component: {fileID: 114999291194090438}
-  - component: {fileID: 114053932216975756}
   - component: {fileID: 114969457893761476}
   - component: {fileID: 114452331490182166}
   m_Layer: 11
@@ -187,21 +186,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.8207247, y: 0.4560275}
   m_EdgeRadius: 0
---- !u!114 &114053932216975756
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1907093438119012}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114268464882101760
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -262,6 +246,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114969457893761476
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -279,12 +265,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114999291194090438
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_51.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_51.prefab
@@ -24,7 +24,6 @@ GameObject:
   - component: {fileID: 114376291158677620}
   - component: {fileID: 114559310912600516}
   - component: {fileID: 114810580295933042}
-  - component: {fileID: 114899107644448570}
   - component: {fileID: 114162110669680936}
   - component: {fileID: 114764355540025994}
   m_Layer: 11
@@ -204,12 +203,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114376291158677620
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -254,6 +250,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114764355540025994
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -287,21 +285,6 @@ MonoBehaviour:
   items: {fileID: 1425752812718570}
   lockLight: {fileID: 0}
   spriteRenderer: {fileID: 212474993368304682}
---- !u!114 &114899107644448570
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1211152131464520}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!212 &212101847286078894
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_55.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_55.prefab
@@ -24,7 +24,6 @@ GameObject:
   - component: {fileID: 114321209064528416}
   - component: {fileID: 114176581051234016}
   - component: {fileID: 114111814946665734}
-  - component: {fileID: 114523606843657202}
   - component: {fileID: 114924802127813078}
   - component: {fileID: 114158540661954676}
   m_Layer: 11
@@ -232,6 +231,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114321209064528416
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -264,21 +265,6 @@ MonoBehaviour:
     i15: 100
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114523606843657202
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1158274957469326}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114924802127813078
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -296,12 +282,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!212 &212559863623603102
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_59.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_59.prefab
@@ -71,7 +71,6 @@ GameObject:
   - component: {fileID: 114329252055502220}
   - component: {fileID: 114967653116276958}
   - component: {fileID: 114077872851233106}
-  - component: {fileID: 114438381810043398}
   - component: {fileID: 114111951740655112}
   - component: {fileID: 114713051113849806}
   m_Layer: 11
@@ -220,12 +219,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114329252055502220
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -258,21 +254,6 @@ MonoBehaviour:
     i15: 72
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114438381810043398
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1716772823250544}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114713051113849806
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -301,6 +282,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!212 &212301907432160954
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_75.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_75.prefab
@@ -72,7 +72,6 @@ GameObject:
   - component: {fileID: 114987699347511260}
   - component: {fileID: 114502573446041974}
   - component: {fileID: 114097983808980254}
-  - component: {fileID: 114256715197370990}
   - component: {fileID: 114505206884239544}
   - component: {fileID: 114743391073407562}
   m_Layer: 11
@@ -204,21 +203,6 @@ MonoBehaviour:
   items: {fileID: 1163350147843892}
   lockLight: {fileID: 0}
   spriteRenderer: {fileID: 212999311790289402}
---- !u!114 &114256715197370990
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1260013458057742}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
 --- !u!114 &114502573446041974
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -231,6 +215,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114505206884239544
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -248,12 +234,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114743391073407562
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_77.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_77.prefab
@@ -56,7 +56,6 @@ GameObject:
   - component: {fileID: 114988128385835288}
   - component: {fileID: 114247083654374572}
   - component: {fileID: 114142976522380120}
-  - component: {fileID: 114823007820511444}
   - component: {fileID: 114070046984260224}
   - component: {fileID: 114869123330114316}
   m_Layer: 11
@@ -204,12 +203,9 @@ MonoBehaviour:
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114142976522380120
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -239,21 +235,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
---- !u!114 &114823007820511444
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1780409705432866}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53718f00af634879afe9838de3e391ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  allowKnifeHarvest: 0
-  initialHealth: 100
-  isNPC: 0
-  maxHealth: 100
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114869123330114316
 MonoBehaviour:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
### Purpose
- Closet health is not needed, death closets look strange and it only gives bugs instead of adding anything to gameplay

### Approach
I gutted the closethealth from the closets and crates.
Later on, possibly around construction, I'll add a feature request to kill closets into rouble. till then: its gone.

### Open Questions and Pre-Merge TODOs

- [X]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes:
Fixes #753