### PR TITLE
Possible fix for #836

### DIFF
--- a/UnityProject/Assets/Scripts/UI/CameraZoomHandler.cs
+++ b/UnityProject/Assets/Scripts/UI/CameraZoomHandler.cs
@@ -16,10 +16,10 @@ namespace UI
         public void Refresh()
         {          
             // Calculate ratio.
-            double ratio = Screen.height / (double) Screen.width;
+            double ratio = Camera.main.pixelHeight / (double) Camera.main.pixelWidth;
             
             // Calculate scaling factor. 409600 is a magic number.
-            double scaleFactor = Math.Sqrt(Screen.height * Screen.width / (409600 * ratio));
+            double scaleFactor = Math.Sqrt(Camera.main.pixelHeight * Camera.main.pixelWidth / (409600 * ratio));
             
             // Automatically set zoom level if it's less than zero.
             if (zoomLevel < 1)

--- a/UnityProject/Assets/Scripts/UI/ResponsiveUI.cs
+++ b/UnityProject/Assets/Scripts/UI/ResponsiveUI.cs
@@ -110,33 +110,35 @@ namespace UI
 		private IEnumerator ForceGameWindowAspect()
 		{
 			yield return new WaitForSeconds(0.2f);
-			if (!Screen.fullScreen) {
-
-				//The following conditions check if the screen width or height
-				//is an odd number. If it is, then it adjusted to be an even number
-				//This fixes the sprite bleeding between tiles:
-				int width = Screen.width;
-				if (width % 2 != 0)
-				{
-					Debug.Log( $"Odd width {width}->{width-1}" );
-					width--;
-				}
-				int height = Screen.height;
-				if (height % 2 != 0)
-				{
-					Debug.Log( $"Odd height {height}->{height-1}" );
-					height--;
-				}
-				
-				// Enforce aspect by resizing the camera rectangle to nearest (lower) even number.
-				Camera.main.rect = new Rect(0, 0, width / (float)Screen.width, height / (float)Screen.height);
-				
-				if (camResizer != null) {
-					camResizer.AdjustCam();
-				}
-				screenWidthCache = Screen.width;
-				screenHeightCache = Screen.height;
+			//The following conditions check if the screen width or height
+			//is an odd number. If it is, then it adjusted to be an even number
+			//This fixes the sprite bleeding between tiles:
+			int width = Screen.width;
+			if (width % 2 != 0)
+			{
+				Debug.Log( $"Odd width {width}->{width-1}" );
+				width--;
 			}
+			int height = Screen.height;
+			if (height % 2 != 0)
+			{
+				Debug.Log( $"Odd height {height}->{height-1}" );
+				height--;
+			}
+			
+			Debug.Log("Screen height before resizing: " + Camera.main.pixelHeight + " Aspect Y: " + height/(float)Screen.height);
+			Debug.Log("Screen height before resizing: " + Camera.main.pixelWidth + " Aspect X: " + width/(float)Screen.width);
+			
+			// Enforce aspect by resizing the camera rectangle to nearest (lower) even number.
+			Camera.main.rect = new Rect(0, 0, width / (float)Screen.width, height / (float)Screen.height);
+			
+			Debug.Log("Screen height after resizing: " + Camera.main.pixelHeight);
+			
+			if (camResizer != null) {
+				camResizer.AdjustCam();
+			}
+			screenWidthCache = Screen.width;
+			screenHeightCache = Screen.height;
 			
 			//Refresh UI (helps avoid event system problems)
 			parentCanvas.enabled = false;

--- a/UnityProject/Assets/Scripts/UI/ResponsiveUI.cs
+++ b/UnityProject/Assets/Scripts/UI/ResponsiveUI.cs
@@ -127,7 +127,10 @@ namespace UI
 					Debug.Log( $"Odd height {height}->{height-1}" );
 					height--;
 				}
-				Screen.SetResolution(width, height, false);
+				
+				// Enforce aspect by resizing the camera rectangle to nearest (lower) even number.
+				Camera.main.rect = new Rect(0, 0, width / (float)Screen.width, height / (float)Screen.height);
+				
 				if (camResizer != null) {
 					camResizer.AdjustCam();
 				}


### PR DESCRIPTION
Changed method of forcing game window aspect from using `Screen.SetResolution(...)` to resizing the viewport rectangle by a small fraction. Fixes #836.

### Purpose
Resolving #836.

### Approach
Buidling on previous attempt at resolving issue #836 and PR #1069.

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer

### Notes:
As this solution reduces the viewport rectangle a tiny bit when the game window is of odd width/height there could be rendering artifacts because the camera would not clear the entire window.
During what little testing I've done there didn't seem to be any noticeable artifacts.