### PR TITLE
Fixes #1020 | Removed error spam when typing 2 messages before job selection

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
@@ -494,9 +494,9 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	[Command]
 	public void CmdToggleChatIcon(bool turnOn)
 	{
-		if (!GetComponent<VisibleBehaviour>().visibleState)
+		if (!GetComponent<VisibleBehaviour>().visibleState || (playerScript.JobType == JobType.NULL))
 		{
-			//Don't do anything with chat icon if player is invisible
+			//Don't do anything with chat icon if player is invisible or not spawned in
 			return;
 		}
 


### PR DESCRIPTION
By adding a check to see if the player was spawned in before attempting to place a chat bubble above their head, I was able to fix #1020.

### Purpose
Fixes the bug shown in #1020. Removes error spam in console (unintended behavior).

### Approach
By checking to see if the player had spawned in (by checking their current job) before attempting to place a chat bubble above their heads. Ghosts and unspawned players should not need a chat bubble.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
N/A