### PR TITLE
Mapped shuttled consoles and Fixed Fov on moving shuttles

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/shuttle_console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/shuttle_console.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4261346550607464}
   - component: {fileID: 212899688356890650}
   m_Layer: 0
-  m_Name: Sprite
+  m_Name: ScreenSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -48,6 +48,35 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1529566477441902
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4121212645089810}
+  - component: {fileID: 212088836976529770}
+  m_Layer: 0
+  m_Name: Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4121212645089810
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1529566477441902}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4426312013641224}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4261346550607464
 Transform:
   m_ObjectHideFlags: 1
@@ -59,7 +88,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4426312013641224}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4426312013641224
 Transform:
@@ -67,10 +96,11 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1413862099450234}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 2, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 4121212645089810}
   - {fileID: 4261346550607464}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -198,6 +228,50 @@ MonoBehaviour:
   ObjectType: 1
   AtmosPassable: 1
   Passable: 0
+--- !u!212 &212088836976529770
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1529566477441902}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 63ad07f389034e49893bdd6e79303e4d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -24161425
+  m_SortingLayer: 4
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300002, guid: 23cac5d228c549fb907782b9c77359f6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
 --- !u!212 &212899688356890650
 SpriteRenderer:
   m_ObjectHideFlags: 1
@@ -231,8 +305,8 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -24161425
   m_SortingLayer: 4
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300002, guid: 23cac5d228c549fb907782b9c77359f6, type: 3}
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 21300218, guid: 23cac5d228c549fb907782b9c77359f6, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
+++ b/UnityProject/Assets/Scenes/OutpostDeathmatch.unity
@@ -45842,57 +45842,6 @@ Transform:
   m_PrefabParentObject: {fileID: 4000012887992874, guid: e1a9ff52d12442f3bf8a03873bcab8ee,
     type: 2}
   m_PrefabInternal: {fileID: 451659831}
---- !u!1001 &453055772
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1658452411}
-    m_Modifications:
-    - target: {fileID: 4227545062110432, guid: 246bff6aa4fe445bfaddb972bd4d5854, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 73
-      objectReference: {fileID: 0}
-    - target: {fileID: 4227545062110432, guid: 246bff6aa4fe445bfaddb972bd4d5854, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 28
-      objectReference: {fileID: 0}
-    - target: {fileID: 4227545062110432, guid: 246bff6aa4fe445bfaddb972bd4d5854, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4227545062110432, guid: 246bff6aa4fe445bfaddb972bd4d5854, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4227545062110432, guid: 246bff6aa4fe445bfaddb972bd4d5854, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4227545062110432, guid: 246bff6aa4fe445bfaddb972bd4d5854, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0.00000014901144
-      objectReference: {fileID: 0}
-    - target: {fileID: 4227545062110432, guid: 246bff6aa4fe445bfaddb972bd4d5854, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4227545062110432, guid: 246bff6aa4fe445bfaddb972bd4d5854, type: 2}
-      propertyPath: m_RootOrder
-      value: 562
-      objectReference: {fileID: 0}
-    - target: {fileID: 1439898276103874, guid: 246bff6aa4fe445bfaddb972bd4d5854, type: 2}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 246bff6aa4fe445bfaddb972bd4d5854, type: 2}
-  m_IsPrefabParent: 0
---- !u!4 &453055773 stripped
-Transform:
-  m_PrefabParentObject: {fileID: 4227545062110432, guid: 246bff6aa4fe445bfaddb972bd4d5854,
-    type: 2}
-  m_PrefabInternal: {fileID: 453055772}
 --- !u!1001 &453691077
 Prefab:
   m_ObjectHideFlags: 0
@@ -47205,7 +47154,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 515577130}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 10, y: -19, z: 0}
+  m_LocalPosition: {x: -17, y: -19, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 562853482}
@@ -48212,6 +48161,7 @@ Transform:
   - {fileID: 1605953427}
   - {fileID: 653553074}
   - {fileID: 865583191}
+  - {fileID: 1379482881}
   m_Father: {fileID: 562853482}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -84104,6 +84054,61 @@ Prefab:
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 224685630179238100, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224261243066335572, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224963789470805622, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224529798827776512, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224082241428792102, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224082241428792102, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224082241428792102, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224652079256797148, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.000015258789
+      objectReference: {fileID: 0}
+    - target: {fileID: 224253814974175500, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224253814974175500, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224253814974175500, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 829f4ca992b848d6bb4d007fb9c112e1, type: 2}
   m_IsPrefabParent: 0
@@ -86965,6 +86970,7 @@ Transform:
   - {fileID: 1387699329}
   - {fileID: 731394909}
   - {fileID: 579805130}
+  - {fileID: 2053330504}
   m_Father: {fileID: 293058355}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -87162,6 +87168,58 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!1001 &1379482880
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 552279807}
+    m_Modifications:
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: -9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_RootOrder
+      value: 85
+      objectReference: {fileID: 0}
+    - target: {fileID: 114660502884524074, guid: 3545a60288a06864980b70ada5d081ee,
+        type: 2}
+      propertyPath: ShuttleMatrixMove
+      value: 
+      objectReference: {fileID: 515577132}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &1379482881 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee,
+    type: 2}
+  m_PrefabInternal: {fileID: 1379482880}
 --- !u!1001 &1387026877
 Prefab:
   m_ObjectHideFlags: 0
@@ -93268,6 +93326,53 @@ Transform:
   m_PrefabParentObject: {fileID: 4000013877075750, guid: fc5783dcb3f74ab1b2187da95b6c932d,
     type: 2}
   m_PrefabInternal: {fileID: 1622871871}
+--- !u!1001 &1624249565
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1658452411}
+    m_Modifications:
+    - target: {fileID: 4335463542504290, guid: 4ce92eb606dc8b34a8b7718dd975fcaa, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 73
+      objectReference: {fileID: 0}
+    - target: {fileID: 4335463542504290, guid: 4ce92eb606dc8b34a8b7718dd975fcaa, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 28
+      objectReference: {fileID: 0}
+    - target: {fileID: 4335463542504290, guid: 4ce92eb606dc8b34a8b7718dd975fcaa, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4335463542504290, guid: 4ce92eb606dc8b34a8b7718dd975fcaa, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4335463542504290, guid: 4ce92eb606dc8b34a8b7718dd975fcaa, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4335463542504290, guid: 4ce92eb606dc8b34a8b7718dd975fcaa, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0.00000014901144
+      objectReference: {fileID: 0}
+    - target: {fileID: 4335463542504290, guid: 4ce92eb606dc8b34a8b7718dd975fcaa, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4335463542504290, guid: 4ce92eb606dc8b34a8b7718dd975fcaa, type: 2}
+      propertyPath: m_RootOrder
+      value: 562
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 4ce92eb606dc8b34a8b7718dd975fcaa, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &1624249566 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4335463542504290, guid: 4ce92eb606dc8b34a8b7718dd975fcaa,
+    type: 2}
+  m_PrefabInternal: {fileID: 1624249565}
 --- !u!1 &1626486380
 GameObject:
   m_ObjectHideFlags: 0
@@ -95328,7 +95433,7 @@ Transform:
   - {fileID: 807094169}
   - {fileID: 2045311478}
   - {fileID: 468772272}
-  - {fileID: 453055773}
+  - {fileID: 1624249566}
   - {fileID: 2018429273}
   - {fileID: 511638688}
   - {fileID: 31011311}
@@ -117976,6 +118081,58 @@ Transform:
   m_PrefabParentObject: {fileID: 4951941870120558, guid: aa0d300c4a5b04dfd95c5e0790207b3b,
     type: 2}
   m_PrefabInternal: {fileID: 2051163281}
+--- !u!1001 &2053330503
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1379343682}
+    m_Modifications:
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 114660502884524074, guid: 3545a60288a06864980b70ada5d081ee,
+        type: 2}
+      propertyPath: ShuttleMatrixMove
+      value: 
+      objectReference: {fileID: 684530371}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 3545a60288a06864980b70ada5d081ee, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &2053330504 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4426312013641224, guid: 3545a60288a06864980b70ada5d081ee,
+    type: 2}
+  m_PrefabInternal: {fileID: 2053330503}
 --- !u!1001 &2056469604
 Prefab:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Camera/FieldOfViewStencil.cs
+++ b/UnityProject/Assets/Scripts/Camera/FieldOfViewStencil.cs
@@ -17,8 +17,8 @@ public class FieldOfViewStencil : MonoBehaviour
 	public float EdgeDistanceThreshhold;
 
 	public float MaskCutawayDst;
-	private Dictionary<Vector3, Tilemap> hitWalls = new Dictionary<Vector3, Tilemap>();
-	private HashSet<Vector3> curWalls = new HashSet<Vector3>();
+	private Dictionary<Vector3Int, Tilemap> hitWalls = new Dictionary<Vector3Int, Tilemap>();
+	private HashSet<Vector3Int> curWalls = new HashSet<Vector3Int>();
 
 	private HashSet<GameObject> hitDoors = new HashSet<GameObject>();
 	private HashSet<GameObject> curDoors = new HashSet<GameObject>();
@@ -53,7 +53,7 @@ public class FieldOfViewStencil : MonoBehaviour
 		for (int i = 0; i < missingWalls.Count() ;i++){
 			Tile newTile = (Tile)ScriptableObject.CreateInstance("Tile");
 			newTile.sprite = SpriteManager.Instance.shroudSprite;
-			hitWalls[missingWalls[i]].SetTile(hitWalls[missingWalls[i]].WorldToCell(missingWalls[i]), newTile);
+			hitWalls[missingWalls[i]].SetTile(missingWalls[i], newTile);
 			hitWalls.Remove(missingWalls[i]);
 		}
 		curWalls.Clear();
@@ -164,18 +164,19 @@ public class FieldOfViewStencil : MonoBehaviour
 			if (hit.collider.gameObject.layer == 9) {
 				//Turn the tilemap color of the wall to white so it is visible
 				hitPosition = Vector3Int.RoundToInt(hit.point + ((Vector2)dir * 0.5f));
-				if (!hitWalls.ContainsKey(hitPosition)) {
+				Tilemap wallTilemap = MatrixManager.Instance.wallsTileMaps[hit.collider];
+				Vector3Int wallCellPos = wallTilemap.WorldToCell(hitPosition);
+				if (!hitWalls.ContainsKey(wallCellPos)) {
 					Tilemap fxTileMap = MatrixManager.Instance.wallsToTopLayerFX[hit.collider];
-					Tilemap wallTilemap = MatrixManager.Instance.wallsTileMaps[hit.collider];
 					/// Check that there actually is a tile on the wall Tilemap as the hitPosition isn't accurate
-					TileBase getTile = wallTilemap.GetTile(wallTilemap.WorldToCell(hitPosition));
+					TileBase getTile = wallTilemap.GetTile(wallCellPos);
 					if (getTile != null) {
 						fxTileMap.SetTile(fxTileMap.WorldToCell(hitPosition), null);
-						hitWalls.Add(hitPosition, fxTileMap);
+						hitWalls.Add(wallCellPos, fxTileMap);
 					}
 				}
-				if (!curWalls.Contains(hitPosition)) {
-					curWalls.Add(hitPosition);
+				if (!curWalls.Contains(wallCellPos)) {
+					curWalls.Add(wallCellPos);
 				}
 			}
 			return new ViewCastInfo(true, hit.point, hit.distance, globalAngle);


### PR DESCRIPTION
## Description
- Added screen sprites to Shuttle Consoles
- Mapped shuttle consoles on OutpostDM and Flashlight DM
- Applied fix for the FoV problems experienced on moving shuttles

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer