### PR TITLE
Use create instance instead of constructor

### DIFF
--- a/UnityProject/Assets/Scripts/Camera/FieldOfViewStencil.cs
+++ b/UnityProject/Assets/Scripts/Camera/FieldOfViewStencil.cs
@@ -1,9 +1,7 @@
-﻿using System.Collections;
-using System.Linq;
+﻿using System.Linq;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Tilemaps;
-using Tilemaps.Tiles;
 using Sprites;
 
 public class FieldOfViewStencil : MonoBehaviour
@@ -53,7 +51,7 @@ public class FieldOfViewStencil : MonoBehaviour
 	void CheckHitWallsCache(){
 		var missingWalls = hitWalls.Keys.Except(curWalls).ToList();
 		for (int i = 0; i < missingWalls.Count() ;i++){
-			Tile newTile = new Tile();
+			Tile newTile = (Tile)ScriptableObject.CreateInstance("Tile");
 			newTile.sprite = SpriteManager.Instance.shroudSprite;
 			hitWalls[missingWalls[i]].SetTile(hitWalls[missingWalls[i]].WorldToCell(missingWalls[i]), newTile);
 			hitWalls.Remove(missingWalls[i]);


### PR DESCRIPTION
Fixes #1091

### Purpose
Stops logs from being spammed by FieldOfViewStencil.

### Approach
FieldOfViewStencil now uses ScriptableObject.CreateInstance instead of new Tile()

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer
