### PR TITLE
Added RanFromSteam verification and fixed #894

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/Tanks/WeldingFuel.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/Tanks/WeldingFuel.prefab
@@ -42,6 +42,7 @@ GameObject:
   - component: {fileID: 114329278433563846}
   - component: {fileID: 114527046222029886}
   - component: {fileID: 114533782473290288}
+  - component: {fileID: 114867396419559272}
   - component: {fileID: 114183243700281508}
   m_Layer: 11
   m_Name: WeldingFuel
@@ -139,6 +140,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SpeedMultiplier: 1
+  isPushing: 0
+  predictivePushing: 0
 --- !u!114 &114117985471735314
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -198,17 +201,16 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
-  moveSpeed: 7
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
-  serverLittleLag: 0
-  timeInPush: 0
 --- !u!114 &114527046222029886
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -235,9 +237,32 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   allowKnifeHarvest: 0
-  initialHealth: 20
+  initialHealth: 25
   isNPC: 0
   maxHealth: 100
+--- !u!114 &114867396419559272
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1942658981970304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isPlayer: 0
+  ignoredSpriteRenderers: []
+  registerTile: {fileID: 0}
+  visibleState: 1
+  allowedToMove: 1
+  currentPos: {x: 0, y: 0, z: 0}
+  isPushable: 1
+  pulledBy: {fileID: 0}
+  custNetActiveState: 0
+  pushing: 0
+  pushTarget: {x: 0, y: 0, z: 0}
+  closetHandlerCache: {fileID: 0}
 --- !u!212 &212357524740156146
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/atmos_5.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/atmos_5.prefab
@@ -42,6 +42,7 @@ GameObject:
   - component: {fileID: 114930344040478920}
   - component: {fileID: 114278101468313644}
   - component: {fileID: 114149446815694932}
+  - component: {fileID: 114415491443398522}
   - component: {fileID: 114672592214754418}
   m_Layer: 0
   m_Name: atmos_5
@@ -154,7 +155,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   allowKnifeHarvest: 0
-  initialHealth: 100
+  initialHealth: 45
   isNPC: 0
   maxHealth: 100
 --- !u!114 &114369194254655814
@@ -169,14 +170,39 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
+--- !u!114 &114415491443398522
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1498044554059982}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isPlayer: 0
+  ignoredSpriteRenderers: []
+  registerTile: {fileID: 0}
+  visibleState: 1
+  allowedToMove: 1
+  currentPos: {x: 0, y: 0, z: 0}
+  isPushable: 1
+  pulledBy: {fileID: 0}
+  custNetActiveState: 0
+  pushing: 0
+  pushTarget: {x: 0, y: 0, z: 0}
+  closetHandlerCache: {fileID: 0}
 --- !u!114 &114672592214754418
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -234,8 +260,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7ab49f7209d2b4a9d94184d4ea24e312, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 150
-  radius: 3
+  damage: 200
+  radius: 4
   spriteRend: {fileID: 212479390356346330}
 --- !u!212 &212479390356346330
 SpriteRenderer:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/atmos_57.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/atmos_57.prefab
@@ -26,6 +26,7 @@ GameObject:
   - component: {fileID: 114021474392254996}
   - component: {fileID: 114375627953232240}
   - component: {fileID: 114703445277859372}
+  - component: {fileID: 114968618203004006}
   - component: {fileID: 114624379089926182}
   m_Layer: 0
   m_Name: atmos_57
@@ -153,7 +154,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   allowKnifeHarvest: 0
-  initialHealth: 100
+  initialHealth: 45
   isNPC: 0
   maxHealth: 100
 --- !u!114 &114509662786697548
@@ -229,14 +230,39 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
+--- !u!114 &114968618203004006
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1051541562388458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isPlayer: 0
+  ignoredSpriteRenderers: []
+  registerTile: {fileID: 0}
+  visibleState: 1
+  allowedToMove: 1
+  currentPos: {x: 0, y: 0, z: 0}
+  isPushable: 1
+  pulledBy: {fileID: 0}
+  custNetActiveState: 0
+  pushing: 0
+  pushTarget: {x: 0, y: 0, z: 0}
+  closetHandlerCache: {fileID: 0}
 --- !u!212 &212188953855684958
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Scripts/Objects/ExplodeWhenShot.cs
+++ b/UnityProject/Assets/Scripts/Objects/ExplodeWhenShot.cs
@@ -39,9 +39,6 @@ public class ExplodeWhenShot : NetworkBehaviour
 		registerTile = GetComponent<RegisterTile>();
 	}
 
-	//#if !ENABLE_PLAYMODE_TESTS_RUNNER
-	//	[Server]
-	//	#endif
 	public void ExplodeOnDamage(string damagedBy)
 	{
 		if (hasExploded)
@@ -57,9 +54,8 @@ public class ExplodeWhenShot : NetworkBehaviour
 		GoBoom();
 	}
 
-#if !ENABLE_PLAYMODE_TESTS_RUNNER
+
 	[Server]
-#endif
 	public void Explode(string thanksTo)
 	{
 		Vector2 explosionPos = transform.position;
@@ -89,6 +85,7 @@ public class ExplodeWhenShot : NetworkBehaviour
 				.ApplyDamage(pair.Key, pair.Value, DamageType.BURN);
 		}
 		RpcClientExplode();
+		gameObject.GetComponent<ObjectBehaviour>().visibleState = false;
 		StartCoroutine(WaitToDestroy());
 	}
 

--- a/UnityProject/Assets/Scripts/Steamworks.NET/SteamManager.cs
+++ b/UnityProject/Assets/Scripts/Steamworks.NET/SteamManager.cs
@@ -75,7 +75,7 @@ public class SteamManager : MonoBehaviour {
 			// Once you get a Steam AppID assigned by Valve, you need to replace AppId_t.Invalid with it and
 			// remove steam_appid.txt from the game depot. eg: "(AppId_t)480" or "new AppId_t(480)".
 			// See the Valve documentation for more information: https://partner.steamgames.com/doc/sdk/api#initialization_and_shutdown
-			if (SteamAPI.RestartAppIfNecessary(AppId_t.Invalid)) {
+			if (SteamAPI.RestartAppIfNecessary(new AppId_t(787180))) {
 				Application.Quit();
 				return;
 			}


### PR DESCRIPTION
### Purpose
- Enabled the "force run from steam" feature, to prevent people running non-up-to-date standalones
- fixed #894

### Approach
- Put in the appid into the steamworks.net manager
- Placed objectbehaviour on the canisters and triggered objectbehaviour.isvisible = false on the server before the 5 second times to destroy the game object, so it is networked-hidden before it is destroyed

### Open Questions and Pre-Merge TODOs

- [X]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes:
