### PR TITLE
Use ChatRelay instead of UIManager when examining objects

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/MessageOnInteract.cs
+++ b/UnityProject/Assets/Scripts/Objects/MessageOnInteract.cs
@@ -17,7 +17,7 @@ public class MessageOnInteract : InputTrigger
 	}
 	public override void Interact(GameObject originator, Vector3 position, string hand)
 	{
-		UIManager.Chat.AddChatEvent(new ChatEvent(Message, ChatChannel.Examine));
+		ChatRelay.Instance.AddToChatLogClient(Message, ChatChannel.Examine);
 	}
 
 }


### PR DESCRIPTION
### Purpose
Fixes #1147 
Updates MessageOnInteract script to use ChatRelay instead of UIManager

### Open Questions and Pre-Merge TODOs

- [ ]  This fix is tested on the same branch it is PR'ed to.
- [ ]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer

### Notes:
