### PR TITLE
[ DNM ] Push / Pull #1001

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet.prefab
@@ -215,9 +215,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -230,12 +229,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -281,7 +282,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!212 &212094264515058204

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Green.prefab
@@ -214,12 +214,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114597010362170592
@@ -233,7 +235,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114615101260203070
@@ -249,9 +250,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Pink.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Pink.prefab
@@ -213,7 +213,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114485734239509306
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114523646684726672
@@ -249,9 +250,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Red_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Red_Plain.prefab
@@ -198,9 +198,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114192154473191574
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -212,7 +211,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114239634461430000
@@ -244,12 +242,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Red_Stripe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_BioHazard_Red_Stripe.prefab
@@ -214,12 +214,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114599001885558102
@@ -233,7 +235,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114622615258334520
@@ -249,9 +250,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Black.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Black.prefab
@@ -197,12 +197,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114310759356319872
@@ -233,7 +235,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114563119404815312
@@ -281,9 +282,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!212 &212288130219440224
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Blue.prefab
@@ -215,9 +215,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -230,12 +229,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -281,7 +282,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!212 &212094264515058204

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Bomb.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Bomb.prefab
@@ -214,12 +214,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114559887282967898
@@ -235,9 +237,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -281,7 +282,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!212 &212094264515058204

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Brown.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Brown.prefab
@@ -198,9 +198,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114178227343361656
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -212,7 +211,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114226188280779116
@@ -276,12 +274,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!212 &212585266423504292

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Electricity.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Electricity.prefab
@@ -213,7 +213,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114485734239509306
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114544474243738448
@@ -249,9 +250,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Enginering.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Enginering.prefab
@@ -196,7 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114235402911808258
@@ -212,9 +211,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -244,12 +242,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Fire_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Fire_Red.prefab
@@ -213,7 +213,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114440515152274470
@@ -229,9 +228,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -244,12 +242,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Fire_Yellow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Fire_Yellow.prefab
@@ -214,12 +214,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -265,7 +267,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114817056745690750
@@ -281,9 +282,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Green.prefab
@@ -197,12 +197,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114471672769914432
@@ -218,9 +220,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114477434517256044
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -264,7 +265,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114672394582474368

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Grey.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Grey.prefab
@@ -197,12 +197,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114107365703837954
@@ -250,9 +252,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114859863419137498
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -281,7 +282,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!212 &212172245744083514

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_HOS.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_HOS.prefab
@@ -196,7 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114086862237097484
@@ -212,9 +211,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -244,12 +242,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_HOS1.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_HOS1.prefab
@@ -213,7 +213,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114485734239509306
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -281,9 +282,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Blue.prefab
@@ -196,7 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114239634461430000
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114644364860119310
@@ -249,9 +250,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_CE.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_CE.prefab
@@ -215,9 +215,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114460486150970724
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -229,7 +228,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114485734239509306
@@ -244,12 +242,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_CMO.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_CMO.prefab
@@ -214,12 +214,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114649345137454126
@@ -235,9 +237,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -281,7 +282,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!212 &212094264515058204

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Captain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Captain.prefab
@@ -214,12 +214,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -265,7 +267,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114935263454225050
@@ -281,9 +282,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Enginering.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Enginering.prefab
@@ -196,7 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114239634461430000
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -281,9 +282,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Green.prefab
@@ -196,7 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114239634461430000
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -281,9 +282,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_HOP.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_HOP.prefab
@@ -196,7 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114239634461430000
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114582121561473138
@@ -249,9 +250,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_HOS2.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_HOS2.prefab
@@ -213,7 +213,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114485734239509306
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -281,9 +282,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Medical_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Medical_Blue.prefab
@@ -213,7 +213,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114485734239509306
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -281,9 +282,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Medical_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Medical_Red.prefab
@@ -214,12 +214,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -267,9 +269,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114850073692931946
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -281,7 +282,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!212 &212094264515058204

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Plain.prefab
@@ -213,7 +213,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114485734239509306
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -281,9 +282,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Purple.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Purple.prefab
@@ -198,9 +198,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -229,7 +228,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114485734239509306
@@ -244,12 +242,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_RD.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_RD.prefab
@@ -215,9 +215,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114360195284987434
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -229,7 +228,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114485734239509306
@@ -244,12 +242,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Security.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Security.prefab
@@ -214,12 +214,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114605337504269064
@@ -235,9 +237,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -281,7 +282,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!212 &212094264515058204

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Warden.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Warden.prefab
@@ -196,7 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114239634461430000
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -281,9 +282,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Yellow_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Yellow_Blue.prefab
@@ -198,9 +198,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -230,12 +229,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114519431623713784
@@ -249,7 +250,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114678338651277788

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Yellow_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Yellow_Green.prefab
@@ -196,7 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114239634461430000
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -281,9 +282,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Yellow_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_Yellow_Red.prefab
@@ -196,7 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114239634461430000
@@ -229,9 +228,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -244,12 +242,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_mining.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Locker_mining.prefab
@@ -196,7 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114159567590582482
@@ -212,9 +211,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -244,12 +242,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Nuclear.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Nuclear.prefab
@@ -214,12 +214,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114547321624010300
@@ -233,7 +235,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114636999251767984
@@ -249,9 +250,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114678338651277788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Oxygen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Oxygen.prefab
@@ -198,9 +198,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114325905384881024
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -230,12 +229,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114473011698291292
@@ -281,7 +282,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!212 &212309241971002690

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Pink_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Pink_Plain.prefab
@@ -215,9 +215,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114485734239509306
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -230,12 +229,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -281,7 +282,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!212 &212094264515058204

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Purple.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Purple.prefab
@@ -197,12 +197,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114092939811341892
@@ -218,9 +220,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114465697400450480
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -264,7 +265,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114835786064520692

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Red.prefab
@@ -198,9 +198,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114110721192159654
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -212,7 +211,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114239634461430000
@@ -244,12 +242,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Red_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Red_Plain.prefab
@@ -196,7 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114239634461430000
@@ -228,12 +227,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788
@@ -281,9 +282,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!212 &212094264515058204
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_YellowBlue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_YellowBlue.prefab
@@ -198,9 +198,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ObjectType: 1
   AtmosPassable: 1
-  Offset: {x: 0, y: 0, z: 0}
   Passable: 0
-  IsClosed: 1
+  PassableWhileOpen: 1
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -229,7 +228,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  SpeedMultiplier: 1
   isPushing: 0
   predictivePushing: 0
 --- !u!114 &114485734239509306
@@ -244,12 +242,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 0
+  ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
   allowedToMove: 1
   currentPos: {x: 0, y: 0, z: 0}
   isPushable: 1
   pulledBy: {fileID: 0}
+  custNetActiveState: 0
   pushing: 0
   pushTarget: {x: 0, y: 0, z: 0}
 --- !u!114 &114678338651277788

--- a/UnityProject/Assets/Scripts/Objects/ObjectBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Objects/ObjectBehaviour.cs
@@ -26,22 +26,6 @@ public class ObjectBehaviour : PushPull
 		playerScript = GetComponent<PlayerScript>();
 	}
 
-	public override void OnMouseDown()
-	{
-		if (PlayerManager.LocalPlayerScript.IsInReach(transform.position))
-		{
-			//If this is an item with a pick up trigger and player is
-			//not holding control, then check if it is being pulled
-			//before adding to inventory
-			if (!Input.GetKey(KeyCode.LeftControl) && pickUpTrigger !=
-			    null && pulledBy != null)
-			{
-				CancelPullBehaviour();
-			}
-		}
-		base.OnMouseDown();
-	}
-
 	public override void OnVisibilityChange(bool state)
 	{
 		if (playerScript != null)

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -56,7 +56,7 @@ public class PushPull : VisibleBehaviour
 		}
 	}
 
-	public virtual void OnMouseDown()
+	public void InteractWithPulling()
 	{
 		// PlayerManager.LocalPlayerScript.playerMove.pushPull.pulledBy == null condition makes sure that the player itself
 		// isn't being pulled. If he is then he is not allowed to pull anything else as this can cause problems

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Cupboards;
 using PlayGroup;
-using Tilemaps.Behaviours.Objects;
 using Tilemaps.Tiles;
 using UI;
 using UnityEngine;
@@ -11,19 +10,12 @@ using UnityEngine.Tilemaps;
 
 namespace PlayGroups.Input
 {
-	public class InputController : MonoBehaviour
-	{
-		/// <summary>
-		///     The cooldown before another action can be performed
-		/// </summary>
-		private float CurrentCooldownTime;
+	public class InputController : MonoBehaviour {
 
-		/// <summary>
-		///     The minimum time limit between each action
-		/// </summary>
-		private float InputCooldownTimer = 0.01f;
+		private const string FieldOfViewName = "FieldOfView";
+		private const float InputCooldownTimer = 0.01f; // Minimum time limit between each action. Currently unused?
 
-		private Vector2 LastTouchedTile;
+		private Vector2 lastTouchedTile;
 		private LayerMask layerMask;
 		private ObjectBehaviour objectBehaviour;
 		private PlayerMove playerMove;
@@ -32,7 +24,7 @@ namespace PlayGroups.Input
 		private void OnDrawGizmos()
 		{
 			Gizmos.color = new Color(1, 0, 0, 0.5F);
-			Gizmos.DrawCube(LastTouchedTile, new Vector3(1, 1, 1));
+			Gizmos.DrawCube(lastTouchedTile, new Vector3(1, 1, 1));
 		}
 
 		private void Start()
@@ -43,14 +35,16 @@ namespace PlayGroups.Input
 			objectBehaviour = GetComponent<ObjectBehaviour>();
 
 			//Do not include the Default layer! Assign your object to one of the layers below:
-			layerMask = LayerMask.GetMask("Furniture", "Walls", "Windows", "Machines", "Players", "Items", "Door Open", "Door Closed", "WallMounts",
-				"HiddenWalls", "Objects");
+			layerMask = LayerMask.GetMask(
+				"Furniture", "Walls", "Windows", "Machines", "Players", "Items", 
+				"Door Open", "Door Closed", "WallMounts","HiddenWalls", "Objects");
 		}
 
 		private void OnGUI() {
 			if ( Event.current.type == EventType.MouseDown ) {
 				CheckHandSwitch();
 				CheckAltClick();
+				CheckControlClick();
 				CheckThrow();
 				CheckClick();
 			}
@@ -66,8 +60,9 @@ namespace PlayGroups.Input
 		}
 
 		private void CheckClick() {
-			Event e = Event.current;
-			if ( e.type != EventType.Used && e.button == 0 && !UnityEngine.Input.GetKey(KeyCode.LeftControl) && !UnityEngine.Input.GetKey(KeyCode.LeftAlt) )
+			if (isLeftClick() 
+			    && !UnityEngine.Input.GetKey(KeyCode.LeftControl) 
+			    && !UnityEngine.Input.GetKey(KeyCode.LeftAlt))
 			{
 				//change the facingDirection of player on click
 				ChangeDirection();
@@ -82,7 +77,8 @@ namespace PlayGroups.Input
 
 		private void CheckAltClick() {
 			Event e = Event.current;
-			if (e.type != EventType.Used && e.button == 0 && (UnityEngine.Input.GetKey(KeyCode.LeftAlt) || UnityEngine.Input.GetKey(KeyCode.RightAlt)))
+			if (isLeftClick() 
+			    && (UnityEngine.Input.GetKey(KeyCode.LeftAlt) || UnityEngine.Input.GetKey(KeyCode.RightAlt)))
 			{
 				//Check for items on the clicked possition, and display them in the Item List Tab, if they're in reach
 				Vector3 position = Camera.main.ScreenToWorldPoint(UnityEngine.Input.mousePosition);
@@ -98,15 +94,18 @@ namespace PlayGroups.Input
 				e.Use();
 			}
 		}
+		
 		private void CheckThrow() {
 			Event e = Event.current;
-			if (e.type != EventType.Used && e.button == 0 && UIManager.IsThrow)
+			if (isLeftClick() && UIManager.IsThrow)
 			{
 				var currentSlot = UIManager.Hands.CurrentSlot;
+				
 				if (!currentSlot.CanPlaceItem())
 				{
 					return;
 				}
+				
 				//Check for items on the clicked possition, and display them in the Item List Tab, if they're in reach
 				Vector3 position = Camera.main.ScreenToWorldPoint(UnityEngine.Input.mousePosition);
 				position.z = 0f;
@@ -114,10 +113,32 @@ namespace PlayGroups.Input
 				Debug.Log( $"Requesting throw from {currentSlot.eventName} to {position}" );
 				PlayerManager.LocalPlayerScript.playerNetworkActions
 					.CmdRequestThrow( currentSlot.eventName, position, (int) UIManager.DamageZone );
-				//Disabling throw button
-				UIManager.Action.Throw();
+				UIManager.Action.Throw(); //Disabling throw button
 				e.Use();
 			}
+		}
+
+		private void CheckControlClick()
+		{
+			if (isLeftClick()
+			    && UnityEngine.Input.GetKey(KeyCode.LeftControl) 
+			    && !UnityEngine.Input.GetKey(KeyCode.LeftAlt))
+			{
+				var objectRender = GetInteractableObject();
+				if (objectRender != null)
+				{
+					objectRender.transform
+						.GetComponentInParent<InputTrigger>()
+						.GetComponentInParent<PushPull>()
+						.InteractWithPulling();
+				}
+			}
+		}
+
+		private bool isLeftClick()
+		{
+			var e = Event.current;
+			return e.type != EventType.Used && e.button == 0;
 		}
 
 		private void ChangeDirection()
@@ -129,27 +150,45 @@ namespace PlayGroups.Input
 			}
 		}
 
+		// Return the top-most object that we are allowed to interact with, or null
+		private Renderer GetInteractableObject()
+		{
+			var clickPosition = Camera.main.ScreenToWorldPoint(UnityEngine.Input.mousePosition);
+			var renderers = GetRenderersFromHits(clickPosition,
+				Physics2D.RaycastAll(clickPosition, Vector2.zero, 10f, layerMask));
+
+			if (renderers.Count == 0 
+			    || playerMove.isGhost 
+				|| !PlayerManager.LocalPlayerScript.IsInReach(clickPosition))
+			{
+				return null;
+			}
+
+			foreach (var objectRenderer in renderers.OrderByDescending(sr => sr.sortingOrder))
+			{
+				if (FieldOfViewName.Equals(objectRenderer.sortingLayerName))
+				{
+					continue;
+				}
+
+				return objectRenderer;
+			}
+
+			return null;
+		}
+
 		private bool RayHit()
 		{
 			Vector3 position = Camera.main.ScreenToWorldPoint(UnityEngine.Input.mousePosition);
 
 			//for debug purpose, mark the most recently touched tile location
-			LastTouchedTile = new Vector2(Mathf.Round(position.x), Mathf.Round(position.y));
+			lastTouchedTile = new Vector2(Mathf.Round(position.x), Mathf.Round(position.y));
 
 			RaycastHit2D[] hits = Physics2D.RaycastAll(position, Vector2.zero, 10f, layerMask);
 
 			//collect all the sprite renderers
-			List<Renderer> renderers = new List<Renderer>();
-
-			foreach (RaycastHit2D hit in hits)
-			{
-				Transform objectTransform = hit.collider.gameObject.transform;
-				Renderer _renderer = IsHit(objectTransform, position - objectTransform.position);
-				if (_renderer != null)
-				{
-					renderers.Add(_renderer);
-				}
-			}
+			List<Renderer> renderers = GetRenderersFromHits(position, hits);
+			
 			bool isInteracting = false;
 			//check which of the sprite renderers we hit and pixel checked is the highest
 			if (renderers.Count > 0)
@@ -157,7 +196,7 @@ namespace PlayGroups.Input
 				foreach (Renderer _renderer in renderers.OrderByDescending(sr => sr.sortingOrder)) 
 				{
 					// If the ray hits a FOVTile, we can continue down (don't count it as an interaction)
-					if (!_renderer.sortingLayerName.Equals("FieldOfView"))
+					if (!FieldOfViewName.Equals(_renderer.sortingLayerName))
 					{
 						if (Interact(_renderer.transform, position))
 						{
@@ -179,6 +218,23 @@ namespace PlayGroups.Input
 			return hits.Any();
 		}
 
+		private List<Renderer> GetRenderersFromHits(Vector3 mouseClickPosition, IEnumerable<RaycastHit2D> hits)
+		{
+			var renderers = new List<Renderer>();
+
+			foreach (var hit in hits)
+			{
+				var objectTransform = hit.collider.gameObject.transform;
+				var objectRenderer = IsHit(objectTransform, mouseClickPosition - objectTransform.position);
+				if (objectRenderer != null)
+				{
+					renderers.Add(objectRenderer);
+				}
+			}
+
+			return renderers;
+		}
+		
 		private Renderer IsHit(Transform _transform, Vector3 hitPosition)
 		{
 			TilemapRenderer tilemapRenderer = _transform.GetComponent<TilemapRenderer>();

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/Triggers/PickUpTrigger.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/Triggers/PickUpTrigger.cs
@@ -53,18 +53,24 @@ namespace Items
 			var slotName = handSlot ?? UIManager.Hands.CurrentSlot.eventName;
 			var cnt = GetComponent<CustomNetTransform>();
 			var state = cnt.ServerState;
+			var pushPull = GetComponent<PushPull>();
+			
 			if (SlotUnavailable(ps, slotName))
 			{
 				return false;
 			}
-			if (cnt.IsFloatingServer ? !CanReachFloating(ps, state) : !ps.IsInReach(state.WorldPosition))
+		
+			if (pushPull.pulledBy == PlayerManager.LocalPlayer) 
+			{ // If this object is being pulled, it should be in reach. Stop pulling it before we pick it up
+				pushPull.CancelPullBehaviour();
+			} 
+			else if (cnt.IsFloatingServer ? !CanReachFloating(ps, state) : !ps.IsInReach(state.WorldPosition))
 			{
 				Debug.LogWarningFormat($"Not in reach! server pos:{state.WorldPosition} player pos:{originator.transform.position} (floating={cnt.IsFloatingServer})");
 				return false;
 			}
 
 //			Debug.LogFormat($"Pickup success! server pos:{state.position} player pos:{originator.transform.position} (floating={cnt.IsFloatingServer()})");
-
 
 			//set ForceInform to false for simulation
 			return ps.playerNetworkActions.AddItem(gameObject, slotName, false /*, false*/);

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.PushPull.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.PushPull.cs
@@ -61,7 +61,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		}
 		var netTransform = obj.GetComponent<CustomNetTransform>();
 		if (netTransform != null) {
-			netTransform.SetPosition(obj.transform.localPosition);
+			netTransform.SetPosition(obj.transform.position);
 		}
 	}
 
@@ -89,7 +89,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		}
 		var netTransform = obj.GetComponent<CustomNetTransform>();
 		if (netTransform != null) {
-			netTransform.SetPosition(obj.transform.localPosition);
+			netTransform.SetPosition(obj.transform.position);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterCloset.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterCloset.cs
@@ -3,13 +3,15 @@
 namespace Tilemaps.Behaviours.Objects
 {
 	[ExecuteInEditMode]
-	public class RegisterCloset : RegisterObject
-	{
+	public class RegisterCloset : RegisterObject {
+
+		public bool PassableWhileOpen;
+		
 		private bool isClosed = true;
 		public bool IsClosed {
 			set {
 				isClosed = value;
-				Passable = !isClosed;
+				Passable = PassableWhileOpen && !isClosed;
 			}
 			get { return isClosed; }
 		}

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
@@ -74,6 +74,15 @@ namespace UI
             {
                 UIManager.Intent.IntentHotkey(3);
             }
+
+			if (Input.GetKeyDown(KeyCode.Delete))
+			{
+				var pulling = PlayerManager.LocalPlayerScript.playerSync.PullingObject;
+				if (pulling)
+				{
+					pulling.GetComponent<PushPull>().CancelPullBehaviour();
+				}
+			}
         }
 
 		public void Resist()


### PR DESCRIPTION

### Purpose
Beginning of work on #1001. 

Fixing interactions with pushing and pulling objects, most notably containers.

### Approach

- Removed OnMouseDown from PushPull and ObjectBehaviour
  - In PushPull, OnMouseDown has changed to be called from InputController
    - InputController has been slightly refactored and cleaned to handle this
  - Previously, this would be incorrectly called when the tile the object is on was clicked
  - Cancelling the pull previously done in ObjectBehaviour when picking up is now handled in PickUpTrigger
- Added functionality to stop pulling an object when hitting forward delete key
- Added variable to toggle whether a container can be walked through when open
  - For all closets, this is now true, staying false for boxes

### Open Issues
- Cancel Pull Issues
  - Previously, when cancelling the pull, the object would shift one tile down and to the left
  - This is changed to position instead of localposition
  - Object appears to blink out of existence when this happens
    - Best guess is that matrix position or something like that updates, and when it does, the object is moved from the position it was picked up to the new location
- When pulling, objects will blink behind the player in certain rotations 
- Pushing doesn't work at all

### Open Questions and Pre-Merge TODOs

- [ ]  I read the contribution guidelines and the wiki.
- [ ]  This fix is tested on the same branch it is PR'ed to.
- [ ]  I correctly commented my code
- [ ]  This PR does not include files without specific need to do so.
- [ ]  This PR does not bring up any new compile errors
- [ ]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer

### Notes
Previously, there was some code in playermove that would push objects that would not be allowed to be pushed (if block at ~243, "not to be checked when doing a replay"). Rebasing to develop seems to have fixed this.

