### PR TITLE
[DNM] Near Fix of #1018 | Adds a back button to the job selection menu

### DIFF
--- a/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
@@ -521,7 +521,15 @@ public class ItemAttributes : NetworkBehaviour
 
 	public void OnMouseEnter()
 	{
-		UIManager.SetToolTip = itemName + " (" + itemDescription + ")";
+		// Removes the parentheses from the item tooltip if it isn't necessary
+		if (itemDescription.Length > 0)
+		{
+			UIManager.SetToolTip = itemName + " (" + itemDescription + ")";
+		}
+		else
+		{
+			UIManager.SetToolTip = itemName;
+		}
 	}
 
 	public void OnMouseExit()

--- a/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
+++ b/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
@@ -1,6 +1,7 @@
 ﻿using PlayGroup;
 using UI;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 public class GUI_PlayerJobs : MonoBehaviour
@@ -30,6 +31,25 @@ public class GUI_PlayerJobs : MonoBehaviour
 		UIManager.Instance.GetComponent<ControlDisplays>().jobSelectWindow.SetActive(false);
 		hasPickedAJob = true;
 	}
+
+    // This will send us back to the lobby
+    public void BackToLobby()
+    {
+        SoundManager.Play("Click01");
+
+        // Remove the job selection window
+        UIManager.Instance.GetComponent<ControlDisplays>().jobSelectWindow.SetActive(false);
+
+        // Load the lobby scene back up
+        CustomNetworkManager.Instance.ServerChangeScene("Lobby");
+
+        // Make sure we kill the server connection, in case the user wants to start a different server
+        // We're only going to do this, if the user is the host
+        if (CustomNetworkManager.Instance._isServer)
+        {
+            CustomNetworkManager.Instance.StopHost();
+        }
+    }
 
 	private void UpdateJobsList()
 	{
@@ -63,6 +83,15 @@ public class GUI_PlayerJobs : MonoBehaviour
 
 			occupation.SetActive(true);
 		}
+
+        // Create a button to go back to the lobby. Tack it on to the end of the job list.
+        GameObject backButton = Instantiate(buttonPrefab);
+        backButton.GetComponentInChildren<Text>().text = "Back";
+        backButton.transform.SetParent(screen_Jobs.transform);
+        backButton.transform.localScale = new Vector3(1.0f, 1.0f, 1.0f);
+        backButton.GetComponent<Button>().onClick.AddListener(() => { BackToLobby(); });
+        backButton.SetActive(true);
+
 		screen_Jobs.SetActive(true);
 		isUpToDate = true;
 	}


### PR DESCRIPTION
Nearly fixes the issue referenced in #1018, adding a back button to the job selection menu. Issue when re-hosting a server.

### Purpose
Adds a back button so that a user can re-name themself or connect to a different server.

Screenshot:
![unity_2018-04-30_18-47-41](https://user-images.githubusercontent.com/5704760/39454037-016fc8c0-4ca7-11e8-8350-926bff2a2ed9.png)

### Approach
Created a new button that is later added to the job menu. When the button is clicked, we hide the job menu and attempt to change the scene back to the lobby. If the user is hosting a server, that server is stopped.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
**This PR introduces a new bug, so please do not merge**. To reproduce this bug you need to host a server, click back, and attempt to host a server again. Unity says that the Tilemap you're trying to access has been destroyed, when it really shouldn't be. Asking for assistance in fixing this.