### PR TITLE
Fixes 1/3 issue on #1048 (WinDoors)

### DIFF
--- a/UnityProject/Assets/Scripts/Doors/DoorController.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorController.cs
@@ -131,7 +131,8 @@ namespace Doors
 		[Command]
 		public void CmdTryClose()
 		{
-            if(isWindowedDoor && IsOpened && !isPerformingAction)
+			// If we're dealing with a sliding door and there are no issues, we can close the sliding door (WinDoor)
+            if(doorType == DoorType.sliding && IsOpened && !isPerformingAction)
             {
                 RpcClose();
             }


### PR DESCRIPTION
### Purpose
Fixes one of the issues on #1048. WinDoors now close on players and normal doors no longer close on players.

### Approach
Removed a conditional that I thought checked to see whether or not a door was a WinDoor. I then added a proper check to see if the door was a WinDoor.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
This fixes one of the issues on #1048. I don't think the entire issue can be closed because other aspects of it are not resolved.