### PR TITLE
Remove Methods from TMS that are only based on the position

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
@@ -43,26 +43,14 @@ using UnityEngine.Tilemaps;
 
 		public virtual bool IsPassableAt(Vector3Int from, Vector3Int to)
 		{
-			if (from == to)
-			{
-				return true;
-			}
-
 			BasicTile tileTo = tilemap.GetTile<BasicTile>(to);
-
 			return TileUtils.IsPassable(tileTo);
 		}
 
-		public virtual bool IsPassableAt(Vector3Int position)
+		public virtual bool IsAtmosPassableAt(Vector3Int from, Vector3Int to)
 		{
-			BasicTile tile = tilemap.GetTile<BasicTile>(position);
-			return TileUtils.IsPassable(tile);
-		}
-
-		public virtual bool IsAtmosPassableAt(Vector3Int position)
-		{
-			BasicTile tile = tilemap.GetTile<BasicTile>(position);
-			return TileUtils.IsAtmosPassable(tile);
+			BasicTile tileTo = tilemap.GetTile<BasicTile>(to);
+			return TileUtils.IsAtmosPassable(tileTo);
 		}
 
 		public virtual bool IsSpaceAt(Vector3Int position)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -35,7 +35,7 @@ public class Matrix : MonoBehaviour
 
     public bool IsPassableAt(Vector3Int position)
     {
-        return IsPassableAt(position + Vector3Int.up, position);
+        return IsPassableAt(position, position);
     }
 
 	public bool IsPassableAt(Vector3Int origin, Vector3Int position)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -33,21 +33,19 @@ public class Matrix : MonoBehaviour
 		initialOffset = Vector3Int.CeilToInt(gameObject.transform.position);
 	}
 
+    public bool IsPassableAt(Vector3Int position)
+    {
+        return IsPassableAt(position + Vector3Int.up, position);
+    }
+
 	public bool IsPassableAt(Vector3Int origin, Vector3Int position)
 	{
 		return metaTileMap.IsPassableAt(origin, position);
 	}
 
-	//TODO:  This should be removed, due to windows mucking things up, and replaced with origin and position
-	public bool IsPassableAt(Vector3Int position)
+	public bool IsAtmosPassableAt(Vector3Int origin, Vector3Int position)
 	{
-		return metaTileMap.IsPassableAt(position);
-	}
-
-	//TODO:  This should also be removed, due to windows mucking things up, and replaced with origin and position
-	public bool IsAtmosPassableAt(Vector3Int position)
-	{
-		return metaTileMap.IsAtmosPassableAt(position);
+		return metaTileMap.IsAtmosPassableAt(origin, position);
 	}
 
 	public bool IsSpaceAt(Vector3Int position)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -17,6 +17,11 @@ using UnityEngine;
 			}
 		}
 
+        public bool IsPassableAt(Vector3Int position)
+        {
+            return IsPassableAt(position, position);
+        }
+
 		public bool IsPassableAt(Vector3Int origin, Vector3Int to)
 		{
 			Vector3Int toX = new Vector3Int(to.x, origin.y, origin.z);
@@ -38,31 +43,31 @@ using UnityEngine;
 
 			return true;
 		}
-		
-		//TODO:  Remove this
-		public bool IsPassableAt(Vector3Int position)
-		{
-			foreach (Layer layer in Layers.Values)
-			{
-				if (!layer.IsPassableAt(position))
-				{
-					return false;
-				}
-			}
-			
-			return true;
-		}
-		
-		//TODO:  Refactor to take origin and destination
+
 		public bool IsAtmosPassableAt(Vector3Int position)
 		{
+			return IsAtmosPassableAt(position, position);
+		}
+
+		public bool IsAtmosPassableAt(Vector3Int origin, Vector3Int to)
+		{
+			Vector3Int toX = new Vector3Int(to.x, origin.y, origin.z);
+			Vector3Int toY = new Vector3Int(origin.x, to.y, origin.z);
+			
+			return _IsAtmosPassableAt(origin, toX) && _IsAtmosPassableAt(toX, to) || 
+					_IsAtmosPassableAt(origin, toY) && _IsAtmosPassableAt(toY, to);
+		}
+
+		private bool _IsAtmosPassableAt(Vector3Int origin, Vector3Int to)
+		{
 			foreach (Layer layer in Layers.Values)
 			{
-				if (!layer.IsAtmosPassableAt(position))
+				if (!layer.IsAtmosPassableAt(origin, to))
 				{
 					return false;
 				}
 			}
+
 			return true;
 		}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
@@ -57,23 +57,23 @@ using UnityEngine;
 			return objectsOrigin.All(o => o.IsPassable(origin)) && base.IsPassableAt(origin, to);
 		}
 
-		public override bool IsPassableAt(Vector3Int position)
+		public override bool IsAtmosPassableAt(Vector3Int origin, Vector3Int to)
 		{
-			List<RegisterTile> objects = Objects.Get<RegisterTile>(position);
+			List<RegisterTile> objectsTo = Objects.Get<RegisterTile>(to);
 
-			return objects.All(x => x.IsPassable()) && base.IsPassableAt(position);
-		}
+            if (!objectsTo.All(o => o.IsAtmosPassable()))
+			{
+				return false;
+			}
+			
+			List<RegisterTile> objectsOrigin = Objects.Get<RegisterTile>(origin);
 
-		public override bool IsAtmosPassableAt(Vector3Int position)
-		{
-			RegisterTile obj = Objects.GetFirst<RegisterTile>(position);
-
-			return obj ? obj.IsAtmosPassable() : base.IsAtmosPassableAt(position);
+			return objectsOrigin.All(o => o.IsAtmosPassable()) && base.IsAtmosPassableAt(origin, to);
 		}
 
 		public override bool IsSpaceAt(Vector3Int position)
 		{
-			return IsAtmosPassableAt(position) && base.IsSpaceAt(position);
+			return IsAtmosPassableAt(position, position) && base.IsSpaceAt(position);
 		}
 
 		public override void ClearAllTiles()


### PR DESCRIPTION
### Purpose
Fixes #942 Remove Methods from TMS that are only based on the position.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
First PR ever, wahoo.

Turned Matrix.IsPassableAt(position) into a wrapper for Matrix.IsPassableAt(origin, position) which passes the displaced position (position + Vector3Int.up) as the origin.
Because: of the classes: DoorController, RandomMove, ExplodeWhenShot, PushPull, PlayerSync, PlayerSync.Server, and MatrixTest which call Matrix.IsPassableAt(position) for various reasons.

Removed IsPassableAt(position) in Layer and it's override in objectLayer.cs.
Because: They now are unused and unneeded.

Turned MetaTileMap.IsPassableAt(position) and MetaTileMap.IsAtmosPassableAt(position) into a wrapper for their (from, to) counterparts, passing the position for both arguments.
Because: of the calls in RoomControl and TileMapCheckEditor which do not have an origin position in their contexts.

Removed the "if (from == to) return true" from layer.IsPassableAt(from, to).
Because: this if statement returns walls as passable, despite them not being passable ingame. This is shown with the "Passable" gizmo in the TileMapCheckEditor tool (under window/TileMapCheck).
		
As shown with the Tilemap Check tool:
Non-"Passable" tiles currently are now objects, walls, and closed doors.
Non-"AtmosPassable" tiles currently are now walls and closed doors.

There is currently no Passable or AtmosPassable code that compares the orgin coordinate/tile with position coordinate/tile for the context of windoors. The code for this, which would compare the "from" and "to" coordinates/tiles should be written in layer.IsPassableAt(from, to) and layer.IsAtmosPassableAt(from, to).
