### PR TITLE
Added feature to hold R to throw

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
@@ -109,8 +109,8 @@ using UnityEngine.Tilemaps;
 				PlayerManager.LocalPlayerScript.playerNetworkActions
 					.CmdRequestThrow( currentSlot.eventName, position, (int) UIManager.DamageZone );
 
-				//Disabling throw button (not needed since holding R now enables throw)
-				// UIManager.Action.Throw();
+				//Disabling throw button
+				UIManager.Action.Throw(false);
 				e.Use();
 			}
 		}

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
@@ -108,8 +108,9 @@ using UnityEngine.Tilemaps;
 //				Logger.Log( $"Requesting throw from {currentSlot.eventName} to {position}" );
 				PlayerManager.LocalPlayerScript.playerNetworkActions
 					.CmdRequestThrow( currentSlot.eventName, position, (int) UIManager.DamageZone );
-				//Disabling throw button
-				UIManager.Action.Throw();
+
+				//Disabling throw button (not needed since holding R now enables throw)
+				// UIManager.Action.Throw();
 				e.Use();
 			}
 		}

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
@@ -129,7 +129,7 @@ using UnityEngine.UI;
 
 		/// Throw mode toggle. Actual throw is in
 		/// <see cref="InputController.CheckThrow()"/>
-		public void Throw(bool enable = true)
+		public void Throw(bool enable)
 		{
 			// See if requesting to enable or disable throw (for keyDown or keyUp)
 			if (enable && UIManager.IsThrow == false)

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
@@ -39,7 +39,12 @@ using UnityEngine.UI;
 
 			if (Input.GetKeyDown(KeyCode.R))
 			{
-				Throw();
+				Throw(true);
+			}
+
+			if (Input.GetKeyUp(KeyCode.R))
+			{
+				Throw(false);
 			}
 			
 			if (Input.GetKeyDown(KeyCode.X))
@@ -124,27 +129,32 @@ using UnityEngine.UI;
 
 		/// Throw mode toggle. Actual throw is in
 		/// <see cref="InputController.CheckThrow()"/>
-		public void Throw()
+		public void Throw(bool enable)
 		{
-			PlayerScript lps = PlayerManager.LocalPlayerScript;
-			UI_ItemSlot currentSlot = UIManager.Hands.CurrentSlot;
-			if (!lps || lps.canNotInteract() || !currentSlot.CanPlaceItem())
+			// See if requesting to enable or disable throw (keyDown or keyUp)
+			if (enable && UIManager.IsThrow == false)
 			{
-				UIManager.IsThrow = false;
-				throwImage.sprite = throwSprites[0];
-				return;
-			}
+				PlayerScript lps = PlayerManager.LocalPlayerScript;
+				UI_ItemSlot currentSlot = UIManager.Hands.CurrentSlot;
 
-			SoundManager.Play("Click01");
-//			Logger.Log("Throw Button");
+				// Check if player can throw
+				if (!lps || lps.canNotInteract() || !currentSlot.CanPlaceItem())
+				{
+					UIManager.IsThrow = false;
+					throwImage.sprite = throwSprites[0];
+					return;
+				}
 
-			if (!UIManager.IsThrow)
-			{
+				SoundManager.Play("Click01");
+				Logger.Log("Throw Button Enabled");
+
+				// Enable throw
 				UIManager.IsThrow = true;
 				throwImage.sprite = throwSprites[1];
 			}
-			else
+			else if (!enable && UIManager.IsThrow == true)
 			{
+				// Disable throw
 				UIManager.IsThrow = false;
 				throwImage.sprite = throwSprites[0];
 			}

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
@@ -129,9 +129,9 @@ using UnityEngine.UI;
 
 		/// Throw mode toggle. Actual throw is in
 		/// <see cref="InputController.CheckThrow()"/>
-		public void Throw(bool enable)
+		public void Throw(bool enable = true)
 		{
-			// See if requesting to enable or disable throw (keyDown or keyUp)
+			// See if requesting to enable or disable throw (for keyDown or keyUp)
 			if (enable && UIManager.IsThrow == false)
 			{
 				PlayerScript lps = PlayerManager.LocalPlayerScript;
@@ -145,16 +145,16 @@ using UnityEngine.UI;
 					return;
 				}
 
-				SoundManager.Play("Click01");
-				Logger.Log("Throw Button Enabled");
-
 				// Enable throw
+				Logger.Log("Throw Button Enabled", Category.UI);
+				SoundManager.Play("Click01");
 				UIManager.IsThrow = true;
 				throwImage.sprite = throwSprites[1];
 			}
 			else if (!enable && UIManager.IsThrow == true)
 			{
 				// Disable throw
+				Logger.Log("Throw Button Disabled", Category.UI);
 				UIManager.IsThrow = false;
 				throwImage.sprite = throwSprites[0];
 			}


### PR DESCRIPTION
### Purpose
Added feature where you can hold R to throw and preserved toggle behaviour when clicking throw button. Fixes #1224. There is still a bug where clicking the GUI when throw is enabled throws toward the GUI (but I think it was already present).

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [~]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer

### Notes:
I'm new to Unity so I'm unsure if I correctly commited the right .meta/.prefab/.unity files necessary for the changes, please let me know if I've messed up!
