### PR TITLE
TileTrigger fixes and Bullet damage updates

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_EnegryShot.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_EnegryShot.prefab
@@ -104,7 +104,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.021432877, y: 0.014288902}
+  m_Offset: {x: -0.046427295, y: -0.037719727}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -115,7 +115,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.7285118, y: 0.79995537}
+  m_Size: {x: 0.2001104, y: 0.124632}
   m_EdgeRadius: 0
 --- !u!114 &114447404059583444
 MonoBehaviour:
@@ -132,6 +132,7 @@ MonoBehaviour:
   shooter: {fileID: 0}
   damageType: 1
   isSuicide: 0
+  trail: {fileID: 0}
 --- !u!212 &212297313088677886
 SpriteRenderer:
   m_ObjectHideFlags: 1
@@ -165,7 +166,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 10
+  m_SortingLayer: 11
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300746, guid: 166411a427a249d692cc1274cc54ce19, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_LaserShot.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_LaserShot.prefab
@@ -104,7 +104,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.021432877, y: 0.014288902}
+  m_Offset: {x: -0.046427295, y: -0.037719727}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -115,7 +115,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.7285118, y: 0.79995537}
+  m_Size: {x: 0.2001104, y: 0.124632}
   m_EdgeRadius: 0
 --- !u!114 &114036214839416986
 MonoBehaviour:
@@ -132,6 +132,7 @@ MonoBehaviour:
   shooter: {fileID: 0}
   damageType: 1
   isSuicide: 0
+  trail: {fileID: 0}
 --- !u!212 &212330207800450856
 SpriteRenderer:
   m_ObjectHideFlags: 1
@@ -165,7 +166,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 10
+  m_SortingLayer: 11
   m_SortingOrder: 0
   m_Sprite: {fileID: 21301844, guid: 166411a427a249d692cc1274cc54ce19, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
@@ -160,8 +160,7 @@ using UnityEngine.Tilemaps;
 					// If the ray hits a FOVTile, we can continue down (don't count it as an interaction)
 					// Matrix is the base Tilemap layer. It is used for matrix detection but gets in the way 
 					// of player interaction
-					if (!_renderer.sortingLayerName.Equals("FieldOfView") &&
-					_renderer.gameObject.layer != LayerMask.NameToLayer("Matrix"))
+					if (!_renderer.sortingLayerName.Equals("FieldOfView"))
 					{
 						if (Interact(_renderer.transform, position))
 						{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Damage/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Damage/TilemapDamage.cs
@@ -49,6 +49,7 @@ public class TilemapDamage : MonoBehaviour
 		var bulletBehaviour = objectColliding.GetComponent<BulletBehaviour>();
 		if (bulletBehaviour != null)
 		{
+			Debug.Log("Bullet behaviour found: " + bulletBehaviour.damage);
 			DoBulletDamage(bulletBehaviour, forceDirection);
 			return;
 		}
@@ -57,7 +58,7 @@ public class TilemapDamage : MonoBehaviour
 	private void DoBulletDamage(BulletBehaviour bullet, Vector3 forceDir)
 	{
 		forceDir.z = 0;
-		var bulletHitTarget = bullet.transform.position + (forceDir * 0.5f);
+		var bulletHitTarget = bullet.transform.position + (forceDir * 0.2f);
 		var cellPos = tileChangeManager.baseTileMap.WorldToCell(bulletHitTarget);
 		var data = metaDataLayer.Get(cellPos);
 
@@ -67,7 +68,7 @@ public class TilemapDamage : MonoBehaviour
 			if (getTile != null)
 			{
 				//TODO damage amt based off type of bullet
-				AddWindowDamage(20, data, cellPos, bulletHitTarget);
+				AddWindowDamage(bullet.damage, data, cellPos, bulletHitTarget);
 				return;
 			}
 		}
@@ -82,7 +83,7 @@ public class TilemapDamage : MonoBehaviour
 				if (getGrillTile != null)
 				{
 					//TODO damage amt based off type of bullet
-					AddGrillDamage(20, data, cellPos, bulletHitTarget);
+					AddGrillDamage(bullet.damage, data, cellPos, bulletHitTarget);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/LayerTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/LayerTile.cs
@@ -20,7 +20,8 @@
 		Floor,
 		Table,
 		Effects,
-		Grill
+		Grill,
+		Base
 	}
 
 	public class LayerTile : GenericTile


### PR DESCRIPTION
### Purpose
- TileTrigger now acts as the gate for all interaction on the tree that it belongs too (it will determine when to trigger a MeleeTrigger for a Tilemap for example)
- Tilemap damage for bullets is now based off the bullet.Damage value
- Energy shots now damage windows and grills

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

