### PR TITLE
Fixed diagonal movement for the player

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -31,7 +31,7 @@ namespace Tilemaps.Scripts.Behaviours.Layers
 			}
 			return true;
 		}
-
+		//TODO:  Remove this
 		public bool IsPassableAt(Vector3Int position)
 		{
 			foreach (Layer layer in Layers.Values)
@@ -43,7 +43,7 @@ namespace Tilemaps.Scripts.Behaviours.Layers
 			}
 			return true;
 		}
-
+		//TODO:  Refactor to take origin and destination
 		public bool IsAtmosPassableAt(Vector3Int position)
 		{
 			foreach (Layer layer in Layers.Values)

--- a/UnityProject/Assets/Scripts/Tilemaps/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Matrix.cs
@@ -5,6 +5,7 @@ using Tilemaps.Scripts.Behaviours.Layers;
 using Tilemaps.Scripts.Tiles;
 using Tilemaps.Scripts.Utils;
 using UnityEngine;
+using System;
 
 namespace Tilemaps
 {
@@ -28,14 +29,44 @@ namespace Tilemaps
 
 		public bool IsPassableAt(Vector3Int origin, Vector3Int position)
 		{
-			return metaTileMap.IsPassableAt(origin, position);
+			if(origin.z != position.z)
+			{
+				//Uhhhhhh, error handling goes here?
+				return false;
+			}
+			//Check if it's a diagonal move
+			Vector3Int diff = position - origin;
+			int diffSum = diff.x + diff.y;
+			//Somewhat hacky way to get if it's diagonal, but it works
+			if(Math.Abs(diffSum) != 1)
+			{
+				//This is a DIAGONAL MOVEMENT!  Now we have to do four checks.
+				//This is confusing, basically there are two ways to travel diagonally so we have to check both of them
+				bool passable = true;
+				passable &= metaTileMap.IsPassableAt(origin, new Vector3Int(origin.x + diff.x, origin.y, origin.z));
+				passable &= metaTileMap.IsPassableAt(new Vector3Int(origin.x + diff.x, origin.y, origin.z), 
+					new Vector3Int(origin.x + diff.x, origin.y + diff.y, origin.z));
+				if(passable)
+				{
+					return passable;
+				}
+				passable = true;
+				passable &= metaTileMap.IsPassableAt(origin, new Vector3Int(origin.x, origin.y + diff.y, origin.z));
+				passable &= metaTileMap.IsPassableAt(new Vector3Int(origin.x, origin.y + diff.y, origin.z),
+					new Vector3Int(origin.x + diff.x, origin.y + diff.y, origin.z));
+				return passable;
+			}
+			else
+			{
+				return metaTileMap.IsPassableAt(origin, position);
+			}
 		}
-
+		//TODO:  This should be removed, due to windows mucking things up, and replaced with origin and position
 		public bool IsPassableAt(Vector3Int position)
 		{
 			return metaTileMap.IsPassableAt(position);
 		}
-
+		//TODO:  This should also be removed, due to windows mucking things up, and replaced with origin and position
 		public bool IsAtmosPassableAt(Vector3Int position)
 		{
 			return metaTileMap.IsAtmosPassableAt(position);


### PR DESCRIPTION
### Purpose
Fixes diagonal movement, now the player will check to make sure it's valid movement
Fixes #801 

### Approach
I made the diagonal check become four checks.  Moving diagonally is technically two moves, and there are two ways to get there, so four checks in total to see if it's a valid move.

### Open Questions and Pre-Merge TODOs

- [X ]  I read the contribution guidelines and the wiki.
- [X ]  This fix is tested on the same branch it is PR'ed to.
- [X ]  I correctly commented my code
- [X ]  This PR does not include files without specific need to do so.
- [X ]  This PR does not bring up any new compile errors
- [X ]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer



### Notes:
Was not tested in multiplayer, I don't actually know how to do that.