### PR TITLE
Fixes issue 3/3 on #1048. Doors will now only open if directly clicked

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
@@ -133,10 +133,14 @@ namespace PlayGroups.Input
 			{
 				foreach (Renderer _renderer in renderers.OrderByDescending(sr => sr.sortingOrder)) 
 				{
-					if (Interact(_renderer.transform, position))
+					// If the ray hits a FOVTile, we can continue down (don't count it as an interaction)
+					if (!_renderer.sortingLayerName.Equals("FieldOfView"))
 					{
-						isInteracting = true;
-						break;
+						if (Interact(_renderer.transform, position))
+						{
+							isInteracting = true;
+							break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### Purpose
Fully fixes #1048. Doors will now only open if you click on them directly (and close only if directly clicked)

### Approach
Checked to see if the sprite currently being clicked on is the FOV Tile, if it is, ignore it.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
Thanks for the help Doobly