### PR TITLE
Chat isFocus check on hiding

### DIFF
--- a/UnityProject/Assets/Scripts/Closets/ClosetPlayerHandler.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetPlayerHandler.cs
@@ -1,6 +1,7 @@
 ﻿using PlayGroup;
 using Tilemaps.Scripts;
 using UnityEngine;
+using UI;
 
 namespace Cupboards
 {
@@ -43,7 +44,8 @@ namespace Cupboards
 
 		private void Update()
 		{
-			if (PlayerManager.LocalPlayerScript.playerNetworkActions.isGhost)
+			if (PlayerManager.LocalPlayerScript.playerNetworkActions.isGhost ||
+			    UIManager.Instance.chatControl.isChatFocus)
 			{
 				return;
 			}			

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
@@ -390,6 +390,10 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	[Command]
 	public void CmdToggleChatIcon(bool turnOn)
 	{
+		if(!GetComponent<VisibleBehaviour>().visibleState){
+			//Don't do anything with chat icon if player is invisible
+			return;
+		}
 		RpcToggleChatIcon(turnOn);
 	}
 


### PR DESCRIPTION
- Checks if the chat window is in focus and stops the player from jumping out of the closet when WASD is pressed
- Checks if the player is hiding before showing chat icon

### Approach
Added the required conditional checks

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
Fixes: #815 #813 