### PR TITLE
Fix for #1122 Player corpse made passable

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerMove.cs
@@ -11,320 +11,337 @@ using UnityEngine.Networking;
 
 namespace PlayGroup
 {
-    /// <summary>
-    ///     Player move queues the directional move keys
-    ///     to be processed along with the server.
-    ///     It also changes the sprite direction and
-    ///     handles interaction with objects that can
-    ///     be walked into it.
-    /// </summary>
-    public class PlayerMove : NetworkBehaviour
-    {
-        private readonly List<KeyCode> pressedKeys = new List<KeyCode>();
+	/// <summary>
+	///     Player move queues the directional move keys
+	///     to be processed along with the server.
+	///     It also changes the sprite direction and
+	///     handles interaction with objects that can
+	///     be walked into it.
+	/// </summary>
+	public class PlayerMove : NetworkBehaviour
+	{
+		public bool diagonalMovement;
+		public bool azerty;
 
-        [SyncVar] public bool allowInput = true;
+		[SyncVar] public bool allowInput = true;
+		[SyncVar] public bool isGhost;
 
-        public bool diagonalMovement;
-        public bool azerty;
-        [SyncVar] public bool isGhost;
+		private readonly List<KeyCode> pressedKeys = new List<KeyCode>();
 
-        public KeyCode[] keyCodes =
-        {
-            KeyCode.W, KeyCode.A, KeyCode.S, KeyCode.D, KeyCode.UpArrow, KeyCode.LeftArrow, KeyCode.DownArrow,
-            KeyCode.RightArrow
-        };
+		public KeyCode[] keyCodes =
+		{
+			KeyCode.W, KeyCode.A, KeyCode.S, KeyCode.D, KeyCode.UpArrow, KeyCode.LeftArrow, KeyCode.DownArrow,
+			KeyCode.RightArrow
+		};
 
-        public PlayerMatrixDetector playerMatrixDetector;
-        private PlayerSprites playerSprites;
-        private IPlayerSync playerSync;
+		public PlayerMatrixDetector playerMatrixDetector;
+		private PlayerSprites playerSprites;
+		private IPlayerSync playerSync;
 
-        [HideInInspector] public PlayerNetworkActions pna;
-        [HideInInspector] public PushPull pushPull; //The push pull component attached to this player
-        public float speed = 10;
+		[HideInInspector] public PlayerNetworkActions pna;
+		[HideInInspector] public PushPull pushPull; //The push pull component attached to this player
+		public float speed = 10;
 
-        public bool IsPushing { get; set; }
+		public bool IsPushing { get; set; }
 
-        private RegisterTile registerTile;
-        private Matrix matrix => registerTile.Matrix;
+		private RegisterTile registerTile;
+		private Matrix matrix => registerTile.Matrix;
 
-        /// temp solution for use with the UI network prediction
-        public bool isMoving { get; } = false;
+		/// temp solution for use with the UI network prediction
+		public bool isMoving { get; } = false;
 
-        private void Start()
-        {
-            playerSprites = gameObject.GetComponent<PlayerSprites>();
-            playerSync = GetComponent<IPlayerSync>();
-            pushPull = GetComponent<PushPull>();
-            registerTile = GetComponent<RegisterTile>();
-            pna = gameObject.GetComponent<PlayerNetworkActions>();
-        }
+		private void Start()
+		{
+			playerSprites = gameObject.GetComponent<PlayerSprites>();
+			playerSync = GetComponent<IPlayerSync>();
+			pushPull = GetComponent<PushPull>();
+			registerTile = GetComponent<RegisterTile>();
+			pna = gameObject.GetComponent<PlayerNetworkActions>();
+		}
 
-        public PlayerAction SendAction()
-        {
-            List<int> actionKeys = new List<int>();
+		public PlayerAction SendAction()
+		{
+			List<int> actionKeys = new List<int>();
 
-            for (int i = 0; i < keyCodes.Length; i++)
-            {
-                if (PlayerManager.LocalPlayer == gameObject && UIManager.IsInputFocus)
-                {
-                    return new PlayerAction { keyCodes = actionKeys.ToArray() };
-                }
+			for (int i = 0; i < keyCodes.Length; i++)
+			{
+				if (PlayerManager.LocalPlayer == gameObject && UIManager.IsInputFocus)
+				{
+					return new PlayerAction { keyCodes = actionKeys.ToArray() };
+				}
 
-                if (Input.GetKey(keyCodes[i]) && allowInput && !IsPushing)
-                {
-                    actionKeys.Add((int)keyCodes[i]);
-                }
-            }
+				if (Input.GetKey(keyCodes[i]) && allowInput && !IsPushing)
+				{
+					actionKeys.Add((int)keyCodes[i]);
+				}
+			}
 
-            return new PlayerAction { keyCodes = actionKeys.ToArray() };
-        }
+			return new PlayerAction { keyCodes = actionKeys.ToArray() };
+		}
 
-        public Vector3Int GetNextPosition(Vector3Int currentPosition, PlayerAction action, bool isReplay, Matrix curMatrix = null)
-        {
-            if (!curMatrix)
-            {
-                curMatrix = matrix;
-            }
-            Vector3Int direction = GetDirection(action, MatrixManager.Get(curMatrix));
-            Vector3Int adjustedDirection = AdjustDirection(currentPosition, direction, isReplay, curMatrix);
+		public Vector3Int GetNextPosition(Vector3Int currentPosition, PlayerAction action, bool isReplay, Matrix curMatrix = null)
+		{
+			if (!curMatrix)
+			{
+				curMatrix = matrix;
+			}
 
-            if (adjustedDirection == Vector3.zero)
-            {
-                Interact(currentPosition, direction);
-            }
-            return currentPosition + adjustedDirection;
-        }
+			Vector3Int direction = GetDirection(action, MatrixManager.Get(curMatrix));
+			Vector3Int adjustedDirection = AdjustDirection(currentPosition, direction, isReplay, curMatrix);
 
-        public string ChangeKeyboardInput(bool setAzerty)
-        {
-            ControlAction controlAction = UIManager.Action;
-            if (setAzerty)
-            {
-                keyCodes = new KeyCode[] { KeyCode.Z, KeyCode.Q, KeyCode.S, KeyCode.D, KeyCode.UpArrow, KeyCode.LeftArrow, KeyCode.DownArrow, KeyCode.RightArrow };
-                azerty = true;
-                controlAction.azerty = true;
-                PlayerPrefs.SetInt("AZERTY", 1);
-                PlayerPrefs.Save();
-                return "AZERTY";
-            }
-            keyCodes = new KeyCode[] { KeyCode.W, KeyCode.A, KeyCode.S, KeyCode.D, KeyCode.UpArrow, KeyCode.LeftArrow, KeyCode.DownArrow, KeyCode.RightArrow };
-            azerty = false;
-            controlAction.azerty = false;
-            PlayerPrefs.SetInt("AZERTY", 0);
-            return "QWERTY";
-        }
+			if (adjustedDirection == Vector3.zero)
+			{
+				Interact(currentPosition, direction);
+			}
 
-        private Vector3Int GetDirection(PlayerAction action, MatrixInfo matrixInfo)
-        {
-            ProcessAction(action);
+			return currentPosition + adjustedDirection;
+		}
 
-            if (diagonalMovement)
-            {
-                return GetMoveDirection(matrixInfo);
-            }
-            if (pressedKeys.Count > 0)
-            {
-                return GetMoveDirection(pressedKeys[pressedKeys.Count - 1]);
-            }
-            return Vector3Int.zero;
-        }
+		public string ChangeKeyboardInput(bool setAzerty)
+		{
+			ControlAction controlAction = UIManager.Action;
 
-        private void ProcessAction(PlayerAction action)
-        {
-            List<int> actionKeys = new List<int>(action.keyCodes);
-            for (int i = 0; i < keyCodes.Length; i++)
-            {
-                if (actionKeys.Contains((int)keyCodes[i]) && !pressedKeys.Contains(keyCodes[i]))
-                {
-                    pressedKeys.Add(keyCodes[i]);
-                }
-                else if (!actionKeys.Contains((int)keyCodes[i]) && pressedKeys.Contains(keyCodes[i]))
-                {
-                    pressedKeys.Remove(keyCodes[i]);
-                }
-            }
-        }
+			if (setAzerty)
+			{
+				keyCodes = new KeyCode[] { KeyCode.Z, KeyCode.Q, KeyCode.S, KeyCode.D, KeyCode.UpArrow, KeyCode.LeftArrow, KeyCode.DownArrow, KeyCode.RightArrow };
+				azerty = true;
+				controlAction.azerty = true;
+				PlayerPrefs.SetInt("AZERTY", 1);
+				PlayerPrefs.Save();
 
-        private Vector3Int GetMoveDirection(MatrixInfo matrixInfo)
-        {
-            Vector3Int direction = Vector3Int.zero;
-            for (int i = 0; i < pressedKeys.Count; i++)
-            {
-                direction += GetMoveDirection(pressedKeys[i]);
-            }
-            direction.x = Mathf.Clamp(direction.x, -1, 1);
-            direction.y = Mathf.Clamp(direction.y, -1, 1);
+				return "AZERTY";
+			}
 
-			Logger.Log(direction.ToString(),Category.Movement);
+			keyCodes = new KeyCode[] { KeyCode.W, KeyCode.A, KeyCode.S, KeyCode.D, KeyCode.UpArrow, KeyCode.LeftArrow, KeyCode.DownArrow, KeyCode.RightArrow };
+			azerty = false;
+			controlAction.azerty = false;
+			PlayerPrefs.SetInt("AZERTY", 0);
 
-            if (!isGhost && PlayerManager.LocalPlayer == gameObject)
-            {
-                playerSprites.CmdChangeDirection(Orientation.From(direction));
-                //Prediction:
-                playerSprites.FaceDirection(Orientation.From(direction));
-            }
+			return "QWERTY";
+		}
 
-            if (matrixInfo.MatrixMove)
-            {
-                //Converting world direction to local direction
-                direction = Vector3Int.RoundToInt(matrixInfo.MatrixMove.ClientState.Orientation.EulerInverted * direction);
-            }
-            return direction;
-        }
+		private Vector3Int GetDirection(PlayerAction action, MatrixInfo matrixInfo)
+		{
+			ProcessAction(action);
 
-        private Vector3Int GetMoveDirection(KeyCode action)
-        {
-            if (PlayerManager.LocalPlayer == gameObject && UIManager.IsInputFocus)
-            {
-                return Vector3Int.zero;
-            }
-            //TODO This needs a refactor, but this way AZERTY will work without weird conflicts.
-            if (azerty)
-            {
-                switch (action)
-                {
-                    case KeyCode.Z:
-                    case KeyCode.UpArrow:
-                        return Vector3Int.up;
-                    case KeyCode.Q:
-                    case KeyCode.LeftArrow:
-                        return Vector3Int.left;
-                    case KeyCode.S:
-                    case KeyCode.DownArrow:
-                        return Vector3Int.down;
-                    case KeyCode.D:
-                    case KeyCode.RightArrow:
-                        return Vector3Int.right;
-                }
-            }
-            else
-            {
-                switch (action)
-                {
-                    case KeyCode.W:
-                    case KeyCode.UpArrow:
-                        return Vector3Int.up;
-                    case KeyCode.A:
-                    case KeyCode.LeftArrow:
-                        return Vector3Int.left;
-                    case KeyCode.S:
-                    case KeyCode.DownArrow:
-                        return Vector3Int.down;
-                    case KeyCode.D:
-                    case KeyCode.RightArrow:
-                        return Vector3Int.right;
-                }
-            }
-            return Vector3Int.zero;
-        }
+			if (diagonalMovement)
+			{
+				return GetMoveDirection(matrixInfo);
+			}
+			if (pressedKeys.Count > 0)
+			{
+				return GetMoveDirection(pressedKeys[pressedKeys.Count - 1]);
+			}
 
-        /// <summary>
-        ///     Check current and next tiles to determine their status and if movement is allowed
-        /// </summary>
-        private Vector3Int AdjustDirection(Vector3Int currentPosition, Vector3Int direction, bool isReplay, Matrix curMatrix)
-        {
-            if (isGhost)
-            {
-                return direction;
-            }
+			return Vector3Int.zero;
+		}
 
-            Vector3Int newPos = currentPosition + direction;
+		private void ProcessAction(PlayerAction action)
+		{
+			List<int> actionKeys = new List<int>(action.keyCodes);
 
-            //isReplay tells AdjustDirection if the move being carried out is a replay move for prediction or not
-            //a replay move is a move that has already been carried out on the LocalPlayer's client
-            if (!isReplay)
-            {
-                //Check the high level matrix detector
-                if (!playerMatrixDetector.CanPass(currentPosition, direction, curMatrix))
-                {
-                    return Vector3Int.zero;
-                }
-                //Not to be checked while performing a replay:
-                if (playerSync.PullingObject != null)
-                {
-                    if (curMatrix.ContainsAt(newPos, playerSync.PullingObject))
-                    {
-                        //Vector2 directionToPullObj =
-                        //	playerSync.pullingObject.transform.localPosition - transform.localPosition;
-                        //if (directionToPullObj.normalized != playerSprites.currentDirection) {
-                        //	// Ran into pullObject but was not facing it, saved direction
-                        //	return direction;
-                        //}
-                        //Hit Pull obj
-                        pna.CmdStopPulling(playerSync.PullingObject);
+			for (int i = 0; i < keyCodes.Length; i++)
+			{
+				if (actionKeys.Contains((int)keyCodes[i]) && !pressedKeys.Contains(keyCodes[i]))
+				{
+					pressedKeys.Add(keyCodes[i]);
+				}
+				else if (!actionKeys.Contains((int)keyCodes[i]) && pressedKeys.Contains(keyCodes[i]))
+				{
+					pressedKeys.Remove(keyCodes[i]);
+				}
+			}
+		}
 
-                        return Vector3Int.zero;
-                    }
-                }
-            }
-            if (!curMatrix.ContainsAt(newPos, gameObject) && curMatrix.IsPassableAt(currentPosition, newPos) && !isReplay)
-            {
-                return direction;
-            }
-            //This is only for replay (to ignore any interactions with the pulled obj):
-            if (playerSync.PullingObject != null)
-            {
-                if (curMatrix.ContainsAt(newPos, playerSync.PullingObject))
-                {
-                    return direction;
-                }
-            }
+		private Vector3Int GetMoveDirection(MatrixInfo matrixInfo)
+		{
+			Vector3Int direction = Vector3Int.zero;
 
-            if (isReplay)
-            {
-                return direction;
-            }
-            //could not pass
-            //Logger.Log("Couldn't pass");
-            return Vector3Int.zero;
+			for (int i = 0; i < pressedKeys.Count; i++)
+			{
+				direction += GetMoveDirection(pressedKeys[i]);
+			}
 
-        }
+			direction.x = Mathf.Clamp(direction.x, -1, 1);
+			direction.y = Mathf.Clamp(direction.y, -1, 1);
+			Logger.Log(direction.ToString(), Category.Movement);
 
-        private void Interact(Vector3 currentPosition, Vector3 direction)
-        {
-            Vector3Int targetPos = Vector3Int.RoundToInt(currentPosition + direction);
-            var worldPos = MatrixManager.Instance.LocalToWorldInt(currentPosition, matrix);
-            var worldTarget = MatrixManager.Instance.LocalToWorldInt(targetPos, matrix);
+			if (!isGhost && PlayerManager.LocalPlayer == gameObject)
+			{
+				playerSprites.CmdChangeDirection(Orientation.From(direction));
+				// Prediction:
+				playerSprites.FaceDirection(Orientation.From(direction));
+			}
 
-            InteractDoor(worldPos, worldTarget);
-            //TODO: adapt for cross-matrix
-            //Is the object pushable (iterate through all of the objects at the position):
-            PushPull[] pushPulls = matrix.Get<PushPull>(targetPos).ToArray();
-            for (int i = 0; i < pushPulls.Length; i++)
-            {
-                if (pushPulls[i] && pushPulls[i].gameObject != gameObject)
-                {
-                    pushPulls[i].TryPush(gameObject, direction);
-                }
-            }
-        }
-        /// Cross-matrix now! uses world positions
-        private void InteractDoor(Vector3Int currentPos, Vector3Int targetPos)
-        {
-            // Make sure there is a door controller
-            DoorTrigger door = MatrixManager.Instance.GetFirst<DoorTrigger>(targetPos);
+			if (matrixInfo.MatrixMove)
+			{
+				// Converting world direction to local direction
+				direction = Vector3Int.RoundToInt(matrixInfo.MatrixMove.ClientState.Orientation.EulerInverted * direction);
+			}
 
-            if (!door)
-            {
-                door = MatrixManager.Instance.GetFirst<DoorTrigger>(Vector3Int.RoundToInt(currentPos));
+			return direction;
+		}
 
-                if (door)
-                {
-                    RegisterDoor registerDoor = door.GetComponent<RegisterDoor>();
+		private Vector3Int GetMoveDirection(KeyCode action)
+		{
+			if (PlayerManager.LocalPlayer == gameObject && UIManager.IsInputFocus)
+			{
+				return Vector3Int.zero;
+			}
 
-                    Vector3Int localPos = MatrixManager.Instance.WorldToLocalInt(targetPos, matrix);
-                    if (registerDoor.IsPassable(localPos))
-                    {
-                        door = null;
-                    }
-                }
-            }
+			// @TODO This needs a refactor, but this way AZERTY will work without weird conflicts.
+			if (azerty)
+			{
+				switch (action)
+				{
+					case KeyCode.Z:
+					case KeyCode.UpArrow:
+						return Vector3Int.up;
+					case KeyCode.Q:
+					case KeyCode.LeftArrow:
+						return Vector3Int.left;
+					case KeyCode.S:
+					case KeyCode.DownArrow:
+						return Vector3Int.down;
+					case KeyCode.D:
+					case KeyCode.RightArrow:
+						return Vector3Int.right;
+				}
+			}
+			else
+			{
+				switch (action)
+				{
+					case KeyCode.W:
+					case KeyCode.UpArrow:
+						return Vector3Int.up;
+					case KeyCode.A:
+					case KeyCode.LeftArrow:
+						return Vector3Int.left;
+					case KeyCode.S:
+					case KeyCode.DownArrow:
+						return Vector3Int.down;
+					case KeyCode.D:
+					case KeyCode.RightArrow:
+						return Vector3Int.right;
+				}
+			}
 
-            // Attempt to open door
-            if (door != null && allowInput)
-            {
-                door.Interact( gameObject, TransformState.HiddenPos );
-            }
-        }
-    }
+			return Vector3Int.zero;
+		}
+
+		/// <summary>
+		///     Check current and next tiles to determine their status and if movement is allowed
+		/// </summary>
+		private Vector3Int AdjustDirection(Vector3Int currentPosition, Vector3Int direction, bool isReplay, Matrix curMatrix)
+		{
+			if (isGhost)
+			{
+				return direction;
+			}
+
+			Vector3Int newPos = currentPosition + direction;
+
+			// isReplay tells AdjustDirection if the move being carried out is a replay move for prediction or not
+			// a replay move is a move that has already been carried out on the LocalPlayer's client
+			if (!isReplay)
+			{
+				// Check the high level matrix detector
+				if (!playerMatrixDetector.CanPass(currentPosition, direction, curMatrix))
+				{
+					return Vector3Int.zero;
+				}
+
+				// Not to be checked while performing a replay:
+				if (playerSync.PullingObject != null)
+				{
+					if (curMatrix.ContainsAt(newPos, playerSync.PullingObject))
+					{
+						//Vector2 directionToPullObj =
+						//	playerSync.pullingObject.transform.localPosition - transform.localPosition;
+						//if (directionToPullObj.normalized != playerSprites.currentDirection) {
+						//	// Ran into pullObject but was not facing it, saved direction
+						//	return direction;
+						//}
+						//Hit Pull obj
+						pna.CmdStopPulling(playerSync.PullingObject);
+
+						return Vector3Int.zero;
+					}
+				}
+			}
+
+			if (!curMatrix.ContainsAt(newPos, gameObject) && curMatrix.IsPassableAt(currentPosition, newPos) && !isReplay)
+			{
+				return direction;
+			}
+
+			// This is only for replay (to ignore any interactions with the pulled obj):
+			if (playerSync.PullingObject != null)
+			{
+				if (curMatrix.ContainsAt(newPos, playerSync.PullingObject))
+				{
+					return direction;
+				}
+			}
+
+			if (isReplay)
+			{
+				return direction;
+			}
+
+			// Could not pass
+			// Logger.Log("Couldn't pass");
+			return Vector3Int.zero;
+
+		}
+
+		private void Interact(Vector3 currentPosition, Vector3 direction)
+		{
+			Vector3Int targetPos = Vector3Int.RoundToInt(currentPosition + direction);
+			var worldPos = MatrixManager.Instance.LocalToWorldInt(currentPosition, matrix);
+			var worldTarget = MatrixManager.Instance.LocalToWorldInt(targetPos, matrix);
+
+			InteractDoor(worldPos, worldTarget);
+			// @TODO: adapt for cross-matrix
+			// Is the object pushable (iterate through all of the objects at the position):
+			PushPull[] pushPulls = matrix.Get<PushPull>(targetPos).ToArray();
+			for (int i = 0; i < pushPulls.Length; i++)
+			{
+				if (pushPulls[i] && pushPulls[i].gameObject != gameObject)
+				{
+					pushPulls[i].TryPush(gameObject, direction);
+				}
+			}
+		}
+
+		// Cross-matrix now! uses world positions
+		private void InteractDoor(Vector3Int currentPos, Vector3Int targetPos)
+		{
+			// Make sure there is a door controller
+			DoorTrigger door = MatrixManager.Instance.GetFirst<DoorTrigger>(targetPos);
+
+			if (!door)
+			{
+				door = MatrixManager.Instance.GetFirst<DoorTrigger>(Vector3Int.RoundToInt(currentPos));
+
+				if (door)
+				{
+					RegisterDoor registerDoor = door.GetComponent<RegisterDoor>();
+					Vector3Int localPos = MatrixManager.Instance.WorldToLocalInt(targetPos, matrix);
+
+					if (registerDoor.IsPassable(localPos))
+					{
+						door = null;
+					}
+				}
+			}
+
+			// Attempt to open door
+			if (door != null && allowInput)
+			{
+				door.Interact(gameObject, TransformState.HiddenPos);
+			}
+		}
+	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -9,110 +9,121 @@ using System;
 
 namespace Tilemaps
 {
-    public class Matrix : MonoBehaviour
-    {
-        private MetaTileMap metaTileMap;
-        private TileList objects;
-        private TileList players;
-        private Vector3Int initialOffset;
-        public Vector3Int InitialOffset => initialOffset;
+	public class Matrix : MonoBehaviour
+	{
+		private MetaTileMap metaTileMap;
+		private TileList objects;
+		private TileList players;
+		private Vector3Int initialOffset;
+		public Vector3Int InitialOffset => initialOffset;
 
-        private MetaDataLayer metaDataLayer;
+		private MetaDataLayer metaDataLayer;
 
-        private void Start()
-        {
-            metaDataLayer = GetComponentInChildren<MetaDataLayer>(true);
-            metaTileMap = GetComponent<MetaTileMap>();
-            try
-            {
-                objects = ((ObjectLayer)metaTileMap.Layers[LayerType.Objects]).Objects;
-            }
-            catch
-            {
+		private void Start()
+		{
+			metaDataLayer = GetComponentInChildren<MetaDataLayer>(true);
+			metaTileMap = GetComponent<MetaTileMap>();
+
+			try
+			{
+				objects = ((ObjectLayer)metaTileMap.Layers[LayerType.Objects]).Objects;
+			}
+			catch
+			{
 				Logger.LogError("CAST ERROR: Make sure everything is in its proper layer type.", Category.Matrix);
-            }
-        }
+			}
+		}
 
-        private void Awake()
-        {
-            initialOffset = Vector3Int.CeilToInt(gameObject.transform.position);
-        }
+		private void Awake()
+		{
+			initialOffset = Vector3Int.CeilToInt(gameObject.transform.position);
+		}
 
-        public bool IsPassableAt(Vector3Int origin, Vector3Int position)
-        {
-            return metaTileMap.IsPassableAt(origin, position);
-        }
+		public bool IsPassableAt(Vector3Int origin, Vector3Int position)
+		{
+			return metaTileMap.IsPassableAt(origin, position);
+		}
 
-        //TODO:  This should be removed, due to windows mucking things up, and replaced with origin and position
-        public bool IsPassableAt(Vector3Int position)
-        {
-            return metaTileMap.IsPassableAt(position);
-        }
+		//TODO:  This should be removed, due to windows mucking things up, and replaced with origin and position
+		public bool IsPassableAt(Vector3Int position)
+		{
+			return metaTileMap.IsPassableAt(position);
+		}
 
-        //TODO:  This should also be removed, due to windows mucking things up, and replaced with origin and position
-        public bool IsAtmosPassableAt(Vector3Int position)
-        {
-            return metaTileMap.IsAtmosPassableAt(position);
-        }
+		//TODO:  This should also be removed, due to windows mucking things up, and replaced with origin and position
+		public bool IsAtmosPassableAt(Vector3Int position)
+		{
+			return metaTileMap.IsAtmosPassableAt(position);
+		}
 
-        public bool IsSpaceAt(Vector3Int position)
-        {
-            return metaDataLayer.IsSpaceAt(position);
-        }
+		public bool IsSpaceAt(Vector3Int position)
+		{
+			return metaDataLayer.IsSpaceAt(position);
+		}
 
-        public bool IsEmptyAt(Vector3Int position)
-        {
-            return metaTileMap.IsEmptyAt(position);
-        }
+		public bool IsEmptyAt(Vector3Int position)
+		{
+			return metaTileMap.IsEmptyAt(position);
+		}
 
-        public bool IsFloatingAt(Vector3Int position)
-        {
-            BoundsInt bounds = new BoundsInt(position - new Vector3Int(1, 1, 0), new Vector3Int(3, 3, 1));
-            foreach (Vector3Int pos in bounds.allPositionsWithin)
-            {
-                if (!metaTileMap.IsEmptyAt(pos))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
+		public bool IsFloatingAt(Vector3Int position)
+		{
+			BoundsInt bounds = new BoundsInt(position - new Vector3Int(1, 1, 0), new Vector3Int(3, 3, 1));
+			foreach (Vector3Int pos in bounds.allPositionsWithin)
+			{
+				if (!metaTileMap.IsEmptyAt(pos))
+				{
+					return false;
+				}
+			}
 
-        public IEnumerable<T> Get<T>(Vector3Int position) where T : MonoBehaviour
-        {
-            return objects.Get(position).Select(x => x.GetComponent<T>()).Where(x => x != null);
-        }
+			return true;
+		}
 
-        public T GetFirst<T>(Vector3Int position) where T : MonoBehaviour
-        {
-            return objects.GetFirst(position)?.GetComponent<T>();
-        }
+		public IEnumerable<T> Get<T>(Vector3Int position) where T : MonoBehaviour
+		{
+			return objects.Get(position).Select(x => x.GetComponent<T>()).Where(x => x != null);
+		}
 
-        public IEnumerable<T> Get<T>(Vector3Int position, ObjectType type) where T : MonoBehaviour
-        {
-            return objects.Get(position, type).Select(x => x.GetComponent<T>()).Where(x => x != null);
-        }
+		public T GetFirst<T>(Vector3Int position) where T : MonoBehaviour
+		{
+			return objects.GetFirst(position)?.GetComponent<T>();
+		}
 
-        public bool ContainsAt(Vector3Int position, GameObject gameObject)
-        {
-            RegisterTile registerTile = gameObject.GetComponent<RegisterTile>();
-            return (registerTile && objects.Get(position, ObjectType.Object).Contains(registerTile)) ||
-                (registerTile && (Get<RegisterTile>(position, ObjectType.Player).Any()) && ContainsAtPlayer(position, gameObject));
-        }
+		public IEnumerable<T> Get<T>(Vector3Int position, ObjectType type) where T : MonoBehaviour
+		{
+			return objects.Get(position, type).Select(x => x.GetComponent<T>()).Where(x => x != null);
+		}
 
-        //Checks if theres a player here and makes sure its not same player that called it. (avoids replay bugs)
-        public bool ContainsAtPlayer(Vector3Int position, GameObject gameObject) 
-        {
-            if(Get<RegisterTile>(position, ObjectType.Player).Count() != 0)
-            {
-                return Get<RegisterTile>(position, ObjectType.Player).First().gameObject.GetInstanceID() != gameObject.GetInstanceID();
-            }
-            return false;
-        }
+		public bool ContainsAt(Vector3Int position, GameObject gameObject)
+		{
+			RegisterTile registerTile = gameObject.GetComponent<RegisterTile>();
+			if (!registerTile)
+			{
+				return false;
+			}
 
-        public IEnumerable<IElectricityIO> GetElectricalConnections(Vector3Int position)
-        {
-            return objects.Get(position).Select(x => x.GetComponent<IElectricityIO>()).Where(x => x != null);
-        }
-    }
+			// Check if tile contains a player
+			if (registerTile.ObjectType == ObjectType.Player)
+			{
+				var playersAtPosition = objects.Get<RegisterPlayer>(position);
+
+				if (playersAtPosition.Count == 0 || playersAtPosition.Contains(registerTile))
+				{
+					return false;
+				}
+
+				// Check if the player is passable (corpse)
+				return playersAtPosition.First().IsBlocking;
+			}
+
+			// Otherwise check for blocking objects
+			return objects.Get<RegisterTile>(position).Contains(registerTile);
+		}
+
+		public IEnumerable<IElectricityIO> GetElectricalConnections(Vector3Int position)
+		{
+			return objects.Get(position).Select(x => x.GetComponent<IElectricityIO>()).Where(x => x != null);
+		}
+	}
 }


### PR DESCRIPTION
### Purpose

Fixes #1122 
Player corpse made passable

![yay](https://user-images.githubusercontent.com/7488674/42872580-7049514a-8ad1-11e8-803b-8b749216e49b.gif)

### Approach

The "ContainsAtPlayer" method in Matrix class is made to check whether the player on another tile is a Ghost (using the PlayerMove component) in addition to a check for the same player IDs.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer