### PR TITLE
Lighting system 2.0 patches and prep for further fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Camera/Camera2DFollow.cs
+++ b/UnityProject/Assets/Scripts/Camera/Camera2DFollow.cs
@@ -42,6 +42,9 @@ public class Camera2DFollow : MonoBehaviour
     public GameObject stencilMask;
 
 	[HideInInspector]
+	public LightingSystem lightingSystem;
+
+	[HideInInspector]
 	public Camera cam;
 
 	private void Awake()
@@ -50,6 +53,7 @@ public class Camera2DFollow : MonoBehaviour
 		{
 			followControl = this;
 			cam = GetComponent<Camera>();
+			lightingSystem = GetComponent<LightingSystem>();
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/Lighting System/LightingSystem.cs
+++ b/UnityProject/Assets/Scripts/Lighting System/LightingSystem.cs
@@ -388,4 +388,15 @@ public class LightingSystem : MonoBehaviour
 			Graphics.Blit(iSource, iDestination, _blitMaterial);
 		}
 	}
+
+	//Called at the start of matrix rotation for localplayer client (if localplayer is a child of the matrixmove that is rotating)
+	public void MatrixMoveStartRotation()
+	{
+		Debug.Log("Matrix has started rotating for local player");
+	}
+
+	public void MatrixMoveStopRotation()
+	{
+		Debug.Log("Matrix has stopped rotating for local player");
+	}
 }

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerScript.cs
@@ -323,4 +323,18 @@ public class PlayerScript : ManagedNetworkBehaviour
 		{
 			UIManager.SetToolTip = "";
 		}
+
+		//MatrixMove is rotating (broadcast via MatrixMove)
+		public void MatrixMoveStartRotation(){
+			if(PlayerManager.LocalPlayer == gameObject){
+				//We need to handle lighting stuff for matrix rotations for local player:
+				Camera2DFollow.followControl.lightingSystem.MatrixMoveStartRotation();
+			}
+		}
+		public void MatrixMoveStopRotation(){
+			if(PlayerManager.LocalPlayer == gameObject){
+				//We need to handle lighting stuff for matrix rotations for local player:
+				Camera2DFollow.followControl.lightingSystem.MatrixMoveStopRotation();
+			}
+		}
 	}


### PR DESCRIPTION
### Purpose
- Adds a lerp to the server target position on the client when client matrix move stops (Known issue with Pixel Perfect movement on client movement updates. Issue ticket is being created soon)
- Adds MatrixMove rotation start and stop actions on LightingSystem for local player in preparation for rotation issue fix with matrix rotations (FOV flicker).
