### PR TITLE
Fixing StopCoroutine calls

### DIFF
--- a/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
@@ -8,6 +8,8 @@ public class ChatEntry : MonoBehaviour {
     private bool isCoolingDown = true;
 	public RectTransform rect;
 
+	private Coroutine coCoolDown;
+
     void OnEnable()
     {
         EventManager.AddHandler(EVENT.ChatFocused, OnChatFocused);
@@ -15,7 +17,7 @@ public class ChatEntry : MonoBehaviour {
         if (!ControlChat.Instance.chatInputWindow.gameObject.activeInHierarchy){
             if (isCoolingDown)
             {
-                StartCoroutine(CoolDown());
+				coCoolDown = StartCoroutine(CoolDown());
             }
         }
     }
@@ -30,7 +32,10 @@ public class ChatEntry : MonoBehaviour {
     {
         if (isCoolingDown)
         {
-            StopCoroutine(CoolDown());
+			if (coCoolDown != null) {
+				StopCoroutine(coCoolDown);
+				coCoolDown = null;
+			}
         }
         text.CrossFadeAlpha(1f, 0f, false);
     }
@@ -39,7 +44,7 @@ public class ChatEntry : MonoBehaviour {
     {
         if (isCoolingDown)
         {
-            StartCoroutine(CoolDown());
+			coCoolDown = StartCoroutine(CoolDown());
         } else
         {
             text.CrossFadeAlpha(0f, 0f, false);

--- a/UnityProject/Assets/Scripts/Electricity/PoweredDevices/FieldGenerator.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PoweredDevices/FieldGenerator.cs
@@ -11,7 +11,7 @@ public class FieldGenerator : InputTrigger
 		[SyncVar(hook = "CheckState")]
 		public bool isOn = false;
 		public bool connectedToOther = false;
-		private bool spriteAnimRunning = false;
+		private Coroutine coSpriteAnimator;
 
 		public Sprite offSprite;
 		public Sprite onSprite;
@@ -54,34 +54,38 @@ public class FieldGenerator : InputTrigger
 		void CheckState(bool _isOn){
 			if(isOn){
 				if(poweredDevice.suppliedElectricity.current == 0){
-					StopCoroutine(SpriteAnimator());
-					spriteAnimRunning = false;
+					if (coSpriteAnimator != null) {
+						StopCoroutine(coSpriteAnimator);
+						coSpriteAnimator = null;
+					}
 					spriteRend.sprite = onSprite;
 				}
 				if(poweredDevice.suppliedElectricity.current > 15){
 					if(!connectedToOther){
 						animSprites = new List<Sprite>(searchingSprites);
-						if (!spriteAnimRunning) {
-							StartCoroutine(SpriteAnimator());
+						if (coSpriteAnimator == null) {
+							coSpriteAnimator = StartCoroutine(SpriteAnimator());
 						}
 					} else {
 						animSprites = new List<Sprite>(connectedSprites);
-						if(!spriteAnimRunning){
-							StartCoroutine(SpriteAnimator());
+						if(coSpriteAnimator == null) {
+							coSpriteAnimator = StartCoroutine(SpriteAnimator());
 						}
 					}
 				}
 			} else {
-				StopCoroutine(SpriteAnimator());
-				spriteAnimRunning = false;
+				if (coSpriteAnimator != null) {
+					StopCoroutine(coSpriteAnimator);
+					coSpriteAnimator = null;
+				}
 				spriteRend.sprite = offSprite;
 			}
 		}
 
 		IEnumerator SpriteAnimator(){
-			spriteAnimRunning = true;
 			int index = 0;
-			while(spriteAnimRunning){
+			while(true){
+				Debug.Log("animating shield");
 				if(index >= animSprites.Count){
 					index = 0;
 				}
@@ -89,7 +93,6 @@ public class FieldGenerator : InputTrigger
 				index++;
 				yield return new WaitForSeconds(0.3f);
 			}
-			yield return new WaitForEndOfFrame();
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Items/Tools/Welder.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/Welder.cs
@@ -40,6 +40,8 @@ public class Welder : NetworkBehaviour
 	[SyncVar(hook = "UpdateState")]
 	public bool isOn;
 
+	private Coroutine coBurnFuel;
+
 	public override void OnStartServer()
 	{
 		Init();
@@ -98,7 +100,8 @@ public class Welder : NetworkBehaviour
 			itemAtts.inHandReferenceRight = rightHandFlame;
 			isBurning = true;
 			flameRenderer.sprite = flameSprites[0];
-			StartCoroutine(BurnFuel());
+			if (coBurnFuel == null)
+				coBurnFuel = StartCoroutine(BurnFuel());
 
 		}
 
@@ -107,7 +110,10 @@ public class Welder : NetworkBehaviour
 			itemAtts.inHandReferenceLeft = leftHandOriginal;
 			itemAtts.inHandReferenceRight = rightHandOriginal;
 			isBurning = false;
-			StopCoroutine(BurnFuel());
+			if (coBurnFuel != null) {
+				StopCoroutine(coBurnFuel);
+				coBurnFuel = null;
+			}
 			flameRenderer.sprite = null;
 		}
 

--- a/UnityProject/Assets/Scripts/NPC/NPC_Clown.cs
+++ b/UnityProject/Assets/Scripts/NPC/NPC_Clown.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 	public class NPC_Clown : MonoBehaviour
 	{
 		public Sprite[] clownSprites;
-		private bool isMoving;
+		private Coroutine coRandMove;
 
 		private bool isRight;
 		private SpriteRenderer spriteRenderer;
@@ -23,20 +23,20 @@ using UnityEngine;
 
 		private void OnDisable()
 		{
-			StopCoroutine(RandMove());
+			if (coRandMove != null) {
+				StopCoroutine(coRandMove);
+				coRandMove = null;
+			}
 		}
 
 		private void Update()
 		{
-			if (!isMoving)
-			{
-				StartCoroutine(RandMove());
-			}
+			if (coRandMove == null)
+				coRandMove = StartCoroutine(RandMove());
 		}
 
 		private IEnumerator RandMove()
 		{
-			isMoving = true;
 			float ranTime = Random.Range(0.2f, 6f);
 
 			yield return new WaitForSeconds(ranTime);
@@ -86,8 +86,6 @@ using UnityEngine;
 
 			float ranPitch = Random.Range(0.5f, 1.5f);
 			SoundManager.Play("ClownHonk", 0.3f, ranPitch);
-
-			isMoving = false;
 		}
 
 		private void Flip()

--- a/UnityProject/Assets/Scripts/NPC/RandomMove.cs
+++ b/UnityProject/Assets/Scripts/NPC/RandomMove.cs
@@ -9,6 +9,7 @@ using UnityEngine.Networking;
 		private Matrix _matrix;
 		private Vector3Int currentPosition, targetPosition, currentDirection;
 		private bool isRight;
+		private Coroutine coRandMove;
 		public float speed = 6f;
 
 		private void Start()
@@ -28,9 +29,9 @@ using UnityEngine.Networking;
 
 		public override void OnStartServer()
 		{
-			if (isServer)
+			if (isServer && coRandMove == null)
 			{
-				StartCoroutine(RandMove());
+				coRandMove = StartCoroutine(RandMove());
 			}
 			base.OnStartServer();
 		}
@@ -45,7 +46,10 @@ using UnityEngine.Networking;
 
 		private void OnDisable()
 		{
-			StopCoroutine(RandMove());
+			if (coRandMove != null) {
+				StopCoroutine(coRandMove);
+				coRandMove = null;
+			}
 		}
 
 		private void OnTriggerExit2D(Collider2D coll)

--- a/UnityProject/Assets/Scripts/PlayGroups/ChatIcon.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/ChatIcon.cs
@@ -8,7 +8,7 @@ public class ChatIcon : MonoBehaviour
 	private SpriteRenderer spriteRend;
 	public Sprite talkSprite;
 
-	private bool waitToTurnOff;
+	private Coroutine coWaitToTurnOff;
 
 	// Use this for initialization
 	private void Start()
@@ -22,28 +22,27 @@ public class ChatIcon : MonoBehaviour
 	{
 		spriteRend.sprite = talkSprite;
 		spriteRend.enabled = true;
-		if (waitToTurnOff)
+		if (coWaitToTurnOff != null)
 		{
-			StopCoroutine(WaitToTurnOff());
-			waitToTurnOff = false;
+			StopCoroutine(coWaitToTurnOff);
+			coWaitToTurnOff = null;
 		}
-		StartCoroutine(WaitToTurnOff());
+		coWaitToTurnOff = StartCoroutine(WaitToTurnOff());
 	}
 
 	public void TurnOffTalkIcon()
 	{
-		if (waitToTurnOff)
+		if (coWaitToTurnOff != null)
 		{
-			StopCoroutine(WaitToTurnOff());
+			StopCoroutine(coWaitToTurnOff);
+			coWaitToTurnOff = null;
 		}
 		spriteRend.enabled = false;
-		waitToTurnOff = false;
 	}
 
 	private IEnumerator WaitToTurnOff()
 	{
 		yield return new WaitForSeconds(3f);
 		spriteRend.enabled = false;
-		waitToTurnOff = false;
 	}
 }


### PR DESCRIPTION
### Purpose
`StopCoroutine` was being called incorrectly in most places, and therefore not actually stopping any coroutines.  This fixes that.  It also cleans up some sprite swapping code for the APCs to waste less memory.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
Noticed that the field generator isn't animating on clients.  Can someone confirm I'm not causing this?
