### PR TITLE
Space death fix

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/Managers.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/Managers.prefab
@@ -1107,7 +1107,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1243512860933058
 GameObject:
   m_ObjectHideFlags: 1
@@ -4649,6 +4649,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1983452292246396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4641742551827622}
+  - component: {fileID: 114676576630493308}
+  m_Layer: 0
+  m_Name: MatrixManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1986731150394052
 GameObject:
   m_ObjectHideFlags: 1
@@ -4973,6 +4989,7 @@ Transform:
   - {fileID: 4129075814513284}
   - {fileID: 4067831875969682}
   - {fileID: 4637464727519376}
+  - {fileID: 4641742551827622}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5272,6 +5289,19 @@ Transform:
   m_Children: []
   m_Father: {fileID: 4244501537706558}
   m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4641742551827622
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1983452292246396}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1148.4224, y: 560.7722, z: -4.7243342}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4244501537706558}
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4646995138993998
 Transform:
@@ -16177,6 +16207,17 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
+--- !u!114 &114676576630493308
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1983452292246396}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1caf0503a858a4b429b80e9460273066, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114676995396685792
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -21185,8 +21226,8 @@ RectTransform:
   m_Father: {fileID: 224965466132211624}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 0.00000011920929}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -21852,9 +21893,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -25.799988, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!224 &224256534148621476
 RectTransform:
@@ -22719,8 +22760,8 @@ RectTransform:
   m_Father: {fileID: 224679394288512756}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 0.021276593}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 641, y: NaN}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -23712,7 +23753,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0.00012207031}
+  m_AnchoredPosition: {x: 0, y: -0.000076293945}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!224 &224653293278829958
@@ -25341,14 +25382,12 @@ VideoPlayer:
   m_DataSource: 0
   m_PlaybackSpeed: 1
   m_AudioOutputMode: 2
-  m_TargetAudioSources:
-  - {fileID: 0}
-  m_DirectAudioVolumes:
-  - 1
+  m_TargetAudioSources: []
+  m_DirectAudioVolumes: []
   m_Url: treamable.com/0st1g
-  m_EnabledAudioTracks: 01
-  m_DirectAudioMutes: 00
-  m_ControlledAudioTrackCount: 1
+  m_EnabledAudioTracks: 
+  m_DirectAudioMutes: 
+  m_ControlledAudioTrackCount: 0
   m_PlayOnAwake: 1
   m_SkipOnDrop: 1
   m_Looping: 0

--- a/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
+++ b/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
@@ -46455,6 +46455,7 @@ GameObject:
   - component: {fileID: 515577132}
   - component: {fileID: 515577134}
   - component: {fileID: 515577135}
+  - component: {fileID: 515577136}
   m_Layer: 0
   m_Name: SyndicateShuttle
   m_TagString: Untagged
@@ -46544,6 +46545,17 @@ MonoBehaviour:
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1629061c87b84efca254e0716499651e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &515577136
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 515577130}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf585bb4ff8944df896c3974105a1d53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &520179358

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.Server.cs
@@ -14,11 +14,11 @@ namespace PlayGroup
 		/// Updates to players, however, are only sent when it approaches target state's position, 
 		/// therefore position is always sent as integer (at least in SendToAll()).
 		private PlayerState serverState;
-		
+
 		/// Future/target server state. All future changes go here 
 		/// and are applied to serverState when their positions match up 
 		private PlayerState serverTargetState;
-		
+
 		private Queue<PlayerAction> serverPendingActions;
 		[SyncVar] [Obsolete] private PlayerState serverStateCache; //todo: phase it out, it actually concerns clients
 
@@ -27,6 +27,7 @@ namespace PlayGroup
 
 		/// Amount of soft punishments before the hard one kicks in
 		private readonly int maxWarnings = 3;
+
 		private int playerWarnings;
 
 		/// Last direction that player moved in. Currently works more like a true impulse, therefore is zero-able
@@ -41,7 +42,8 @@ namespace PlayGroup
 		/// Do current and target server positions match?
 		private bool ServerPositionsMatch => serverTargetState.WorldPosition == serverState.WorldPosition;
 
-		public override void OnStartServer() {
+		public override void OnStartServer()
+		{
 			PullObjectID = NetworkInstanceId.Invalid;
 			base.OnStartServer();
 			InitServerState();
@@ -49,10 +51,12 @@ namespace PlayGroup
 
 		/// 
 		[Server]
-		private void InitServerState() {
-			Vector3Int worldPos = Vector3Int.RoundToInt( (Vector2) transform.position ); //cutting off Z-axis & rounding
-			MatrixInfo matrixAtPoint = MatrixManager.Instance.AtPoint( worldPos );
-			PlayerState state = new PlayerState {
+		private void InitServerState()
+		{
+			Vector3Int worldPos = Vector3Int.RoundToInt((Vector2) transform.position); //cutting off Z-axis & rounding
+			MatrixInfo matrixAtPoint = MatrixManager.Instance.AtPoint(worldPos);
+			PlayerState state = new PlayerState
+			{
 				MoveNumber = 0,
 				MatrixId = matrixAtPoint.Id,
 				WorldPosition = worldPos
@@ -63,28 +67,36 @@ namespace PlayGroup
 			serverTargetState = state;
 		}
 
-		[Command( channel = 0 )]
-		private void CmdProcessAction( PlayerAction action ) {
+		[Command(channel = 0)]
+		private void CmdProcessAction(PlayerAction action)
+		{
 			//add action to server simulation queue
-			serverPendingActions.Enqueue( action );
+			serverPendingActions.Enqueue(action);
 
 			//Do not cache the position if the player is a ghost
 			//or else new players will sync the deadbody with the last pos
 			//of the gost:
-			if ( playerMove.isGhost ) {
+			if (playerMove.isGhost)
+			{
 				return;
 			}
+
 			//Rollback pos and punish player if server queue size is more than max size
-			if ( serverPendingActions.Count > maxServerQueue ) {
+			if (serverPendingActions.Count > maxServerQueue)
+			{
 				RollbackPosition();
-				if ( ++playerWarnings < maxWarnings ) {
-					TortureChamber.Torture( playerScript, TortureSeverity.S );
-				} else {
-					TortureChamber.Torture( playerScript, TortureSeverity.L );
+				if (++playerWarnings < maxWarnings)
+				{
+					TortureChamber.Torture(playerScript, TortureSeverity.S);
 				}
+				else
+				{
+					TortureChamber.Torture(playerScript, TortureSeverity.L);
+				}
+
 				return;
 			}
-				
+
 			serverStateCache = serverState;
 		}
 
@@ -92,22 +104,29 @@ namespace PlayGroup
 		/// Impulse should be consumed after one tile if indoors,
 		/// and last indefinitely (until hit by obstacle) if you pushed someone into deep space 
 		[Server]
-		public void Push( Vector2Int direction ) {
-			if ( direction == Vector2Int.zero ) {
-				Debug.Log( "Push with zero impulse??" );
+		public void Push(Vector2Int direction)
+		{
+			if (direction == Vector2Int.zero)
+			{
+				Debug.Log("Push with zero impulse??");
 				return;
 			}
+
 			serverState.Impulse = direction;
 			serverTargetState.Impulse = direction;
-			if ( matrix != null ) {
+			if (matrix != null)
+			{
 				Vector3Int pushGoal =
-					Vector3Int.RoundToInt( serverState.Position + (Vector3) serverTargetState.Impulse );
-				if ( matrix.IsPassableAt( pushGoal ) ) {
-					Debug.Log( $"Server push to {pushGoal}" );
+					Vector3Int.RoundToInt(serverState.Position + (Vector3) serverTargetState.Impulse);
+				if (matrix.IsPassableAt(pushGoal))
+				{
+					Debug.Log($"Server push to {pushGoal}");
 					serverTargetState.Position = pushGoal;
 					serverTargetState.ImportantFlightUpdate = true;
 					serverTargetState.ResetClientQueue = true;
-				} else {
+				}
+				else
+				{
 					serverState.Impulse = Vector2.zero;
 					serverTargetState.Impulse = Vector2.zero;
 				}
@@ -118,12 +137,14 @@ namespace PlayGroup
 		/// Also clears prediction queues.
 		/// <param name="worldPos">The new position to "teleport" player</param>
 		[Server]
-		public void SetPosition( Vector3 worldPos ) {
+		public void SetPosition(Vector3 worldPos)
+		{
 			ClearQueueServer();
-			Vector3Int roundedPos = Vector3Int.RoundToInt( (Vector2) worldPos ); //cutting off z-axis
-			MatrixInfo newMatrix = MatrixManager.Instance.AtPoint( roundedPos );
+			Vector3Int roundedPos = Vector3Int.RoundToInt((Vector2) worldPos); //cutting off z-axis
+			MatrixInfo newMatrix = MatrixManager.Instance.AtPoint(roundedPos);
 			//Note the client queue reset
-			var newState = new PlayerState {
+			var newState = new PlayerState
+			{
 				MoveNumber = 0,
 				MatrixId = newMatrix.Id,
 				WorldPosition = roundedPos,
@@ -138,8 +159,10 @@ namespace PlayGroup
 
 		///	When lerp is finished, inform players of new state  
 		[Server]
-		private void TryNotifyPlayers() {
-			if ( ServerPositionsMatch ) {
+		private void TryNotifyPlayers()
+		{
+			if (ServerPositionsMatch)
+			{
 //				When serverState reaches its planned destination,
 //				embrace all other updates like updated moveNumber and flags
 				serverState = serverTargetState;
@@ -147,39 +170,49 @@ namespace PlayGroup
 				NotifyPlayers();
 			}
 		}
+
 		/// Register player to matrix from serverState (ParentNetId is a SyncVar) 
 		[Server]
-		private void SyncMatrix() {
-			registerTile.ParentNetId = MatrixManager.Instance.Get( serverState.MatrixId ).NetId;
+		private void SyncMatrix()
+		{
+			registerTile.ParentNetId = MatrixManager.Instance.Get(serverState.MatrixId).NetId;
 		}
+
 		/// Send current serverState to just one player
 		[Server]
-		public void NotifyPlayer( GameObject recipient ) {
-			PlayerMoveMessage.Send( recipient, gameObject, serverState );
+		public void NotifyPlayer(GameObject recipient)
+		{
+			PlayerMoveMessage.Send(recipient, gameObject, serverState);
 		}
 
 		/// Send current serverState to all players
 		[Server]
-		public void NotifyPlayers() {
+		public void NotifyPlayers()
+		{
 			//Do not cache the position if the player is a ghost
 			//or else new players will sync the deadbody with the last pos
 			//of the ghost:
-			if ( !playerMove.isGhost ) {
+			if (!playerMove.isGhost)
+			{
 				serverStateCache = serverState;
 			}
+
 			//Generally not sending mid-flight updates (unless there's a sudden change of course etc.)
-			if ( !serverState.ImportantFlightUpdate && consideredFloatingServer ) {
+			if (!serverState.ImportantFlightUpdate && consideredFloatingServer)
+			{
 				return;
 			}
 
-			PlayerMoveMessage.SendToAll( gameObject, serverState );
+			PlayerMoveMessage.SendToAll(gameObject, serverState);
 			ClearStateFlags();
 		}
 
 		/// Clears server pending actions queue
-		private void ClearQueueServer() {
+		private void ClearQueueServer()
+		{
 //			Debug.Log("Server queue wiped!");
-			if ( serverPendingActions != null && serverPendingActions.Count > 0 ) {
+			if (serverPendingActions != null && serverPendingActions.Count > 0)
+			{
 				serverPendingActions.Clear();
 			}
 		}
@@ -187,15 +220,18 @@ namespace PlayGroup
 		/// Clear all queues and
 		/// inform players of true serverState
 		[Server]
-		private void RollbackPosition() {
-			SetPosition( serverState.WorldPosition );
+		private void RollbackPosition()
+		{
+			SetPosition(serverState.WorldPosition);
 		}
 
 		/// try getting moves from server queue if server and target states match
 		[Server]
-		private void CheckTargetUpdate() {
+		private void CheckTargetUpdate()
+		{
 			//checking only player movement for now
-			if ( ServerPositionsMatch ) {
+			if (ServerPositionsMatch)
+			{
 				TryUpdateServerTarget();
 			}
 		}
@@ -203,144 +239,176 @@ namespace PlayGroup
 		///Currently used to set the pos of a player that has just been dragged by another player
 		//Fixme: prone to exploits, very hacky
 		[Command]
-		public void CmdSetPositionFromReset( GameObject fromObj, GameObject otherPlayer, Vector3 setPos ) {
-			if ( fromObj.GetComponent<IPlayerSync>() == null ) //Validation
+		public void CmdSetPositionFromReset(GameObject fromObj, GameObject otherPlayer, Vector3 setPos)
+		{
+			if (fromObj.GetComponent<IPlayerSync>() == null) //Validation
 			{
 				return;
 			}
+
 			IPlayerSync otherPlayerSync = otherPlayer.GetComponent<IPlayerSync>();
-			otherPlayerSync.SetPosition( setPos );
+			otherPlayerSync.SetPosition(setPos);
 		}
 
 		/// Tries to assign next target from queue to serverTargetState if there are any
 		/// (In order to start lerping towards it)
 		[Server]
-		private void TryUpdateServerTarget() {
-			if ( serverPendingActions.Count == 0 ) {
+		private void TryUpdateServerTarget()
+		{
+			if (serverPendingActions.Count == 0)
+			{
 				return;
 			}
 
 			var nextAction = serverPendingActions.Peek();
-			if ( !IsPointlessMove( serverTargetState, nextAction ) ) {
-				if ( consideredFloatingServer ) {
-					Debug.LogWarning( "Server ignored move while player is floating" );
+			if (!IsPointlessMove(serverTargetState, nextAction))
+			{
+				if (consideredFloatingServer)
+				{
+					Debug.LogWarning("Server ignored move while player is floating");
 					serverPendingActions.Dequeue();
 					return;
 				}
-				PlayerState nextState = NextStateServer( serverTargetState, serverPendingActions.Dequeue() );
-				serverLastDirection = Vector2Int.RoundToInt( nextState.WorldPosition - serverTargetState.WorldPosition );
+
+				PlayerState nextState = NextStateServer(serverTargetState, serverPendingActions.Dequeue());
+				serverLastDirection = Vector2Int.RoundToInt(nextState.WorldPosition - serverTargetState.WorldPosition);
 				serverTargetState = nextState;
 				//In case positions already match
 				TryNotifyPlayers();
 //				Debug.Log($"Server Updated target {serverTargetState}. {serverPendingActions.Count} pending");
-			} else {
+			}
+			else
+			{
 				Debug.LogWarning(
-					$"Pointless move {serverTargetState}+{nextAction.keyCodes[0]} Rolling back to {serverState}" );
+					$"Pointless move {serverTargetState}+{nextAction.keyCodes[0]} Rolling back to {serverState}");
 				RollbackPosition();
 			}
 		}
+
 		/// NextState that also subscribes player to matrix rotations 
 		[Server]
-		private PlayerState NextStateServer( PlayerState state, PlayerAction action ) {
+		private PlayerState NextStateServer(PlayerState state, PlayerAction action)
+		{
 			bool matrixChangeDetected;
-			PlayerState nextState = NextState( state, action, out matrixChangeDetected );
+			PlayerState nextState = NextState(state, action, out matrixChangeDetected);
 
-			if ( !matrixChangeDetected ) {
+			if (!matrixChangeDetected)
+			{
 				return nextState;
 			}
+
 			//todo: subscribe to current matrix rotations on spawn
-			var newMatrix = MatrixManager.Instance.Get( nextState.MatrixId );
-			Debug.Log( $"Matrix will change to {newMatrix}" );
-			if ( newMatrix.MatrixMove ) {
+			var newMatrix = MatrixManager.Instance.Get(nextState.MatrixId);
+			Debug.Log($"Matrix will change to {newMatrix}");
+			if (newMatrix.MatrixMove)
+			{
 				//Subbing to new matrix rotations
 				newMatrix.MatrixMove.onRotation += OnRotation;
 //				Debug.Log( $"Registered rotation listener to {newMatrix.MatrixMove}" );
 			}
+
 			//Unsubbing from old matrix rotations
-			MatrixMove oldMatrixMove = MatrixManager.Instance.Get( matrix ).MatrixMove;
-			if ( oldMatrixMove ) {
+			MatrixMove oldMatrixMove = MatrixManager.Instance.Get(matrix).MatrixMove;
+			if (oldMatrixMove)
+			{
 //				Debug.Log( $"Unregistered rotation listener from {oldMatrixMove}" );
 				oldMatrixMove.onRotation -= OnRotation;
 			}
+
 			return nextState;
 		}
-		
+
 		[Server]
-		private void OnRotation(Orientation from, Orientation to) {
+		private void OnRotation(Orientation from, Orientation to)
+		{
 			//fixme: doesn't seem to change orientation for clients from their point of view
-			playerSprites.ChangePlayerDirection( Orientation.DegreeBetween( from, to ) );
+			playerSprites.ChangePlayerDirection(Orientation.DegreeBetween(from, to));
 		}
 
 		/// Lerping and ensuring server authority for space walk
 		[Server]
-		private void CheckMovementServer() { 
-			if ( !ServerPositionsMatch ) {
+		private void CheckMovementServer()
+		{
+			if (!ServerPositionsMatch)
+			{
 				//Lerp on server if it's worth lerping 
 				//and inform players if serverState reached targetState afterwards 
 				serverState.WorldPosition =
-					Vector3.MoveTowards( serverState.WorldPosition, serverTargetState.WorldPosition, playerMove.speed * Time.deltaTime );
+					Vector3.MoveTowards(serverState.WorldPosition, serverTargetState.WorldPosition, playerMove.speed * Time.deltaTime);
 				//failsafe
-				var distance = Vector3.Distance( serverState.WorldPosition, serverTargetState.WorldPosition );
-				if ( distance > 1.5 ) {
-					Debug.LogWarning( $"Dist {distance} > 1:{serverState}\n" +
-					                  $"Target    :{serverTargetState}" );
+				var distance = Vector3.Distance(serverState.WorldPosition, serverTargetState.WorldPosition);
+				if (distance > 1.5)
+				{
+					Debug.LogWarning($"Dist {distance} > 1:{serverState}\n" +
+					                 $"Target    :{serverTargetState}");
 					serverState.WorldPosition = serverTargetState.WorldPosition;
 				}
+
 				TryNotifyPlayers();
 			}
-			//Space walk checks
-			bool isFloating = MatrixManager.Instance.IsFloatingAt( Vector3Int.RoundToInt(serverTargetState.WorldPosition) );
 
-			if ( isFloating ) {
-				if ( serverTargetState.Impulse == Vector2.zero && serverLastDirection != Vector2.zero ) {
+			//Space walk checks
+			bool isFloating = MatrixManager.Instance.IsFloatingAt(Vector3Int.RoundToInt(serverTargetState.WorldPosition));
+
+			if (isFloating)
+			{
+				if (serverTargetState.Impulse == Vector2.zero && serverLastDirection != Vector2.zero)
+				{
 					//server initiated space dive. 						
 					serverTargetState.Impulse = serverLastDirection;
 					serverTargetState.ImportantFlightUpdate = true;
 					serverTargetState.ResetClientQueue = true;
 				}
+
 				//Perpetual floating sim
-				if ( ServerPositionsMatch && !serverTargetState.ImportantFlightUpdate ) {
+				if (ServerPositionsMatch && !serverTargetState.ImportantFlightUpdate)
+				{
 					//Extending prediction by one tile if player's transform reaches previously set goal
-					Vector3Int newGoal = Vector3Int.RoundToInt( serverTargetState.Position + (Vector3) serverTargetState.Impulse );
+					Vector3Int newGoal = Vector3Int.RoundToInt(serverTargetState.Position + (Vector3) serverTargetState.Impulse);
 					serverTargetState.Position = newGoal;
 					ClearQueueServer();
 				}
 			}
-			if ( consideredFloatingServer && !isFloating ) 
+
+			if (consideredFloatingServer && !isFloating)
 			{
 				//finish floating. players will be notified as soon as serverState catches up
 				serverState.Impulse = Vector2.zero;
 				serverTargetState.Impulse = Vector2.zero;
 				serverTargetState.ResetClientQueue = true;
-			
+
 				//Stopping spacewalk increases move number
 				serverTargetState.MoveNumber++;
-				
+
 				//removing lastDirection when we hit an obstacle in space
 				serverLastDirection = Vector2.zero;
-				
+
 				//Notify if position stayed the same
 				TryNotifyPlayers();
 			}
+
 			CheckSpaceDamage();
 		}
 
 		/// Checking whether player should suffocate
 		[Server]
-		private void CheckSpaceDamage() {
-			if ( MatrixManager.Instance.IsSpaceAt( Vector3Int.RoundToInt( serverState.WorldPosition ) )
-			     && !healthBehaviorScript.IsDead && !isApplyingSpaceDmg ) {
+		private void CheckSpaceDamage()
+		{
+			if (MatrixManager.Instance.IsSpaceAt(Vector3Int.RoundToInt(serverState.WorldPosition))
+			    && !healthBehaviorScript.IsDead && !isApplyingSpaceDmg)
+			{
 //				Hurting people in space even if they are next to the wall
-				StartCoroutine( ApplyTempSpaceDamage() );
+				StartCoroutine(ApplyTempSpaceDamage());
 				isApplyingSpaceDmg = true;
 			}
 		}
 
 		//TODO: Remove this when atmos is implemented 
 		///This prevents players drifting into space indefinitely 
-		private IEnumerator ApplyTempSpaceDamage() {
-			yield return new WaitForSeconds( 1f );
-			healthBehaviorScript.ApplyDamage( null, 5, DamageType.OXY, BodyPartType.HEAD );
+		private IEnumerator ApplyTempSpaceDamage()
+		{
+			yield return new WaitForSeconds(1f);
+			healthBehaviorScript.ApplyDamage(null, 5, DamageType.OXY, BodyPartType.HEAD);
 			isApplyingSpaceDmg = false;
 		}
 	}

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.Server.cs
@@ -397,14 +397,14 @@ namespace PlayGroup
 			if (MatrixManager.Instance.IsSpaceAt(Vector3Int.RoundToInt(serverState.WorldPosition))
 			    && !healthBehaviorScript.IsDead && !isApplyingSpaceDmg)
 			{
-//				Hurting people in space even if they are next to the wall
+				// Hurting people in space even if they are next to the wall
 				StartCoroutine(ApplyTempSpaceDamage());
 				isApplyingSpaceDmg = true;
 			}
 		}
 
-		//TODO: Remove this when atmos is implemented 
-		///This prevents players drifting into space indefinitely 
+		// TODO: Remove this when atmos is implemented 
+		// This prevents players drifting into space indefinitely 
 		private IEnumerator ApplyTempSpaceDamage()
 		{
 			yield return new WaitForSeconds(1f);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -55,7 +55,7 @@ namespace Tilemaps
 
 		public bool IsSpaceAt(Vector3Int position)
 		{
-			return metaDataLayer.Get(position).IsSpace();
+			return metaDataLayer.IsSpaceAt(position);
 		}
 
 		public bool IsEmptyAt(Vector3Int position)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -1,4 +1,5 @@
-﻿using Tilemaps.Behaviours.Meta;
+﻿using System.Security.Permissions;
+using Tilemaps.Behaviours.Meta;
 using Tilemaps.Utils;
 using UnityEngine;
 
@@ -31,6 +32,13 @@ namespace Tilemaps.Behaviours.Layers
 			}
 
 			return nodes[position];
+		}
+
+		public bool IsSpaceAt(Vector3Int position)
+		{
+			var node = Get(position, false);
+
+			return node == null || node.IsSpace();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Editor/TilemapCheckEditor.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Editor/TilemapCheckEditor.cs
@@ -91,6 +91,9 @@ namespace Tilemaps.Editor
 			Color red = Color.red;
 			red.a = 0.5f;
 			
+			Color green = Color.green;
+			green.a = 0.5f;
+			
 			foreach (Vector3Int position in new BoundsInt(start, end - start).allPositionsWithin)
 			{
 				MetaDataNode node = scr.Get(position, false);
@@ -98,7 +101,7 @@ namespace Tilemaps.Editor
 				{
 					if (node.Room == 0)
 					{
-						continue;
+						Gizmos.color = green;
 					}
 					
 					if(node.Room > 0)


### PR DESCRIPTION
### Purpose
Death in space not working. Need to get rid of the "Vacuum of space conspiracy" before it's too late.

### Approach
MetaDataLayer created a new MetaNode, which is by default not Space. Fixed this by not creating that node. If no node exists, it must be space.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer