### PR TITLE
Add a .editorconfig file with tab-indents for .cs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.cs]
+indent_size = 4
+indent_style = tab
+trim_trailing_whitespace = true


### PR DESCRIPTION
- [X]  This fix is tested on the same branch it is PR'ed to.
- [ ]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [ ]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer
