### PR TITLE
Fixed players being unaware of other players positions in some occasions

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using Facepunch.Steamworks;
 using PlayGroup;
@@ -307,17 +308,23 @@ public class CustomNetworkManager : NetworkManager
 	/// Warning: sending a lot of data, make sure client receives it only once
 	public void SyncPlayerData(GameObject playerGameObject)
 	{
+		//All matrices
 		MatrixMove[] matrices = FindObjectsOfType<MatrixMove>();
 		for (var i = 0; i < matrices.Length; i++) {
 			matrices[i].NotifyPlayer(playerGameObject, true);
 		}
+		//All transforms
 		CustomNetTransform[] scripts = FindObjectsOfType<CustomNetTransform>();
 		for (var i = 0; i < scripts.Length; i++) {
 			scripts[i].NotifyPlayer(playerGameObject, true);
 		}
-		//tell player his position (required for spawning in moving ship)
-		playerGameObject.GetComponent<PlayerSync>().NotifyPlayer( playerGameObject, true );
-		Debug.LogFormat($"Sent sync data ({matrices.Length} matrices, {scripts.Length} transforms) to {playerGameObject.name}");
+		//All players
+		List<ConnectedPlayer> players = PlayerList.Instance.InGamePlayers;
+		for ( var i = 0; i < players.Count; i++ ) {
+			players[i].Script.playerSync.NotifyPlayer( playerGameObject, true );
+		}
+
+		Debug.LogFormat($"Sent sync data ({matrices.Length} matrices, {scripts.Length} transforms, {players.Count} players) to {playerGameObject.name}");
 	}
 
 	private IEnumerator WaitForSpawnListSetUp(NetworkConnection conn)

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -13,15 +13,17 @@ public static class SpawnHandler
 	public static void SpawnPlayer(NetworkConnection conn, short playerControllerId, JobType jobType = JobType.NULL)
 	{
 		GameObject player = CreatePlayer(jobType);
-		PlayerList.Instance.UpdatePlayer(conn, player);
+		var connectedPlayer = PlayerList.Instance.UpdatePlayer(conn, player);
 		NetworkServer.AddPlayerForConnection(conn, player, playerControllerId);
+		connectedPlayer.Script.playerSync.NotifyPlayers( true );
 	}
 
 	public static void RespawnPlayer(NetworkConnection conn, short playerControllerId, JobType jobType)
 	{
 		GameObject player = CreatePlayer(jobType);
-		PlayerList.Instance.UpdatePlayer(conn, player);
+		var connectedPlayer = PlayerList.Instance.UpdatePlayer(conn, player);
 		NetworkServer.ReplacePlayerForConnection(conn, player, playerControllerId);
+		connectedPlayer.Script.playerSync.NotifyPlayers( true );
 	}
 
 	private static GameObject CreatePlayer(JobType jobType)

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -154,10 +154,11 @@ public class PlayerList : NetworkBehaviour
 	}
 
 	[Server]
-	public void UpdatePlayer(NetworkConnection conn, GameObject newGameObject)
+	public ConnectedPlayer UpdatePlayer(NetworkConnection conn, GameObject newGameObject)
 	{
 		ConnectedPlayer connectedPlayer = Get(conn);
 		connectedPlayer.GameObject = newGameObject;
+		return connectedPlayer;
 	}
 
 	/// Add previous ConnectedPlayer state to the old values list

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
@@ -40,7 +40,16 @@ namespace PlayGroup
 
 		public PlayerSprites playerSprites { get; set; }
 
-		public PlayerSync playerSync { get; set; }
+		private PlayerSync _playerSync;
+		public PlayerSync playerSync {
+			get {
+				if ( !_playerSync ) {
+					_playerSync = GetComponent<PlayerSync>();
+				}
+
+				return _playerSync;
+			}
+		}
 		
 		public RegisterTile registerTile { get; set; }
 
@@ -96,7 +105,7 @@ namespace PlayGroup
 		private void Start()
 		{
 			playerNetworkActions = GetComponent<PlayerNetworkActions>();
-			playerSync = GetComponent<PlayerSync>();
+//			playerSync = GetComponent<PlayerSync>();
 			registerTile = GetComponent<RegisterTile>();
 			playerHealth = GetComponent<PlayerHealth>();
 			weaponNetworkActions = GetComponent<WeaponNetworkActions>();

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.Server.cs
@@ -190,16 +190,20 @@ namespace PlayGroup
 
 		/// Send current serverState to all players
 		[Server]
-		public void NotifyPlayers()
+		public void NotifyPlayers(bool noLerp = false)
 		{
 			//Generally not sending mid-flight updates (unless there's a sudden change of course etc.)
 			if (!serverState.ImportantFlightUpdate && consideredFloatingServer)
 			{
 				return;
 			}
-			serverState.NoLerp = false;
+			serverState.NoLerp = noLerp;
 			PlayerMoveMessage.SendToAll(gameObject, serverState);
-			ClearStateFlags();
+			//Clearing state flags
+			serverTargetState.ImportantFlightUpdate = false;
+			serverTargetState.ResetClientQueue = false;
+			serverState.ImportantFlightUpdate = false;
+			serverState.ImportantFlightUpdate = false;
 		}
 
 		/// Clears server pending actions queue

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.cs
@@ -227,13 +227,6 @@ namespace PlayGroup
 			}
 		}
 
-		private void ClearStateFlags() {
-			serverTargetState.ImportantFlightUpdate = false;
-			serverTargetState.ResetClientQueue = false;
-			serverState.ImportantFlightUpdate = false;
-			serverState.ImportantFlightUpdate = false;
-		}
-
 		private void GhostLerp( PlayerState state ) {
 			playerScript.ghost.transform.position =
 				Vector3.MoveTowards( playerScript.ghost.transform.position,


### PR DESCRIPTION
### Purpose
Notifies ingame players of (re)spawned player;
Sync on join includes all ingame players positions
All of this is because implicit unity spawning provides wrong spawn position

### Open Questions and Pre-Merge TODOs

- [x]  I read the contribution guidelines and the wiki.
- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  This PR does not include files without specific need to do so.
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
- Tested by hosting from editor and joining with 200ms client
- Spawning players might look a bit jerky