### PR TITLE
Fixes unreliable PlayerScript.PlayerSync component reference init

### DIFF
--- a/UnityProject/Assets/Scripts/Editor/Tools/Networking.cs
+++ b/UnityProject/Assets/Scripts/Editor/Tools/Networking.cs
@@ -30,14 +30,14 @@ public class Networking : Editor
 	{
 		foreach (ConnectedPlayer player in PlayerList.Instance.InGamePlayers)
 		{
-			player.GameObject.GetComponent<PlayerScript>().playerSync.Push(Vector2Int.up);
+			player.GameObject.GetComponent<PlayerScript>().PlayerSync.Push(Vector2Int.up);
 		}
 	}
 	[MenuItem("Networking/Spawn some meat")]
 	private static void SpawnMeat()
 	{
 		foreach (ConnectedPlayer player in PlayerList.Instance.InGamePlayers) {
-			Vector3 playerPos = player.GameObject.GetComponent<PlayerScript>().playerSync.ServerState.WorldPosition;
+			Vector3 playerPos = player.GameObject.GetComponent<PlayerScript>().PlayerSync.ServerState.WorldPosition;
 			Vector3 spawnPos = playerPos + new Vector3( 0, 2, 0 );
 			GameObject mealPrefab = CraftingManager.Meals.FindOutputMeal("Meat Steak");
 			var slabs = new List<CustomNetTransform>();

--- a/UnityProject/Assets/Scripts/Equipment/ObjectPool.cs
+++ b/UnityProject/Assets/Scripts/Equipment/ObjectPool.cs
@@ -62,7 +62,7 @@ using UnityEngine.Networking;
 			var objTransform = gObj.GetComponent<CustomNetTransform>();
 			if ( Owner ) {
 				//Inertia drop works only if player has external impulse (space floating etc.)
-				objTransform.InertiaDrop( dropPos, Owner.playerMove.speed, Owner.playerSync.ServerState.Impulse );
+				objTransform.InertiaDrop( dropPos, Owner.playerMove.speed, Owner.PlayerSync.ServerState.Impulse );
 			} else {
 				objTransform.AppearAtPositionServer(dropPos); 
 			}

--- a/UnityProject/Assets/Scripts/Health/TortureChamber.cs
+++ b/UnityProject/Assets/Scripts/Health/TortureChamber.cs
@@ -51,7 +51,7 @@ public class TortureChamber
 	{
 		int randX = (int)severity * 100 * Random.Range(-5, 5);
 		int randY = (int)severity * 100 * Random.Range(-5, 5);
-		ps.playerSync.SetPosition(new Vector2(randX,randY));
+		ps.PlayerSync.SetPosition(new Vector2(randX,randY));
 	}
 
 }

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -325,7 +325,7 @@ public class CustomNetworkManager : NetworkManager
 		//All players
 		List<ConnectedPlayer> players = PlayerList.Instance.InGamePlayers;
 		for ( var i = 0; i < players.Count; i++ ) {
-			players[i].Script.playerSync.NotifyPlayer( playerGameObject, true );
+			players[i].Script.PlayerSync.NotifyPlayer( playerGameObject, true );
 		}
 
 		Logger.Log($"Sent sync data ({matrices.Length} matrices, {scripts.Length} transforms, {players.Count} players) to {playerGameObject.name}", Category.Connections);

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -12,8 +12,8 @@ public static class SpawnHandler
 		GameObject player = CreatePlayer(jobType);
 		var connectedPlayer = PlayerList.Instance.UpdatePlayer(conn, player);
 		NetworkServer.AddPlayerForConnection(conn, player, playerControllerId);
-		if (connectedPlayer.Script.playerSync != null) {
-			connectedPlayer.Script.playerSync.NotifyPlayers(true);
+		if (connectedPlayer.Script.PlayerSync != null) {
+			connectedPlayer.Script.PlayerSync.NotifyPlayers(true);
 		} else {
 			Debug.LogWarning("why is playerSync missing here?");
 		}
@@ -24,8 +24,8 @@ public static class SpawnHandler
 		GameObject player = CreatePlayer(jobType);
 		var connectedPlayer = PlayerList.Instance.UpdatePlayer(conn, player);
 		NetworkServer.ReplacePlayerForConnection(conn, player, playerControllerId);
-		if (connectedPlayer.Script.playerSync != null) {
-			connectedPlayer.Script.playerSync.NotifyPlayers(true);
+		if (connectedPlayer.Script.PlayerSync != null) {
+			connectedPlayer.Script.PlayerSync.NotifyPlayers(true);
 		} else {
 			Debug.LogWarning("why is playerSync missing here?");
 		}
@@ -37,7 +37,7 @@ public static class SpawnHandler
 
 		Transform spawnPosition = GetSpawnForJob(jobType);
 
-		GameObject player; 
+		GameObject player;
 
 		if (spawnPosition != null)
 		{
@@ -51,7 +51,7 @@ public static class SpawnHandler
 		{
 			player = Object.Instantiate(playerPrefab);
 		}
-		
+
 		player.GetComponent<PlayerScript>().JobType = jobType;
 
 		return player;

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -59,9 +59,9 @@ public class PushPull : VisibleBehaviour
 		if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.LeftCommand)){
 			if (PlayerManager.LocalPlayerScript.IsInReach(transform.position) &&
 				transform != PlayerManager.LocalPlayerScript.transform && PlayerManager.LocalPlayerScript.playerMove.pushPull.pulledBy == null) {
-				if (PlayerManager.LocalPlayerScript.playerSync.PullingObject != null &&
-				   PlayerManager.LocalPlayerScript.playerSync.PullingObject != gameObject) {
-					PlayerManager.LocalPlayerScript.playerNetworkActions.CmdStopPulling(PlayerManager.LocalPlayerScript.playerSync.PullingObject);
+				if (PlayerManager.LocalPlayerScript.PlayerSync.PullingObject != null &&
+				   PlayerManager.LocalPlayerScript.PlayerSync.PullingObject != gameObject) {
+					PlayerManager.LocalPlayerScript.playerNetworkActions.CmdStopPulling(PlayerManager.LocalPlayerScript.PlayerSync.PullingObject);
 				}
 
 				if (pulledBy == PlayerManager.LocalPlayer) {
@@ -73,7 +73,7 @@ public class PushPull : VisibleBehaviour
 					if (customNetTransform != null) {
 						customNetTransform.enabled = false;
 					}
-					PlayerManager.LocalPlayerScript.playerSync.PullingObject = gameObject;
+					PlayerManager.LocalPlayerScript.PlayerSync.PullingObject = gameObject;
 				}
 			}
 		}
@@ -88,7 +88,7 @@ public class PushPull : VisibleBehaviour
 		if (pulledBy != PlayerManager.LocalPlayer) {
 			PlayerManager.LocalPlayerScript.playerNetworkActions.CmdStopOtherPulling(gameObject);
 		}
-		PlayerManager.LocalPlayerScript.playerSync.PullReset(gameObject.GetComponent<NetworkIdentity>().netId);
+		PlayerManager.LocalPlayerScript.PlayerSync.PullReset(gameObject.GetComponent<NetworkIdentity>().netId);
 	}
 
 	public void TryPush(GameObject pushedBy, Vector2 pushDir)
@@ -107,7 +107,7 @@ public class PushPull : VisibleBehaviour
 			} else {
 				pulledBy.GetComponent<PlayerNetworkActions>().CmdStopPulling(gameObject);
 				PlayerManager.LocalPlayerScript.playerNetworkActions.isPulling = false;
-				PlayerManager.LocalPlayerScript.playerSync.PullingObject = null;
+				PlayerManager.LocalPlayerScript.PlayerSync.PullingObject = null;
 			}
 
 			pulledBy = null;
@@ -124,7 +124,7 @@ public class PushPull : VisibleBehaviour
 			if (pusher == PlayerManager.LocalPlayer) {
 				//pushing for local player is set to true from CNT, to make sure prediction isn't overwhelmed
 				customNetTransform.PushToPosition(pushTarget, PlayerManager.LocalPlayerScript.playerMove.speed, this);
-				PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryPush(gameObject, transform.localPosition, pushTarget, 
+				PlayerManager.LocalPlayerScript.playerNetworkActions.CmdTryPush(gameObject, transform.localPosition, pushTarget,
 				                                                                PlayerManager.LocalPlayerScript.playerMove.speed);
 			}
 		}
@@ -134,17 +134,13 @@ public class PushPull : VisibleBehaviour
 	public void BreakPull()
 	{
 		PlayerScript player = PlayerManager.LocalPlayerScript;
-		if (player.playerSync == null) //FIXME: this doesn't exist on the client sometimes
-		{
-			return;
-		}
-		GameObject pullingObject = player.playerSync.PullingObject;
+		GameObject pullingObject = player.PlayerSync.PullingObject;
 		if (!pullingObject || !pullingObject.Equals(gameObject)) {
 			return;
 		}
-		player.playerSync.PullReset(NetworkInstanceId.Invalid);
-		player.playerSync.PullingObject = null;
-		player.playerSync.PullObjectID = NetworkInstanceId.Invalid;
+		player.PlayerSync.PullReset(NetworkInstanceId.Invalid);
+		player.PlayerSync.PullingObject = null;
+		player.PlayerSync.PullObjectID = NetworkInstanceId.Invalid;
 		player.playerNetworkActions.isPulling = false;
 		pulledBy = null;
 	}

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
@@ -324,7 +324,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		}
 		GameObject throwable = Inventory[slot];
 		
-		Vector3 playerPos = playerScript.playerSync.ServerState.WorldPosition;
+		Vector3 playerPos = playerScript.PlayerSync.ServerState.WorldPosition;
 
 		EquipmentPool.DisposeOfObject(gameObject, throwable); 
 		ClearInventorySlot(slot);
@@ -339,8 +339,8 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		throwable.GetComponent<CustomNetTransform>().Throw( throwInfo );
 		
 		//Simplified counter-impulse for players in space
-		if ( playerScript.playerSync.IsInSpace ) {
-			playerScript.playerSync.Push( Vector2Int.RoundToInt(-throwInfo.Trajectory.normalized) );
+		if ( playerScript.PlayerSync.IsInSpace ) {
+			playerScript.PlayerSync.Push( Vector2Int.RoundToInt(-throwInfo.Trajectory.normalized) );
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
@@ -34,7 +34,8 @@ public class PlayerScript : ManagedNetworkBehaviour
 
 		public PlayerSprites playerSprites { get; set; }
 
-		public PlayerSync playerSync { get; set; }
+		private PlayerSync playerSync; //Example of good on-demand reference init
+		public PlayerSync PlayerSync => playerSync ? playerSync : ( playerSync = GetComponent<PlayerSync>() );
 
 		public RegisterTile registerTile { get; set; }
 
@@ -90,7 +91,6 @@ public class PlayerScript : ManagedNetworkBehaviour
 		private void Start()
 		{
 			playerNetworkActions = GetComponent<PlayerNetworkActions>();
-			playerSync = GetComponent<PlayerSync>();
 			registerTile = GetComponent<RegisterTile>();
 			playerHealth = GetComponent<PlayerHealth>();
 			weaponNetworkActions = GetComponent<WeaponNetworkActions>();


### PR DESCRIPTION
### Purpose
Fixes #1167 

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
It happened because PlayerSync reference was queried before Start() had a chance to execute.
Making it init on-demand solved the issue