### PR TITLE
Adds mining asteroids (mapping and matrixmove stuff)

### DIFF
--- a/UnityProject/Assets/Scripts/Map/Asteroid.cs
+++ b/UnityProject/Assets/Scripts/Map/Asteroid.cs
@@ -1,25 +1,30 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Networking;
 
-public class Asteroid : MonoBehaviour {
+public class Asteroid : NetworkBehaviour {
 
 	private MatrixMove mm;
 
 	private float asteroidDistances = 550; //How far can asteroids be spawned
 
 
-	private void Awake()
+	private void Start()
 	{
 		mm = GetComponent<MatrixMove>();
 
 		SpawnNearStation();
 	}
 
+	[Server]
 	public void SpawnNearStation()
 	{
-		//Based on EscapeShuttle.cs
-		mm.SetPosition(Random.insideUnitCircle * 500 + new Vector2(500, -500));
+		if (isServer)
+		{
+			//Based on EscapeShuttle.cs
+			mm.SetPosition(Random.insideUnitCircle * 500 + new Vector2(500, -500));
+		}
 	}
 
 }

--- a/UnityProject/Assets/Scripts/Map/Asteroid.cs
+++ b/UnityProject/Assets/Scripts/Map/Asteroid.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Asteroid : MonoBehaviour {
+
+	private MatrixMove mm;
+
+	private float asteroidDistances = 550; //How far can asteroids be spawned
+
+
+	private void Awake()
+	{
+		mm = GetComponent<MatrixMove>();
+
+		SpawnNearStation();
+	}
+
+	public void SpawnNearStation()
+	{
+		//Based on EscapeShuttle.cs
+		mm.SetPosition(Random.insideUnitCircle * 500 + new Vector2(500, -500));
+	}
+
+}

--- a/UnityProject/Assets/Scripts/Map/Asteroid.cs
+++ b/UnityProject/Assets/Scripts/Map/Asteroid.cs
@@ -25,8 +25,18 @@ public class Asteroid : NetworkBehaviour {
 	[Server]
 	public void SpawnNearStation()
 	{
-		//Based on EscapeShuttle.cs
-		mm.SetPosition(Random.insideUnitCircle * asteroidDistance + new Vector2(distanceFromStation, -distanceFromStation));
+		//Makes sure asteroids don't spawn at/Inside station
+		Vector2 clampVal = Random.insideUnitCircle * asteroidDistance;
+		
+		if(clampVal.x > 0)
+		{
+			clampVal.x = Mathf.Clamp(clampVal.x, distanceFromStation, asteroidDistance);
+		}
+		else
+		{
+			clampVal.x = Mathf.Clamp(clampVal.x, -distanceFromStation, -asteroidDistance);
+		}
+		mm.SetPosition(clampVal);
 	}
 
 }

--- a/UnityProject/Assets/Scripts/Map/Asteroid.cs
+++ b/UnityProject/Assets/Scripts/Map/Asteroid.cs
@@ -16,17 +16,17 @@ public class Asteroid : NetworkBehaviour {
 	{
 		mm = GetComponent<MatrixMove>();
 
-		SpawnNearStation();
+		if (isServer)
+		{
+			SpawnNearStation();
+		}
 	}
 
 	[Server]
 	public void SpawnNearStation()
 	{
-		if (isServer)
-		{
-			//Based on EscapeShuttle.cs
-			mm.SetPosition(Random.insideUnitCircle * asteroidDistance + new Vector2(distanceFromStation, -distanceFromStation));
-		}
+		//Based on EscapeShuttle.cs
+		mm.SetPosition(Random.insideUnitCircle * asteroidDistance + new Vector2(distanceFromStation, -distanceFromStation));
 	}
 
 }

--- a/UnityProject/Assets/Scripts/Map/Asteroid.cs
+++ b/UnityProject/Assets/Scripts/Map/Asteroid.cs
@@ -9,6 +9,8 @@ public class Asteroid : NetworkBehaviour {
 
 	private float asteroidDistance = 550; //How far can asteroids be spawned
 
+	private float distanceFromStation = 175; //Offset from station so it doesnt spawn into station
+
 
 	private void Start()
 	{
@@ -23,7 +25,7 @@ public class Asteroid : NetworkBehaviour {
 		if (isServer)
 		{
 			//Based on EscapeShuttle.cs
-			mm.SetPosition(Random.insideUnitCircle * asteroidDistance);
+			mm.SetPosition(Random.insideUnitCircle * asteroidDistance + new Vector2(distanceFromStation, -distanceFromStation));
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Map/Asteroid.cs
+++ b/UnityProject/Assets/Scripts/Map/Asteroid.cs
@@ -7,7 +7,7 @@ public class Asteroid : NetworkBehaviour {
 
 	private MatrixMove mm;
 
-	private float asteroidDistances = 550; //How far can asteroids be spawned
+	private float asteroidDistance = 550; //How far can asteroids be spawned
 
 
 	private void Start()
@@ -23,7 +23,7 @@ public class Asteroid : NetworkBehaviour {
 		if (isServer)
 		{
 			//Based on EscapeShuttle.cs
-			mm.SetPosition(Random.insideUnitCircle * 500 + new Vector2(500, -500));
+			mm.SetPosition(Random.insideUnitCircle * asteroidDistance);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Map/Asteroid.cs
+++ b/UnityProject/Assets/Scripts/Map/Asteroid.cs
@@ -11,6 +11,8 @@ public class Asteroid : NetworkBehaviour {
 
 	private float distanceFromStation = 175; //Offset from station so it doesnt spawn into station
 
+	private float startDelay = 0.25f;
+
 
 	private void Start()
 	{
@@ -18,8 +20,7 @@ public class Asteroid : NetworkBehaviour {
 
 		if (isServer)
 		{
-			SpawnNearStation();
-			RandomRotation();
+			StartCoroutine(DelayedStart());
 		}
 	}
 
@@ -60,6 +61,15 @@ public class Asteroid : NetworkBehaviour {
 				mm.RotateTo(Orientation.Left);
 				break;
 		}
+	}
+
+	//Delays start functions to avoid issues with matrixmove
+	IEnumerator DelayedStart()
+	{
+		yield return new WaitForSeconds(startDelay);
+
+		SpawnNearStation();
+		RandomRotation();
 	}
 
 }

--- a/UnityProject/Assets/Scripts/Map/Asteroid.cs
+++ b/UnityProject/Assets/Scripts/Map/Asteroid.cs
@@ -19,13 +19,14 @@ public class Asteroid : NetworkBehaviour {
 		if (isServer)
 		{
 			SpawnNearStation();
+			RandomRotation();
 		}
 	}
 
 	[Server]
 	public void SpawnNearStation()
 	{
-		//Makes sure asteroids don't spawn at/Inside station
+		//Makes sure asteroids don't spawn at/inside station
 		Vector2 clampVal = Random.insideUnitCircle * asteroidDistance;
 		
 		if(clampVal.x > 0)
@@ -37,6 +38,28 @@ public class Asteroid : NetworkBehaviour {
 			clampVal.x = Mathf.Clamp(clampVal.x, -distanceFromStation, -asteroidDistance);
 		}
 		mm.SetPosition(clampVal);
+	}
+
+	[Server] //Asigns random rotation to each asteroid at startup for variety.
+	public void RandomRotation()
+	{
+		int rand = Random.Range(0, 3);
+
+		switch(rand)
+		{
+			case 0:
+				mm.RotateTo(Orientation.Up);
+				break;
+			case 1:
+				mm.RotateTo(Orientation.Down);
+				break;
+			case 2:
+				mm.RotateTo(Orientation.Right);
+				break;
+			case 3:
+				mm.RotateTo(Orientation.Left);
+				break;
+		}
 	}
 
 }

--- a/UnityProject/Assets/Scripts/Map/Asteroid.cs.meta
+++ b/UnityProject/Assets/Scripts/Map/Asteroid.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c75f7949ab361c342aeec3ae2b09adca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Tilemaps/Tiles/test3.unitypackage.meta
+++ b/UnityProject/Assets/Tilemaps/Tiles/test3.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f7a0a31980a76464eace26b8f537f45a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Implements #1291, adds 6 asteroids for use in mining (tiny, very small, small, medium, large, very large - each with their tilemaps) and gives them random matrixmove position on round start.

They all have their own matrixmove, as updated on "station" prefab by Dooby. (I think)

Thanks to Foma and Doobly for help with different stuff.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer

### Notes:
On minimap, asteroids show up as shuttles with their icon because thats how matrixmove is recognised, I will try to fix this up in a bit, feel free to merge this though, if it looks good.