### PR TITLE
fixed NRE on client while putting things on the table

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Interaction/TableInteraction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Interaction/TableInteraction.cs
@@ -1,4 +1,5 @@
 ﻿using PlayGroup;
+using Tilemaps.Behaviours.Layers;
 using UI;
 using UnityEngine;
 
@@ -33,7 +34,7 @@ namespace Tilemaps.Behaviours.Interaction
 
 			Vector3 targetPosition = position;
 			targetPosition.z = -0.2f;
-			ps.playerNetworkActions.CmdPlaceItem(hand, targetPosition, gameObject);
+			ps.playerNetworkActions.CmdPlaceItem(hand, targetPosition, gameObject.GetComponentInChildren<ObjectLayer>().gameObject);
 
 			item.BroadcastMessage("OnRemoveFromInventory", null, SendMessageOptions.DontRequireReceiver);
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TileTrigger.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TileTrigger.cs
@@ -27,7 +27,7 @@ namespace Tilemaps.Behaviours
 
 			if (tile?.TileType == TileType.Table)
 			{
-				TableInteraction interaction = new TableInteraction(objectLayer.gameObject, originator, position, hand);
+				TableInteraction interaction = new TableInteraction(gameObject, originator, position, hand);
 
 				interaction.Interact(isServer);
 			}


### PR DESCRIPTION
### Purpose
fixes #951

### Approach
Client used a GameObject without netid when sending a InteractMessage. Leading to an NRE.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer