### PR TITLE
Fixed an error when trying to reload with no magazine in hand

### DIFF
--- a/UnityProject/Assets/Scripts/Weapons/Weapon.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Weapon.cs
@@ -153,10 +153,10 @@ namespace Weapons
 				GameObject otherHandItem = UIManager.Hands.OtherSlot.Item;
 				string hand;
 
-				if (currentHandItem != null)
+				if ((currentHandItem != null) && (otherHandItem != null))
 				{
 					if (CurrentMagazine == null)
-					{
+					{  
 						//RELOAD
 						if (currentHandItem.GetComponent<MagazineBehaviour>() && otherHandItem.GetComponent<Weapon>())
 						{


### PR DESCRIPTION
UnityStation would throw an error if the user tried to reload a weapon without a magazine in hand. No check was made to see if there didn't exist an item the other hand, so I put one in there.

Co-Authored-By: Doobly Noobly <dooblynoobly@users.noreply.github.com>

### Purpose
Fixes an unintended error thrown by a check not being put in place to see if the other hand held an item.

### Approach
Edited the Weapon.cs file to make sure both the current hand _and_ the other hand have items in them.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
@DooblyNoobly helped debug and fix this issue.