### PR TITLE
Fixes #1019 | WinDoors Not Closing On Players Fix

### DIFF
--- a/UnityProject/Assets/Scripts/Doors/DoorController.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorController.cs
@@ -131,7 +131,11 @@ namespace Doors
 		[Command]
 		public void CmdTryClose()
 		{
-			if (IsOpened && !isPerformingAction && matrix.IsPassableAt(registerTile.Position))
+            if(isWindowedDoor && IsOpened && !isPerformingAction)
+            {
+                RpcClose();
+            }
+            else if (IsOpened && !isPerformingAction && matrix.IsPassableAt(registerTile.Position))
 			{
 				RpcClose();
 			}


### PR DESCRIPTION
Fixed the WinDoors so that they now close even if a player is standing on the tile that the WinDoor is on. Used the already working "isWindowedDoor" method.

### Purpose
Fixes #1019. Fix for the issue regarding WinDoors not closing when players occupy their tiles.

### Approach
Added a check to the "CmdTryClose()" method checking to see if the current tile was a windowed door, and if it is, close it regardless of obstruction. Referring to the issue, "WinDoors should always close, as it can not be obstructed." The fix was a one-line fix.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
Given that it is such a simple fix, I have not tested it in multiplayer and I have not commented the code. I don't think it requires it, but can do so if need be.