### PR TITLE
Make .gitignore comments more consistent.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ UnityProject/ProjectSettings/UnityAdsSettings.asset
 *.app/
 .DS_Store
 
-#IDE
+# IDE
 .idea/
 workspace.xml
 UnityProject/ProjectSettings/ProjectVersion.txt


### PR DESCRIPTION
### Purpose
The comments in the `.gitignore` all had a space after the `#`, except one. This fixes that.

### Open Questions and Pre-Merge TODOs

- [ ]  I read the contribution guidelines and the wiki.
- [ ]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [ ]  This PR does not include files without specific need to do so.
- [ ]  This PR does not bring up any new compile errors
- [ ]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer