### PR TITLE
remove unnecessary Equipment.meta

### DIFF
--- a/UnityProject/Assets/Prefabs/Equipment.meta
+++ b/UnityProject/Assets/Prefabs/Equipment.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: b3d0705f4501846ce87f2bcb277db696
-folderAsset: yes
-timeCreated: 1490933382
-licenseType: Pro
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Removes a .meta for a folder that no longer exists.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [ ]  I correctly commented my code
- [ ]  My code is indented with tabs and not spaces
- [ ]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer

### Notes:
First PR, mainly just want to make sure I'm doing it correctly.
