### PR TITLE
UIManager.ResetAllUI() now also resets inactive ItemSlots

### DIFF
--- a/UnityProject/Assets/Scripts/UI/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/UIManager.cs
@@ -79,7 +79,7 @@ namespace UI
 
 		public static void ResetAllUI()
 		{
-			UI_ItemSlot[] slots = Instance.GetComponentsInChildren<UI_ItemSlot>();
+			UI_ItemSlot[] slots = Instance.GetComponentsInChildren<UI_ItemSlot>(true);
 			foreach (UI_ItemSlot slot in slots)
 			{
 				slot.Reset();


### PR DESCRIPTION
### Purpose
Inactive Items were not reset.

### Approach
UIManager.ResetAllUI() now also resets inactive ItemSlots

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
fixes #812