### PR TITLE
Modified AdjustedDirection to recognize replay moves

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.cs
@@ -294,17 +294,20 @@ namespace PlayGroup
 
 		private void UpdatePredictedState()
 		{
+			int curPredictedMove = predictedState.MoveNumber;
 			predictedState = serverState;
 
 			foreach (PlayerAction action in pendingActions)
 			{
-				predictedState = NextState(predictedState, action);
+				//isReplay determines if this action is a replayed action for use in the prediction system
+				bool isReplay = predictedState.MoveNumber <= curPredictedMove;
+				predictedState = NextState(predictedState, action, isReplay);
 			}
 		}
 
-		private PlayerState NextState(PlayerState state, PlayerAction action)
+		private PlayerState NextState(PlayerState state, PlayerAction action, bool isReplay = false)
 		{
-			return new PlayerState {MoveNumber = state.MoveNumber + 1, Position = playerMove.GetNextPosition(Vector3Int.RoundToInt(state.Position), action)};
+			return new PlayerState {MoveNumber = state.MoveNumber + 1, Position = playerMove.GetNextPosition(Vector3Int.RoundToInt(state.Position), action, isReplay)};
 		}
 
 		public void PullReset(NetworkInstanceId netID)


### PR DESCRIPTION
- When replaying moves due to the serverState being behind the predictedState all of the matrix checks are done again while the player is no longer at the positions it is checking from. Separated AdjustedDirection to do certain checks when it is a replay action or not. The lerp back problems of high lag players mentioned in #961 has been resolved but it exposes a lot of problems with Matrix Detection and Object pulling

### Purpose
Fixes #961

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
Exposes underlying problems with PushPull and Matrix detection