### PR TITLE
Steam Auth & Kick; Chat bug squash

### DIFF
--- a/UnityProject/Assets/Scripts/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Equipment/Equipment.cs
@@ -214,7 +214,7 @@ namespace Equipment
 				}
 				else if (!string.IsNullOrEmpty(gearItem.Value))
 				{
-					Debug.Log(gearItem.Value + " creation not implemented yet.");
+//					Debug.Log(gearItem.Value + " creation not implemented yet.");
 				}
 			}
 			SpawnID(jobOutfit);

--- a/UnityProject/Assets/Scripts/Health/Living/PlayerHealth.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/PlayerHealth.cs
@@ -222,7 +222,7 @@ namespace PlayGroup
 
 				ConnectedPlayer player = PlayerList.Instance.Get(gameObject);
 				
-				string killerName = "stressfull work";
+				string killerName = "Stressful work";
 				if (LastDamagedBy != null)
 				{
 					killerName = PlayerList.Instance.Get(LastDamagedBy).Name;

--- a/UnityProject/Assets/Scripts/Managers/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Managers/ChatRelay.cs
@@ -70,16 +70,12 @@ public class ChatRelay : NetworkBehaviour
 	[Server]
 	private void PropagateChatToClients(ChatEvent chatEvent)
 	{
-		PlayerScript[] players = FindObjectsOfType<PlayerScript>();
-
-		for (int i = 0; i < players.Length; i++)
+		var players = PlayerList.Instance.InGamePlayers;
+		for ( var i = 0; i < players.Count; i++ )
 		{
-			//Make sure we're not sending to inactive players
-			if (players[i].playerMove.allowInput)
-			{
-				ChatChannel channels = players[i].GetAvailableChannelsMask(false) & chatEvent.channels;
-				UpdateChatMessage.Send(players[i].gameObject, channels, chatEvent.message);
-			}
+			var playerScript = players[i].GameObject.GetComponent<PlayerScript>();
+			ChatChannel channels = playerScript.GetAvailableChannelsMask( false ) & chatEvent.channels;
+			UpdateChatMessage.Send( players[i].GameObject, channels, chatEvent.message );
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
+++ b/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
@@ -1,0 +1,148 @@
+﻿using UnityEngine;
+using UnityEngine.Networking;
+
+/// Server-only full player information class
+public class ConnectedPlayer
+{
+    private string name;
+    private JobType job;
+    private ulong steamId;
+    private GameObject gameObject;
+    private NetworkConnection connection;
+
+    public bool IsAuthenticated => steamId != 0;
+
+    public static readonly ConnectedPlayer Invalid = new ConnectedPlayer
+    {
+        connection = new NetworkConnection(),
+        gameObject = null,
+        name = "kek",
+        job = JobType.NULL,
+        steamId = 0
+    };
+
+    public static ConnectedPlayer ArchivedPlayer( ConnectedPlayer player )
+    {
+        return new ConnectedPlayer
+        {
+            connection = Invalid.Connection,
+            gameObject = player.GameObject,
+            name = player.Name,
+            job = player.Job,
+            steamId = player.SteamId
+        };
+    }
+
+    public NetworkConnection Connection
+    {
+        get { return connection; }
+        set { connection = value ?? Invalid.Connection; }
+    }
+
+    public GameObject GameObject
+    {
+        get { return gameObject; }
+        set
+        {
+            if ( PlayerList.Instance != null && gameObject )
+            {
+                //Add to history if player had different body previously
+                PlayerList.Instance.AddPrevious( this );
+            }
+            gameObject = value;
+        }
+    }
+
+    public string Name
+    {
+        get { return name; }
+        set
+        {
+            TryChangeName(value);
+            TrySendUpdate();
+        }
+    }
+
+    public ulong SteamId
+    {
+        get { return steamId; }
+        set
+        {
+            if ( value != 0 )
+            {
+                steamId = value;
+                Debug.Log( $"Updated steamID! {this}" );
+            }
+        }
+    }
+
+    public JobType Job
+    {
+        get { return job; }
+        set
+        {
+            job = value;
+            TrySendUpdate();
+        }
+    }
+
+    public bool HasNoName()
+    {
+        return name == null || name.Trim().Equals("");
+    }
+
+    private void TryChangeName(string playerName)
+    {
+        if ( playerName == null || playerName.Trim().Equals("") || name == playerName )
+        {
+            return;
+        }
+        var playerList = PlayerList.Instance;
+        if ( playerList == null )
+        {
+//			Debug.Log("PlayerList not instantiated, setting name blindly");
+            name = playerName;
+            return;
+        }
+
+        string uniqueName = GetUniqueName(playerName);
+        name = uniqueName;
+		
+//        if ( !playerList.playerScores.ContainsKey(uniqueName) )
+//        {
+//            playerList.playerScores.Add(uniqueName, 0);
+//        }
+    }
+
+    /// Generating a unique name (Player -> Player2 -> Player3 ...)
+    private static string GetUniqueName(string name, int sameNames = 0)
+    {
+        string proposedName = name;
+        if ( sameNames != 0 )
+        {
+            proposedName = $"{name}{sameNames + 1}";
+            Debug.Log($"TRYING: {proposedName}");
+        }
+        if ( PlayerList.Instance.ContainsName(proposedName) )
+        {
+            Debug.Log($"NAME ALREADY EXISTS: {proposedName}");
+            sameNames++;
+            return GetUniqueName(name, sameNames);
+        }
+
+        return proposedName;
+    }
+
+    private static void TrySendUpdate()
+    {
+        if ( CustomNetworkManager.Instance != null && CustomNetworkManager.Instance._isServer && PlayerList.Instance != null )
+        {
+            UpdateConnectedPlayersMessage.Send();
+        }
+    }
+
+    public override string ToString()
+    {
+        return $"[conn={Connection.connectionId}|go={gameObject}|name='{name}'|job={job}|steamId={steamId}]";
+    }
+}

--- a/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs.meta
+++ b/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f24420451ffa47f88887c3500cda70e2
+timeCreated: 1517087053

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -97,7 +97,7 @@ public class CustomNetworkManager : NetworkManager
 
 	private void OnDisable()
 	{
-		if (_isServer && server.IsValid)
+		if (_isServer && server != null && server.IsValid)
 		{
 			server.Auth.OnAuthChange += AuthChange;
 		}
@@ -151,17 +151,23 @@ public class CustomNetworkManager : NetworkManager
 
 	}
 	
-
-// This method processes the callback data when authentication statuses change
-public void AuthChange(ulong steamid, ulong ownerid, ServerAuth.Status status)
-{
-	Debug.Log( $"steamid: {steamid}, ownerid: {ownerid}, status: {status}" );
-}
+	/// Processes the callback data when authentication statuses change
+	public void AuthChange(ulong steamid, ulong ownerid, ServerAuth.Status status)
+	{
+		Debug.Log( $"steamid: {steamid}, ownerid: {ownerid}, status: {status}" );
+	}
+	
 	public static void Kick( ConnectedPlayer player, string raisins="4 no raisins" )
 	{
-		Debug.Log( $"Kicking {player}" );
-		PostToChatMessage.Send($"{player.Name} got kicked: {raisins}", ChatChannel.System);
-//		player.Connection.Disconnect();
+		if ( !player.Connection.isConnected )
+		{
+			Debug.Log($"Not kicking, already disconnected: {player}");
+			return;
+		}
+		Debug.Log( $"Kicking {player} : {raisins}" );
+		PostToChatMessage.Send($"Player '{player.Name}' got kicked: {raisins}", ChatChannel.System);
+		player.Connection.Disconnect();
+		player.Connection.Dispose();
 	}
 
 

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -155,14 +155,14 @@ public class CustomNetworkManager : NetworkManager
 // This method processes the callback data when authentication statuses change
 public void AuthChange(ulong steamid, ulong ownerid, ServerAuth.Status status)
 {
-	//TODO Add function to authentication and set persistent authentication flag on player.
-	bool Authed;
-	Authed = status == ServerAuth.Status.OK;
-
-	Debug.Log( "steamid: {0}" + steamid );
-	Debug.Log( "ownerid: {0}" + ownerid );
-	Debug.Log( "status: {0}" + status );
+	Debug.Log( $"steamid: {steamid}, ownerid: {ownerid}, status: {status}" );
 }
+	public static void Kick( ConnectedPlayer player, string raisins="4 no raisins" )
+	{
+		Debug.Log( $"Kicking {player}" );
+		PostToChatMessage.Send($"{player.Name} got kicked: {raisins}", ChatChannel.System);
+//		player.Connection.Disconnect();
+	}
 
 
 	public override void OnServerAddPlayer(NetworkConnection conn, short playerControllerId)

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -192,15 +192,15 @@ public class PlayerList : NetworkBehaviour
 		else
 		{
 			values.Add(player);
-
 			Debug.Log($"Added {player}. Total:{values.Count}; {string.Join("; ",values)}");
+			//Adding kick timer for new players only
+			StartCoroutine(KickTimer(player));
 		}
-		StartCoroutine(KickTimer(player));
 	}
 
 	private IEnumerator KickTimer(ConnectedPlayer player)
 	{
-		if ( IsConnWhitelisted( player ))
+		if ( IsConnWhitelisted( player ) || !Managers.instance.isForRelease )
 		{
 //			Debug.Log( "Ignoring kick timer for invalid connection" );
 			yield break;
@@ -208,10 +208,9 @@ public class PlayerList : NetworkBehaviour
 		int tries = 5;
 		while ( !player.IsAuthenticated )
 		{			
-			if ( tries-- < 1 )
+			if ( tries-- < 0 )
 			{
-				Debug.LogWarning( $"KickTimer: Failed to auth, kicking {player}" );
-				CustomNetworkManager.Kick( player );
+				CustomNetworkManager.Kick( player, "Auth timed out" );
 				yield break;
 			}
 			yield return YieldHelper.Second;
@@ -222,7 +221,7 @@ public class PlayerList : NetworkBehaviour
 	{
 		return player.Connection == null || 
 		       player.Connection == ConnectedPlayer.Invalid.Connection ||
-		       player.Connection.connectionId.Equals( -1 ) ||
+//		       player.Connection.connectionId.Equals( -1 ) ||
 //		       player.Connection.connectionId.Equals( 0 ) || //Serverplayer connection
 		       !player.Connection.isConnected;
 	}

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -13,13 +14,14 @@ public class PlayerList : NetworkBehaviour
 {
 	//ConnectedPlayer list, server only
 	private static List<ConnectedPlayer> values = new List<ConnectedPlayer>();
-	
+	private static List<ConnectedPlayer> oldValues = new List<ConnectedPlayer>();
+
 	//For client needs: updated via UpdateConnectedPlayersMessage, useless for server
 	public List<ClientConnectedPlayer> ClientConnectedPlayers = new List<ClientConnectedPlayer>();
 
 	public static PlayerList Instance;
 	public int ConnectionCount => values.Count;
-	public int PlayerCount => values.FindAll(player => player.GameObject != null).Count;
+	public List<ConnectedPlayer> InGamePlayers => values.FindAll( player => player.GameObject != null );
 
 	//For TDM demo
 	public Dictionary<JobDepartment, int> departmentScores = new Dictionary<JobDepartment, int>();
@@ -28,16 +30,7 @@ public class PlayerList : NetworkBehaviour
 	public Dictionary<string, int> playerScores = new Dictionary<string, int>();
 
 	//For job formatting purposes
-
 	private static readonly TextInfo textInfo = new CultureInfo("en-US", false).TextInfo;
-
-	public static readonly ConnectedPlayer InvalidConnectedPlayer = new ConnectedPlayer
-	{
-		Connection = new NetworkConnection(),
-		GameObject = null,
-		Name = "kek",
-		Job = JobType.NULL
-	};
 
 	private void Awake()
 	{
@@ -60,7 +53,7 @@ public class PlayerList : NetworkBehaviour
 			return;
 		}
 
-		var playerName = Get(perpetrator).Name;
+		var playerName = Get(perpetrator, true).Name;
 		if ( playerScores.ContainsKey(playerName) )
 		{
 			playerScores[playerName]++;
@@ -89,6 +82,15 @@ public class PlayerList : NetworkBehaviour
 		else
 		{
 			departmentScores[perpetratorDept]++;
+		}
+	}
+
+	[Server]
+	public void TryAddScores(string uniqueName)
+	{
+		if ( !playerScores.ContainsKey(uniqueName) )
+		{
+			playerScores.Add(uniqueName, 0);
 		}
 	}
 
@@ -150,12 +152,20 @@ public class PlayerList : NetworkBehaviour
 		connectedPlayer.GameObject = newGameObject;
 	}
 
+	/// Add previous ConnectedPlayer state to the old values list
+	/// So that you could find owner of the long dead body GameObject
+	[Server]
+	public void AddPrevious( ConnectedPlayer oldPlayer )
+	{
+		oldValues.Add( ConnectedPlayer.ArchivedPlayer( oldPlayer ) );
+	}
+
 	//filling a struct without connections and gameobjects for client's ClientConnectedPlayers list
 	public List<ClientConnectedPlayer> ClientConnectedPlayerList =>
 		values.Aggregate(new List<ClientConnectedPlayer>(), (list, player) =>
 		{
 			//not including headless server player
-			if ( !GameData.IsHeadlessServer || player.Connection != InvalidConnectedPlayer.Connection )
+			if ( !GameData.IsHeadlessServer || player.Connection != ConnectedPlayer.Invalid.Connection )
 			{
 				list.Add(new ClientConnectedPlayer {Name = player.Name, Job = player.Job});
 			}
@@ -165,7 +175,7 @@ public class PlayerList : NetworkBehaviour
 	[Server]
 	private void TryAdd(ConnectedPlayer player)
 	{
-		if ( player.Equals(InvalidConnectedPlayer) )
+		if ( player.Equals(ConnectedPlayer.Invalid) )
 		{
 			Debug.Log("Refused to add invalid connected player");
 			return;
@@ -177,6 +187,7 @@ public class PlayerList : NetworkBehaviour
 			existingPlayer.GameObject = player.GameObject;
 			existingPlayer.Name = player.Name; //Note that name won't be changed to empties/nulls
 			existingPlayer.Job = player.Job;
+			existingPlayer.SteamId = player.SteamId;
 		}
 		else
 		{
@@ -184,7 +195,36 @@ public class PlayerList : NetworkBehaviour
 
 			Debug.Log($"Added {player}. Total:{values.Count}; {string.Join("; ",values)}");
 		}
-		
+		StartCoroutine(KickTimer(player));
+	}
+
+	private IEnumerator KickTimer(ConnectedPlayer player)
+	{
+		if ( IsConnWhitelisted( player ))
+		{
+//			Debug.Log( "Ignoring kick timer for invalid connection" );
+			yield break;
+		}
+		int tries = 5;
+		while ( !player.IsAuthenticated )
+		{			
+			if ( tries-- < 1 )
+			{
+				Debug.LogWarning( $"KickTimer: Failed to auth, kicking {player}" );
+				CustomNetworkManager.Kick( player );
+				yield break;
+			}
+			yield return YieldHelper.Second;
+		}
+	}
+
+	public static bool IsConnWhitelisted( ConnectedPlayer player )
+	{
+		return player.Connection == null || 
+		       player.Connection == ConnectedPlayer.Invalid.Connection ||
+		       player.Connection.connectionId.Equals( -1 ) ||
+//		       player.Connection.connectionId.Equals( 0 ) || //Serverplayer connection
+		       !player.Connection.isConnected;
 	}
 
 	[Server]
@@ -192,6 +232,7 @@ public class PlayerList : NetworkBehaviour
 	{
 		Debug.Log($"Removed {player}");
 		values.Remove(player);
+		AddPrevious( player );
 		NetworkServer.Destroy(player.GameObject);
 		UpdateConnectedPlayersMessage.Send();
 	}
@@ -201,40 +242,40 @@ public class PlayerList : NetworkBehaviour
 
 	public bool ContainsConnection(NetworkConnection connection)
 	{
-		return !Get(connection).Equals(InvalidConnectedPlayer);
+		return !Get(connection).Equals(ConnectedPlayer.Invalid);
 	}
 	
 	[Server]
 	public bool ContainsName(string name)
 	{
-		return !Get(name).Equals(InvalidConnectedPlayer);
+		return !Get(name).Equals(ConnectedPlayer.Invalid);
 	}
 	
 	[Server]
 	public bool ContainsGameObject(GameObject gameObject)
 	{
-		return !Get(gameObject).Equals(InvalidConnectedPlayer);
+		return !Get(gameObject).Equals(ConnectedPlayer.Invalid);
 	}
 	
 	[Server]
-	public ConnectedPlayer Get(NetworkConnection byConnection)
+	public ConnectedPlayer Get(NetworkConnection byConnection, bool lookupOld = false)
 	{
-		return getInternal(player => player.Connection == byConnection);
+		return getInternal(player => player.Connection == byConnection, lookupOld);
 	}
 	
 	[Server]
-	public ConnectedPlayer Get(string byName)
+	public ConnectedPlayer Get(string byName, bool lookupOld = false)
 	{
-		return getInternal(player => player.Name == byName);
+		return getInternal(player => player.Name == byName, lookupOld);
 	}
 	
 	[Server]
-	public ConnectedPlayer Get(GameObject byGameObject)
+	public ConnectedPlayer Get(GameObject byGameObject, bool lookupOld = false)
 	{
-		return getInternal(player => player.GameObject == byGameObject);
+		return getInternal(player => player.GameObject == byGameObject, lookupOld);
 	}
 
-	private ConnectedPlayer getInternal(Func<ConnectedPlayer,bool> condition)
+	private ConnectedPlayer getInternal(Func<ConnectedPlayer,bool> condition, bool lookupOld = false)
 	{
 		for ( var i = 0; i < values.Count; i++ )
 		{
@@ -243,15 +284,26 @@ public class PlayerList : NetworkBehaviour
 				return values[i];
 			}
 		}
+		if ( lookupOld )
+		{
+			for ( var i = 0; i < oldValues.Count; i++ )
+			{
+				if ( condition(oldValues[i]) )
+				{
+					Debug.Log( $"Returning old player {oldValues[i]}" );
+					return oldValues[i];
+				}
+			}
+		}
 
-		return InvalidConnectedPlayer;
+		return ConnectedPlayer.Invalid;
 	}
 
 	[Server]
 	public void Remove(NetworkConnection connection)
 	{
 		ConnectedPlayer connectedPlayer = Get(connection);
-		if ( connectedPlayer.Equals(InvalidConnectedPlayer) )
+		if ( connectedPlayer.Equals(ConnectedPlayer.Invalid) )
 		{
 			Debug.LogError($"Cannot remove by {connection}, not found");
 		}
@@ -271,96 +323,5 @@ public struct ClientConnectedPlayer
 	public override string ToString()
 	{
 		return $"[{nameof( Name )}='{Name}', {nameof( Job )}={Job}]";
-	}
-}
-
-/// Server-only full player information class
-public class ConnectedPlayer
-{
-	private string name;
-	private JobType job;
-
-	public NetworkConnection Connection { get; set; }
-
-	public GameObject GameObject { get; set; }
-
-	public string Name
-	{
-		get { return name; }
-		set
-		{
-			TryChangeName(value);
-			TrySendUpdate();
-		}
-	}
-
-	public JobType Job
-	{
-		get { return job; }
-		set
-		{
-			job = value;
-			TrySendUpdate();
-		}
-	}
-
-	public bool HasNoName()
-	{
-		return name == null || name.Trim().Equals("");
-	}
-
-	private void TryChangeName(string playerName)
-	{
-		if ( playerName == null || playerName.Trim().Equals("") || name == playerName )
-		{
-			return;
-		}
-		var playerList = PlayerList.Instance;
-		if ( playerList == null )
-		{
-//			Debug.Log("PlayerList not instantiated, setting name blindly");
-			name = playerName;
-			return;
-		}
-
-		string uniqueName = GetUniqueName(playerName);
-		name = uniqueName;
-		
-		if ( !playerList.playerScores.ContainsKey(uniqueName) )
-		{
-			playerList.playerScores.Add(uniqueName, 0);
-		}
-	}
-
-	/// Generating a unique name (Player -> Player2 -> Player3 ...)
-	private static string GetUniqueName(string name, int sameNames = 0)
-	{
-		string proposedName = name;
-		if ( sameNames != 0 )
-		{
-			proposedName = $"{name}{sameNames + 1}";
-			Debug.Log($"TRYING: {proposedName}");
-		}
-		if ( PlayerList.Instance.ContainsName(proposedName) )
-		{
-			Debug.Log($"NAME ALREADY EXISTS: {proposedName}");
-			sameNames++;
-			return GetUniqueName(name, sameNames);
-		}
-
-		return proposedName;
-	}
-
-	private static void TrySendUpdate()
-	{
-		if ( CustomNetworkManager.Instance != null && CustomNetworkManager.Instance._isServer && PlayerList.Instance != null )
-		{
-			UpdateConnectedPlayersMessage.Send();
-		}
-	}
-
-	public override string ToString()
-	{
-		return $"[conn={Connection.connectionId}|go={GameObject.name}|name='{Name}'|job={Job}]";
 	}
 }

--- a/UnityProject/Assets/Scripts/Messages/Client/RequestAuthMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/RequestAuthMessage.cs
@@ -15,6 +15,12 @@ public class RequestAuthMessage : ClientMessage
 	{
 		//	Debug.Log("Processed " + ToString());
 		yield return WaitFor(SentBy);
+
+//		if ( !Managers.instance.isForRelease )
+//		{
+//			Debug.Log($"Ignoring {this}, not for release");
+//			yield break;
+//		}
 		
 		var connectedPlayer = PlayerList.Instance.Get( NetworkObject );
 
@@ -39,9 +45,8 @@ public class RequestAuthMessage : ClientMessage
 				// This can trigger for a lot of reasons
 				// More info: http://projectzomboid.com/modding//net/puppygames/steam/BeginAuthSessionResult.html
 				// if triggered does prevent the authchange callback.
-				Debug.Log("Start Session returned false, kicking");
-				//Kick
-				CustomNetworkManager.Kick( connectedPlayer );
+//				Debug.Log("Start Session returned false, kicking");
+				CustomNetworkManager.Kick( connectedPlayer, "Steam auth failed" );
 			}
 			else
 			{
@@ -66,7 +71,7 @@ public class RequestAuthMessage : ClientMessage
 
 	public override string ToString()
 	{
-		return string.Format("[RequestAuthMessage SteamID={0} TicketBinary={1} Type={2} SentBy={3}]", SteamID, TicketBinary, MessageType, SentBy);
+		return $"[RequestAuthMessage SteamID={SteamID} TicketBinary={TicketBinary} Type={MessageType} SentBy={SentBy}]";
 	}
 
 	public override void Deserialize(NetworkReader reader)

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
@@ -183,6 +183,7 @@ namespace PlayGroup
 					player.Name = name;
 				}
 				playerName = player.Name;
+				PlayerList.Instance.TryAddScores( player.Name );
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
@@ -132,6 +132,10 @@ namespace PlayGroup
 					// Send Clientmessage to authenticate
 					RequestAuthMessage.Send(Client.Instance.SteamId, ticketBinary);
 				}
+				else
+				{
+					Debug.Log("Client NOT requesting auth");
+				}
 				//Request sync to get all the latest transform data
 				new RequestSyncMessage().Send();
 				SelectedChannels = ChatChannel.Local;


### PR DESCRIPTION
### Purpose
Steam ID is now included in PlayerList;
If steam auth fails (bogus ID/Ticket or auth message timeout), player is getting kicked.
A couple of score/chat bugs that I've spotted in Beta 7 were fixed:
1) Dying from already dead person showed his name as 'kek' (invalid player)
2) Chat relay wasn't robust enough and player would still get service messages for dead bodies he owned previously

### Approach
Auth:
Added steamId field to ConnectedPlayer – it is being assigned only if StartSession returns true;
When player connects, KickTimer is added that waits for steamId to become non-zero.
Bugs:
1) Added a list of archived players in PlayerList (with old bodies and names), so that previous body owner could be looked up when adding scores etc.
2) Rewrote relay to reference PlayerList for active players

### Open Questions and Pre-Merge TODOs

- [ X ]  I read the contribution guidelines and the wiki.
- [ X ]  This fix is tested on the same branch it is PR'ed to.
- [ X ]  I correctly commented my code
- [ X ]  This PR does not include files without specific need to do so.
- [ X ]  This PR does not bring up any new compile errors
- [ X ]  This PR has been tested in editor
- [ X ]  This PR has been tested in multiplayer



### Notes:
Steam auth & kicks only work if isRelease flag is on