### PR TITLE
Food no longer triggers melee action

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Food/Resources/4no raisins.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Resources/4no raisins.prefab
@@ -168,6 +168,7 @@ MonoBehaviour:
   inHandReferenceRight: -1
   itemDescription: Best raisins in the universe. Not sure why.
   itemName: 4no raisins
+  itemType: 14
   size: 0
   spriteType: 0
   type: 14
@@ -265,7 +266,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 10
+  m_SortingLayer: 11
   m_SortingOrder: 10
   m_Sprite: {fileID: 21300068, guid: 7604d4a595ad0420bbb16ef2e5e6675d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Prefabs/Items/Food/Resources/Beef Jerky.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Resources/Beef Jerky.prefab
@@ -168,6 +168,7 @@ MonoBehaviour:
   inHandReferenceRight: -1
   itemDescription: Beef jerky made from the finest space cows.
   itemName: Scaredy's Private Reserve Beef Jerky
+  itemType: 14
   size: 0
   spriteType: 0
   type: 14
@@ -265,7 +266,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 10
+  m_SortingLayer: 11
   m_SortingOrder: 10
   m_Sprite: {fileID: 21300066, guid: 7604d4a595ad0420bbb16ef2e5e6675d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Prefabs/Items/Food/Resources/Cappuccino.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Resources/Cappuccino.prefab
@@ -168,6 +168,7 @@ MonoBehaviour:
   inHandReferenceRight: -1
   itemDescription: 
   itemName: A Cappuccino in an edible mug
+  itemType: 14
   size: 0
   spriteType: 0
   type: 14
@@ -265,7 +266,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 10
+  m_SortingLayer: 11
   m_SortingOrder: 10
   m_Sprite: {fileID: 21300292, guid: 3547c548ae071487c84212e8ee25d554, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Prefabs/Items/Food/Resources/Cookie.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Resources/Cookie.prefab
@@ -168,6 +168,7 @@ MonoBehaviour:
   inHandReferenceRight: -1
   itemDescription: COOKIE!!!
   itemName: cookie
+  itemType: 14
   size: 0
   spriteType: 0
   type: 14
@@ -265,7 +266,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 10
+  m_SortingLayer: 11
   m_SortingOrder: 10
   m_Sprite: {fileID: 21300152, guid: 7604d4a595ad0420bbb16ef2e5e6675d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Prefabs/Items/Food/Resources/Icy Soda.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Resources/Icy Soda.prefab
@@ -168,6 +168,7 @@ MonoBehaviour:
   inHandReferenceRight: -1
   itemDescription: This one looks like it's 90% ice...
   itemName: Icy Soda
+  itemType: 14
   size: 0
   spriteType: 0
   type: 14
@@ -265,7 +266,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 10
+  m_SortingLayer: 11
   m_SortingOrder: 10
   m_Sprite: {fileID: 21300410, guid: 3547c548ae071487c84212e8ee25d554, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Prefabs/Items/Food/Resources/Meat Steak.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Resources/Meat Steak.prefab
@@ -180,6 +180,7 @@ MonoBehaviour:
   inHandReferenceRight: -1
   itemDescription: 
   itemName: Meat Steak
+  itemType: 14
   size: 1
   spriteType: 0
   type: 14
@@ -277,7 +278,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 10
+  m_SortingLayer: 11
   m_SortingOrder: 10
   m_Sprite: {fileID: 21300136, guid: 8921c37e5eed4f7abcfe981a559805e4, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Prefabs/Items/Food/Resources/Meat.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Food/Resources/Meat.prefab
@@ -141,6 +141,7 @@ MonoBehaviour:
   inHandReferenceRight: -1
   itemDescription: 
   itemName: Meat
+  itemType: 14
   size: 1
   spriteType: 0
   type: 14
@@ -251,7 +252,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 10
+  m_SortingLayer: 11
   m_SortingOrder: 10
   m_Sprite: {fileID: 21300046, guid: 8921c37e5eed4f7abcfe981a559805e4, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/MeleeTrigger.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/MeleeTrigger.cs
@@ -28,6 +28,12 @@ public class MeleeTrigger : MonoBehaviour
 		{
 			var mousePos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
 			var handItem = UIManager.Hands.CurrentSlot.Item.GetComponent<ItemAttributes>();
+
+			if(handItem.itemType == ItemType.Food){
+				//TODO Add medical stuff too
+				return false;
+			}
+
 			if (handItem.itemType != ItemType.ID &&
 				handItem.itemType != ItemType.Back &&
 				handItem.itemType != ItemType.Ear &&


### PR DESCRIPTION
### Purpose
Fixes #1256 

- Melee trigger now checks to see if the item is food or not

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer
