### PR TITLE
Fixes #1373 - fix blood splatter effect position

### DIFF
--- a/UnityProject/Assets/Scripts/Factories/EffectsFactory.cs
+++ b/UnityProject/Assets/Scripts/Factories/EffectsFactory.cs
@@ -1,15 +1,13 @@
 ﻿using UnityEngine;
 using UnityEngine.Networking;
 
-/// <summary>
-/// Creates various visual effects
-/// </summary>
 public class EffectsFactory : NetworkBehaviour
 {
 	public static EffectsFactory Instance;
 
 	//Parents to make tidy
 	private GameObject shroudParent;
+	private GameObject bloodParent;
 
 	private GameObject fireTile { get; set; }
 	private GameObject scorchMarksTile { get; set; }
@@ -74,7 +72,10 @@ public class EffectsFactory : NetworkBehaviour
 	[Server]
 	public void BloodSplat(Vector3 pos, BloodSplatSize splatSize)
 	{
-		GameObject b = PoolManager.Instance.PoolNetworkInstantiate(bloodTile, pos, Quaternion.identity);
+		//blood splat should be relative to the matrix it appears in, but parented to Objects just like all
+		// the other objects in the matrix
+		GameObject b = PoolManager.Instance.PoolNetworkInstantiate(bloodTile, pos, Quaternion.identity,
+			MatrixManager.AtPoint(Vector3Int.RoundToInt(pos)).Objects);
 		BloodSplat bSplat = b.GetComponent<BloodSplat>();
 		//choose a random blood sprite
 		int spriteNum = 0;

--- a/UnityProject/Assets/Scripts/Factories/EffectsFactory.cs
+++ b/UnityProject/Assets/Scripts/Factories/EffectsFactory.cs
@@ -5,13 +5,8 @@ public class EffectsFactory : NetworkBehaviour
 {
 	public static EffectsFactory Instance;
 
-	//Parents to make tidy
-	private GameObject shroudParent;
-	private GameObject bloodParent;
-
 	private GameObject fireTile { get; set; }
 	private GameObject scorchMarksTile { get; set; }
-	private GameObject shroudTile { get; set; }
 
 	private GameObject bloodTile { get; set; }
 
@@ -32,13 +27,7 @@ public class EffectsFactory : NetworkBehaviour
 		//Do init stuff
 		fireTile = Resources.Load("FireTile") as GameObject;
 		scorchMarksTile = Resources.Load("ScorchMarks") as GameObject;
-		shroudTile = Resources.Load("ShroudTile") as GameObject;
 		bloodTile = Resources.Load("BloodSplat") as GameObject;
-		//Parents
-		shroudParent = new GameObject();
-		shroudParent.transform.position += new Vector3(0.5f, 0.5f, 0);
-		shroudParent.name = "FieldOfView(Shrouds)";
-		shroudParent.tag = "FogOfWar";
 	}
 
 	//FileTiles are client side effects only, no need for network sync (triggered by same event on all clients/server)
@@ -60,13 +49,6 @@ public class EffectsFactory : NetworkBehaviour
 			PoolManager.Instance.PoolClientInstantiate(scorchMarksTile, parent.position, Quaternion.identity);
 		sM.transform.parent = parent;
 		return sM;
-	}
-
-	public GameObject SpawnShroudTile(Vector3 pos)
-	{
-		GameObject sT = PoolManager.Instance.PoolClientInstantiate(shroudTile, pos, Quaternion.identity);
-		sT.transform.parent = shroudParent.transform;
-		return sT;
 	}
 
 	[Server]

--- a/UnityProject/Assets/Scripts/Factories/EffectsFactory.cs
+++ b/UnityProject/Assets/Scripts/Factories/EffectsFactory.cs
@@ -1,6 +1,9 @@
 ﻿using UnityEngine;
 using UnityEngine.Networking;
 
+/// <summary>
+/// Creates various visual effects
+/// </summary>
 public class EffectsFactory : NetworkBehaviour
 {
 	public static EffectsFactory Instance;
@@ -71,8 +74,7 @@ public class EffectsFactory : NetworkBehaviour
 	[Server]
 	public void BloodSplat(Vector3 pos, BloodSplatSize splatSize)
 	{
-		GameObject b = PoolManager.Instance.PoolNetworkInstantiate(bloodTile, pos, Quaternion.identity, 
-			MatrixManager.AtPoint( Vector3Int.RoundToInt( pos ) ).GameObject.transform);
+		GameObject b = PoolManager.Instance.PoolNetworkInstantiate(bloodTile, pos, Quaternion.identity);
 		BloodSplat bSplat = b.GetComponent<BloodSplat>();
 		//choose a random blood sprite
 		int spriteNum = 0;

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager.cs
@@ -178,6 +178,7 @@ public class MatrixManager : MonoBehaviour
 				Id = i,
 				Matrix = findMatrices[i],
 				GameObject = findMatrices[i].gameObject,
+				Objects = findMatrices[i].gameObject.transform.GetComponentInChildren<ObjectLayer>().transform,
 				MatrixMove = findMatrices[i].gameObject.GetComponentInParent<MatrixMove>(),
 				MetaTileMap = findMatrices[i].gameObject.GetComponent<MetaTileMap>(),
 //				NetId is initialized later
@@ -318,6 +319,9 @@ public struct MatrixInfo
 	public Matrix Matrix;
 	public MetaTileMap MetaTileMap;
 	public GameObject GameObject;
+	/// <summary>
+	/// Transform containing all the physical objects on the map
+	public Transform Objects;
 
 	public Vector3Int InitialOffset;
 


### PR DESCRIPTION
### Purpose
Fixes #1373 - fix blood splatter effect position so it appears under the mob rather than off to the side

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
The BloodSplatter method was trying to instantiate the BloodSplatter GameObject under a parent. The parent caused the blood splatter to be offset.

There doesn't seem to be a need to have the splatter created underneath the parent (none of the other effects do it when they call PoolNetworkInstantiate) so I think it's fine to leave the parent as null.
