### PR TITLE
Reordering ChatRelay startup execution

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Managers/ChatRelay.cs
@@ -26,9 +26,8 @@ public class ChatRelay : NetworkBehaviour
 
 	public List<ChatEvent> ChatLog { get; } = new List<ChatEvent>();
 
-	public override void OnStartClient()
+	public void Start()
 	{
-		RefreshLog();
 		chatColors = new Dictionary<ChatChannel, string>
 		{
 			{ChatChannel.Binary, "#ff00ff"},
@@ -50,7 +49,8 @@ public class ChatRelay : NetworkBehaviour
 			{ChatChannel.Ghost, "#386aff"}
 		};
 		namelessChannels = ChatChannel.Examine | ChatChannel.Local | ChatChannel.None | ChatChannel.System;
-		base.OnStartClient();
+		
+		RefreshLog();
 	}
 
 	[Server]

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -9,7 +9,7 @@ using UnityEngine.Rendering;
 public class GameManager : MonoBehaviour
 {
 	public static GameManager Instance;
-	private readonly float cacheTime = 480f;
+	public float RoundTime = 480f;
 	public bool counting;
 	public List<GameObject> Occupations = new List<GameObject>();
 	public float restartTime = 10f;
@@ -53,7 +53,7 @@ public class GameManager : MonoBehaviour
 
 	private void OnLevelFinishedLoading(Scene scene, LoadSceneMode mode)
 	{
-		GetRoundTime = cacheTime;
+		GetRoundTime = RoundTime;
 	}
 
 	public void SyncTime(float currentTime)
@@ -70,7 +70,7 @@ public class GameManager : MonoBehaviour
 
 	public void ResetRoundTime()
 	{
-		GetRoundTime = cacheTime;
+		GetRoundTime = RoundTime;
 		waitForRestart = false;
 		counting = true;
 		restartTime = 10f;

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
@@ -52,6 +52,7 @@ namespace PlayGroup
 		{
 			//Local player is set a frame or two after OnStartClient
 			StartCoroutine(WaitForLoad());
+			Init();
 			base.OnStartClient();
 		}
 


### PR DESCRIPTION
### Purpose
Due to ordering issues, chatrelay stuff was initialised before the playerscript, leading to NREs after restart. Also made the game time a public variable so it's easy to change it.

### Approach
reorder the execution of the chatrelay (moved stuff to the Start() method which is executed after Network stuff)

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
fixes #879 and maybe others?