### PR TITLE
Moved Table collider back to 0,0

### DIFF
--- a/UnityProject/Assets/Prefabs/Station.prefab
+++ b/UnityProject/Assets/Prefabs/Station.prefab
@@ -487,7 +487,7 @@ TilemapCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.5, y: -0.5}
+  m_Offset: {x: 0, y: 0}
 --- !u!156049354 &2569400267726922214
 Grid:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
+++ b/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
@@ -68873,7 +68873,7 @@ TilemapCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.5, y: -0.5}
+  m_Offset: {x: 0, y: 0}
 --- !u!1001 &970444958
 Prefab:
   m_ObjectHideFlags: 0
@@ -70058,12 +70058,12 @@ Prefab:
     - target: {fileID: 224082241428792102, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 2}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.000000059604645
       objectReference: {fileID: 0}
     - target: {fileID: 224652079256797148, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0.000045776367
+      value: -0.000045776367
       objectReference: {fileID: 0}
     - target: {fileID: 224347802705061360, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 2}

--- a/UnityProject/ProjectSettings/ProjectVersion.txt
+++ b/UnityProject/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.3.0p2
+m_EditorVersion: 2017.3.0f3


### PR DESCRIPTION
### Purpose
It was offset by -0.5, -0.5. Moving this back to 0, 0 seems to fix #850 .

### Approach
Moved Table (i.e. Object Layer) collider back to 0,0

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
The original offset by -0.5, -0.5 was done to fix a similar bug where the collider was offset. Apparently that's not the case anymore.