### PR TITLE
Added playerStoppedBreathing check, Replaced windoors with public doors for time being

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/Managers.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/Managers.prefab
@@ -10436,9 +10436,9 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 63a0881c51dacb447bdf7b9ea2c37e44, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.2
+  m_Volume: 0.321
   m_Pitch: 1
-  Loop: 0
+  Loop: 1
   Mute: 0
   Spatialize: 0
   SpatializePostEffects: 0
@@ -14764,7 +14764,7 @@ MonoBehaviour:
     holeRadius: 0.03
     holeShape: 2
     shroudActive: 1
-    shroudColor: {r: 0, g: 0, b: 0, a: 0}
+    shroudColor: {r: 0.509434, g: 0, b: 0, a: 1}
   currentState: 0
   holeMat: {fileID: 2100000, guid: ecc97e9b19bc34985b4b01b0121c9683, type: 2}
   injuredSettings:

--- a/UnityProject/Assets/Scripts/Health/Living/PlayerHealth.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/PlayerHealth.cs
@@ -45,6 +45,8 @@ public class PlayerHealth : HealthBehaviour
 			}
 
 			ConsciousState = ConsciousState.DEAD;
+
+			//Fixme: No more setting allowInputs on client:
 			playerMove.allowInput = false;
 		}
 

--- a/UnityProject/Assets/Scripts/Health/Living/PlayerHealthReporting.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/PlayerHealthReporting.cs
@@ -2,114 +2,138 @@ using System.Collections;
 using UnityEngine;
 using UnityEngine.Networking;
 
+/// <summary>
+///     Player health reporting.
+///     This is the Server -> Client reporting for player health
+///     The server also calculates the overall health values in this component
+///     (To determine maxHealth for huds, ui overlays etc)
+/// </summary>
+public class PlayerHealthReporting : ManagedNetworkBehaviour
+{
+	private int bloodLevelCache;
+	private float BloodPercentage = 100f;
 
-	/// <summary>
-	///     Player health reporting.
-	///     This is the Server -> Client reporting for player health
-	///     The server also calculates the overall health values in this component
-	///     (To determine maxHealth for huds, ui overlays etc)
-	/// </summary>
-	public class PlayerHealthReporting : ManagedNetworkBehaviour
+	private bool hasStoppedBreathing = false;
+	private float breathingDamagedRate = 2f; //dmg every 2 seconds
+	private float stoppedBreathingCount = 0f;
+
+	//server only caches
+	private int healthServerCache;
+	//TODO if client disconnects and reconnects then the clients UI needs to 
+	//poll this component and request updated values from the server to set
+	//the current state of the UI overlays and hud
+
+	public PlayerHealth playerHealth;
+	private PlayerMove playerMove;
+
+	protected override void OnEnable()
 	{
-		private int bloodLevelCache;
-		private float BloodPercentage = 100f;
+		//Do not call base method for this OnEnable.
+	}
 
-		//server only caches
-		private int healthServerCache;
-		//TODO if client disconnects and reconnects then the clients UI needs to 
-		//poll this component and request updated values from the server to set
-		//the current state of the UI overlays and hud
-
-		public PlayerHealth playerHealth;
-		private PlayerMove playerMove;
-
-		protected override void OnEnable()
+	public override void OnStartServer()
+	{
+		if (isServer)
 		{
-			//Do not call base method for this OnEnable.
+			healthServerCache = playerHealth.Health;
+			bloodLevelCache = playerHealth.BloodLevel;
+			playerMove = GetComponent<PlayerMove>();
+			UpdateManager.Instance.Add(this);
+			StartCoroutine(WaitForLoad());
 		}
+		base.OnStartServer();
+	}
 
-		public override void OnStartServer()
+	private IEnumerator WaitForLoad()
+	{
+		yield return new WaitForSeconds(1f); //1000ms wait for lag
+
+		UpdateClientUI(100); //Set the UI for this player to 100 percent
+	}
+
+	private void OnDestroy()
+	{
+		if (isServer)
 		{
-			if (isServer)
-			{
-				healthServerCache = playerHealth.Health;
-				bloodLevelCache = playerHealth.BloodLevel;
-				playerMove = GetComponent<PlayerMove>();
-				UpdateManager.Instance.Add(this);
-				StartCoroutine(WaitForLoad());
-			}
-			base.OnStartServer();
-		}
-
-		private IEnumerator WaitForLoad()
-		{
-			yield return new WaitForSeconds(1f); //1000ms wait for lag
-
-			UpdateClientUI(100); //Set the UI for this player to 100 percent
-		}
-
-		private void OnDestroy()
-		{
-			if (isServer)
-			{
-				UpdateManager.Instance.Remove(this);
-			}
-		}
-
-		//This only runs on the server, server will do the calculations and send
-		//messages to the client when needed (or requested)
-		public override void UpdateMe()
-		{
-			ServerMonitorHealth();
-			base.UpdateMe();
-		}
-
-		private void ServerMonitorHealth()
-		{
-			//Add other damage methods here like burning, 
-			//suffication, etc
-
-			//If already dead then do not check the status of the body anymore
-			if (playerMove.isGhost)
-			{
-				return;
-			}
-
-			//Blood calcs:
-			if (bloodLevelCache != playerHealth.BloodLevel)
-			{
-				bloodLevelCache = playerHealth.BloodLevel;
-				if (playerHealth.BloodLevel >= 560)
-				{
-					//Full blood (or more)
-					BloodPercentage = 100f;
-				}
-				else
-				{
-					BloodPercentage = playerHealth.BloodLevel / 560f * 100f;
-				}
-			}
-
-			//If blood level falls below health level, then set the health level
-			//manually and update the clients UI
-			if (BloodPercentage < playerHealth.Health)
-			{
-				healthServerCache = (int) BloodPercentage;
-				playerHealth.ServerOnlySetHealth(healthServerCache);
-				UpdateClientUI(healthServerCache);
-			}
-
-			if (playerHealth.Health != healthServerCache)
-			{
-				healthServerCache = playerHealth.Health;
-				UpdateClientUI(healthServerCache);
-			}
-		}
-
-		//Sends msg to the owner of this player to update their UI
-		[Server]
-		private void UpdateClientUI(int newHealth)
-		{
-			UpdateUIMessage.Send(gameObject, newHealth);
+			UpdateManager.Instance.Remove(this);
 		}
 	}
+
+	//This only runs on the server, server will do the calculations and send
+	//messages to the client when needed (or requested)
+	public override void UpdateMe()
+	{
+		ServerMonitorHealth();
+		base.UpdateMe();
+	}
+
+	private void ServerMonitorHealth()
+	{
+		//Add other damage methods here like burning, 
+		//suffication, etc
+
+		//If already dead then do not check the status of the body anymore
+		if (playerMove.isGhost)
+		{
+			return;
+		}
+
+		//Blood calcs:
+		if (bloodLevelCache != playerHealth.BloodLevel)
+		{
+			bloodLevelCache = playerHealth.BloodLevel;
+			if (playerHealth.BloodLevel >= 560)
+			{
+				//Full blood (or more)
+				BloodPercentage = 100f;
+			}
+			else
+			{
+				BloodPercentage = playerHealth.BloodLevel / 560f * 100f;
+			}
+		}
+
+		//If blood level falls below health level, then set the health level
+		//manually and update the clients UI
+		if (BloodPercentage < playerHealth.Health)
+		{
+			healthServerCache = (int) BloodPercentage;
+			playerHealth.ServerOnlySetHealth(healthServerCache);
+			UpdateClientUI(healthServerCache);
+		}
+
+		//Player has stopped breathing:
+		if (hasStoppedBreathing && playerHealth.Health > -1f)
+		{
+			stoppedBreathingCount += Time.deltaTime;
+			if (stoppedBreathingCount > breathingDamagedRate)
+			{
+				stoppedBreathingCount = 0f;
+
+				playerHealth.ServerOnlySetHealth(healthServerCache -= 3);
+			}
+		}
+
+		if (playerHealth.Health != healthServerCache)
+		{
+			healthServerCache = playerHealth.Health;
+			UpdateClientUI(healthServerCache);
+		}
+
+		if (playerHealth.Health < 30 && !hasStoppedBreathing)
+		{
+			hasStoppedBreathing = true;
+		}
+		else if (playerHealth.Health >= 30 && hasStoppedBreathing)
+		{
+			hasStoppedBreathing = false;
+		}
+	}
+
+	//Sends msg to the owner of this player to update their UI
+	[Server]
+	private void UpdateClientUI(int newHealth)
+	{
+		UpdateUIMessage.Send(gameObject, newHealth);
+	}
+}

--- a/UnityProject/Assets/Scripts/UI/UI_HeartMonitor.cs
+++ b/UnityProject/Assets/Scripts/UI/UI_HeartMonitor.cs
@@ -115,7 +115,7 @@ using UnityEngine.UI;
 		private void CheckHealth(int cHealth)
 		{
 			//PlayGroup.PlayerManager.PlayerScript.playerNetworkActions.CmdSendAlertMessage("mHealth: " + cHealth, true);
-			//Logger.Log("PlayerHealth: " + PlayGroup.PlayerManager.PlayerScript.playerHealth.Health);
+			//Logger.Log("PlayerHealth: " + PlayerManager.PlayerScript.playerHealth.Health);
 			if (cHealth >= 90
 			    && spriteStart != fullHealthStart)
 			{


### PR DESCRIPTION
### Purpose
- When you die from suffocating you stay in crit forever as long as you are not in space. I changed this that if you are in crit and knocked out you slowly stop breathing and suffocate to death anyway
- Replaced all the windoors with public glass doors until we can fix the windoor bugs

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer
