### PR TITLE
Show item description parenthesis only if the item has a description

### DIFF
--- a/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
@@ -521,7 +521,15 @@ public class ItemAttributes : NetworkBehaviour
 
 	public void OnMouseEnter()
 	{
-		UIManager.SetToolTip = itemName + " (" + itemDescription + ")";
+		// Show the parenthesis for an item's description only if the item has a description
+		if (itemDescription.Length > 0)
+		{
+			UIManager.SetToolTip = itemName + " (" + itemDescription + ")";
+		}
+		else
+		{
+			UIManager.SetToolTip = itemName;
+		}
 	}
 
 	public void OnMouseExit()


### PR DESCRIPTION
### Purpose
Removes redundant parenthesis in the UI Tooltip when an item doesn't have a description.

### Approach
Simply check to see if the length of the description is greater than zero. This should be a permanent fix, as long as the prefabs for the items are created correctly.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
_Please enter any other relevant information here_