### PR TITLE
Ghost movement while floating fixed

### DIFF
--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.Client.cs
@@ -61,7 +61,7 @@ using UnityEngine;
 
 				//experiment: not enqueueing or processing action if floating.
 				//arguably it shouldn't really be like that in the future 
-				if ( (!isPseudoFloatingClient && !isFloatingClient && !blockClientMovement) || (playerScript.gameObject.GetComponent<PlayerMove>().isGhost && !blockClientMovement)) {
+				if ( (!isPseudoFloatingClient && !isFloatingClient && !blockClientMovement) || (playerMove.isGhost && !blockClientMovement)) {
 //				Logger.Log($"{gameObject.name} requesting {action.Direction()} ({pendingActions.Count} in queue)");
 					pendingActions.Enqueue( action );
 

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.Client.cs
@@ -61,7 +61,7 @@ using UnityEngine;
 
 				//experiment: not enqueueing or processing action if floating.
 				//arguably it shouldn't really be like that in the future 
-				if ( !isPseudoFloatingClient && !isFloatingClient && !blockClientMovement ) {
+				if ( (!isPseudoFloatingClient && !isFloatingClient && !blockClientMovement) || (playerScript.gameObject.GetComponent<PlayerMove>().isGhost && !blockClientMovement)) {
 //				Logger.Log($"{gameObject.name} requesting {action.Direction()} ({pendingActions.Count} in queue)");
 					pendingActions.Enqueue( action );
 


### PR DESCRIPTION
### Purpose
Adds an exception for ghosts to the condition which prevents players from doing actions while floating. 
Fixes #1130 

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
While in outer space the ghost is forced to move toward the station, you can move freely again once your back at the station, I assume that's intended and not a bug. 