### PR TITLE
Implemented damage in MetaDataNode

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/Managers.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/Managers.prefab
@@ -494,6 +494,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4503573660594256}
   - component: {fileID: 114125862687263714}
+  - component: {fileID: 114951106656437044}
   m_Layer: 0
   m_Name: ObjectManager
   m_TagString: Untagged
@@ -579,6 +580,22 @@ GameObject:
   - component: {fileID: 82331298859978462}
   m_Layer: 0
   m_Name: Ambient01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1129734734361024
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4742497414384692}
+  - component: {fileID: 114992406981847666}
+  m_Layer: 0
+  m_Name: NetworkTabManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4762,6 +4779,7 @@ Transform:
   - {fileID: 4067831875969682}
   - {fileID: 4637464727519376}
   - {fileID: 4341117916031160}
+  - {fileID: 4742497414384692}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5168,6 +5186,19 @@ Transform:
   m_Children: []
   m_Father: {fileID: 4275372777489054}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4742497414384692
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1129734734361024}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4244501537706558}
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4775090733053778
 Transform:
@@ -18917,6 +18948,17 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+--- !u!114 &114951106656437044
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1100039377420734}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8079a567854c41a28799b3762ed3cb0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114959438629828204
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -19334,6 +19376,17 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+--- !u!114 &114992406981847666
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1129734734361024}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c26b8a781ec24e1aa2f11eb242bd7150, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114995580279116192
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Damage.meta
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Damage.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b14e5eaa86bc4829848c96db8844612
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Damage/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Damage/TilemapDamage.cs
@@ -22,27 +22,34 @@ public class TilemapDamage : MonoBehaviour
 	}
 	public void OnCollisionEnter2D(Collision2D coll)
 	{
-		DetermineAction(coll.gameObject);
+		var firstContact = coll.GetContact(0);
+		var dirOfForce = (firstContact.point - (Vector2)coll.transform.position).normalized;
+		DetermineAction(coll.gameObject, dirOfForce);
 	}
 
-	private void DetermineAction(GameObject objectColliding)
+	private void DetermineAction(GameObject objectColliding, Vector2 forceDirection)
 	{
 		var bulletBehaviour = objectColliding.GetComponent<BulletBehaviour>();
 		if (bulletBehaviour != null)
 		{
-			DoBulletDamage(bulletBehaviour);
+			DoBulletDamage(bulletBehaviour, forceDirection);
 			return;
 		}
 	}
 
-	private void DoBulletDamage(BulletBehaviour bullet)
+	private void DoBulletDamage(BulletBehaviour bullet, Vector2 forceDir)
 	{
 		if (thisLayer.LayerType == LayerType.Windows)
 		{
-			var cellPos = tileChangeManager.wallTileMap.WorldToCell((Vector2) bullet.transform.position + bullet.Direction);
+			var cellPos = tileChangeManager.windowTileMap.WorldToCell((Vector2) bullet.transform.position + (forceDir * 0.5f));
 			var data = metaDataLayer.Get(cellPos);
-			data.AddDamage(40);
-			Debug.Log("DAMAGE!: " + data.GetDamage);
+			var getTile = tileChangeManager.windowTileMap.GetTile(cellPos);
+			if (getTile != null)
+			{
+				data.AddDamage(40);
+				Debug.Log("OBJ NAME: " + getTile.ToString());
+				Debug.Log("DAMAGE!: " + data.GetDamage);
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Damage/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Damage/TilemapDamage.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TilemapDamage : MonoBehaviour
+{
+	private TileChangeManager tileChangeManager;
+	private TileTrigger tileTrigger;
+
+	private MetaDataLayer metaDataLayer;
+	private MetaTileMap metaTileMap;
+
+	private Layer thisLayer;
+
+	void Awake()
+	{
+		tileChangeManager = transform.root.GetComponent<TileChangeManager>();
+		tileTrigger = transform.root.GetComponent<TileTrigger>();
+		metaDataLayer = transform.parent.GetComponent<MetaDataLayer>();
+		metaTileMap = transform.parent.GetComponent<MetaTileMap>();
+		thisLayer = GetComponent<Layer>();
+	}
+	public void OnCollisionEnter2D(Collision2D coll)
+	{
+		DetermineAction(coll.gameObject);
+	}
+
+	private void DetermineAction(GameObject objectColliding)
+	{
+		var bulletBehaviour = objectColliding.GetComponent<BulletBehaviour>();
+		if (bulletBehaviour != null)
+		{
+			DoBulletDamage(bulletBehaviour);
+			return;
+		}
+	}
+
+	private void DoBulletDamage(BulletBehaviour bullet)
+	{
+		if (thisLayer.LayerType == LayerType.Windows)
+		{
+			var cellPos = tileChangeManager.wallTileMap.WorldToCell((Vector2) bullet.transform.position + bullet.Direction);
+			var data = metaDataLayer.Get(cellPos);
+			data.AddDamage(40);
+			Debug.Log("DAMAGE!: " + data.GetDamage);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Damage/TilemapDamage.cs.meta
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Damage/TilemapDamage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d007c14d2939f4fb2a1121b89c7a030e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
@@ -1,25 +1,32 @@
 ﻿using System;
 
+[Serializable]
+public class MetaDataNode
+{
+	private int room = 0;
 
-	
-	[Serializable]
-	public class MetaDataNode
+	private int damage = 0;
+
+	public int Room
 	{
-		private int room = 0;
-
-		public int Room
-		{
-			get { return room; }
-			set { room = value; }
-		}
-
-		public void Reset()
-		{
-			Room = 0;
-		}
-
-		public bool IsSpace()
-		{
-			return Room < 0;
-		}
+		get { return room; }
+		set { room = value; }
 	}
+
+	public void Reset()
+	{
+		Room = 0;
+	}
+
+	public bool IsSpace()
+	{
+		return Room < 0;
+	}
+
+	public int GetDamage { get { return damage; } }
+
+	public void AddDamage(int amt)
+	{
+		damage += amt;
+	}
+}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
@@ -8,11 +8,11 @@ using UnityEngine.Tilemaps;
 //To track tile changes on the server and update on the client
 public class TileChangeManager : NetworkBehaviour
 {
-	private Tilemap floorTileMap;
-	private Tilemap baseTileMap;
-	private Tilemap wallTileMap;
-	private Tilemap windowTileMap;
-	private Tilemap objectTileMap;
+	public Tilemap floorTileMap{ get; private set; }
+	public Tilemap baseTileMap{ get; private set; }
+	public Tilemap wallTileMap{ get; private set; }
+	public Tilemap windowTileMap{ get; private set; }
+	public Tilemap objectTileMap{ get; private set; }
 
 	public GameObject ObjectParent => objectTileMap.gameObject;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/TilesManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/TilesManager.cs
@@ -1,0 +1,134 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+
+public class TilesManager : MonoBehaviour
+{
+	private static TilesManager tilesManager;
+
+	public static TilesManager Instance
+	{
+		get
+		{
+			if (tilesManager == null)
+			{
+				tilesManager = FindObjectOfType<TilesManager>();
+			}
+			return tilesManager;
+		}
+	}
+
+	private Dictionary<string, TileBase> floorAssets = new Dictionary<string, TileBase>();
+	private Dictionary<string, TileBase> wallAssets = new Dictionary<string, TileBase>();
+	private Dictionary<string, TileBase> windowAssets = new Dictionary<string, TileBase>();
+	private Dictionary<string, TileBase> tableAssets = new Dictionary<string, TileBase>();
+
+	public static Dictionary<string, TileBase> FloorAssets => Instance.floorAssets;
+	public static Dictionary<string, TileBase> WallAssets => Instance.wallAssets;
+	public static Dictionary<string, TileBase> WindowAssets => Instance.windowAssets;
+	public static Dictionary<string, TileBase> TableAssets => Instance.tableAssets;
+
+	void Start()
+	{
+		LoadAllTileAssets();
+	}
+
+	void LoadAllTileAssets()
+	{
+		TileBase[] floorTiles = Resources.LoadAll<TileBase>("Tiles/Floors");
+		for (int i = 0; i < floorTiles.Length; i++)
+		{
+			floorAssets.Add(floorTiles[i].name, floorTiles[i]);
+		}
+
+		TileBase[] windowTiles = Resources.LoadAll<TileBase>("Tiles/Windows");
+		for (int i = 0; i < windowTiles.Length; i++)
+		{
+			windowAssets.Add(windowTiles[i].name, windowTiles[i]);
+		}
+
+		TileBase[] wallTiles = Resources.LoadAll<TileBase>("Tiles/Walls");
+		for (int i = 0; i < wallTiles.Length; i++)
+		{
+			wallAssets.Add(wallTiles[i].name, wallTiles[i]);
+		}
+
+		TileBase[] tableTiles = Resources.LoadAll<TileBase>("Tiles/Tables");
+		for (int i = 0; i < tableTiles.Length; i++)
+		{
+			tableAssets.Add(tableTiles[i].name, tableTiles[i]);
+		}
+	}
+
+	public static TileBase GetTile(TileChangeLayer layer, string tileKey)
+	{
+		switch (layer)
+		{
+			case TileChangeLayer.Base:
+			case TileChangeLayer.Floor:
+				if (FloorAssets.ContainsKey(tileKey))
+				{
+					return FloorAssets[tileKey];
+				}
+				break;
+			case TileChangeLayer.Object:
+				if (TableAssets.ContainsKey(tileKey))
+				{
+					return TableAssets[tileKey];
+				}
+				break;
+			case TileChangeLayer.Wall:
+				if (WallAssets.ContainsKey(tileKey))
+				{
+					return WallAssets[tileKey];
+				}
+				break;
+			case TileChangeLayer.Window:
+				if (WindowAssets.ContainsKey(tileKey))
+				{
+					return WindowAssets[tileKey];
+				}
+				break;
+		}
+		return null;
+	}
+
+	public static bool ValidateTileKey(TileChangeLayer layer, string tileKey)
+	{
+		if (string.IsNullOrEmpty(tileKey))
+		{
+			return true;
+		}
+
+		switch (layer)
+		{
+			case TileChangeLayer.Base:
+			case TileChangeLayer.Floor:
+				if (FloorAssets.ContainsKey(tileKey))
+				{
+					return true;
+				}
+				break;
+			case TileChangeLayer.Object:
+				if (TableAssets.ContainsKey(tileKey))
+				{
+					return true;
+				}
+				break;
+			case TileChangeLayer.Wall:
+				if (WallAssets.ContainsKey(tileKey))
+				{
+					return true;
+				}
+				break;
+			case TileChangeLayer.Window:
+				if (WindowAssets.ContainsKey(tileKey))
+				{
+					return true;
+				}
+				break;
+		}
+		return false;
+	}
+}

--- a/UnityProject/Assets/Scripts/Tilemaps/TilesManager.cs.meta
+++ b/UnityProject/Assets/Scripts/Tilemaps/TilesManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8079a567854c41a28799b3762ed3cb0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
@@ -11,6 +11,8 @@ public abstract class BulletBehaviour : MonoBehaviour
 	private Rigidbody2D thisRigi;
 	//	public BodyPartType BodyPartAim { get; private set; };
 
+	public Vector2 Direction { get; private set; }
+
 
 	public void Shoot(Vector2 dir, float angle, GameObject controlledByPlayer, BodyPartType targetZone = BodyPartType.CHEST)
 	{
@@ -20,6 +22,7 @@ public abstract class BulletBehaviour : MonoBehaviour
 
 	private void StartShoot(Vector2 dir, float angle, GameObject controlledByPlayer, BodyPartType targetZone)
 	{
+		Direction = dir;
 		bodyAim = targetZone;
 		shooter = controlledByPlayer;
 		transform.rotation = Quaternion.AngleAxis(angle, Vector3.forward);


### PR DESCRIPTION
### Purpose
- Shooting at windows now increments damage on the relevant MetaDataNode
- Separated the Tile asset dictionaries and added them to a central obj called TilesManager. Also added public methods for validating the tile keys and retrieving a tile to the manager.
- Fixed NetworkTabManager NRE
