### PR TITLE
Fix for #836, forced window aspect.

### DIFF
--- a/UnityProject/Assets/Scripts/UI/ResponsiveUI.cs
+++ b/UnityProject/Assets/Scripts/UI/ResponsiveUI.cs
@@ -109,22 +109,6 @@ namespace UI
 			yield return new WaitForSeconds(0.2f);
 			if (!Screen.fullScreen)
 			{
-				float screenWidth = Screen.height * targetAspect;
-
-				//The following conditions check if the screen width or height
-				//is an odd number. If it is, then it adjusted to be an even number
-				//This fixes the sprite bleeding between tiles:
-				if ((int) screenWidth % 2 != 0)
-				{
-					screenWidth += 1f;
-				}
-				int screenHeight = Screen.height;
-				if (screenHeight % 2 != 0)
-				{
-					screenHeight++;
-				}
-
-				Screen.SetResolution((int) screenWidth, screenHeight, false);
 				if (camResizer != null) {
 					camResizer.AdjustCam();
 				}


### PR DESCRIPTION
ForceGameWindowAspect() now only resizes the game window, not the entire window.

### Purpose
Fixes #836.

### Approach
I first tried to isolate the cause of the issue, then removed the code that was causing the entire window to resize, which turned out to be a call to `Screen.SetResolution(...)`.
Removing this line and the additional lines providing the arguments to the function seems to fix the problem reported in issue #836.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in standalone build
- [ ]  This PR has been tested in multiplayer

### Notes:
As I am new to the project there might be unintended consequences to it that I'm not seeing, please notify me if there is anything that seems off with this fix.