### PR TITLE
Severely reduced allocations; Inertia for locker contents; Body part Randomizer

### DIFF
--- a/UnityProject/Assets/Prefabs/Blood/Resources/BloodSplat.prefab
+++ b/UnityProject/Assets/Prefabs/Blood/Resources/BloodSplat.prefab
@@ -21,7 +21,6 @@ GameObject:
   - component: {fileID: 4726396450817676}
   - component: {fileID: 114334507638544654}
   - component: {fileID: 114418950606787226}
-  - component: {fileID: 114081522580257648}
   - component: {fileID: 114595774069620348}
   - component: {fileID: 114262681174990446}
   m_Layer: 0
@@ -67,24 +66,13 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1069497300762596}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1843.988, y: 1143, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4477121353083166}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114081522580257648
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1069497300762596}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114262681174990446
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -99,7 +87,7 @@ MonoBehaviour:
   ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
-  isNotPushable: 0
+  isNotPushable: 1
   closetHandlerCache: {fileID: 0}
 --- !u!114 &114334507638544654
 MonoBehaviour:
@@ -157,7 +145,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ObjectType: 0
+  ObjectType: 1
 --- !u!212 &212268240904160500
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Scripts/Blood/BloodSplat.cs
+++ b/UnityProject/Assets/Scripts/Blood/BloodSplat.cs
@@ -1,8 +1,9 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Networking;
 
-public class BloodSplat : NetworkBehaviour
+public class BloodSplat : CustomNetTransform
 {
 	[SyncVar(hook = "SetSprite")] public int bloodSprite;
 	private Sprite[] bloodSprites;
@@ -30,5 +31,11 @@ public class BloodSplat : NetworkBehaviour
 		}
 		spriteRend.sprite = bloodSprites[spritenum];
 		spriteRend.enabled = true;
+	}
+
+	protected override void OnHit( Vector3Int pos, ThrowInfo info, List<HealthBehaviour> objects, List<TilemapDamage> tiles )
+	{
+//		base.OnHit( pos, info, objects, tiles );
+		//umm todo
 	}
 }

--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -10,9 +10,9 @@ using UnityEngine.Networking;
 		public Sprite doorOpened;
 
 		//Inventory
-		private IEnumerable<ObjectBehaviour> heldItems = new List<ObjectBehaviour>();
+		private List<ObjectBehaviour> heldItems = new List<ObjectBehaviour>();
 
-		private IEnumerable<ObjectBehaviour> heldPlayers = new List<ObjectBehaviour>();
+		private List<ObjectBehaviour> heldPlayers = new List<ObjectBehaviour>();
 
 		[SyncVar(hook = nameof(OpenClose))] public bool IsClosed;
 
@@ -221,62 +221,57 @@ using UnityEngine.Networking;
 			}
 		}
 
-		private void SetItemsAliveState(bool on)
-		{
+		private void SetItemsAliveState(bool on) {
 			if (!on)
 			{
 				heldItems = matrix.Get<ObjectBehaviour>(registerTile.Position, ObjectType.Item);
 			}
-			foreach (ObjectBehaviour item in heldItems)
-			{
+
+			for ( var i = 0; i < heldItems.Count; i++ ) {
+				ObjectBehaviour item = heldItems[i];
 				CustomNetTransform netTransform = item.GetComponent<CustomNetTransform>();
-				if (on)
-				{
+				if ( @on ) {
 					//avoids blinking of premapped items when opening first time in another place:
 					Vector3Int pos = registerTile.WorldPosition;
-					netTransform.AppearAtPosition(pos);
+					netTransform.AppearAtPosition( pos );
 					if ( pushPull && pushPull.Pushable.IsMovingServer ) {
 						netTransform.InertiaDrop( pos, pushPull.Pushable.MoveSpeedServer, pushPull.InheritedImpulse.To2Int() );
 					} else {
-						netTransform.AppearAtPositionServer(pos);
+						netTransform.AppearAtPositionServer( pos );
 					}
-				}
-				else
-				{
+				} else {
 					netTransform.DisappearFromWorldServer();
 				}
 
-				item.visibleState = on;
+				item.visibleState = @on;
 			}
 		}
 
-		private void SetPlayersAliveState(bool on)
-		{
+		private void SetPlayersAliveState(bool on) {
 			if (!on)
 			{
 				heldPlayers = matrix.Get<ObjectBehaviour>(registerTile.Position, ObjectType.Player);
 			}
 
-			foreach (ObjectBehaviour player in heldPlayers)
-			{
+			for ( var i = 0; i < heldPlayers.Count; i++ ) {
+				ObjectBehaviour player = heldPlayers[i];
 				var playerScript = player.GetComponent<PlayerScript>();
 				var playerSync = playerScript.PlayerSync;
-				if (on)
-				{
+				if ( @on ) {
 					playerSync.AppearAtPositionServer( registerTile.WorldPosition );
 					if ( pushPull && pushPull.Pushable.IsMovingServer ) {
 						playerScript.pushPull.TryPush( pushPull.InheritedImpulse.To2Int(), pushPull.Pushable.MoveSpeedServer );
 					}
 				}
-				player.visibleState = on;
 
-				if (!on)
-				{
+				player.visibleState = @on;
+
+				if ( !@on ) {
 					playerSync.DisappearFromWorldServer();
 					//Make sure a ClosetPlayerHandler is created on the client to monitor
 					//the players input inside the storage. The handler also controls the camera follow targets:
-					if (!playerScript.playerMove.isGhost) {
-						ClosetHandlerMessage.Send(player.gameObject, gameObject);
+					if ( !playerScript.playerMove.isGhost ) {
+						ClosetHandlerMessage.Send( player.gameObject, gameObject );
 					}
 				}
 			}

--- a/UnityProject/Assets/Scripts/Doors/ShutterController.cs
+++ b/UnityProject/Assets/Scripts/Doors/ShutterController.cs
@@ -89,13 +89,12 @@ public class ShutterController : ObjectTrigger
 	}
 
     [Server]
-    private void DamageOnClose()
-    {
-        IEnumerable<HealthBehaviour> healthBehaviours = matrix.Get<HealthBehaviour>(registerTile.Position);
-        foreach (HealthBehaviour healthBehaviour in healthBehaviours)
-        {
-            healthBehaviour.ApplyDamage(gameObject, 500, DamageType.BRUTE);
-        }
+    private void DamageOnClose() {
+	    var healthBehaviours = matrix.Get<HealthBehaviour>(registerTile.Position);
+	    for ( var i = 0; i < healthBehaviours.Count; i++ ) {
+		    HealthBehaviour healthBehaviour = healthBehaviours[i];
+		    healthBehaviour.ApplyDamage( gameObject, 500, DamageType.BRUTE );
+	    }
     }
 
 	//Handle network spawn sync failure

--- a/UnityProject/Assets/Scripts/Inventory/InventoryManager.cs
+++ b/UnityProject/Assets/Scripts/Inventory/InventoryManager.cs
@@ -187,7 +187,7 @@ public class InventoryManager : MonoBehaviour
 			if (slot.Owner != null)
 			{
 				//Inertia drop works only if player has external impulse (space floating etc.)
-				objTransform.InertiaDrop(dropPos, slot.Owner.playerMove.speed, slot.Owner.PlayerSync.ServerState.Impulse);
+				objTransform.InertiaDrop(dropPos, slot.Owner.PlayerSync.MoveSpeedServer, slot.Owner.PlayerSync.ServerImpulse);
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager.cs
@@ -305,9 +305,7 @@ public class MatrixManager : MonoBehaviour
 			return worldPos - matrix.Offset;
 		}
 
-		Vector3 rotatedClean = worldPos - matrix.Offset - matrix.MatrixMove.Pivot;
-		Vector3 unrotatedPos = matrix.MatrixMove.ClientState.Orientation.EulerInverted * rotatedClean;
-		return unrotatedPos + matrix.MatrixMove.Pivot;
+		return matrix.MatrixMove.ClientState.Orientation.EulerInverted * (worldPos - matrix.Offset - matrix.MatrixMove.Pivot) + matrix.MatrixMove.Pivot;
 	}
 }
 
@@ -361,6 +359,22 @@ public struct MatrixInfo
 		return Equals(Invalid) ?
 			"[Invalid matrix]" :
 			$"[({Id}){GameObject.name},offset={Offset},pivot={MatrixMove?.Pivot},state={MatrixMove?.State},netId={NetId}]";
+	}
+
+	public bool Equals( MatrixInfo other ) {
+		return Id == other.Id;
+	}
+
+	public override bool Equals( object obj ) {
+		if ( ReferenceEquals( null, obj ) ) {
+			return false;
+		}
+
+		return obj is MatrixInfo && Equals( ( MatrixInfo ) obj );
+	}
+
+	public override int GetHashCode() {
+		return Id;
 	}
 
 	///Figuring out netId. NetworkIdentity is located on the pivot (parent) gameObject for MatrixMove-equipped matrices

--- a/UnityProject/Assets/Scripts/Objects/IPushable.cs
+++ b/UnityProject/Assets/Scripts/Objects/IPushable.cs
@@ -21,6 +21,8 @@ public interface IPushable {
 	UnityEvent OnPullInterrupt();
 	bool CanPredictPush { get; }
 	bool IsMovingClient { get; }
+	bool IsMovingServer { get; }
+	Vector2 ServerImpulse { get; }
 	float MoveSpeedServer { get; }
 	float MoveSpeedClient { get; }
 	/// Try stopping object if it's flying

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Networking;
+using Random = UnityEngine.Random;
 
 public class PushPull : VisibleBehaviour {
 	[SyncVar]
@@ -92,6 +93,8 @@ public class PushPull : VisibleBehaviour {
 		     && pullable != this && !IsBeingPulled ) {
 
 			if ( pullable.StartFollowing( this ) ) {
+				PlayerManager.LocalPlayerScript.soundNetworkActions.RpcPlayNetworkSound("Rustle0" + Random.Range(1, 4), pullable.transform.position);
+
 				PulledObject = pullable;
 				//Kill its impulses if we grabbed it
 				PulledObject.Stop();
@@ -290,7 +293,6 @@ public class PushPull : VisibleBehaviour {
 
 	[ContextMethod("Pull","Drag_Hand")]
 	public void TryPullThis() {
-		PlayerManager.LocalPlayerScript.soundNetworkActions.CmdPlaySoundAtPlayerPos("Rustle0" + UnityEngine.Random.Range(1, 4).ToString());
 		var initiator = PlayerManager.LocalPlayerScript.pushPull;
 		//client pre-validation
 		if ( PlayerScript.IsInReach( this.registerTile, initiator.registerTile ) && initiator != this ) {

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -103,6 +103,8 @@ public class PushPull : VisibleBehaviour {
 
 	private Coroutine revertPullHandle;
 
+	public Vector2 InheritedImpulse => IsBeingPulled ? PulledBy.InheritedImpulse : Pushable.ServerImpulse;
+
 	private IEnumerator RevertPullTimer() {
 		yield return YieldHelper.Second;
 		yield return YieldHelper.Second;
@@ -114,7 +116,7 @@ public class PushPull : VisibleBehaviour {
 			Logger.LogFormat( "{0}: Reverted pull position", Category.PushPull, gameObject.name );
 			Pushable.RollbackPrediction();
 		} else {
-			Logger.LogFormat( "{0}: No need to revert pull position", Category.PushPull, gameObject.name );
+			Logger.LogTraceFormat( "{0}: No need to revert pull position", Category.PushPull, gameObject.name );
 		}
 	}
 
@@ -385,13 +387,13 @@ public class PushPull : VisibleBehaviour {
 
 
 	[Server]
-	public bool TryPush( Vector2Int dir )
+	public bool TryPush( Vector2Int dir, float speed = Single.NaN )
 	{
-		return TryPush( registerTile.WorldPosition, dir );
+		return TryPush( registerTile.WorldPosition, dir, speed );
 	}
 
 	[Server]
-	public bool TryPush( Vector3Int from, Vector2Int dir ) {
+	public bool TryPush( Vector3Int from, Vector2Int dir, float speed = Single.NaN ) {
 		if ( isNotPushable || isPushing || Pushable == null || !isAllowedDir( dir ) ) {
 			return false;
 		}
@@ -412,7 +414,7 @@ public class PushPull : VisibleBehaviour {
 		}
 
 
-		bool success = Pushable.Push( dir );
+		bool success = Pushable.Push( dir, speed );
 		if ( success )
 		{
 			if ( IsBeingPulled && //Break pull only if pushable will end up far enough
@@ -433,7 +435,7 @@ public class PushPull : VisibleBehaviour {
 		return success;
 	}
 
-	public bool TryPredictivePush( Vector3Int from, Vector2Int dir ) {
+	public bool TryPredictivePush( Vector3Int from, Vector2Int dir, float speed = Single.NaN ) {
 		if ( isNotPushable || !CanPredictPush || Pushable == null || !isAllowedDir( dir ) ) {
 			return false;
 		}
@@ -447,7 +449,7 @@ public class PushPull : VisibleBehaviour {
 			return false;
 		}
 
-		bool success = Pushable.PredictivePush( target.To2Int() );
+		bool success = Pushable.PredictivePush( target.To2Int(), speed );
 		if ( success ) {
 			pushPrediction = PushState.InProgress;
 			pushApproval = ApprovalState.None;

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.Server.cs
@@ -50,6 +50,9 @@ public partial class PlayerSync
 	public bool CanNotSpaceMoveServer => IsWeightlessServer && !IsAroundPushables( serverState );
 
 
+	public bool IsMovingServer => consideredFloatingServer || !ServerPositionsMatch;
+	public Vector2 ServerImpulse => serverState.Impulse;
+
 	/// Whether player is considered to be floating on server
 	private bool consideredFloatingServer => serverState.Impulse != Vector2.zero /*&& !IsBeingPulledServer*/;
 

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerSync.cs
@@ -21,8 +21,8 @@ using UnityEngine.Networking;
 				{
 					return TransformState.HiddenPos;
 				}
-				MatrixInfo matrix = MatrixManager.Get( MatrixId );
-				return MatrixManager.LocalToWorld( Position, matrix );
+
+				return MatrixManager.LocalToWorld( Position, MatrixManager.Get( MatrixId ) );
 			}
 			set {
 				if (value == TransformState.HiddenPos) {
@@ -30,8 +30,7 @@ using UnityEngine.Networking;
 				}
 				else
 				{
-					MatrixInfo matrix = MatrixManager.Get( MatrixId );
-					Position = MatrixManager.WorldToLocal( value, matrix );
+					Position = MatrixManager.WorldToLocal( value, MatrixManager.Get( MatrixId ) );
 				}
 			}
 		}
@@ -53,7 +52,7 @@ using UnityEngine.Networking;
 		[NonSerialized] public bool ImportantFlightUpdate;
 
 		public int MatrixId;
-		
+
 		/// Means that this player is hidden
 		public static readonly PlayerState HiddenState =
 			new PlayerState{ Position = TransformState.HiddenPos, MatrixId = 0};
@@ -222,7 +221,7 @@ using UnityEngine.Networking;
 			transform.position = pos;
 			UpdateActiveStatus();
 		}
-		
+
 		/// Registers if unhidden, unregisters if hidden
 		private void UpdateActiveStatus()
 		{
@@ -243,7 +242,7 @@ using UnityEngine.Networking;
 		}
 
 		#endregion
-		
+
 		private void Start() {
 			//Init pending actions queue for your local player
 			if ( isLocalPlayer ) {

--- a/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
@@ -19,6 +19,24 @@ public struct MatrixState
 
 	public static readonly MatrixState Invalid = new MatrixState{Position = TransformState.HiddenPos};
 
+	public bool Equals( MatrixState other ) {
+		return Position.Equals( other.Position ) && Orientation.Equals( other.Orientation );
+	}
+
+	public override bool Equals( object obj ) {
+		if ( ReferenceEquals( null, obj ) ) {
+			return false;
+		}
+
+		return obj is MatrixState && Equals( ( MatrixState ) obj );
+	}
+
+	public override int GetHashCode() {
+		unchecked {
+			return ( Position.GetHashCode() * 397 ) ^ Orientation.GetHashCode();
+		}
+	}
+
 	public override string ToString() {
 		return $"{nameof( Inform )}: {Inform}, {nameof( IsMoving )}: {IsMoving}, {nameof( Speed )}: {Speed}, " +
 		       $"{nameof( Direction )}: {Direction}, {nameof( Position )}: {Position}, {nameof( Orientation )}: {Orientation}, {nameof( RotationTime )}: {RotationTime}";
@@ -80,7 +98,7 @@ public class MatrixMove : ManagedNetworkBehaviour {
 	private Vector3 mPreviousPosition;
 	private Vector2 mPreviousFilteredPosition;
 	private bool monitorOnRot = false;
-		
+
 	private Vector3 clampedPosition
 	{
 		set
@@ -280,7 +298,7 @@ public class MatrixMove : ManagedNetworkBehaviour {
 						Time.deltaTime * clientState.RotationTime );
 			} else {
 				// Finishes the job of Lerp and straightens the ship with exact angle value
-				transform.rotation = Quaternion.Euler( 0, 0, clientState.Orientation.Degree );	
+				transform.rotation = Quaternion.Euler( 0, 0, clientState.Orientation.Degree );
 			}
 		} else if ( isMovingClient ) {
 			//Only move target if rotation is finished
@@ -305,7 +323,7 @@ public class MatrixMove : ManagedNetworkBehaviour {
 			}
 
 			//FIXME Remove this once lerping has been properly fixed with Pixel Perfect movement:
-			//If stopped then lerp to target 
+			//If stopped then lerp to target
 			if(!clientState.IsMoving && distance > 0f){
 				transform.position = Vector3.MoveTowards( transform.position, clientState.Position, clientState.Speed * Time.deltaTime * ( shouldWarp ? (distance * 2) : 1 ) );
 				mPreviousPosition = transform.position;

--- a/UnityProject/Assets/Scripts/Sound/SoundNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Sound/SoundNetworkActions.cs
@@ -9,6 +9,8 @@ public class SoundNetworkActions : NetworkBehaviour
 		RpcPlayNetworkSound(soundName, pos);
 	}
 
+	// fixme: unsecure af, lets client play arbitrary sounds at will ^v
+
 	[Command]
 	public void CmdPlaySoundAtPlayerPos(string soundName)
 	{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
@@ -43,20 +43,17 @@ using UnityEngine.Tilemaps;
 
 		public virtual bool IsPassableAt( Vector3Int from, Vector3Int to, bool inclPlayers = true, GameObject context = null )
 		{
-			BasicTile tileTo = tilemap.GetTile<BasicTile>(to);
-			return TileUtils.IsPassable(tileTo);
+			return TileUtils.IsPassable(tilemap.GetTile<BasicTile>(to));
 		}
 
 		public virtual bool IsAtmosPassableAt(Vector3Int from, Vector3Int to)
 		{
-			BasicTile tileTo = tilemap.GetTile<BasicTile>(to);
-			return TileUtils.IsAtmosPassable(tileTo);
+			return TileUtils.IsAtmosPassable(tilemap.GetTile<BasicTile>(to));
 		}
 
 		public virtual bool IsSpaceAt(Vector3Int position)
 		{
-			BasicTile tile = tilemap.GetTile<BasicTile>(position);
-			return TileUtils.IsSpace(tile);
+			return TileUtils.IsSpace(tilemap.GetTile<BasicTile>(position));
 		}
 
 		public virtual void SetTile(Vector3Int position, GenericTile tile, Matrix4x4 transformMatrix)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -111,9 +112,16 @@ public class Matrix : MonoBehaviour
 		return true;
 	}
 
-	public IEnumerable<T> Get<T>(Vector3Int position) where T : MonoBehaviour
-	{
-		return objects.Get(position).Select(x => x.GetComponent<T>()).Where(x => x != null);
+	public List<T> Get<T>(Vector3Int position) where T : MonoBehaviour {
+		List<RegisterTile> xes = objects.Get( position );
+		var filtered = new List<T>();
+		for ( var i = 0; i < xes.Count; i++ ) {
+			T x = xes[i].GetComponent<T>();
+			if ( x != null ) {
+				filtered.Add( x );
+			}
+		}
+		return filtered;
 	}
 
 
@@ -133,9 +141,17 @@ public class Matrix : MonoBehaviour
 		//return objects.GetFirst(position)?.GetComponent<T>();
 	}
 
-	public IEnumerable<T> Get<T>(Vector3Int position, ObjectType type) where T : MonoBehaviour
+	public List<T> Get<T>(Vector3Int position, ObjectType type) where T : MonoBehaviour
 	{
-		return objects.Get(position, type).Select(x => x.GetComponent<T>()).Where(x => x != null);
+		List<RegisterTile> xes = objects.Get( position, type );
+		var filtered = new List<T>();
+		for ( var i = 0; i < xes.Count; i++ ) {
+			T x = xes[i].GetComponent<T>();
+			if ( x != null ) {
+				filtered.Add( x );
+			}
+		}
+		return filtered;
 	}
 
 	public bool ContainsAt(Vector3Int position, GameObject gameObject)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -8,6 +8,9 @@ using UnityEngine;
 	public class MetaTileMap : MonoBehaviour
 	{
 		public Dictionary<LayerType, Layer> Layers { get; private set; }
+		//Lists for speed
+		private List<LayerType> LayersKeys { get; set; }
+		private List<Layer> LayersValues { get; set; }
 
 		private Matrix matrix;
 		private Matrix Matrix => matrix ? matrix : ( matrix = GetComponent<Matrix>() );
@@ -15,10 +18,14 @@ using UnityEngine;
 		private void OnEnable()
 		{
 			Layers = new Dictionary<LayerType, Layer>();
+			LayersKeys = new List<LayerType>();
+			LayersValues = new List<Layer>();
 
 			foreach (Layer layer in GetComponentsInChildren<Layer>(true))
 			{
 				Layers[layer.LayerType] = layer;
+				LayersKeys.Add( layer.LayerType );
+				LayersValues.Add( layer );
 			}
 		}
 
@@ -36,12 +43,9 @@ using UnityEngine;
 			        _IsPassableAt(origin, toY, inclPlayers, context) && _IsPassableAt(toY, to, inclPlayers, context);
 		}
 
-		private bool _IsPassableAt( Vector3Int origin, Vector3Int to, bool inclPlayers = true, GameObject context = null )
-		{
-			foreach (Layer layer in Layers.Values)
-			{
-				if (!layer.IsPassableAt(origin, to, inclPlayers, context))
-				{
+		private bool _IsPassableAt( Vector3Int origin, Vector3Int to, bool inclPlayers = true, GameObject context = null ) {
+			for ( var i = 0; i < LayersValues.Count; i++ ) {
+				if ( !LayersValues[i].IsPassableAt( origin, to, inclPlayers, context ) ) {
 					return false;
 				}
 			}
@@ -63,12 +67,9 @@ using UnityEngine;
 					_IsAtmosPassableAt(origin, toY) && _IsAtmosPassableAt(toY, to);
 		}
 
-		private bool _IsAtmosPassableAt(Vector3Int origin, Vector3Int to)
-		{
-			foreach (Layer layer in Layers.Values)
-			{
-				if (!layer.IsAtmosPassableAt(origin, to))
-				{
+		private bool _IsAtmosPassableAt(Vector3Int origin, Vector3Int to) {
+			for ( var i = 0; i < LayersValues.Count; i++ ) {
+				if ( !LayersValues[i].IsAtmosPassableAt( origin, to ) ) {
 					return false;
 				}
 			}
@@ -76,15 +77,13 @@ using UnityEngine;
 			return true;
 		}
 
-		public bool IsSpaceAt(Vector3Int position)
-		{
-			foreach (Layer layer in Layers.Values)
-			{
-				if (!layer.IsSpaceAt(position))
-				{
+		public bool IsSpaceAt(Vector3Int position) {
+			for ( var i = 0; i < LayersValues.Count; i++ ) {
+				if ( !LayersValues[i].IsSpaceAt( position ) ) {
 					return false;
 				}
 			}
+
 			return true;
 		}
 
@@ -100,13 +99,10 @@ using UnityEngine;
 			return layer ? Layers[layerType].GetTile(position) : null;
 		}
 
-		public LayerTile GetTile(Vector3Int position)
-		{
-			foreach (Layer layer in Layers.Values)
-			{
-				LayerTile tile = layer.GetTile(position);
-				if (tile != null)
-				{
+		public LayerTile GetTile(Vector3Int position) {
+			for ( var i = 0; i < LayersValues.Count; i++ ) {
+				LayerTile tile = LayersValues[i].GetTile( position );
+				if ( tile != null ) {
 					return tile;
 				}
 			}
@@ -114,16 +110,16 @@ using UnityEngine;
 			return null;
 		}
 
-		public bool IsEmptyAt(Vector3Int position)
-		{
-			foreach (LayerType layer in Layers.Keys)
-			{
-				if (layer != LayerType.Objects && HasTile(position, layer)) {
+		public bool IsEmptyAt(Vector3Int position) {
+			for ( var index = 0; index < LayersKeys.Count; index++ ) {
+				LayerType layer = LayersKeys[index];
+				if ( layer != LayerType.Objects && HasTile( position, layer ) ) {
 					return false;
 				}
+
 				if ( layer == LayerType.Objects ) {
-					var objects = Matrix.Get<RegisterTile>( position ).ToArray();
-					for ( var i = 0; i < objects.Length; i++ ) {
+					var objects = Matrix.Get<RegisterTile>( position );
+					for ( var i = 0; i < objects.Count; i++ ) {
 						var o = objects[i];
 						if ( !o.IsPassable() ) {
 							return false;
@@ -131,29 +127,30 @@ using UnityEngine;
 					}
 				}
 			}
+
 			return true;
 		}
-		public bool IsNoGravityAt(Vector3Int position)
-		{
-			foreach (LayerType layer in Layers.Keys)
-			{
-				if (layer != LayerType.Objects && HasTile(position, layer)) {
+		public bool IsNoGravityAt(Vector3Int position) {
+			for ( var i = 0; i < LayersKeys.Count; i++ ) {
+				LayerType layer = LayersKeys[i];
+				if ( layer != LayerType.Objects && HasTile( position, layer ) ) {
 					return false;
 				}
 			}
+
 			return true;
 		}
 
-		public bool IsEmptyAt(GameObject[] context, Vector3Int position)
-		{
-			foreach (LayerType layer in Layers.Keys)
-			{
-				if (layer != LayerType.Objects && HasTile(position, layer)) {
+		public bool IsEmptyAt(GameObject[] context, Vector3Int position) {
+			for ( var i1 = 0; i1 < LayersKeys.Count; i1++ ) {
+				LayerType layer = LayersKeys[i1];
+				if ( layer != LayerType.Objects && HasTile( position, layer ) ) {
 					return false;
 				}
+
 				if ( layer == LayerType.Objects ) {
-					var objects = Matrix.Get<RegisterTile>( position ).ToArray();
-					for ( var i = 0; i < objects.Length; i++ ) {
+					var objects = Matrix.Get<RegisterTile>( position );
+					for ( var i = 0; i < objects.Count; i++ ) {
 						var o = objects[i];
 						if ( !o.IsPassable() ) {
 							bool isExcluded = false;
@@ -171,6 +168,7 @@ using UnityEngine;
 					}
 				}
 			}
+
 			return true;
 		}
 
@@ -179,25 +177,21 @@ using UnityEngine;
 			return Layers[layerType].HasTile(position);
 		}
 
-		public void RemoveTile(Vector3Int position, LayerType refLayer)
-		{
-			foreach (Layer layer in Layers.Values)
-			{
-				if (layer.LayerType < refLayer &&
-				    !(refLayer == LayerType.Objects &&
-					layer.LayerType == LayerType.Floors) &&
-					refLayer != LayerType.Grills)
-				{
-					layer.RemoveTile(position);
+		public void RemoveTile(Vector3Int position, LayerType refLayer) {
+			for ( var i = 0; i < LayersValues.Count; i++ ) {
+				Layer layer = LayersValues[i];
+				if ( layer.LayerType < refLayer &&
+				     !( refLayer == LayerType.Objects &&
+				        layer.LayerType == LayerType.Floors ) &&
+				     refLayer != LayerType.Grills ) {
+					layer.RemoveTile( position );
 				}
 			}
 		}
 
-		public void ClearAllTiles()
-		{
-			foreach (Layer layer in Layers.Values)
-			{
-				layer.ClearAllTiles();
+		public void ClearAllTiles() {
+			for ( var i = 0; i < LayersValues.Count; i++ ) {
+				LayersValues[i].ClearAllTiles();
 			}
 		}
 
@@ -206,12 +200,11 @@ using UnityEngine;
 			Vector3Int minPosition = Vector3Int.one * int.MaxValue;
 			Vector3Int maxPosition = Vector3Int.one * int.MinValue;
 
-			foreach (Layer layer in Layers.Values)
-			{
-				BoundsInt layerBounds = layer.Bounds;
+			for ( var i = 0; i < LayersValues.Count; i++ ) {
+				BoundsInt layerBounds = LayersValues[i].Bounds;
 
-				minPosition = Vector3Int.Min(layerBounds.min, minPosition);
-				maxPosition = Vector3Int.Max(layerBounds.max, maxPosition);
+				minPosition = Vector3Int.Min( layerBounds.min, minPosition );
+				maxPosition = Vector3Int.Max( layerBounds.max, maxPosition );
 			}
 
 			return new BoundsInt(minPosition, maxPosition-minPosition);
@@ -221,13 +214,13 @@ using UnityEngine;
 #if UNITY_EDITOR
 		public void SetPreviewTile(Vector3Int position, LayerTile tile, Matrix4x4 transformMatrix)
 		{
-			foreach (Layer layer in Layers.Values)
-			{
-				if (layer.LayerType < tile.LayerType)
-				{
-					Layers[layer.LayerType].SetPreviewTile(position, LayerTile.EmptyTile, Matrix4x4.identity);
+			for ( var i = 0; i < LayersValues.Count; i++ ) {
+				Layer layer = LayersValues[i];
+				if ( layer.LayerType < tile.LayerType ) {
+					Layers[layer.LayerType].SetPreviewTile( position, LayerTile.EmptyTile, Matrix4x4.identity );
 				}
 			}
+
 			if(!Layers.ContainsKey(tile.LayerType)){
 				Debug.LogError($"LAYER TYPE: {tile.LayerType} not found!");
 				return;
@@ -235,11 +228,9 @@ using UnityEngine;
 			Layers[tile.LayerType].SetPreviewTile(position, tile, transformMatrix);
 		}
 
-		public void ClearPreview()
-		{
-			foreach (Layer layer in Layers.Values)
-			{
-				layer.ClearPreview();
+		public void ClearPreview() {
+			for ( var i = 0; i < LayersValues.Count; i++ ) {
+				LayersValues[i].ClearPreview();
 			}
 		}
 #endif

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
@@ -35,9 +35,10 @@ using UnityEngine;
 
 		public override void RemoveTile(Vector3Int position)
 		{
-			foreach (RegisterTile obj in Objects.Get(position).ToArray())
-			{
-				DestroyImmediate(obj.gameObject);
+			List<RegisterTile> objs = Objects.Get(position);
+			for ( var i = 0; i < objs.Count; i++ ) {
+				RegisterTile obj = objs[i];
+				DestroyImmediate( obj.gameObject );
 			}
 
 			base.RemoveTile(position);
@@ -47,17 +48,33 @@ using UnityEngine;
 		{
 			//Targeting windoors here
 			List<RegisterTile> objectsOrigin = Objects.Get<RegisterTile>(origin);
-			if ( !objectsOrigin.All(o => o.IsPassableTo( to )) )
-			{ //Can't get outside the tile because windoor doesn't allow us
-				return false;
+			for ( var i = 0; i < objectsOrigin.Count; i++ ) {
+				if ( !objectsOrigin[i].IsPassableTo( to ) ) {
+					//Can't get outside the tile because windoor doesn't allow us
+					return false;
+				}
 			}
 
 			List<RegisterTile> objectsTo = Objects.Get<RegisterTile>(to);
 			bool toPass;
 			if ( inclPlayers ) {
-				toPass = objectsTo.All( o => o.IsPassable(origin) || (context && o.gameObject == context) );
+				toPass = true;
+				for ( var i = 0; i < objectsTo.Count; i++ ) {
+					RegisterTile o = objectsTo[i];
+					if ( !o.IsPassable( origin ) && ( !context || o.gameObject != context ) ) {
+						toPass = false;
+						break;
+					}
+				}
 			} else {
-				toPass = objectsTo.All( o => o.ObjectType == ObjectType.Player || o.IsPassable(origin) || (context && o.gameObject == context) );
+				toPass = true;
+				for ( var i = 0; i < objectsTo.Count; i++ ) {
+					RegisterTile o = objectsTo[i];
+					if ( o.ObjectType != ObjectType.Player && !o.IsPassable( origin ) && ( !context || o.gameObject != context ) ) {
+						toPass = false;
+						break;
+					}
+				}
 			}
 
 			bool rods = base.IsPassableAt(origin, to, inclPlayers);
@@ -86,13 +103,11 @@ using UnityEngine;
 			return IsAtmosPassableAt(position, position) && base.IsSpaceAt(position);
 		}
 
-		public override void ClearAllTiles()
-		{
-			foreach (RegisterTile obj in Objects.AllObjects)
-			{
-				if (obj != null)
-				{
-					DestroyImmediate(obj.gameObject);
+		public override void ClearAllTiles() {
+			for ( var i = 0; i < Objects.AllObjects.Count; i++ ) {
+				RegisterTile obj = Objects.AllObjects[i];
+				if ( obj != null ) {
+					DestroyImmediate( obj.gameObject );
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Utils/TileList.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Utils/TileList.cs
@@ -8,6 +8,8 @@ using UnityEngine;
 		private readonly Dictionary<Vector3Int, List<RegisterTile>> _objects =
 			new Dictionary<Vector3Int, List<RegisterTile>>();
 
+		private static readonly List<RegisterTile> emptyList = new List<RegisterTile>();
+
 		public List<RegisterTile> AllObjects {
 			get {
 				List<RegisterTile> list = new List<RegisterTile>();
@@ -36,7 +38,7 @@ using UnityEngine;
 
 		public List<RegisterTile> Get(Vector3Int position)
 		{
-			return _objects.ContainsKey(position) ? _objects[position] : new List<RegisterTile>();
+			return _objects.ContainsKey(position) ? _objects[position] : emptyList;
 		}
 
 		public List<RegisterTile> Get(Vector3Int position, ObjectType type) {

--- a/UnityProject/Assets/Scripts/Tilemaps/Utils/TileList.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Utils/TileList.cs
@@ -8,7 +8,18 @@ using UnityEngine;
 		private readonly Dictionary<Vector3Int, List<RegisterTile>> _objects =
 			new Dictionary<Vector3Int, List<RegisterTile>>();
 
-		public List<RegisterTile> AllObjects => _objects.Values.SelectMany(x => x).ToList();
+		public List<RegisterTile> AllObjects {
+			get {
+				List<RegisterTile> list = new List<RegisterTile>();
+				foreach ( List<RegisterTile> x in _objects.Values ) {
+					for ( var i = 0; i < x.Count; i++ ) {
+						list.Add( x[i] );
+					}
+				}
+
+				return list;
+			}
+		}
 
 		public void Add(Vector3Int position, RegisterTile obj)
 		{
@@ -28,14 +39,28 @@ using UnityEngine;
 			return _objects.ContainsKey(position) ? _objects[position] : new List<RegisterTile>();
 		}
 
-		public List<RegisterTile> Get(Vector3Int position, ObjectType type)
-		{
-			return Get(position).Where(x => x.ObjectType == type).ToList();
+		public List<RegisterTile> Get(Vector3Int position, ObjectType type) {
+			List<RegisterTile> list = new List<RegisterTile>();
+			List<RegisterTile> xes = Get( position );
+			for ( var i = 0; i < xes.Count; i++ ) {
+				RegisterTile x = xes[i];
+				if ( x.ObjectType == type ){}
+					list.Add( x );
+			}
+
+			return list;
 		}
 
-		public List<T> Get<T>(Vector3Int position) where T : RegisterTile
-		{
-			return Get(position).OfType<T>().ToList();
+		public List<T> Get<T>(Vector3Int position) where T : RegisterTile {
+			List<T> list = new List<T>();
+			List<RegisterTile> tiles = Get( position );
+			for ( var i = 0; i < tiles.Count; i++ ) {
+				T unknown = tiles[i] as T;
+				if ( unknown != null )
+					list.Add( unknown );
+			}
+
+			return list;
 		}
 
 		public RegisterTile GetFirst(Vector3Int position)

--- a/UnityProject/Assets/Scripts/Tilemaps/Utils/TileUtils.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Utils/TileUtils.cs
@@ -1,21 +1,33 @@
-﻿using System.Linq;
-
-
-public static class TileUtils
+﻿public static class TileUtils
 	{
-		public static bool IsPassable(params BasicTile[] tile)
-		{
-			return tile.All(t => !t || t.IsPassable());
+		public static bool IsPassable(params BasicTile[] tile) {
+			for ( var i = 0; i < tile.Length; i++ ) {
+				BasicTile t = tile[i];
+				if ( t && !t.IsPassable() )
+					return false;
+			}
+
+			return true;
 		}
-		
-		public static bool IsAtmosPassable(params BasicTile[] tile)
-		{
-			return tile.All(t => !t || t.IsAtmosPassable());
+
+		public static bool IsAtmosPassable(params BasicTile[] tile) {
+			for ( var i = 0; i < tile.Length; i++ ) {
+				BasicTile t = tile[i];
+				if ( t && !t.IsAtmosPassable() )
+					return false;
+			}
+
+			return true;
 		}
-		
-		public static bool IsSpace(params BasicTile[] tile)
-		{
-			return tile.All(t => !t || t.IsSpace());
+
+		public static bool IsSpace(params BasicTile[] tile) {
+			for ( var i = 0; i < tile.Length; i++ ) {
+				BasicTile t = tile[i];
+				if ( t && !t.IsSpace() )
+					return false;
+			}
+
+			return true;
 		}
-		
+
 	}

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
@@ -317,7 +317,7 @@ public partial class CustomNetTransform {
 		}
 		bool isRecursive = goal != TransformState.HiddenPos;
 
-		Vector3 worldPosition = ServerPosition;
+		Vector3 worldPosition = serverState.WorldPosition;
 		Vector3 moveDelta;
 
 		if ( !isRecursive ) {//Normal delta if not recursive

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
@@ -30,6 +30,24 @@ public struct ThrowInfo
 			$"[{nameof( OriginPos )}: {OriginPos}, {nameof( TargetPos )}: {TargetPos}, {nameof( ThrownBy )}: {ThrownBy}, " +
 			$"{nameof( Aim )}: {Aim}, {nameof( InitialSpeed )}: {InitialSpeed}, {nameof( SpinMode )}: {SpinMode}]";
 	}
+
+	public bool Equals( ThrowInfo other ) {
+		return OriginPos.Equals( other.OriginPos ) && TargetPos.Equals( other.TargetPos );
+	}
+
+	public override bool Equals( object obj ) {
+		if ( ReferenceEquals( null, obj ) ) {
+			return false;
+		}
+
+		return obj is ThrowInfo && Equals( ( ThrowInfo ) obj );
+	}
+
+	public override int GetHashCode() {
+		unchecked {
+			return ( OriginPos.GetHashCode() * 397 ) ^ TargetPos.GetHashCode();
+		}
+	}
 }
 
 public partial class CustomNetTransform {

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
@@ -40,6 +40,14 @@ public partial class CustomNetTransform {
 	/// Containers and other objects meant to be snapped by tile
 	public bool IsTileSnap => registerTile.ObjectType == ObjectType.Object;
 
+	public bool IsClientLerping => transform.localPosition != MatrixManager.WorldToLocal( predictedState.WorldPosition, MatrixManager.Get( matrix ) );
+	public bool IsServerLerping => serverLerpState.WorldPosition != serverState.WorldPosition;
+	public bool CanPredictPush => !IsClientLerping;
+	public bool IsMovingClient => IsClientLerping;
+	public bool IsMovingServer => IsServerLerping;
+	public Vector2 ServerImpulse => serverState.Impulse;
+	public float MoveSpeedServer => ServerState.speed;
+	public float MoveSpeedClient => PredictedState.speed;
 	public bool IsFloatingServer => serverState.Impulse != Vector2.zero && serverState.Speed > 0f && !IsBeingPulledServer;
 	public bool IsFloatingClient => predictedState.Impulse != Vector2.zero && predictedState.Speed > 0f && !IsBeingPulledClient;
 	public bool IsBeingThrown => !serverState.ActiveThrow.Equals( ThrowInfo.NoThrow );
@@ -128,16 +136,9 @@ public partial class CustomNetTransform {
 		return true;
 	}
 
-	public bool CanPredictPush => !IsClientLerping;
-	public bool IsMovingClient => IsClientLerping;
-	public float MoveSpeedServer => ServerState.speed;
-	public float MoveSpeedClient => PredictedState.speed;
-
 	public void Stop() {
 		StopFloating();
 	}
-
-	public bool IsClientLerping => transform.localPosition != MatrixManager.WorldToLocal( predictedState.WorldPosition, MatrixManager.Get( matrix ) );
 
 	/// Predictive client movement
 	/// Mimics server collision checks for obviously impassable things.
@@ -227,7 +228,7 @@ public partial class CustomNetTransform {
 	public void InertiaDrop( Vector3 initialPos, float speed, Vector2 impulse ) {
 		SetPosition( initialPos, false );
 		serverState.Impulse = impulse;
-		serverState.Speed = Random.Range( -0.3f, 0f ) + speed;
+		serverState.Speed = Mathf.Clamp(Random.Range( -1.5f, -0.1f ) + speed, 0, float.MaxValue);
 		NotifyPlayers();
 	}
 
@@ -356,6 +357,8 @@ public partial class CustomNetTransform {
 		}
 	}
 
+	public static readonly float SpeedHitThreshold = 5f;
+
 	/// Verifies if we can proceed to the next tile and hurts objects if we can not
 	/// This check works only for 2 adjacent tiles, that's why floating check is recursive
 	[Server]
@@ -365,36 +368,51 @@ public partial class CustomNetTransform {
 		Vector3Int intGoal = Vector3Int.RoundToInt( goal );
 		var info = serverState.ActiveThrow;
 		List<HealthBehaviour> hitDamageables;
-		if ( CanDriftTo( intOrigin, intGoal ) & !HittingSomething( intGoal, info.ThrownBy, out hitDamageables ) ) {
+		if ( CanDriftTo( intOrigin, intGoal ) & !HittingSomething( intGoal, info.ThrownBy, out hitDamageables ) )
+		{
 			//if object is solid, check if player is nearby to make it stop
 			return registerTile && registerTile.IsPassable() || !IsPlayerNearby(serverState);
-		} else {
-			//Can't drift to goal for some reason:
-			//Check Tile damage from throw
-			var hit2D = Physics2D.RaycastAll(origin, info.Trajectory.normalized, 1.5f, tileDmgMask);
+		}
 
-			for(int i = 0; i < hit2D.Length; i++){
-				//Debug.Log("THROW HIT: " + hit2D[i].collider.gameObject.name);
+		if ( serverState.Speed > SpeedHitThreshold ) {
+			serverState.ActiveThrow = new ThrowInfo {
+				Aim = BodyPartType.CHEST.Randomize(0),
+				OriginPos = origin,
+				TargetPos = goal,
+				SpinMode = SpinMode.None
+			};
+			info = serverState.ActiveThrow;
+		}
 
-				//TilemapDamage automatically detects if a layer is below another damageable layer and won't affect it
-				var tileDmg = hit2D[i].collider.gameObject.GetComponent<TilemapDamage>();
-				if(tileDmg != null){
-					var damage = ( int ) ( ItemAttributes.throwDamage * 2 );
-					tileDmg.DoThrowDamage(intGoal, info, damage);
-				}
+		//Can't drift to goal for some reason:
+		//Check Tile damage from throw
+		var hit2D = Physics2D.RaycastAll(origin, info.Trajectory.normalized, 1.5f, tileDmgMask);
+
+		for (int i = 0; i < hit2D.Length; i++) {
+			//Debug.Log("THROW HIT: " + hit2D[i].collider.gameObject.name);
+
+			//TilemapDamage automatically detects if a layer is below another damageable layer and won't affect it
+			var tileDmg = hit2D[i].collider.gameObject.GetComponent<TilemapDamage>();
+			if ( tileDmg != null && ItemAttributes ) {
+				var damage = (int)( ItemAttributes.throwDamage * 2 );
+				tileDmg.DoThrowDamage(intGoal, info, damage);
 			}
 		}
 
 		//Hurting what we can
-		if ( hitDamageables != null && hitDamageables.Count > 0 && !Equals( info, ThrowInfo.NoThrow )) {
+		if ( hitDamageables != null && hitDamageables.Count > 0 && !Equals( info, ThrowInfo.NoThrow ) && ItemAttributes) {
 			for ( var i = 0; i < hitDamageables.Count; i++ ) {
 				//Remove cast to int when moving health values to float
-				var damage = ( int ) ( ItemAttributes.throwDamage * 2 );
-				hitDamageables[i].ApplyDamage( info.ThrownBy, damage, DamageType.BRUTE, info.Aim );
-				PostToChatMessage.SendThrowHitMessage( gameObject, hitDamageables[i].gameObject, damage, info.Aim );
+				var damage = (int)( ItemAttributes.throwDamage * 2 );
+				var hitZone = info.Aim.Randomize();
+				hitDamageables[i].ApplyDamage( info.ThrownBy, damage, DamageType.BRUTE, hitZone );
+				PostToChatMessage.SendThrowHitMessage( gameObject, hitDamageables[i].gameObject, damage, hitZone );
 			}
 			//hit sound
 			PlaySoundMessage.SendToAll("GenericHit", transform.position, 1f);
+		} else {
+			//todo different sound for no-damage hit?
+			PlaySoundMessage.SendToAll("GenericHit", transform.position, 0.8f);
 		}
 
 		return false;
@@ -442,7 +460,7 @@ public partial class CustomNetTransform {
 	/// Use World positions
 	/// </Summary>
 	private bool CanDriftTo( Vector3Int originPos, Vector3Int targetPos ) {
-		return MatrixManager.IsPassableAt( originPos, targetPos );
+		return MatrixManager.IsPassableAt( originPos, targetPos, false );
 	}
 
 	/// Lists objects to be damaged on given tile. Prob should be moved elsewhere
@@ -462,9 +480,18 @@ public partial class CustomNetTransform {
 					continue;
 				}
 				//Skip dead bodies
-				if ( !obj.IsDead ) {
-					damageables.Add( obj );
+				if ( obj.IsDead ) {
+					continue;
 				}
+
+				var commonTransform = obj.GetComponent<IPushable>();
+				if ( commonTransform != null ) {
+					if ( this.ServerImpulse.To2Int() == commonTransform.ServerImpulse.To2Int() && this.MoveSpeedServer <= commonTransform.MoveSpeedServer ) {
+						Logger.LogTraceFormat( "{0} not hitting {1} as they fly in the same direction", Category.Throwing, gameObject.name, obj.gameObject.name );
+						continue;
+					}
+				}
+				damageables.Add( obj );
 			}
 			if ( damageables.Count > 0 ) {
 				victims = damageables;

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
@@ -296,28 +296,30 @@ public partial class CustomNetTransform {
 		}
 		bool isRecursive = goal != TransformState.HiddenPos;
 
+		Vector3 worldPosition = ServerPosition;
 		Vector3 moveDelta;
+
 		if ( !isRecursive ) {//Normal delta if not recursive
 			moveDelta = ( Vector3 ) serverState.Impulse * serverState.Speed * Time.deltaTime;
 		} else {//Artificial delta if recursive
-			moveDelta = goal - serverState.WorldPosition;
+			moveDelta = goal - worldPosition;
 		}
 
-		Vector3Int intOrigin = Vector3Int.RoundToInt( serverState.WorldPosition );
+		Vector3Int intOrigin = Vector3Int.RoundToInt( worldPosition );
 		float distance = moveDelta.magnitude;
 		Vector3 newGoal;
 
 		if ( distance > 1 ) {
 			//limit goal to just one tile away and run this method recursively afterwards
-			newGoal = serverState.WorldPosition + ( Vector3 ) serverState.Impulse;
+			newGoal = worldPosition + ( Vector3 ) serverState.Impulse;
 		} else {
-			newGoal = serverState.WorldPosition + moveDelta;
+			newGoal = worldPosition + moveDelta;
 		}
 		Vector3Int intGoal = Vector3Int.RoundToInt( newGoal );
 
 		bool isWithinTile = intOrigin == intGoal; //same tile, no need to validate stuff
-		if ( isWithinTile || ValidateFloating( serverState.WorldPosition, newGoal ) ) {
-			AdvanceMovement( serverState.WorldPosition, newGoal );
+		if ( isWithinTile || ValidateFloating( worldPosition, newGoal ) ) {
+			AdvanceMovement( worldPosition, newGoal );
 		} else {
 			StopFloating();
 		}

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
@@ -36,8 +36,8 @@ public struct TransformState {
 			{
 				return HiddenPos;
 			}
-			MatrixInfo matrix = MatrixManager.Get( MatrixId );
-			return MatrixManager.LocalToWorld( Position, matrix );
+
+			return MatrixManager.LocalToWorld( Position, MatrixManager.Get( MatrixId ) );
 		}
 		set {
 			if (value == HiddenPos) {
@@ -45,8 +45,7 @@ public struct TransformState {
 			}
 			else
 			{
-				MatrixInfo matrix = MatrixManager.Get( MatrixId );
-				Position = MatrixManager.WorldToLocal( value, matrix );
+				Position = MatrixManager.WorldToLocal( value, MatrixManager.Get( MatrixId ) );
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/UI/UITileList.cs
+++ b/UnityProject/Assets/Scripts/UI/UITileList.cs
@@ -42,11 +42,11 @@ public class UITileList : MonoBehaviour
 		{
 			return new List<GameObject>();
 		}
-		
+
 		position = matrix.transform.InverseTransformPoint(position);
 		Vector3Int tilePosition = Vector3Int.FloorToInt(position);
 
-		IEnumerable<RegisterTile> registerTiles = matrix.Get<RegisterTile>(tilePosition);
+		var registerTiles = matrix.Get<RegisterTile>(tilePosition);
 
 		return registerTiles.Select(x => x.gameObject).ToList();
 	}
@@ -58,7 +58,7 @@ public class UITileList : MonoBehaviour
 	public static LayerTile GetTileAtPosition(Vector3 position)
 	{
 		MetaTileMap metaTileMap = PlayerManager.LocalPlayerScript.gameObject.GetComponentInParent<MetaTileMap>();
-		
+
 		position = metaTileMap.transform.InverseTransformPoint(position);
 		Vector3Int tilePosition = Vector3Int.FloorToInt(position);
 
@@ -135,7 +135,7 @@ public class UITileList : MonoBehaviour
 
 		IEnumerable<GameObject> newList = GetItemsAtPosition(position);
 		LayerTile newTile = GetTileAtPosition(position);
-		
+
 		List<GameObject> oldList = new List<GameObject>();
 
 		foreach (GameObject gameObject in Instance.listedObjects)
@@ -163,7 +163,7 @@ public class UITileList : MonoBehaviour
 		{
 			AddTileToItemPanel(tile, position);
 		}
-			
+
 		foreach (GameObject itemObject in objects)
 		{
 			AddObjectToItemPanel(itemObject);

--- a/UnityProject/Assets/Scripts/Util/ConverterExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/ConverterExtensions.cs
@@ -35,4 +35,22 @@
 		public static Vector3Int To3Int( this Vector2Int other ) {
 			return Vector3Int.RoundToInt( (Vector2)other );
 		}
+
+		public static Vector3 ToLocal( this Vector3 worldPos, Matrix matrix ) {
+			return MatrixManager.WorldToLocal(worldPos, MatrixManager.Get( matrix ));
+		}
+
+		public static Vector3 ToWorld( this Vector3 localPos, Matrix matrix ) {
+			return MatrixManager.LocalToWorld( localPos, MatrixManager.Get( matrix ));
+		}
+
+		public static Vector3Int ToLocalInt( this Vector3 worldPos, Matrix matrix ) {
+			return MatrixManager.WorldToLocalInt(worldPos, MatrixManager.Get( matrix ));
+		}
+
+		public static Vector3Int ToWorldInt( this Vector3 localPos, Matrix matrix ) {
+			return MatrixManager.LocalToWorldInt( localPos, MatrixManager.Get( matrix ));
+		}
+
+
 	}

--- a/UnityProject/Assets/Scripts/Util/ConverterExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/ConverterExtensions.cs
@@ -19,6 +19,10 @@
 		public static Vector3Int CutToInt( this Vector3 other ) {
 			return Vector3Int.RoundToInt( ( Vector2 ) other );
 		}
+		/// Round to int
+		public static Vector2Int To2Int( this Vector2 other ) {
+			return Vector2Int.RoundToInt( other );
+		}
 		/// Round to int while cutting z-axis
 		public static Vector2Int To2Int( this Vector3 other ) {
 			return Vector2Int.RoundToInt( other );

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using UnityEngine;
 using UnityEngine.Networking;
+using Random = UnityEngine.Random;
 
-	public static class SweetExtensions {
+public static class SweetExtensions {
 		public static ConnectedPlayer Player( this GameObject go ) {
 			var connectedPlayer = PlayerList.Instance?.Get( go );
 			return connectedPlayer == ConnectedPlayer.Invalid ? null : connectedPlayer;
@@ -58,6 +60,36 @@ using UnityEngine.Networking;
 				Logger.LogTraceFormat( "Lerp speed boost exceeded by {0}", Category.Lerp, boost );
 			}
 			return 1 + boost;
+		}
+
+		/// Randomized hitzone. 0f for totally random, 0.99f for 99% chance of provided one
+		/// <param name="aim"></param>
+		/// <param name="hitProbability">0f to 1f: chance of hitting the requested body part</param>
+		public static BodyPartType Randomize( this BodyPartType aim, float hitProbability = 0.8f )
+		{
+			float normalizedRange = Mathf.Clamp( hitProbability, 0f, 1f );
+			if ( Random.value < (normalizedRange/100f) ) {
+				return aim;
+			}
+			int t = (int) Mathf.Floor(Random.value * 40);
+			//	3/40
+			if (t <= 3)
+				return BodyPartType.HEAD;
+			if (t <= 10)
+			//	7/40
+				return BodyPartType.LEFT_ARM;
+			if (t <= 17)
+			//	7/40
+				return BodyPartType.RIGHT_ARM;
+			if (t <= 24)
+			//	7/40
+				return BodyPartType.LEFT_LEG;
+			if (t <= 31)
+			//	7/40
+				return BodyPartType.RIGHT_LEG;
+			//todo: don't forget to add groin!
+			//	9/40
+			return BodyPartType.CHEST;
 		}
 
 		/// Serializing Vector2 (rounded to int) into plaintext

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
@@ -54,7 +54,7 @@ public abstract class BulletBehaviour : MonoBehaviour
 		{
 			return;
 		}
-		damageable.ApplyDamage(shooter, damage, damageType, bodyAim);
+		damageable.ApplyDamage(shooter, damage, damageType, bodyAim.Randomize());
 		Logger.LogTraceFormat("Hit {0} for {1} with HealthBehaviour! bullet absorbed", Category.Firearms, damageable.gameObject.name, damage);
 		ReturnToPool();
 	}


### PR DESCRIPTION
### Purpose
Partially fixes #1011
100 bullet shells flying simultaneously used to generate around 4,1mb of garbage.
This was reduced to 400-700kb.

![screenshot_13](https://user-images.githubusercontent.com/10403536/50303297-b4ba5e00-049d-11e9-8750-adf9f8a6a73a.png)


### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [ ]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer