### PR TITLE
Implemented click to eat and suicide shot

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V3(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V3(uNet).prefab
@@ -151,6 +151,7 @@ GameObject:
   - component: {fileID: 114600992077934460}
   - component: {fileID: 114285504268110804}
   - component: {fileID: 114803877374308862}
+  - component: {fileID: 114449635359748350}
   m_Layer: 8
   m_Name: Player_V3(uNet)
   m_TagString: Untagged
@@ -1388,6 +1389,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   eventName: leftHand
+--- !u!114 &114449635359748350
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1133514949248654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7694dd331aa6a4114bb8f0f996d2e71a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114457795912083674
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -60,23 +60,25 @@ public class PushPull : VisibleBehaviour
 	{
 		// PlayerManager.LocalPlayerScript.playerMove.pushPull.pulledBy == null condition makes sure that the player itself
 		// isn't being pulled. If he is then he is not allowed to pull anything else as this can cause problems
-		if (Input.GetKey(KeyCode.LeftControl) && PlayerManager.LocalPlayerScript.IsInReach(transform.position) &&
-			transform != PlayerManager.LocalPlayerScript.transform && PlayerManager.LocalPlayerScript.playerMove.pushPull.pulledBy == null) {
-			if(PlayerManager.LocalPlayerScript.playerSync.pullingObject != null && 
-			   PlayerManager.LocalPlayerScript.playerSync.pullingObject != gameObject){
-				PlayerManager.LocalPlayerScript.playerNetworkActions.CmdStopPulling(PlayerManager.LocalPlayerScript.playerSync.pullingObject);
-			}
-
-			if (pulledBy == PlayerManager.LocalPlayer) {
-				CancelPullBehaviour();
-			} else {
-				CancelPullBehaviour();
-				PlayerManager.LocalPlayerScript.playerNetworkActions.CmdPullObject(gameObject);
-				//Predictive pull:
-				if (customNetTransform != null) {
-					customNetTransform.enabled = false;
+		if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.LeftCommand)){
+			if (PlayerManager.LocalPlayerScript.IsInReach(transform.position) &&
+				transform != PlayerManager.LocalPlayerScript.transform && PlayerManager.LocalPlayerScript.playerMove.pushPull.pulledBy == null) {
+				if (PlayerManager.LocalPlayerScript.playerSync.pullingObject != null &&
+				   PlayerManager.LocalPlayerScript.playerSync.pullingObject != gameObject) {
+					PlayerManager.LocalPlayerScript.playerNetworkActions.CmdStopPulling(PlayerManager.LocalPlayerScript.playerSync.pullingObject);
 				}
-				PlayerManager.LocalPlayerScript.playerSync.pullingObject = gameObject;
+
+				if (pulledBy == PlayerManager.LocalPlayer) {
+					CancelPullBehaviour();
+				} else {
+					CancelPullBehaviour();
+					PlayerManager.LocalPlayerScript.playerNetworkActions.CmdPullObject(gameObject);
+					//Predictive pull:
+					if (customNetTransform != null) {
+						customNetTransform.enabled = false;
+					}
+					PlayerManager.LocalPlayerScript.playerSync.pullingObject = gameObject;
+				}
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
@@ -225,6 +225,16 @@ namespace PlayGroups.Input
 					if (objectBehaviour.visibleState)
 					{
 						inputTrigger.Trigger(position);
+
+						//FIXME currently input controller only uses the first InputTrigger found on an object
+						/////// some objects have more then 1 input trigger, like players for example
+						/////// below is a solution that should be removed when InputController is refactored
+						/////// to support multiple InputTriggers on the target object
+						if (inputTrigger.gameObject.layer == 8) {
+							//This is a player. Attempt to use the player based inputTrigger
+							P2PInteractions playerInteractions = inputTrigger.gameObject.GetComponent<P2PInteractions>();
+							playerInteractions.Trigger(position);
+						}
 						return true;
 					}
 					//Allow interact with cupboards we are inside of!

--- a/UnityProject/Assets/Scripts/PlayGroups/P2PInteractions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/P2PInteractions.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using PlayGroups.Input;
+using UI;
+using Weapons;
+
+namespace PlayGroup
+{
+	/// <summary>
+	/// Player 2 Player interactions. Also used for clicking on yourself
+	/// </summary>
+	public class P2PInteractions : InputTrigger
+	{
+		public override void Interact(GameObject originator, Vector3 position, string hand)
+		{
+			if(Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.LeftCommand)){
+				return;
+			}
+
+			if(UIManager.Hands.CurrentSlot.Item != null){
+				//Is the item edible?
+				if(CheckEdible(UIManager.Hands.CurrentSlot.Item)){
+					return;
+				}
+
+				//Is it a weapon/ballistic or specific hand to hand melee combat with weapons?
+				if(CheckWeapon(UIManager.Hands.CurrentSlot.Item)){
+					return;
+				}
+			}
+		}
+
+		private bool CheckEdible(GameObject itemInHand)
+		{
+			FoodBehaviour baseFood = itemInHand.GetComponent<FoodBehaviour>();
+			if (baseFood == null){
+				return false;
+			} 
+
+			if(PlayerManager.LocalPlayer == gameObject){
+				//Clicked on yourself, try to eat the food
+				baseFood.TryEat();
+			} else {
+				//Clicked on someone else
+				//TODO create a new method on FoodBehaviour for feeding others
+				//and use that here
+			}
+			return true;
+		}
+
+		private bool CheckWeapon(GameObject itemInHand){
+			Weapon weapon = itemInHand.GetComponent<Weapon>();
+			if(weapon == null){
+				return false;
+			}
+
+			if (PlayerManager.LocalPlayer == gameObject) {
+				//You no longer have the desire to live
+				weapon.AttemptSuicideShot();
+			} else {
+				//Someone else
+				//TODO any hand to hand specifics or intent based fighting here
+				weapon.Trigger();
+			}
+			return true;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/PlayGroups/P2PInteractions.cs.meta
+++ b/UnityProject/Assets/Scripts/PlayGroups/P2PInteractions.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 7694dd331aa6a4114bb8f0f996d2e71a
+timeCreated: 1517102967
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
@@ -6,6 +6,7 @@ public abstract class BulletBehaviour : MonoBehaviour
 	public int damage = 25;
 	public GameObject shooter;
 	public DamageType damageType;
+	public bool isSuicide = false;
 
 	private Rigidbody2D thisRigi;
 	//	public BodyPartType BodyPartAim { get; private set; };
@@ -39,7 +40,12 @@ public abstract class BulletBehaviour : MonoBehaviour
 	private void OnTriggerEnter2D(Collider2D coll)
 	{
 		HealthBehaviour damageable = coll.GetComponent<HealthBehaviour>();
-		if (damageable == null || damageable.IsDead || coll.gameObject == shooter)
+
+		if(coll.gameObject == shooter && !isSuicide){
+			return;
+		}
+
+		if (damageable == null || damageable.IsDead)
 		{
 			return;
 		}

--- a/UnityProject/Assets/Scripts/Weapons/Weapon.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Weapon.cs
@@ -274,7 +274,7 @@ namespace Weapons
 		public override void Interact(GameObject originator, Vector3 position, string hand)
 		{
 			//todo: validate fire attempts on server
-			if (Input.GetKey(KeyCode.LeftControl))
+			if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.LeftCommand))
 			{
 				return;
 			}
@@ -290,7 +290,16 @@ namespace Weapons
 			}
 		}
 
-		private void AttemptToFireWeapon()
+		public void AttemptSuicideShot(){
+			//Hand slot checks are already done before calling this method (i.e. is weapon in current hand)
+			if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.LeftCommand)) {
+				return;
+			}
+
+			AttemptToFireWeapon(true);
+		}
+
+		private void AttemptToFireWeapon(bool suicideShot = false)
 		{
 			//ignore if we are hovering over UI
 			if (EventSystem.current.IsPointerOverGameObject())
@@ -324,7 +333,7 @@ namespace Weapons
 						Vector2 dir = (Camera.main.ScreenToWorldPoint(Input.mousePosition) - PlayerManager.LocalPlayer.transform.position).normalized;
 						PlayerScript lps = PlayerManager.LocalPlayerScript;
 						lps.weaponNetworkActions.CmdShootBullet(gameObject, CurrentMagazine.gameObject, dir, Projectile.name,
-							UIManager.DamageZone /*PlayerScript.SelectedDamageZone*/);
+						                                        UIManager.DamageZone /*PlayerScript.SelectedDamageZone*/, suicideShot);
 						if (WeaponType == WeaponType.FullyAutomatic)
 						{
 							lps.inputController.OnMouseDownDir(dir);

--- a/UnityProject/Assets/Scripts/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Weapons/WeaponNetworkActions.cs
@@ -60,7 +60,7 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 
 	[Command]
 	public void CmdShootBullet(GameObject weapon, GameObject magazine, Vector2 direction, string bulletName,
-		BodyPartType damageZone)
+		BodyPartType damageZone, bool isSuicideShot)
 	{
 		if (!playerMove.allowInput || playerMove.isGhost)
 		{
@@ -86,6 +86,7 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 		}
 
 		BulletBehaviour b = bullet.GetComponent<BulletBehaviour>();
+		b.isSuicide = isSuicideShot;
 		b.Shoot(direction, angle, gameObject, damageZone);
 
 		//add additional recoil after shooting for the next round


### PR DESCRIPTION
### Purpose
- Too allow the ability to click on yourself to eat instead of using Use key
- Allow the ability to shoot yourself and to determine if a shot is a suicide shot or a normal shot

### Approach
- Created a new root level component on the Player prefab to handle Player 2 Player interactions (P2PInteractions.cs)
- This now checks if you have clicked on yourself or someone else and can be used for behaviour customization. Can also easily be used to quickly implement hand to hand actions based on the players current intent along with all of the expected behaviours (punching, hugging, pushing over, disarm, strangle hold etc)
- P2PInteractions will most likely be used in surgery and medical based actions as well

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
At somepoint InputController will need a refactor to handle multiple InputTriggers on one object. Have put a FIXME where I needed to add special case for P2PInteractions