### PR TITLE
Adds a Top Layer Effects Tilemap

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/TopLayerEffects - (fov, fire, atmos gfx).prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/TopLayerEffects - (fov, fire, atmos gfx).prefab
@@ -1,0 +1,132 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1521719749537320}
+  m_IsPrefabParent: 1
+--- !u!1 &1521719749537320
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4929042165598166}
+  - component: {fileID: 8195094281969235012}
+  - component: {fileID: 3664157344112019904}
+  - component: {fileID: 114248088054569844}
+  m_Layer: 30
+  m_Name: TopLayerEffects - (fov, fire, atmos gfx)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4929042165598166
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1521719749537320}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114248088054569844
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1521719749537320}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 594d5aea377441d42a292019e6edbe58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LayerType: 6
+  topLayerFX: {fileID: 0}
+--- !u!483693784 &3664157344112019904
+TilemapRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1521719749537320}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -2035547137
+  m_SortingLayer: 17
+  m_SortingOrder: 0
+  m_ChunkSize: {x: 32, y: 32, z: 32}
+  m_MaxChunkCount: 16
+  m_MaxFrameAge: 16
+  m_SortOrder: 0
+  m_MaskInteraction: 0
+--- !u!1839735485 &8195094281969235012
+Tilemap:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1521719749537320}
+  m_Enabled: 1
+  m_Tiles: {}
+  m_AnimatedTiles: {}
+  m_TileAssetArray: []
+  m_TileSpriteArray: []
+  m_TileMatrixArray: []
+  m_TileColorArray: []
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Origin: {x: 0, y: 0, z: 0}
+  m_Size: {x: 0, y: 0, z: 1}
+  m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1

--- a/UnityProject/Assets/Prefabs/SceneConstruction/TopLayerEffects - (fov, fire, atmos gfx).prefab.meta
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/TopLayerEffects - (fov, fire, atmos gfx).prefab.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 0defa5e6005db42059d98be74b7d13a9
+timeCreated: 1526190397
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
+++ b/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
@@ -3341,6 +3341,7 @@ Transform:
   m_LocalPosition: {x: -37.321472, y: -36.197353, z: 0.5625}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 445565423}
   - {fileID: 817340206}
   - {fileID: 205315832}
   - {fileID: 1658452411}
@@ -4220,7 +4221,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 169189433}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &205315833
 MonoBehaviour:
@@ -4234,6 +4235,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 1
+  topLayerFX: {fileID: 445565427}
 --- !u!66 &205315834
 CompositeCollider2D:
   m_ObjectHideFlags: 0
@@ -7302,7 +7304,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 460993101}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &209337021
 MonoBehaviour:
@@ -7316,6 +7318,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 4
+  topLayerFX: {fileID: 513949764}
 --- !u!66 &209337022
 CompositeCollider2D:
   m_ObjectHideFlags: 0
@@ -11102,6 +11105,7 @@ Transform:
   m_LocalPosition: {x: -0.5, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 1197796692}
   - {fileID: 1587762690}
   - {fileID: 317462224}
   - {fileID: 1379343682}
@@ -11951,7 +11955,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 293058355}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &317462225
 MonoBehaviour:
@@ -11965,6 +11969,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 1
+  topLayerFX: {fileID: 1197796696}
 --- !u!66 &317462226
 CompositeCollider2D:
   m_ObjectHideFlags: 0
@@ -12360,7 +12365,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 169189433}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &328540596
 MonoBehaviour:
@@ -12375,6 +12380,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 4
+  topLayerFX: {fileID: 445565427}
 --- !u!483693784 &328540597
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -42055,7 +42061,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 460993101}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &332277346
 MonoBehaviour:
@@ -42069,6 +42075,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 3
+  topLayerFX: {fileID: 513949764}
 --- !u!483693784 &332277347
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -43644,7 +43651,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 460993101}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &335177443
 MonoBehaviour:
@@ -43658,6 +43665,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 1
+  topLayerFX: {fileID: 513949764}
 --- !u!66 &335177444
 CompositeCollider2D:
   m_ObjectHideFlags: 0
@@ -45722,6 +45730,16 @@ Transform:
   m_PrefabParentObject: {fileID: 4915435593579346, guid: b102a55282e4d4f639b2da0307a4280a,
     type: 2}
   m_PrefabInternal: {fileID: 444288348}
+--- !u!4 &445565423 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4929042165598166, guid: 0defa5e6005db42059d98be74b7d13a9,
+    type: 2}
+  m_PrefabInternal: {fileID: 1599309301}
+--- !u!1839735485 &445565427 stripped
+Tilemap:
+  m_PrefabParentObject: {fileID: 8195094281969235012, guid: 0defa5e6005db42059d98be74b7d13a9,
+    type: 2}
+  m_PrefabInternal: {fileID: 1599309301}
 --- !u!1001 &449849689
 Prefab:
   m_ObjectHideFlags: 0
@@ -46164,6 +46182,7 @@ Transform:
   m_LocalPosition: {x: -48.5, y: 8.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 513949760}
   - {fileID: 1309157832}
   - {fileID: 335177442}
   - {fileID: 1498980246}
@@ -47026,6 +47045,139 @@ Transform:
   m_PrefabParentObject: {fileID: 4409860773913266, guid: 08b1b62f71d104f16bae72f04014662d,
     type: 2}
   m_PrefabInternal: {fileID: 511638687}
+--- !u!1 &513949759
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 513949760}
+  - component: {fileID: 513949764}
+  - component: {fileID: 513949763}
+  - component: {fileID: 513949762}
+  - component: {fileID: 513949761}
+  m_Layer: 30
+  m_Name: TopLayerEffects - (fov, fire, atmos gfx) (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &513949760
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 513949759}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 460993101}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &513949761
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 513949759}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 594d5aea377441d42a292019e6edbe58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LayerType: 6
+  topLayerFX: {fileID: 0}
+--- !u!19719996 &513949762
+TilemapCollider2D:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 513949759}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+--- !u!483693784 &513949763
+TilemapRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 513949759}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -2035547137
+  m_SortingLayer: 17
+  m_SortingOrder: 0
+  m_ChunkSize: {x: 32, y: 32, z: 32}
+  m_MaxChunkCount: 16
+  m_MaxFrameAge: 16
+  m_SortOrder: 0
+  m_MaskInteraction: 0
+--- !u!1839735485 &513949764
+Tilemap:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 513949759}
+  m_Enabled: 1
+  m_Tiles: {}
+  m_AnimatedTiles: {}
+  m_TileAssetArray: []
+  m_TileSpriteArray: []
+  m_TileMatrixArray: []
+  m_TileColorArray: []
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Origin: {x: 0, y: 0, z: 0}
+  m_Size: {x: 0, y: 0, z: 1}
+  m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
 --- !u!1 &515577130
 GameObject:
   m_ObjectHideFlags: 0
@@ -48061,7 +48213,7 @@ Transform:
   - {fileID: 653553074}
   - {fileID: 865583191}
   m_Father: {fileID: 562853482}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!19719996 &552279808
 TilemapCollider2D:
@@ -48088,6 +48240,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 2
+  topLayerFX: {fileID: 1847292135}
 --- !u!483693784 &552279810
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -48926,6 +49079,7 @@ Transform:
   m_LocalPosition: {x: -10.5, y: 19.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 1847292131}
   - {fileID: 797656924}
   - {fileID: 1645626344}
   - {fileID: 552279807}
@@ -49289,7 +49443,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 293058355}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!66 &579719636
 CompositeCollider2D:
@@ -49356,6 +49510,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 4
+  topLayerFX: {fileID: 1197796696}
 --- !u!483693784 &579719640
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -55909,7 +56064,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 562853482}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &797656925
 MonoBehaviour:
@@ -55923,6 +56078,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 0
+  topLayerFX: {fileID: 1847292135}
 --- !u!66 &797656926
 CompositeCollider2D:
   m_ObjectHideFlags: 0
@@ -57379,7 +57535,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 169189433}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &817340207
 MonoBehaviour:
@@ -57394,6 +57550,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 0
+  topLayerFX: {fileID: 445565427}
 --- !u!483693784 &817340208
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -68759,6 +68916,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 2
+  topLayerFX: {fileID: 445565427}
 --- !u!483693784 &969617903
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -76356,7 +76514,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 562853482}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1174741990
 MonoBehaviour:
@@ -76370,6 +76528,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 3
+  topLayerFX: {fileID: 1847292135}
 --- !u!483693784 &1174741991
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -77905,7 +78064,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 562853482}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1175550008
 MonoBehaviour:
@@ -77919,6 +78078,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 4
+  topLayerFX: {fileID: 1847292135}
 --- !u!66 &1175550009
 CompositeCollider2D:
   m_ObjectHideFlags: 0
@@ -81072,6 +81232,139 @@ Transform:
   m_PrefabParentObject: {fileID: 4529258304337178, guid: afa5cc272972d406eac7e8e62bcb5e4b,
     type: 2}
   m_PrefabInternal: {fileID: 1192645990}
+--- !u!1 &1197796691
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1197796692}
+  - component: {fileID: 1197796696}
+  - component: {fileID: 1197796695}
+  - component: {fileID: 1197796694}
+  - component: {fileID: 1197796693}
+  m_Layer: 30
+  m_Name: TopLayerEffects - (fov, fire, atmos gfx) (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1197796692
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1197796691}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 293058355}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1197796693
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1197796691}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 594d5aea377441d42a292019e6edbe58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LayerType: 6
+  topLayerFX: {fileID: 1587762696}
+--- !u!19719996 &1197796694
+TilemapCollider2D:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1197796691}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+--- !u!483693784 &1197796695
+TilemapRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1197796691}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -2035547137
+  m_SortingLayer: 17
+  m_SortingOrder: 0
+  m_ChunkSize: {x: 32, y: 32, z: 32}
+  m_MaxChunkCount: 16
+  m_MaxFrameAge: 16
+  m_SortOrder: 0
+  m_MaskInteraction: 0
+--- !u!1839735485 &1197796696
+Tilemap:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1197796691}
+  m_Enabled: 1
+  m_Tiles: {}
+  m_AnimatedTiles: {}
+  m_TileAssetArray: []
+  m_TileSpriteArray: []
+  m_TileMatrixArray: []
+  m_TileColorArray: []
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Origin: {x: 0, y: 0, z: 0}
+  m_Size: {x: 0, y: 0, z: 1}
+  m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
 --- !u!1001 &1199370398
 Prefab:
   m_ObjectHideFlags: 0
@@ -83770,6 +84063,18 @@ Prefab:
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 114239957664027200, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: blankSprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 722f1d71f4f3c6f4fba5d1bd8e3d6992,
+        type: 3}
+    - target: {fileID: 114239957664027200, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: shroudSprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 722f1d71f4f3c6f4fba5d1bd8e3d6992,
+        type: 3}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 829f4ca992b848d6bb4d007fb9c112e1, type: 2}
   m_IsPrefabParent: 0
@@ -84022,7 +84327,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 460993101}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1309157833
 MonoBehaviour:
@@ -84036,6 +84341,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 0
+  topLayerFX: {fileID: 513949764}
 --- !u!66 &1309157834
 CompositeCollider2D:
   m_ObjectHideFlags: 0
@@ -86631,7 +86937,7 @@ Transform:
   - {fileID: 731394909}
   - {fileID: 579805130}
   m_Father: {fileID: 293058355}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!19719996 &1379343683
 TilemapCollider2D:
@@ -86658,6 +86964,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 2
+  topLayerFX: {fileID: 1197796696}
 --- !u!483693784 &1379343685
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -89559,7 +89866,7 @@ Transform:
   - {fileID: 744900045}
   - {fileID: 1645251150}
   m_Father: {fileID: 460993101}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!19719996 &1498980247
 TilemapCollider2D:
@@ -89586,6 +89893,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 2
+  topLayerFX: {fileID: 513949764}
 --- !u!483693784 &1498980249
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -91977,7 +92285,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 293058355}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!66 &1587762691
 CompositeCollider2D:
@@ -92044,6 +92352,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 0
+  topLayerFX: {fileID: 1197796696}
 --- !u!483693784 &1587762695
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -92590,6 +92899,48 @@ Transform:
   m_PrefabParentObject: {fileID: 4133012119868568, guid: f3277c354886f47d0a9d58e4ad69f8af,
     type: 2}
   m_PrefabInternal: {fileID: 1597659829}
+--- !u!1001 &1599309301
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 169189433}
+    m_Modifications:
+    - target: {fileID: 4929042165598166, guid: 0defa5e6005db42059d98be74b7d13a9, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4929042165598166, guid: 0defa5e6005db42059d98be74b7d13a9, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4929042165598166, guid: 0defa5e6005db42059d98be74b7d13a9, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4929042165598166, guid: 0defa5e6005db42059d98be74b7d13a9, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4929042165598166, guid: 0defa5e6005db42059d98be74b7d13a9, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4929042165598166, guid: 0defa5e6005db42059d98be74b7d13a9, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4929042165598166, guid: 0defa5e6005db42059d98be74b7d13a9, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4929042165598166, guid: 0defa5e6005db42059d98be74b7d13a9, type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 0defa5e6005db42059d98be74b7d13a9, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1001 &1603424309
 Prefab:
   m_ObjectHideFlags: 0
@@ -93669,7 +94020,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 562853482}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1645626345
 MonoBehaviour:
@@ -93683,6 +94034,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 1
+  topLayerFX: {fileID: 1847292135}
 --- !u!66 &1645626346
 CompositeCollider2D:
   m_ObjectHideFlags: 0
@@ -95171,7 +95523,7 @@ Transform:
   - {fileID: 2023775915}
   - {fileID: 507862002}
   m_Father: {fileID: 169189433}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1658583841
 Prefab:
@@ -99182,6 +99534,139 @@ Transform:
   m_PrefabParentObject: {fileID: 4905743905385754, guid: 281a9627782b7bd4a9ad7283af0300ce,
     type: 2}
   m_PrefabInternal: {fileID: 1847142077}
+--- !u!1 &1847292130
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1847292131}
+  - component: {fileID: 1847292135}
+  - component: {fileID: 1847292134}
+  - component: {fileID: 1847292133}
+  - component: {fileID: 1847292132}
+  m_Layer: 30
+  m_Name: TopLayerEffects - (fov, fire, atmos gfx) (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1847292131
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1847292130}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 562853482}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1847292132
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1847292130}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 594d5aea377441d42a292019e6edbe58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LayerType: 6
+  topLayerFX: {fileID: 0}
+--- !u!19719996 &1847292133
+TilemapCollider2D:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1847292130}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+--- !u!483693784 &1847292134
+TilemapRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1847292130}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -2035547137
+  m_SortingLayer: 17
+  m_SortingOrder: 0
+  m_ChunkSize: {x: 32, y: 32, z: 32}
+  m_MaxChunkCount: 16
+  m_MaxFrameAge: 16
+  m_SortOrder: 0
+  m_MaskInteraction: 0
+--- !u!1839735485 &1847292135
+Tilemap:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1847292130}
+  m_Enabled: 1
+  m_Tiles: {}
+  m_AnimatedTiles: {}
+  m_TileAssetArray: []
+  m_TileSpriteArray: []
+  m_TileMatrixArray: []
+  m_TileColorArray: []
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Origin: {x: 0, y: 0, z: 0}
+  m_Size: {x: 0, y: 0, z: 1}
+  m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
 --- !u!1001 &1855216921
 Prefab:
   m_ObjectHideFlags: 0
@@ -100304,7 +100789,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 293058355}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1905770904
 MonoBehaviour:
@@ -100318,6 +100803,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 3
+  topLayerFX: {fileID: 1197796696}
 --- !u!483693784 &1905770905
 TilemapRenderer:
   m_ObjectHideFlags: 0
@@ -101729,7 +102215,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 169189433}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1952859008
 MonoBehaviour:
@@ -101744,6 +102230,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LayerType: 3
+  topLayerFX: {fileID: 445565427}
 --- !u!483693784 &1952859009
 TilemapRenderer:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Camera/FieldOfViewStencil.cs
+++ b/UnityProject/Assets/Scripts/Camera/FieldOfViewStencil.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Tilemaps;
+using Tilemaps.Tiles;
+using Sprites;
 
 public class FieldOfViewStencil : MonoBehaviour
 {
@@ -38,18 +40,22 @@ public class FieldOfViewStencil : MonoBehaviour
 
 	void LateUpdate()
 	{
-		waitToCheckWalls += Time.deltaTime;
-		if (waitToCheckWalls > 0.1f) {
-			waitToCheckWalls = 0f;
+		//FIXME Wait is turned off, consider removing in the future if GC isn't too bad
+
+		//waitToCheckWalls += Time.deltaTime;
+		//if (waitToCheckWalls > 0.1f) {
+			//waitToCheckWalls = 0f;
 			CheckHitWallsCache();
-		}
+		//}
 		DrawFieldOfView();
 	}
 
 	void CheckHitWallsCache(){
 		var missingWalls = hitWalls.Keys.Except(curWalls).ToList();
 		for (int i = 0; i < missingWalls.Count() ;i++){
-			hitWalls[missingWalls[i]].SetColor(hitWalls[missingWalls[i]].WorldToCell(missingWalls[i]), Color.black);
+			Tile newTile = new Tile();
+			newTile.sprite = SpriteManager.Instance.shroudSprite;
+			hitWalls[missingWalls[i]].SetTile(hitWalls[missingWalls[i]].WorldToCell(missingWalls[i]), newTile);
 			hitWalls.Remove(missingWalls[i]);
 		}
 		curWalls.Clear();
@@ -161,10 +167,14 @@ public class FieldOfViewStencil : MonoBehaviour
 				//Turn the tilemap color of the wall to white so it is visible
 				hitPosition = Vector3Int.RoundToInt(hit.point + ((Vector2)dir * 0.5f));
 				if (!hitWalls.ContainsKey(hitPosition)) {
-					Tilemap tileMap = MatrixManager.Instance.wallTileMaps[hit.collider];
-					tileMap.SetTileFlags(tileMap.WorldToCell(hitPosition), TileFlags.None);
-					tileMap.SetColor(tileMap.WorldToCell(hitPosition), Color.white);
-					hitWalls.Add(hitPosition, tileMap);
+					Tilemap fxTileMap = MatrixManager.Instance.wallsToTopLayerFX[hit.collider];
+					Tilemap wallTilemap = MatrixManager.Instance.wallsTileMaps[hit.collider];
+					/// Check that there actually is a tile on the wall Tilemap as the hitPosition isn't accurate
+					TileBase getTile = wallTilemap.GetTile(wallTilemap.WorldToCell(hitPosition));
+					if (getTile != null) {
+						fxTileMap.SetTile(fxTileMap.WorldToCell(hitPosition), null);
+						hitWalls.Add(hitPosition, fxTileMap);
+					}
 				}
 				if (!curWalls.Contains(hitPosition)) {
 					curWalls.Add(hitPosition);

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager.cs
@@ -5,6 +5,8 @@ using Tilemaps;
 using UnityEngine;
 using UnityEngine.Networking;
 using UnityEngine.Tilemaps;
+using Tilemaps.Behaviours.Layers;
+using Tilemaps.Tiles;
 
 /// Matrix manager keeps a list of matrices that you can access from both client and server.
 /// Contains world/local position conversion methods, as well as several cross-matrix adaptations of Matrix methods.
@@ -18,8 +20,16 @@ public class MatrixManager : MonoBehaviour
 	/// List of active matrices
 	public List<MatrixInfo> Matrices => activeMatrices;
 
-	///Used for FoV ray hits and turning walls on and off:
-	public Dictionary<Collider2D, Tilemap> wallTileMaps = new Dictionary<Collider2D, Tilemap>();
+	/// <summary>
+	/// using the Collider2D of a wall tile you can find the tilemap of the topLayerFX in that matrix.
+	/// Used for FOV and any effects that can be shown over the top of walls
+	/// </summary>
+	public Dictionary<Collider2D, Tilemap> wallsToTopLayerFX = new Dictionary<Collider2D, Tilemap>();
+
+	/// <summary>
+	/// Find a wall tilemap via its Tilemap collider
+	/// </summary>
+	public Dictionary<Collider2D, Tilemap> wallsTileMaps = new Dictionary<Collider2D, Tilemap>();
 
 	/// Finds first matrix that is not empty at given world pos
 	public MatrixInfo AtPoint(Vector3Int worldPos)

--- a/UnityProject/Assets/Scripts/Managers/SpriteManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SpriteManager.cs
@@ -51,6 +51,11 @@ namespace Sprites
 			}
 		}
 
+		/// <summary>
+		/// The shroud sprite. Used on the topLayer TileMap to hide things, like walls
+		/// </summary>
+		public Sprite shroudSprite;
+
 		public static Sprites PlayerSprites => Instance.playerSprites;
 
 		public static Sprites ConnectSprites => Instance.wallSprites;

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerMove.cs
@@ -204,6 +204,8 @@ namespace PlayGroup
 				return direction;
 			}
 
+			Debug.Log("CURRENT MATRIX: " + curMatrix.gameObject.name);
+
 			Vector3Int newPos = currentPosition + direction;
 
 			//isReplay tells AdjustDirection if the move being carried out is a replay move for prediction or not

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
@@ -15,6 +15,7 @@ namespace Tilemaps.Behaviours.Layers
 		protected Tilemap tilemap;
 
 		public BoundsInt Bounds => tilemap.cellBounds;
+		public Tilemap topLayerFX;
 
 		public void Awake()
 		{
@@ -37,7 +38,10 @@ namespace Tilemaps.Behaviours.Layers
 			{
 				if (LayerType == LayerType.Walls)
 				{
-					MatrixManager.Instance.wallTileMaps.Add(GetComponent<TilemapCollider2D>(), tilemap);
+					if (topLayerFX != null) {
+						MatrixManager.Instance.wallsToTopLayerFX.Add(GetComponent<TilemapCollider2D>(), topLayerFX);
+					}
+					MatrixManager.Instance.wallsTileMaps.Add(GetComponent<TilemapCollider2D>(), tilemap);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/ConnectedTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/ConnectedTile.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using UnityEngine;
 using UnityEngine.Tilemaps;
+using Tilemaps.Behaviours.Layers;
+using Sprites;
 
 namespace Tilemaps.Tiles
 {
@@ -49,12 +51,22 @@ namespace Tilemaps.Tiles
 			}
 		}
 
-		public override bool StartUp(Vector3Int location, ITilemap tilemap, GameObject go){
+		public override bool StartUp(Vector3Int location, ITilemap tilemap, GameObject go)
+		{
 			if (Application.isPlaying) {
-				tilemap.GetComponent<Tilemap>().SetColor(location, Color.black);
-			} else {
-				tilemap.GetComponent<Tilemap>().SetColor(location, Color.white);
+				Layer layer = tilemap.GetComponent<Layer>();
 
+				/// Walls Only:
+				if (layer.LayerType == LayerType.Walls) {
+					
+					/// Add the black fov above all wall tiles
+					Tilemap topLayer = layer.topLayerFX;
+					if (topLayer != null) {
+						Tile newTile = new Tile();
+						newTile.sprite = SpriteManager.Instance.shroudSprite;
+						topLayer.SetTile(location, newTile);
+					}
+				}
 			}
 				return true;
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/LayerTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/LayerTile.cs
@@ -9,7 +9,8 @@ namespace Tilemaps.Tiles
 		Objects,
 		Floors,
 		Base,
-		None
+		None,
+		TopLayerEffects
 	}
 
 	public enum TileType
@@ -18,7 +19,8 @@ namespace Tilemaps.Tiles
 		Wall,
 		Window,
 		Floor,
-		Table
+		Table,
+		TopLayerEffects
 	}
 
 	public class LayerTile : GenericTile


### PR DESCRIPTION
### Purpose
- Walls were being hidden by turning their tile in the tilemap black. This created a bug where wallmounts would not be masked by the shroud because they were on a higher sorting layer then the walls.

### Approach
- Created a new Tilemap layer specifically for various effects like Wall Fov shrouds, Fire and Atmos tile graphics and animations (any effect that should go above everything else).
- Moved the wall tile Fov shrouds to the new TopLayerEffects Tilemap

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer



### Notes:
- When trying to port the changes to Flashlight Deathmatch scene I discovered that player matrix detection is broken there and most likely has been since the new matrix changes. Will make an issue for it.