### PR TITLE
Excludes dead players from ServerMessages

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/Server/ServerMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/ServerMessage.cs
@@ -15,12 +15,19 @@ public abstract class ServerMessage : GameMessageBase
 
 	public void SendTo(GameObject recipient)
 	{
-		if (recipient == null)
-		{
+		NetworkIdentity netIdentity = recipient.GetComponent<NetworkIdentity>();
+
+		//Only send to the client of the currently owned player as some
+		//netID's being used in this method could be dead players, exclude them:
+		if (PlayerList.Instance.connectedPlayers.ContainsValue(recipient)) {
+			netIdentity.connectionToClient.Send(GetMessageType(), this);
+		} else {
+			//only send to players that are currently controlled by a client
 			return;
 		}
 
-		NetworkServer.SendToClientOfPlayer(recipient, GetMessageType(), this);
-		//		Debug.LogFormat("SentTo {0}", this);
+		//Obsolete version:
+		//NetworkServer.SendToClientOfPlayer(recipient, GetMessageType(), this);
+		//Debug.LogFormat("SentTo {0}", this);
 	}
 }


### PR DESCRIPTION
### Purpose
This change makes it more forgiving when sending server messages to clients. First it checks if the player being sent-to exists in the PlayerList (excluding dead bodies) and then uses the actual client connection to send the message on.
Using the client connection is more efficient then using 'SendToClientOfPlayer' and is less error prone

### Approach
First check if the player object being sent to is a value in the PlayerList connectedPlayers collection. Then if it is, use the clientConnection from the NetworkIdentity to send the NetworkMessage on.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
tested on mp high lag