### PR TITLE
Updated Diagonal Player Movement

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerMove.cs
@@ -300,8 +300,7 @@ namespace PlayGroup
 			{
 				if (pushPulls[i] && pushPulls[i].gameObject != gameObject)
 				{
-					if(pushPulls[i].TryPush(gameObject, direction))
-					result = true;
+					pushPulls [i].TryPush (gameObject, direction);
 				}
 			}
 			return result;

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerMove.cs
@@ -11,328 +11,339 @@ using UnityEngine.Networking;
 
 namespace PlayGroup
 {
-    /// <summary>
-    ///     Player move queues the directional move keys
-    ///     to be processed along with the server.
-    ///     It also changes the sprite direction and
-    ///     handles interaction with objects that can
-    ///     be walked into it.
-    /// </summary>
-    public class PlayerMove : NetworkBehaviour
-    {
-        private readonly List<KeyCode> pressedKeys = new List<KeyCode>();
+	/// <summary>
+	///     Player move queues the directional move keys
+	///     to be processed along with the server.
+	///     It also changes the sprite direction and
+	///     handles interaction with objects that can
+	///     be walked into it.
+	/// </summary>
+	public class PlayerMove : NetworkBehaviour
+	{
+		private readonly List<KeyCode> pressedKeys = new List<KeyCode>();
 
-        [SyncVar] public bool allowInput = true;
+		[SyncVar] public bool allowInput = true;
 
-        public bool diagonalMovement;
-        public bool azerty;
-        [SyncVar] public bool isGhost;
+		public bool diagonalMovement;
+		public bool azerty;
+		[SyncVar] public bool isGhost;
 
-        public KeyCode[] keyCodes =
-        {
-            KeyCode.W, KeyCode.A, KeyCode.S, KeyCode.D, KeyCode.UpArrow, KeyCode.LeftArrow, KeyCode.DownArrow,
-            KeyCode.RightArrow
-        };
+		public KeyCode[] keyCodes =
+		{
+			KeyCode.W, KeyCode.A, KeyCode.S, KeyCode.D, KeyCode.UpArrow, KeyCode.LeftArrow, KeyCode.DownArrow,
+			KeyCode.RightArrow
+		};
 
-        public PlayerMatrixDetector playerMatrixDetector;
-        private PlayerSprites playerSprites;
-        private IPlayerSync playerSync;
+		public PlayerMatrixDetector playerMatrixDetector;
+		private PlayerSprites playerSprites;
+		private IPlayerSync playerSync;
 
-        [HideInInspector] public PlayerNetworkActions pna;
-        [HideInInspector] public PushPull pushPull; //The push pull component attached to this player
-        public float speed = 10;
+		[HideInInspector] public PlayerNetworkActions pna;
+		[HideInInspector] public PushPull pushPull; //The push pull component attached to this player
+		public float speed = 10;
 
-        public bool IsPushing { get; set; }
+		public bool IsPushing { get; set; }
 
-        private RegisterTile registerTile;
-        private Matrix matrix => registerTile.Matrix;
+		private RegisterTile registerTile;
+		private Matrix matrix => registerTile.Matrix;
 
-        /// temp solution for use with the UI network prediction
-        public bool isMoving { get; } = false;
+		private Vector3Int lastMove = Vector3Int.zero;
 
-        private void Start()
-        {
-            playerSprites = gameObject.GetComponent<PlayerSprites>();
-            playerSync = GetComponent<IPlayerSync>();
-            pushPull = GetComponent<PushPull>();
-            registerTile = GetComponent<RegisterTile>();
-            pna = gameObject.GetComponent<PlayerNetworkActions>();
-        }
+		/// temp solution for use with the UI network prediction
+		public bool isMoving { get; } = false;
 
-        public PlayerAction SendAction()
-        {
-            List<int> actionKeys = new List<int>();
+		private void Start()
+		{
+			playerSprites = gameObject.GetComponent<PlayerSprites>();
+			playerSync = GetComponent<IPlayerSync>();
+			pushPull = GetComponent<PushPull>();
+			registerTile = GetComponent<RegisterTile>();
+			pna = gameObject.GetComponent<PlayerNetworkActions>();
+		}
 
-            for (int i = 0; i < keyCodes.Length; i++)
-            {
-                if (PlayerManager.LocalPlayer == gameObject && UIManager.IsInputFocus)
-                {
-                    return new PlayerAction { keyCodes = actionKeys.ToArray() };
-                }
+		public PlayerAction SendAction()
+		{
+			List<int> actionKeys = new List<int>();
 
-                if (Input.GetKey(keyCodes[i]) && allowInput && !IsPushing)
-                {
-                    actionKeys.Add((int)keyCodes[i]);
-                }
-            }
+			for (int i = 0; i < keyCodes.Length; i++)
+			{
+				if (PlayerManager.LocalPlayer == gameObject && UIManager.IsInputFocus)
+				{
+					return new PlayerAction { keyCodes = actionKeys.ToArray() };
+				}
 
-            return new PlayerAction { keyCodes = actionKeys.ToArray() };
-        }
+				if (Input.GetKey(keyCodes[i]) && allowInput && !IsPushing)
+				{
+					actionKeys.Add((int)keyCodes[i]);
+				}
+			}
 
-        public Vector3Int GetNextPosition(Vector3Int currentPosition, PlayerAction action, bool isReplay, Matrix curMatrix = null)
-        {
-            if (!curMatrix)
-            {
-                curMatrix = matrix;
-            }
-            Vector3Int direction = GetDirection(action, MatrixManager.Get(curMatrix));
-            Vector3Int adjustedDirection = AdjustDirection(currentPosition, direction, isReplay, curMatrix);
+			return new PlayerAction { keyCodes = actionKeys.ToArray() };
+		}
 
-            if (adjustedDirection == Vector3.zero)
-            {
-                Interact(currentPosition, direction);
-            }
-            return currentPosition + adjustedDirection;
-        }
+		public Vector3Int GetNextPosition(Vector3Int currentPosition, PlayerAction action, bool isReplay, Matrix curMatrix = null)
+		{
+			if (!curMatrix)
+			{
+				curMatrix = matrix;
+			}
+			Vector3Int direction = GetDirection(action, MatrixManager.Get(curMatrix));
+			Vector3Int adjustedDirection = AdjustDirection(currentPosition, direction, isReplay, curMatrix);
 
-        public string ChangeKeyboardInput(bool setAzerty)
-        {
-            ControlAction controlAction = UIManager.Action;
-            if (setAzerty)
-            {
-                keyCodes = new KeyCode[] { KeyCode.Z, KeyCode.Q, KeyCode.S, KeyCode.D, KeyCode.UpArrow, KeyCode.LeftArrow, KeyCode.DownArrow, KeyCode.RightArrow };
-                azerty = true;
-                controlAction.azerty = true;
-                PlayerPrefs.SetInt("AZERTY", 1);
-                PlayerPrefs.Save();
-                return "AZERTY";
-            }
-            keyCodes = new KeyCode[] { KeyCode.W, KeyCode.A, KeyCode.S, KeyCode.D, KeyCode.UpArrow, KeyCode.LeftArrow, KeyCode.DownArrow, KeyCode.RightArrow };
-            azerty = false;
-            controlAction.azerty = false;
-            PlayerPrefs.SetInt("AZERTY", 0);
-            return "QWERTY";
-        }
+			Debug.Log (adjustedDirection.ToString());
 
-        private Vector3Int GetDirection(PlayerAction action, MatrixInfo matrixInfo)
-        {
-            ProcessAction(action);
+			lastMove = adjustedDirection;
 
-            if (diagonalMovement)
-            {
-                return GetMoveDirection(matrixInfo);
-            }
-            if (pressedKeys.Count > 0)
-            {
-                return GetMoveDirection(pressedKeys[pressedKeys.Count - 1]);
-            }
-            return Vector3Int.zero;
-        }
+			return currentPosition + adjustedDirection;
+		}
 
-        private void ProcessAction(PlayerAction action)
-        {
-            List<int> actionKeys = new List<int>(action.keyCodes);
-            for (int i = 0; i < keyCodes.Length; i++)
-            {
-                if (actionKeys.Contains((int)keyCodes[i]) && !pressedKeys.Contains(keyCodes[i]))
-                {
-                    pressedKeys.Add(keyCodes[i]);
-                }
-                else if (!actionKeys.Contains((int)keyCodes[i]) && pressedKeys.Contains(keyCodes[i]))
-                {
-                    pressedKeys.Remove(keyCodes[i]);
-                }
-            }
-        }
+		public string ChangeKeyboardInput(bool setAzerty)
+		{
+			ControlAction controlAction = UIManager.Action;
+			if (setAzerty)
+			{
+				keyCodes = new KeyCode[] { KeyCode.Z, KeyCode.Q, KeyCode.S, KeyCode.D, KeyCode.UpArrow, KeyCode.LeftArrow, KeyCode.DownArrow, KeyCode.RightArrow };
+				azerty = true;
+				controlAction.azerty = true;
+				PlayerPrefs.SetInt("AZERTY", 1);
+				PlayerPrefs.Save();
+				return "AZERTY";
+			}
+			keyCodes = new KeyCode[] { KeyCode.W, KeyCode.A, KeyCode.S, KeyCode.D, KeyCode.UpArrow, KeyCode.LeftArrow, KeyCode.DownArrow, KeyCode.RightArrow };
+			azerty = false;
+			controlAction.azerty = false;
+			PlayerPrefs.SetInt("AZERTY", 0);
+			return "QWERTY";
+		}
 
-        private Vector3Int GetMoveDirection(MatrixInfo matrixInfo)
-        {
-            Vector3Int direction = Vector3Int.zero;
-            for (int i = 0; i < pressedKeys.Count; i++)
-            {
-                direction += GetMoveDirection(pressedKeys[i]);
-            }
-            direction.x = Mathf.Clamp(direction.x, -1, 1);
-            direction.y = Mathf.Clamp(direction.y, -1, 1);
+		private Vector3Int GetDirection(PlayerAction action, MatrixInfo matrixInfo)
+		{
+			ProcessAction(action);
 
-            if (!isGhost && PlayerManager.LocalPlayer == gameObject)
-            {
-                playerSprites.CmdChangeDirection(Orientation.From(direction));
-                //Prediction:
-                playerSprites.FaceDirection(Orientation.From(direction));
-            }
+			if (diagonalMovement)
+			{
+				return GetMoveDirection(matrixInfo);
+			}
+			if (pressedKeys.Count > 0)
+			{
+				return GetMoveDirection(pressedKeys[pressedKeys.Count - 1]);
+			}
+			return Vector3Int.zero;
+		}
 
-            if (matrixInfo.MatrixMove)
-            {
-                //Converting world direction to local direction
-                direction = Vector3Int.RoundToInt(matrixInfo.MatrixMove.ClientState.Orientation.EulerInverted * direction);
-            }
-            return direction;
-        }
+		private void ProcessAction(PlayerAction action)
+		{
+			List<int> actionKeys = new List<int>(action.keyCodes);
+			for (int i = 0; i < keyCodes.Length; i++)
+			{
+				if (actionKeys.Contains((int)keyCodes[i]) && !pressedKeys.Contains(keyCodes[i]))
+				{
+					pressedKeys.Add(keyCodes[i]);
+				}
+				else if (!actionKeys.Contains((int)keyCodes[i]) && pressedKeys.Contains(keyCodes[i]))
+				{
+					pressedKeys.Remove(keyCodes[i]);
+				}
+			}
+		}
 
-        private Vector3Int GetMoveDirection(KeyCode action)
-        {
-            if (PlayerManager.LocalPlayer == gameObject && UIManager.IsInputFocus)
-            {
-                return Vector3Int.zero;
-            }
-            //TODO This needs a refactor, but this way AZERTY will work without weird conflicts.
-            if (azerty)
-            {
-                switch (action)
-                {
-                    case KeyCode.Z:
-                    case KeyCode.UpArrow:
-                        return Vector3Int.up;
-                    case KeyCode.Q:
-                    case KeyCode.LeftArrow:
-                        return Vector3Int.left;
-                    case KeyCode.S:
-                    case KeyCode.DownArrow:
-                        return Vector3Int.down;
-                    case KeyCode.D:
-                    case KeyCode.RightArrow:
-                        return Vector3Int.right;
-                }
-            }
-            else
-            {
-                switch (action)
-                {
-                    case KeyCode.W:
-                    case KeyCode.UpArrow:
-                        return Vector3Int.up;
-                    case KeyCode.A:
-                    case KeyCode.LeftArrow:
-                        return Vector3Int.left;
-                    case KeyCode.S:
-                    case KeyCode.DownArrow:
-                        return Vector3Int.down;
-                    case KeyCode.D:
-                    case KeyCode.RightArrow:
-                        return Vector3Int.right;
-                }
-            }
-            return Vector3Int.zero;
-        }
+		private Vector3Int GetMoveDirection(MatrixInfo matrixInfo)
+		{
+			Vector3Int direction = Vector3Int.zero;
+			for (int i = 0; i < pressedKeys.Count; i++)
+			{
+				direction += GetMoveDirection(pressedKeys[i]);
+			}
+			direction.x = Mathf.Clamp(direction.x, -1, 1);
+			direction.y = Mathf.Clamp(direction.y, -1, 1);
 
-        /// <summary>
-        ///     Check current and next tiles to determine their status and if movement is allowed
-        /// </summary>
-        private Vector3Int AdjustDirection(Vector3Int currentPosition, Vector3Int direction, bool isReplay, Matrix curMatrix)
-        {
-            if (isGhost)
-            {
-                return direction;
-            }
+			if (!isGhost && PlayerManager.LocalPlayer == gameObject)
+			{
+				playerSprites.CmdChangeDirection(Orientation.From(direction));
+				//Prediction:
+				playerSprites.FaceDirection(Orientation.From(direction));
+			}
 
-            Vector3Int newPos = currentPosition + direction;
+			if (matrixInfo.MatrixMove)
+			{
+				//Converting world direction to local direction
+				direction = Vector3Int.RoundToInt(matrixInfo.MatrixMove.ClientState.Orientation.EulerInverted * direction);
+			}
+			return direction;
+		}
 
-            //isReplay tells AdjustDirection if the move being carried out is a replay move for prediction or not
-            //a replay move is a move that has already been carried out on the LocalPlayer's client
-            if (!isReplay)
-            {
-                //Check the high level matrix detector
-                if (!playerMatrixDetector.CanPass(currentPosition, direction, curMatrix))
-                {
-                    return Vector3Int.zero;
-                }
-                //Not to be checked while performing a replay:
-                if (playerSync.PullingObject != null)
-                {
-                    if (curMatrix.ContainsAt(newPos, playerSync.PullingObject))
-                    {
-                        //Vector2 directionToPullObj =
-                        //	playerSync.pullingObject.transform.localPosition - transform.localPosition;
-                        //if (directionToPullObj.normalized != playerSprites.currentDirection) {
-                        //	// Ran into pullObject but was not facing it, saved direction
-                        //	return direction;
-                        //}
-                        //Hit Pull obj
-                        pna.CmdStopPulling(playerSync.PullingObject);
+		private Vector3Int GetMoveDirection(KeyCode action)
+		{
+			if (PlayerManager.LocalPlayer == gameObject && UIManager.IsInputFocus)
+			{
+				return Vector3Int.zero;
+			}
+			//TODO This needs a refactor, but this way AZERTY will work without weird conflicts.
+			if (azerty)
+			{
+				switch (action)
+				{
+				case KeyCode.Z:
+				case KeyCode.UpArrow:
+					return Vector3Int.up;
+				case KeyCode.Q:
+				case KeyCode.LeftArrow:
+					return Vector3Int.left;
+				case KeyCode.S:
+				case KeyCode.DownArrow:
+					return Vector3Int.down;
+				case KeyCode.D:
+				case KeyCode.RightArrow:
+					return Vector3Int.right;
+				}
+			}
+			else
+			{
+				switch (action)
+				{
+				case KeyCode.W:
+				case KeyCode.UpArrow:
+					return Vector3Int.up;
+				case KeyCode.A:
+				case KeyCode.LeftArrow:
+					return Vector3Int.left;
+				case KeyCode.S:
+				case KeyCode.DownArrow:
+					return Vector3Int.down;
+				case KeyCode.D:
+				case KeyCode.RightArrow:
+					return Vector3Int.right;
+				}
+			}
+			return Vector3Int.zero;
+		}
 
-                        return Vector3Int.zero;
-                    }
-                }
-            }
-            if (!curMatrix.ContainsAt(newPos, gameObject) && curMatrix.IsPassableAt(currentPosition, newPos) && !isReplay)
-            {
-                return direction;
-            }
-            //This is only for replay (to ignore any interactions with the pulled obj):
-            if (playerSync.PullingObject != null)
-            {
-                if (curMatrix.ContainsAt(newPos, playerSync.PullingObject))
-                {
-                    return direction;
-                }
-            }
+		/// <summary>
+		///     Check current and next tiles to determine their status and if movement is allowed
+		/// </summary>
+		private Vector3Int AdjustDirection(Vector3Int currentPosition, Vector3Int direction, bool isReplay, Matrix curMatrix)
+		{
+			if (isGhost)
+				return direction;
 
-            if (isReplay)
-            {
-                return direction;
-            }
-            //could not pass
-            //Debug.Log("Couldn't pass");
-            return Vector3Int.zero;
+			Vector3Int newPos = currentPosition + direction;
 
-        }
+			//isReplay tells AdjustDirection if the move being carried out is a replay move for prediction or not
+			//a replay move is a move that has already been carried out on the LocalPlayer's client
+			if (!isReplay)
+			{
+				//Check the high level matrix detector
+				if (!playerMatrixDetector.CanPass(currentPosition, direction, curMatrix))
+				{
+					Interact(currentPosition, direction);
 
-        private void Interact(Vector3 currentPosition, Vector3 direction)
-        {
-            Vector3Int targetPos = Vector3Int.RoundToInt(currentPosition + direction);
-            var worldPos = MatrixManager.Instance.LocalToWorldInt(currentPosition, matrix);
-            var worldTarget = MatrixManager.Instance.LocalToWorldInt(targetPos, matrix);
+					//Checks if it's possible to move horizontally
+					if ( direction.x != 0 && playerMatrixDetector.CanPass (currentPosition, new Vector3Int (direction.x, 0, 0), curMatrix)) {
 
-            InteractDoor(worldPos, worldTarget);
-            //TODO: adapt for cross-matrix
-            //Is the object pushable (iterate through all of the objects at the position):
-            PushPull[] pushPulls = matrix.Get<PushPull>(targetPos).ToArray();
-            for (int i = 0; i < pushPulls.Length; i++)
-            {
-                if (pushPulls[i] && pushPulls[i].gameObject != gameObject)
-                {
-                    pushPulls[i].TryPush(gameObject, direction);
-                }
-            }
-        }
-        /// Cross-matrix now! uses world positions
-        private void InteractDoor(Vector3Int currentPos, Vector3Int targetPos)
-        {
-            // Make sure there is a door controller
-            DoorController doorController = MatrixManager.Instance.GetFirst<DoorController>(targetPos);
+						return new Vector3Int (direction.x, 0, 0);
+					}
 
-            if (!doorController)
-            {
-                doorController = MatrixManager.Instance.GetFirst<DoorController>(Vector3Int.RoundToInt(currentPos));
+					//Checks if it's possible to move vertically
+					if ( direction.y != 0 && playerMatrixDetector.CanPass (currentPosition, new Vector3Int (0, direction.y, 0), curMatrix)) {
 
-                if (doorController)
-                {
-                    RegisterDoor registerDoor = doorController.GetComponent<RegisterDoor>();
+						return new Vector3Int (0, direction.y, 0);
+					}
 
-                    Vector3Int localPos = MatrixManager.Instance.WorldToLocalInt(targetPos, matrix);
-                    if (registerDoor.IsPassable(localPos))
-                    {
-                        doorController = null;
-                    }
-                }
-            }
+					return Vector3Int.zero;
+				}
+				//Not to be checked while performing a replay:
+				if (playerSync.PullingObject != null)
+				{
+					if (curMatrix.ContainsAt(newPos, playerSync.PullingObject))
+					{
+						//Vector2 directionToPullObj =
+						//	playerSync.pullingObject.transform.localPosition - transform.localPosition;
+						//if (directionToPullObj.normalized != playerSprites.currentDirection) {
+						//	// Ran into pullObject but was not facing it, saved direction
+						//	return direction;
+						//}
+						//Hit Pull obj
+						pna.CmdStopPulling(playerSync.PullingObject);
 
-            // Attempt to open door
-            if (doorController != null && allowInput)
-            {
-                pna.CmdCheckDoorPermissions(doorController.gameObject, gameObject);
+						return Vector3Int.zero;
+					}
+				}
+				return direction;
+			}
 
-                allowInput = false;
-                StartCoroutine(DoorInputCoolDown());
-            }
-        }
+			//This is only for replay (to ignore any interactions with the pulled obj):
+			if (playerSync.PullingObject != null)
+			{
+				if (curMatrix.ContainsAt(newPos, playerSync.PullingObject))
+				{
+					return direction;
+				}
+			}
 
-        //FIXME an ugly temp fix for an ugly problem. Will implement callbacks after 0.1.3
-        public IEnumerator DoorInputCoolDown()
-        {
-            yield return new WaitForSeconds(0.3f);
-            allowInput = true;
-        }
-    }
+			if (isReplay){
+				return lastMove;
+			}
+			//could not pass
+			//Debug.Log("Couldn't pass");
+			return Vector3Int.zero;
+
+		}
+
+		private void Interact(Vector3 currentPosition, Vector3 direction)
+		{
+			Vector3Int targetPos = Vector3Int.RoundToInt(currentPosition + direction);
+			var worldPos = MatrixManager.Instance.LocalToWorldInt(currentPosition, matrix);
+			var worldTarget = MatrixManager.Instance.LocalToWorldInt(targetPos, matrix);
+
+			InteractDoor(worldPos, worldTarget);
+			//TODO: adapt for cross-matrix
+			//Is the object pushable (iterate through all of the objects at the position):
+			PushPull[] pushPulls = matrix.Get<PushPull>(targetPos).ToArray();
+			for (int i = 0; i < pushPulls.Length; i++)
+			{
+				if (pushPulls[i] && pushPulls[i].gameObject != gameObject)
+				{
+					pushPulls[i].TryPush(gameObject, direction);
+				}
+			}
+		}
+		/// Cross-matrix now! uses world positions
+		private void InteractDoor(Vector3Int currentPos, Vector3Int targetPos)
+		{
+			// Make sure there is a door controller
+			DoorController doorController = MatrixManager.Instance.GetFirst<DoorController>(targetPos);
+
+			if (!doorController)
+			{
+				doorController = MatrixManager.Instance.GetFirst<DoorController>(Vector3Int.RoundToInt(currentPos));
+
+				if (doorController)
+				{
+					RegisterDoor registerDoor = doorController.GetComponent<RegisterDoor>();
+
+					Vector3Int localPos = MatrixManager.Instance.WorldToLocalInt(targetPos, matrix);
+					if (registerDoor.IsPassable(localPos))
+					{
+						doorController = null;
+					}
+				}
+			}
+
+			// Attempt to open door
+			if (doorController != null && allowInput)
+			{
+				pna.CmdCheckDoorPermissions(doorController.gameObject, gameObject);
+
+				allowInput = false;
+				StartCoroutine(DoorInputCoolDown());
+			}
+		}
+
+		//FIXME an ugly temp fix for an ugly problem. Will implement callbacks after 0.1.3
+		public IEnumerator DoorInputCoolDown()
+		{
+			yield return new WaitForSeconds(0.3f);
+			allowInput = true;
+		}
+	}
 }

--- a/UnityProject/ProjectSettings/GraphicsSettings.asset
+++ b/UnityProject/ProjectSettings/GraphicsSettings.asset
@@ -38,7 +38,6 @@ GraphicsSettings:
   - {fileID: 10782, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}

--- a/UnityProject/ProjectSettings/ProjectSettings.asset
+++ b/UnityProject/ProjectSettings/ProjectSettings.asset
@@ -744,6 +744,7 @@ PlayerSettings:
   XboxOneSplashScreen: {fileID: 0}
   XboxOneAllowedProductIds: []
   XboxOnePersistentLocalStorageSize: 0
+  XboxOneXTitleMemory: 8
   xboxOneScriptCompiler: 0
   vrEditorSettings:
     daydream:


### PR DESCRIPTION
### Purpose
Updated diagonal movement for players when they walk into walls to make it more like the original /tg/. Players will now slide alongside walls when walking into them diagonally instead of stopping completely.

### Approach
The "AdjustDirection" function now checks if it's possible to walk alongside the obstacle instead of completeley stopping the player. Also changed the function to repeat the last move when "Replaying" client moves.

- [x]  I read the contribution guidelines and the wiki.
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  This PR does not include files without specific need to do so.
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer



### Notes: