### PR TITLE
Fixes #1376 - you can now shoot yourself

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Energy/Resources/LaserGun.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Energy/Resources/LaserGun.prefab
@@ -118,7 +118,7 @@ MonoBehaviour:
   inHandReferenceRight: 32
   itemDescription: 
   itemName: LaserGun
-  itemType: 0
+  itemType: 16
   size: 1
   spriteType: 2
   type: 16
@@ -139,17 +139,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isPlayer: 0
   ignoredSpriteRenderers: []
   registerTile: {fileID: 0}
   visibleState: 1
-  allowedToMove: 1
-  currentPos: {x: 0, y: 0, z: 0}
-  isPushable: 0
-  pulledBy: {fileID: 0}
-  custNetActiveState: 0
-  pushing: 0
-  pushTarget: {x: 0, y: 0, z: 0}
+  isNotPushable: 0
   closetHandlerCache: {fileID: 0}
 --- !u!114 &114449825066554946
 MonoBehaviour:
@@ -230,8 +223,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isPushing: 0
-  predictivePushing: 0
 --- !u!212 &212710221609474322
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -4,276 +4,298 @@ using UnityEngine;
 using UnityEngine.Networking;
 
 
-	public class ClosetControl : InputTrigger
+public class ClosetControl : InputTrigger
+{
+	private Sprite doorClosed;
+	public Sprite doorOpened;
+
+	//Inventory
+	private List<ObjectBehaviour> heldItems = new List<ObjectBehaviour>();
+
+	private List<ObjectBehaviour> heldPlayers = new List<ObjectBehaviour>();
+
+	[SyncVar(hook = nameof(OpenClose))] public bool IsClosed;
+
+	[SyncVar(hook = nameof(LockUnlock))] public bool IsLocked;
+	public GameObject items;
+	public LockLightController lockLight;
+
+	private RegisterCloset registerTile;
+	private PushPull pushPull;
+	private Matrix matrix => registerTile.Matrix;
+
+	public SpriteRenderer spriteRenderer;
+
+	private void Awake()
 	{
-		private Sprite doorClosed;
-		public Sprite doorOpened;
+		doorClosed = spriteRenderer.sprite;
+	}
 
-		//Inventory
-		private List<ObjectBehaviour> heldItems = new List<ObjectBehaviour>();
+	private void Start()
+	{
+		registerTile = GetComponent<RegisterCloset>();
+		pushPull = GetComponent<PushPull>();
+	}
 
-		private List<ObjectBehaviour> heldPlayers = new List<ObjectBehaviour>();
+	public override void OnStartServer()
+	{
+		StartCoroutine(WaitForServerReg());
+		base.OnStartServer();
+	}
 
-		[SyncVar(hook = nameof(OpenClose))] public bool IsClosed;
+	private IEnumerator WaitForServerReg()
+	{
+		yield return new WaitForSeconds(1f);
+		IsClosed = true;
+		SetItems(!IsClosed);
+	}
 
-		[SyncVar(hook = nameof(LockUnlock))] public bool IsLocked;
-		public GameObject items;
-		public LockLightController lockLight;
+	public override void OnStartClient()
+	{
+		StartCoroutine(WaitForLoad());
+		base.OnStartClient();
+	}
 
-		private RegisterCloset registerTile;
-		private PushPull pushPull;
-		private Matrix matrix => registerTile.Matrix;
-
-		public SpriteRenderer spriteRenderer;
-
-		private void Awake()
+	/// SERVERSIDE -- Does this closet contain this object? (if it's closed)
+	public bool Contains(GameObject gameObject)
+	{
+		if (!IsClosed)
 		{
-			doorClosed = spriteRenderer.sprite;
-		}
-
-		private void Start()
-		{
-			registerTile = GetComponent<RegisterCloset>();
-			pushPull = GetComponent<PushPull>();
-		}
-
-		public override void OnStartServer()
-		{
-			StartCoroutine(WaitForServerReg());
-			base.OnStartServer();
-		}
-
-		private IEnumerator WaitForServerReg()
-		{
-			yield return new WaitForSeconds(1f);
-			IsClosed = true;
-			SetItems(!IsClosed);
-		}
-
-		public override void OnStartClient()
-		{
-			StartCoroutine(WaitForLoad());
-			base.OnStartClient();
-		}
-
-		/// SERVERSIDE -- Does this closet contain this object? (if it's closed)
-		public bool Contains( GameObject gameObject )
-		{
-			if ( !IsClosed )
-			{
-				return false;
-			}
-
-			foreach ( var player in heldPlayers )
-			{
-				if ( player.gameObject == gameObject )
-				{
-					return true;
-				}
-			}
-			foreach ( var item in heldItems )
-			{
-				if ( item.gameObject == gameObject )
-				{
-					return true;
-				}
-			}
-
 			return false;
 		}
 
-		private IEnumerator WaitForLoad()
+		foreach (var player in heldPlayers)
 		{
-			yield return new WaitForSeconds(3f);
-			bool iC = IsClosed;
-			bool iL = IsLocked;
-			OpenClose(iC);
-			LockUnlock(iL);
+			if (player.gameObject == gameObject)
+			{
+				return true;
+			}
+		}
+		foreach (var item in heldItems)
+		{
+			if (item.gameObject == gameObject)
+			{
+				return true;
+			}
 		}
 
-		[Server]
-		public void ServerToggleCupboard()
+		return false;
+	}
+
+	private IEnumerator WaitForLoad()
+	{
+		yield return new WaitForSeconds(3f);
+		bool iC = IsClosed;
+		bool iL = IsLocked;
+		OpenClose(iC);
+		LockUnlock(iL);
+	}
+
+	[Server]
+	public void ServerToggleCupboard()
+	{
+		if (IsClosed)
+		{
+			if (lockLight != null)
+			{
+				if (lockLight.IsLocked())
+				{
+					IsLocked = false;
+					return;
+				}
+				IsClosed = false;
+				SetItems(true);
+			}
+			else
+			{
+				IsClosed = false;
+				SetItems(true);
+			}
+		}
+		else
+		{
+			IsClosed = true;
+			SetItems(false);
+		}
+	}
+
+	private void OpenClose(bool isClosed)
+	{
+		IsClosed = isClosed;
+		if (isClosed)
+		{
+			Close();
+		}
+		else
+		{
+			Open();
+		}
+	}
+
+	private void LockUnlock(bool lockIt)
+	{
+		IsLocked = lockIt;
+		if (lockLight == null)
+		{
+			return;
+		}
+		if (lockIt)
+		{
+		}
+		else
+		{
+			lockLight.Unlock();
+		}
+	}
+
+	private void Close()
+	{
+		registerTile.IsClosed = true;
+		SoundManager.PlayAtPosition("OpenClose", transform.position);
+		spriteRenderer.sprite = doorClosed;
+		if (lockLight != null)
+		{
+			lockLight.Show();
+		}
+	}
+
+	private void Open()
+	{
+		registerTile.IsClosed = false;
+		SoundManager.PlayAtPosition("OpenClose", transform.position);
+		spriteRenderer.sprite = doorOpened;
+		if (lockLight != null)
+		{
+			lockLight.Hide();
+		}
+	}
+	[ContextMethod("Open/close", "hand")]
+	public void GUIInteract()
+	{
+		//don't put your hand contents on open/close rmb action!
+		InteractInternal(false);
+	}
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
+	{
+		return InteractInternal();
+	}
+
+	private bool InteractInternal(bool placeItem = true)
+	{
+		//this better be rewritten to net messages: following code is executed on clientside
+		PlayerScript localPlayer = PlayerManager.LocalPlayerScript;
+		if (localPlayer.canNotInteract())
+		{
+			return true;
+		}
+
+		bool isInReach = localPlayer.IsInReach(registerTile);
+		if (isInReach || localPlayer.IsHidden)
 		{
 			if (IsClosed)
 			{
-				if (lockLight != null)
+				localPlayer.playerNetworkActions.CmdToggleCupboard(gameObject);
+				return true;
+			}
+
+			GameObject item = UIManager.Hands.CurrentSlot.Item;
+			if (placeItem && item != null && isInReach)
+			{
+				localPlayer.playerNetworkActions.CmdPlaceItem(
+					UIManager.Hands.CurrentSlot.eventName, transform.position, null, false);
+
+				item.BroadcastMessage("OnRemoveFromInventory", null, SendMessageOptions.DontRequireReceiver);
+			}
+			else
+			{
+				localPlayer.playerNetworkActions.CmdToggleCupboard(gameObject);
+			}
+			return true;
+		}
+		return true;
+	}
+
+	private void SetItems(bool open)
+	{
+		if (!open)
+		{
+			SetItemsAliveState(false);
+			SetPlayersAliveState(false);
+		}
+		else
+		{
+			SetItemsAliveState(true);
+			SetPlayersAliveState(true);
+		}
+	}
+
+	private void SetItemsAliveState(bool on)
+	{
+		if (!on)
+		{
+			heldItems = matrix.Get<ObjectBehaviour>(registerTile.Position, ObjectType.Item);
+		}
+
+		for (var i = 0; i < heldItems.Count; i++)
+		{
+			ObjectBehaviour item = heldItems[i];
+			CustomNetTransform netTransform = item.GetComponent<CustomNetTransform>();
+			if (@on)
+			{
+				//avoids blinking of premapped items when opening first time in another place:
+				Vector3Int pos = registerTile.WorldPosition;
+				netTransform.AppearAtPosition(pos);
+				if (pushPull && pushPull.Pushable.IsMovingServer)
 				{
-					if (lockLight.IsLocked())
-					{
-						IsLocked = false;
-						return;
-					}
-					IsClosed = false;
-					SetItems(true);
+					netTransform.InertiaDrop(pos, pushPull.Pushable.MoveSpeedServer, pushPull.InheritedImpulse.To2Int());
 				}
 				else
 				{
-					IsClosed = false;
-					SetItems(true);
+					netTransform.AppearAtPositionServer(pos);
 				}
 			}
 			else
 			{
-				IsClosed = true;
-				SetItems(false);
+				netTransform.DisappearFromWorldServer();
 			}
-		}
 
-		private void OpenClose(bool isClosed)
+			item.visibleState = @on;
+		}
+	}
+
+	private void SetPlayersAliveState(bool on)
+	{
+		if (!on)
 		{
-			IsClosed = isClosed;
-			if (isClosed)
-			{
-				Close();
-			}
-			else
-			{
-				Open();
-			}
+			heldPlayers = matrix.Get<ObjectBehaviour>(registerTile.Position, ObjectType.Player);
 		}
 
-		private void LockUnlock(bool lockIt)
+		for (var i = 0; i < heldPlayers.Count; i++)
 		{
-			IsLocked = lockIt;
-			if (lockLight == null)
+			ObjectBehaviour player = heldPlayers[i];
+			var playerScript = player.GetComponent<PlayerScript>();
+			var playerSync = playerScript.PlayerSync;
+			if (@on)
 			{
-				return;
-			}
-			if (lockIt)
-			{
-			}
-			else
-			{
-				lockLight.Unlock();
-			}
-		}
-
-		private void Close()
-		{
-			registerTile.IsClosed = true;
-			SoundManager.PlayAtPosition("OpenClose", transform.position);
-			spriteRenderer.sprite = doorClosed;
-			if (lockLight != null)
-			{
-				lockLight.Show();
-			}
-		}
-
-		private void Open()
-		{
-			registerTile.IsClosed = false;
-			SoundManager.PlayAtPosition("OpenClose", transform.position);
-			spriteRenderer.sprite = doorOpened;
-			if (lockLight != null)
-			{
-				lockLight.Hide();
-			}
-		}
-		[ContextMethod("Open/close","hand")]
-		public void GUIInteract(){
-			//don't put your hand contents on open/close rmb action!
-			InteractInternal( false );
-		}
-		public override void Interact(GameObject originator, Vector3 position, string hand) {
-			InteractInternal();
-		}
-
-		private void InteractInternal(bool placeItem = true) {
-			//this better be rewritten to net messages: following code is executed on clientside
-			PlayerScript localPlayer = PlayerManager.LocalPlayerScript;
-			if ( localPlayer.canNotInteract() ) {
-				return;
-			}
-
-			bool isInReach = localPlayer.IsInReach( registerTile );
-			if ( isInReach || localPlayer.IsHidden ) {
-				if ( IsClosed ) {
-					localPlayer.playerNetworkActions.CmdToggleCupboard(gameObject);
-					return;
-				}
-
-				GameObject item = UIManager.Hands.CurrentSlot.Item;
-				if ( placeItem && item != null && isInReach )
+				playerSync.AppearAtPositionServer(registerTile.WorldPosition);
+				if (pushPull && pushPull.Pushable.IsMovingServer)
 				{
-					localPlayer.playerNetworkActions.CmdPlaceItem(
-						UIManager.Hands.CurrentSlot.eventName, transform.position, null, false);
-
-					item.BroadcastMessage("OnRemoveFromInventory", null, SendMessageOptions.DontRequireReceiver);
+					playerScript.pushPull.TryPush(pushPull.InheritedImpulse.To2Int(), pushPull.Pushable.MoveSpeedServer);
 				}
-				else
+			}
+
+			player.visibleState = @on;
+
+			if (!@on)
+			{
+				playerSync.DisappearFromWorldServer();
+				//Make sure a ClosetPlayerHandler is created on the client to monitor
+				//the players input inside the storage. The handler also controls the camera follow targets:
+				if (!playerScript.playerMove.isGhost)
 				{
-					localPlayer.playerNetworkActions.CmdToggleCupboard(gameObject);
-				}
-			}
-		}
-
-		private void SetItems(bool open)
-		{
-			if (!open)
-			{
-				SetItemsAliveState(false);
-				SetPlayersAliveState(false);
-			}
-			else
-			{
-				SetItemsAliveState(true);
-				SetPlayersAliveState(true);
-			}
-		}
-
-		private void SetItemsAliveState(bool on) {
-			if (!on)
-			{
-				heldItems = matrix.Get<ObjectBehaviour>(registerTile.Position, ObjectType.Item);
-			}
-
-			for ( var i = 0; i < heldItems.Count; i++ ) {
-				ObjectBehaviour item = heldItems[i];
-				CustomNetTransform netTransform = item.GetComponent<CustomNetTransform>();
-				if ( @on ) {
-					//avoids blinking of premapped items when opening first time in another place:
-					Vector3Int pos = registerTile.WorldPosition;
-					netTransform.AppearAtPosition( pos );
-					if ( pushPull && pushPull.Pushable.IsMovingServer ) {
-						netTransform.InertiaDrop( pos, pushPull.Pushable.MoveSpeedServer, pushPull.InheritedImpulse.To2Int() );
-					} else {
-						netTransform.AppearAtPositionServer( pos );
-					}
-				} else {
-					netTransform.DisappearFromWorldServer();
-				}
-
-				item.visibleState = @on;
-			}
-		}
-
-		private void SetPlayersAliveState(bool on) {
-			if (!on)
-			{
-				heldPlayers = matrix.Get<ObjectBehaviour>(registerTile.Position, ObjectType.Player);
-			}
-
-			for ( var i = 0; i < heldPlayers.Count; i++ ) {
-				ObjectBehaviour player = heldPlayers[i];
-				var playerScript = player.GetComponent<PlayerScript>();
-				var playerSync = playerScript.PlayerSync;
-				if ( @on ) {
-					playerSync.AppearAtPositionServer( registerTile.WorldPosition );
-					if ( pushPull && pushPull.Pushable.IsMovingServer ) {
-						playerScript.pushPull.TryPush( pushPull.InheritedImpulse.To2Int(), pushPull.Pushable.MoveSpeedServer );
-					}
-				}
-
-				player.visibleState = @on;
-
-				if ( !@on ) {
-					playerSync.DisappearFromWorldServer();
-					//Make sure a ClosetPlayerHandler is created on the client to monitor
-					//the players input inside the storage. The handler also controls the camera follow targets:
-					if ( !playerScript.playerMove.isGhost ) {
-						ClosetHandlerMessage.Send( player.gameObject, gameObject );
-					}
+					ClosetHandlerMessage.Send(player.gameObject, gameObject);
 				}
 			}
 		}
 	}
+}

--- a/UnityProject/Assets/Scripts/Closets/ClosetPlayerHandler.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetPlayerHandler.cs
@@ -2,73 +2,74 @@
 
 
 //TODO make into a more generic component to handle coffins, disposal bins etc. Will
-	//require a rename also
-	/// <summary>
-	///     A temporary component added to the players localplayer
-	///     by ObjectBehaviour.cs when they are hidden in a cupboard.
-	///     It is also removed by ObjectBehaviour when they leave.
-	///     It will wait for directional key inputs and then check
-	///     if the player can leave.
-	/// </summary>
-	public class ClosetPlayerHandler : MonoBehaviour
+//require a rename also
+/// <summary>
+///     A temporary component added to the players localplayer
+///     by ObjectBehaviour.cs when they are hidden in a cupboard.
+///     It is also removed by ObjectBehaviour when they leave.
+///     It will wait for directional key inputs and then check
+///     if the player can leave.
+/// </summary>
+public class ClosetPlayerHandler : MonoBehaviour
+{
+	private ClosetControl closetControl;
+	private bool monitor;
+
+	public void Init(ClosetControl closetCtrl)
 	{
-		private ClosetControl closetControl;
-		private bool monitor;
+		closetControl = closetCtrl;
 
-		public void Init(ClosetControl closetCtrl)
+		if (!PlayerManager.LocalPlayerScript.playerNetworkActions.isGhost)
 		{
-			closetControl = closetCtrl;
-
-			if (!PlayerManager.LocalPlayerScript.playerNetworkActions.isGhost)
-			{
-				// TODO: Change this stuff to the proper settings once re-entering corpse becomes a feature.
-				Camera2DFollow.followControl.target = closetControl.transform;
-				Camera2DFollow.followControl.damping = 0.2f;
-			}
-
-			if (!closetControl)
-			{
-				//this is not a closet. Could be a coffin or disposals 
-				Logger.LogWarning("No closet found for ClosetPlayerHandler!" + " maybe it's time to update this component? (see the todo's)", Category.Containers);
-				Destroy(this);
-			}
-			else
-			{
-				monitor = true;
-			}
+			// TODO: Change this stuff to the proper settings once re-entering corpse becomes a feature.
+			Camera2DFollow.followControl.target = closetControl.transform;
+			Camera2DFollow.followControl.damping = 0.2f;
 		}
 
-		private void Update()
+		if (!closetControl)
 		{
-			if (PlayerManager.LocalPlayerScript.playerNetworkActions.isGhost || UIManager.IsInputFocus)
-			{
-				return;
-			}			
-			if (monitor)
-			{
-				if (CheckForDirectionalKeyPress())
-				{
-					if (!closetControl.IsLocked)
-					{
-						closetControl.Interact(gameObject, "lefthand");
-					}
-				}
-				//take the player with the closet so they can interact with it
-				if (closetControl.transform.position != transform.position)
-				{
-					transform.position = closetControl.transform.position;
-				}
-			}
+			//this is not a closet. Could be a coffin or disposals 
+			Logger.LogWarning("No closet found for ClosetPlayerHandler!" + " maybe it's time to update this component? (see the todo's)", Category.Containers);
+			Destroy(this);
 		}
-
-		private bool CheckForDirectionalKeyPress() //fixme: OW
+		else
 		{
-			if (Input.GetKeyDown(KeyCode.W) || Input.GetKeyDown(KeyCode.D) || Input.GetKeyDown(KeyCode.S) || Input.GetKeyDown(KeyCode.A) ||
-			    Input.GetKeyDown(KeyCode.UpArrow) || Input.GetKeyDown(KeyCode.LeftArrow) || Input.GetKeyDown(KeyCode.DownArrow) ||
-			    Input.GetKeyDown(KeyCode.RightArrow))
-			{
-				return true;
-			}
-			return false;
+			monitor = true;
 		}
 	}
+
+	private void Update()
+	{
+		if (PlayerManager.LocalPlayerScript.playerNetworkActions.isGhost || UIManager.IsInputFocus)
+		{
+			return;
+		}
+		if (monitor)
+		{
+			if (CheckForDirectionalKeyPress())
+			{
+				if (!closetControl.IsLocked)
+				{
+					//TODO: This should probably be done in the main inputcontroller rather than in Update
+					closetControl.Interact(gameObject, "lefthand");
+				}
+			}
+			//take the player with the closet so they can interact with it
+			if (closetControl.transform.position != transform.position)
+			{
+				transform.position = closetControl.transform.position;
+			}
+		}
+	}
+
+	private bool CheckForDirectionalKeyPress() //fixme: OW
+	{
+		if (Input.GetKeyDown(KeyCode.W) || Input.GetKeyDown(KeyCode.D) || Input.GetKeyDown(KeyCode.S) || Input.GetKeyDown(KeyCode.A) ||
+			Input.GetKeyDown(KeyCode.UpArrow) || Input.GetKeyDown(KeyCode.LeftArrow) || Input.GetKeyDown(KeyCode.DownArrow) ||
+			Input.GetKeyDown(KeyCode.RightArrow))
+		{
+			return true;
+		}
+		return false;
+	}
+}

--- a/UnityProject/Assets/Scripts/Closets/FireCabinetTrigger.cs
+++ b/UnityProject/Assets/Scripts/Closets/FireCabinetTrigger.cs
@@ -55,7 +55,7 @@ public class FireCabinetTrigger : InputTrigger
 		SyncItemSprite(isFull);
 	}
 
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		if (IsClosed)
 		{
@@ -97,6 +97,8 @@ public class FireCabinetTrigger : InputTrigger
 				}
 			}
 		}
+
+		return true;
 	}
 
 	private void HandleInteraction(bool forItemInteract, string currentHand)

--- a/UnityProject/Assets/Scripts/Construction/WeldingFuel/WeldingFuel.cs
+++ b/UnityProject/Assets/Scripts/Construction/WeldingFuel/WeldingFuel.cs
@@ -2,7 +2,7 @@
 
 public class WeldingFuel : InputTrigger
 {
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		if (originator == PlayerManager.LocalPlayer)
 		{
@@ -15,5 +15,7 @@ public class WeldingFuel : InputTrigger
 				}
 			}
 		}
+
+		return true;
 	}
 }

--- a/UnityProject/Assets/Scripts/Doors/DoorTrigger.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorTrigger.cs
@@ -2,62 +2,70 @@
 using UnityEngine;
 
 
-	/// <summary>
-	///     Handles Interact messages from InputController.cs
-	///     It also checks for access restrictions on the players ID card
-	/// </summary>
-	public class DoorTrigger : InputTrigger
+/// <summary>
+///     Handles Interact messages from InputController.cs
+///     It also checks for access restrictions on the players ID card
+/// </summary>
+public class DoorTrigger : InputTrigger
+{
+	public bool allowInput = true;
+
+	private DoorController controller;
+	public DoorController Controller
 	{
-		public bool allowInput = true;
-
-		private DoorController controller;
-		public DoorController Controller {
-			get {
-				if ( !controller ) {
-					controller = GetComponent<DoorController>();
-				}
-				return controller;
-			}
-		}
-
-		public override void Interact(GameObject originator, Vector3 position, string interactSlot = null)
+		get
 		{
-			if ( Controller == null || !allowInput ) {
-				return;
-			}
-			var playerScript = originator.GetComponent<PlayerScript>();
-			if (playerScript.canNotInteract() || !playerScript.IsInReach( gameObject ))
-			{ //check for both client and server
-				return;
-			}
-			if (!isServer)
+			if (!controller)
 			{
-				//Client wants this code to be run on server
-				InteractMessage.Send(gameObject, interactSlot);
+				controller = GetComponent<DoorController>();
+			}
+			return controller;
+		}
+	}
+
+	public override bool Interact(GameObject originator, Vector3 position, string interactSlot = null)
+	{
+		if (Controller == null || !allowInput)
+		{
+			return true;
+		}
+		var playerScript = originator.GetComponent<PlayerScript>();
+		if (playerScript.canNotInteract() || !playerScript.IsInReach(gameObject))
+		{ //check for both client and server
+			return true;
+		}
+		if (!isServer)
+		{
+			//Client wants this code to be run on server
+			InteractMessage.Send(gameObject, interactSlot);
+		}
+		else
+		{
+			//Server actions
+			// Close the door if it's open
+			if (Controller.IsOpened)
+			{
+				//Not even trying to close when bumping into door
+				if (interactSlot == null)
+				{
+					return true;
+				}
+				Controller.TryClose();
 			}
 			else
 			{
-				//Server actions
-				// Close the door if it's open
-				if ( Controller.IsOpened )
-				{
-					//Not even trying to close when bumping into door
-					if ( interactSlot == null ) {
-						return;
-					}
-					Controller.TryClose();
-				} else {
 				// Attempt to open if it's closed
-					Controller.TryOpen(originator, interactSlot);//fixme: hand can be null
-				}
+				Controller.TryOpen(originator, interactSlot);//fixme: hand can be null
 			}
-			allowInput = false;
-			StartCoroutine(DoorInputCoolDown());
 		}
-		/// Disables any interactions with door for a while
-		private IEnumerator DoorInputCoolDown()
-		{
-			yield return new WaitForSeconds(0.3f);
-			allowInput = true;
-		}
+		allowInput = false;
+		StartCoroutine(DoorInputCoolDown());
+		return true;
 	}
+	/// Disables any interactions with door for a while
+	private IEnumerator DoorInputCoolDown()
+	{
+		yield return new WaitForSeconds(0.3f);
+		allowInput = true;
+	}
+}

--- a/UnityProject/Assets/Scripts/Doors/WinDoorTrigger.cs
+++ b/UnityProject/Assets/Scripts/Doors/WinDoorTrigger.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 	public class WinDoorTrigger : InputTrigger
 	{
-		public override void Interact(GameObject originator, Vector3 position, string hand)
+		public override bool Interact(GameObject originator, Vector3 position, string hand)
 		{
 			throw new NotImplementedException();
 		}

--- a/UnityProject/Assets/Scripts/Electricity/InLineDevices/InLineDevice types/DepartmentBattery.cs
+++ b/UnityProject/Assets/Scripts/Electricity/InLineDevices/InLineDevice types/DepartmentBattery.cs
@@ -223,7 +223,7 @@ public class DepartmentBattery : InputTrigger, IElectricalNeedUpdate, IInLineDev
 		}
 
 	}
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		//Interact stuff with the SMES here
 		if (!isServer)
@@ -238,6 +238,8 @@ public class DepartmentBattery : InputTrigger, IElectricalNeedUpdate, IInLineDev
 				UpdateServerState(isOn);
 			}
 		}
+
+		return true;
 	}
 
 	public float ModifyElectricityInput(int tick, float Current, GameObject SourceInstance, IElectricityIO ComingFrom)

--- a/UnityProject/Assets/Scripts/Electricity/PowerSupply/Power Supply categories/PowerGenerator.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PowerSupply/Power Supply categories/PowerGenerator.cs
@@ -181,9 +181,8 @@ public class PowerGenerator : InputTrigger, IDeviceControl
 		}
 	}
 
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
-
 		if (!isServer)
 		{
 			InteractMessage.Send(gameObject, hand);
@@ -200,7 +199,7 @@ public class PowerGenerator : InputTrigger, IDeviceControl
 					isOn = !isOn;
 					UpdateServerState(isOn);
 				}
-				return;
+				return true;
 			}
 
 			var solidPlasma = slot.Item?.GetComponent<SolidPlasma>();
@@ -208,7 +207,7 @@ public class PowerGenerator : InputTrigger, IDeviceControl
 			{
 				plasmaFuel.Add(solidPlasma);
 				InventoryManager.UpdateInvSlot(true, "", slot.Item, slot.UUID);
-				return;
+				return true;
 			}
 
 			if (isSecured)
@@ -216,5 +215,7 @@ public class PowerGenerator : InputTrigger, IDeviceControl
 				UpdateServerState(!isOn);
 			}
 		}
+
+		return true;
 	}
 }

--- a/UnityProject/Assets/Scripts/Electricity/PowerSupply/Power Supply categories/RadiationCollector.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PowerSupply/Power Supply categories/RadiationCollector.cs
@@ -84,7 +84,7 @@ public class RadiationCollector : InputTrigger, IDeviceControl
 		}
 	}
 
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		//Interact stuff with the Radiation collector here
 		if (!isServer)
@@ -96,5 +96,7 @@ public class RadiationCollector : InputTrigger, IDeviceControl
 			isOn = !isOn;
 			UpdateServerState(isOn);
 		}
+
+		return true;
 	}
 }

--- a/UnityProject/Assets/Scripts/Electricity/PowerSupply/Power Supply categories/SMES.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PowerSupply/Power Supply categories/SMES.cs
@@ -247,7 +247,7 @@ public class SMES : InputTrigger, IElectricalNeedUpdate, IBattery, IDeviceContro
 		}
 	}
 
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		//Interact stuff with the SMES here
 		if (!isServer)
@@ -262,6 +262,8 @@ public class SMES : InputTrigger, IElectricalNeedUpdate, IBattery, IDeviceContro
 				ServerState(isOn);
 			}
 		}
+
+		return true;
 	}
 
 	[ContextMethod("Toggle Charge", "Power_Button")]

--- a/UnityProject/Assets/Scripts/Electricity/PoweredDevices/FieldGenerator.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PoweredDevices/FieldGenerator.cs
@@ -44,7 +44,7 @@ public class FieldGenerator : InputTrigger, IElectricalNeedUpdate, IDeviceContro
 		CheckState(isOn);
 	}
 
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		if (!isServer)
 		{
@@ -55,6 +55,8 @@ public class FieldGenerator : InputTrigger, IElectricalNeedUpdate, IDeviceContro
 			isOn = !isOn;
 			CheckState(isOn);
 		}
+
+		return true;
 	}
 
 	public void PotentialDestroyed()

--- a/UnityProject/Assets/Scripts/Electricity/Wire/WireAttackController.cs
+++ b/UnityProject/Assets/Scripts/Electricity/Wire/WireAttackController.cs
@@ -1,47 +1,49 @@
 ﻿using UnityEngine;
 
 
-	public class WireAttackController : InputTrigger
+public class WireAttackController : InputTrigger
+{
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
-		public override void Interact(GameObject originator, Vector3 position, string hand)
-		{
-			//if no glubs
-			//zap him
-			//if object == null
-			//return
-			//if attackby wirecutters
-			//delete self 
-			//visible message: wires are snibbedy snabd
-			//play audio: snip
-			//int wireCount = 1;
-			//if(DirectionEnd != 0)
-			//the wire is two long
-			//wireCount++
-			//check floor for wires
-			//if wire exists
-			//add wireCount to it
-			//assume that the stack object handles that perfectly
-			//return
-			//make a new wire stack object
-			//set the count to wireCount
-			//return
-			//if attackby multitool
-			//if power network
-			//handle power diagnostics
-			//ss13 prints some message saying how much W is in the cable
-			//may want to do something more fancy? idk
-			//print something to the user: "no current on this wire, sorry mang"
-			//if attackby wire stack object
-			//if DirectionEnd != 0
-			//int newDirectionEnd = relative direction of the attacking mob
-			//check the floor for wires
-			//for (StructurePowerWire wire in List)
-			//if(wire.DirectionStart == DirectionStart && wire.DirectionEnd == newDirectionEnd)
-			//print to mob: "there's already a wire there"
-			//return
-			//reduce wire stack object's count by 1
-			//Color = wire stack object's color
-			//setDirection(DirectionStart, newDirectionEnd)
-			//return
-		}
+		//if no glubs
+		//zap him
+		//if object == null
+		//return
+		//if attackby wirecutters
+		//delete self 
+		//visible message: wires are snibbedy snabd
+		//play audio: snip
+		//int wireCount = 1;
+		//if(DirectionEnd != 0)
+		//the wire is two long
+		//wireCount++
+		//check floor for wires
+		//if wire exists
+		//add wireCount to it
+		//assume that the stack object handles that perfectly
+		//return
+		//make a new wire stack object
+		//set the count to wireCount
+		//return
+		//if attackby multitool
+		//if power network
+		//handle power diagnostics
+		//ss13 prints some message saying how much W is in the cable
+		//may want to do something more fancy? idk
+		//print something to the user: "no current on this wire, sorry mang"
+		//if attackby wire stack object
+		//if DirectionEnd != 0
+		//int newDirectionEnd = relative direction of the attacking mob
+		//check the floor for wires
+		//for (StructurePowerWire wire in List)
+		//if(wire.DirectionStart == DirectionStart && wire.DirectionEnd == newDirectionEnd)
+		//print to mob: "there's already a wire there"
+		//return
+		//reduce wire stack object's count by 1
+		//Color = wire stack object's color
+		//setDirection(DirectionStart, newDirectionEnd)
+		//return
+
+		return true;
 	}
+}

--- a/UnityProject/Assets/Scripts/Health/HealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/HealthBehaviour.cs
@@ -83,8 +83,6 @@ public abstract class HealthBehaviour : NetworkBehaviour
 	public virtual int ReceiveAndCalculateDamage(GameObject damagedBy, int damage, DamageType damageType,
 		BodyPartType bodyPartAim)
 	{
-		var playerNetAction = GetComponent<PlayerScript>().playerNetworkActions;
-		PostToChatMessage.SendItemAttackMessage(playerNetAction.GetActiveHandItem(), damagedBy, gameObject, damage, bodyPartAim);
 		LastDamageType = damageType;
 		LastDamagedBy = damagedBy;
 		return damage;

--- a/UnityProject/Assets/Scripts/Health/HealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/HealthBehaviour.cs
@@ -74,7 +74,6 @@ public abstract class HealthBehaviour : NetworkBehaviour
 			return;
 		}
 		int calculatedDamage = ReceiveAndCalculateDamage(damagedBy, damage, damageType, bodyPartAim);
-
 		Logger.LogTraceFormat("{3} received {0} {4} damage from {6} aimed for {5}. Health: {1}->{2}", Category.Health,
 		calculatedDamage, Health, Health - calculatedDamage, gameObject.name, damageType, bodyPartAim, damagedBy);
 		Health -= calculatedDamage;
@@ -84,6 +83,8 @@ public abstract class HealthBehaviour : NetworkBehaviour
 	public virtual int ReceiveAndCalculateDamage(GameObject damagedBy, int damage, DamageType damageType,
 		BodyPartType bodyPartAim)
 	{
+		var playerNetAction = GetComponent<PlayerScript>().playerNetworkActions;
+		PostToChatMessage.SendItemAttackMessage(playerNetAction.GetActiveHandItem(), damagedBy, gameObject, damage, bodyPartAim);
 		LastDamageType = damageType;
 		LastDamagedBy = damagedBy;
 		return damage;

--- a/UnityProject/Assets/Scripts/Items/HeadsetKeyTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/HeadsetKeyTrigger.cs
@@ -2,13 +2,12 @@
 
 public class HeadsetKeyTrigger : PickUpTrigger
 {
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		//Only peform EncryptionKey actions on other things when holding the encryptionkey
 		if (UIManager.Hands.CurrentSlot.Item != gameObject)
 		{
-			base.Interact(originator, position, hand);
-			return;
+			return base.Interact(originator, position, hand);
 		}
 
 		GameObject otherHandsItem = UIManager.Hands.OtherSlot.Item;
@@ -18,6 +17,6 @@ public class HeadsetKeyTrigger : PickUpTrigger
 			UpdateHeadsetKeyMessage.Send(otherHandsItem, gameObject);
 		}
 
-		base.Interact(originator, position, hand);
+		return base.Interact(originator, position, hand);
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Tools/CrowbarTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/CrowbarTrigger.cs
@@ -6,14 +6,13 @@ public class CrowbarTrigger : PickUpTrigger
     [SyncVar]
     private bool canBeUsed = false;
 
-    public override void Interact (GameObject originator, Vector3 position, string hand)
+    public override bool Interact (GameObject originator, Vector3 position, string hand)
     {
         //TODO:  Fill this in.
 
         if (UIManager.Hands.CurrentSlot.Item != gameObject)
         {
-            base.Interact (originator, position, hand);
-            return;
+            return base.Interact (originator, position, hand);
         }
         var targetWorldPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
         if (canBeUsed && PlayerManager.PlayerScript.IsInReach(targetWorldPos))
@@ -21,7 +20,7 @@ public class CrowbarTrigger : PickUpTrigger
             //TODO You can do special things with crow bar here
         }
 
-        base.Interact (originator, position, hand);
+        return base.Interact (originator, position, hand);
     }
 
     //Broadcast from EquipmentPool.cs **ServerSide**

--- a/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
@@ -6,14 +6,13 @@ public class MopTrigger : PickUpTrigger
 	[SyncVar]
 	private bool canBeUsed = false;
 
-    public override void Interact (GameObject originator, Vector3 position, string hand)
+    public override bool Interact (GameObject originator, Vector3 position, string hand)
     {
         //TODO:  Fill this in.
 
         if (UIManager.Hands.CurrentSlot.Item != gameObject)
         {
-            base.Interact (originator, position, hand);
-            return;
+            return base.Interact (originator, position, hand);
         }
         var targetWorldPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
         if (canBeUsed && PlayerManager.PlayerScript.IsInReach(targetWorldPos))
@@ -21,7 +20,7 @@ public class MopTrigger : PickUpTrigger
             //TODO INSERT CLEANING FUNCTION
         }
 
-        base.Interact (originator, position, hand);
+        return base.Interact (originator, position, hand);
     }
 
     //Broadcast from EquipmentPool.cs **ServerSide**

--- a/UnityProject/Assets/Scripts/Items/Tools/ScrewdriverTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/ScrewdriverTrigger.cs
@@ -2,13 +2,12 @@
 
 public class ScrewdriverTrigger : PickUpTrigger
 {
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		//Only peform screwdriver actions on other things when holding the screwdriver
 		if (UIManager.Hands.CurrentSlot.Item != gameObject)
 		{
-			base.Interact(originator, position, hand);
-			return;
+			return base.Interact(originator, position, hand);
 		}
 
 		//TODO detect the actual target of the interact, instead of requiring the headset to be in the other hand
@@ -20,6 +19,6 @@ public class ScrewdriverTrigger : PickUpTrigger
 			UpdateHeadsetKeyMessage.Send(otherHandsItem);
 		}
 
-		base.Interact(originator, position, hand);
+		return base.Interact(originator, position, hand);
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Tools/WelderTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/WelderTrigger.cs
@@ -9,7 +9,7 @@ public class WelderTrigger : PickUpTrigger
     {
         welder = GetComponent<Welder>();
     }
-    public override void Interact(GameObject originator, Vector3 position, string hand)
+    public override bool Interact(GameObject originator, Vector3 position, string hand)
     {
         //make sure that interactmessage doesn't tell the server to pick it up for server player:
         if (originator == PlayerManager.LocalPlayer)
@@ -17,11 +17,10 @@ public class WelderTrigger : PickUpTrigger
             if (UIManager.Hands.CurrentSlot.Item != gameObject)
             {
                 welder.heldByPlayer = originator;
-                base.Interact(originator, position, hand);
-                return;
+                return base.Interact(originator, position, hand);
             }
         }
-        base.Interact(originator, position, hand);
+        return base.Interact(originator, position, hand);
     }
 
     public override void UI_Interact(GameObject originator, string hand)

--- a/UnityProject/Assets/Scripts/Items/Tools/WirecutterTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/WirecutterTrigger.cs
@@ -2,16 +2,15 @@
 
 public class WirecutterTrigger : PickUpTrigger
 {
-    public override void Interact(GameObject originator, Vector3 position, string hand)
+    public override bool Interact(GameObject originator, Vector3 position, string hand)
     {
         //TODO:  Fill this in.
 
         if (UIManager.Hands.CurrentSlot.Item != gameObject)
         {
-            base.Interact(originator, position, hand);
-            return;
+            return base.Interact(originator, position, hand);
         }
 
-        base.Interact(originator, position, hand);
+        return base.Interact(originator, position, hand);
     }
 }

--- a/UnityProject/Assets/Scripts/Items/Tools/WrenchTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/WrenchTrigger.cs
@@ -2,16 +2,15 @@
 
 public class WrenchTrigger : PickUpTrigger
 {
-    public override void Interact(GameObject originator, Vector3 position, string hand)
+    public override bool Interact(GameObject originator, Vector3 position, string hand)
     {
         //TODO:  Fill this in.
 
         if (UIManager.Hands.CurrentSlot.Item != gameObject)
         {
-            base.Interact(originator, position, hand);
-            return;
+            return base.Interact(originator, position, hand);
         }
 
-        base.Interact(originator, position, hand);
+        return base.Interact(originator, position, hand);
     }
 }

--- a/UnityProject/Assets/Scripts/Lighting/LightSwitchTrigger.cs
+++ b/UnityProject/Assets/Scripts/Lighting/LightSwitchTrigger.cs
@@ -68,30 +68,32 @@ public class LightSwitchTrigger : InputTrigger
 		SyncLightSwitch(isOn);
 	}
 
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		if (!PlayerManager.LocalPlayerScript.IsInReach(position))
 		{
-			return;
+			return true;
 		}
 
 		if (RelatedAPC == null)
 		{
-			return;
+			return true;
 		}
 
 		if (RelatedAPC.Voltage == 0f)
 		{
-			return;
+			return true;
 		}
 
 		if (switchCoolDown)
 		{
-			return;
+			return true;
 		}
 
 		StartCoroutine(CoolDown());
 		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdToggleLightSwitch(gameObject);
+
+		return true;
 	}
 
 	private IEnumerator CoolDown()

--- a/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs
@@ -45,6 +45,14 @@ public class PostToChatMessage : ClientMessage
 		} );
 	}
 
+	/// <summary>
+	/// Sends a message to all players about an attack that took place
+	/// </summary>
+	/// <param name="item">gameobject with an itemattributes, representing the item the attack was made with</param>
+	/// <param name="attacker">GameObject of the player that attacked</param>
+	/// <param name="victim">GameObject of the player hat was the victim</param>
+	/// <param name="damage">damage done</param>
+	/// <param name="hitZone">zone that was damaged</param>
 	public static void SendItemAttackMessage( GameObject item, GameObject attacker, GameObject victim, int damage, BodyPartType hitZone = BodyPartType.NONE ) 
 	{
 		var itemAttributes = item.GetComponent<ItemAttributes>();

--- a/UnityProject/Assets/Scripts/Messages/Server/ShootMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/ShootMessage.cs
@@ -41,7 +41,7 @@ public class ShootMessage : ServerMessage {
 		Vector2 dir = (EndPos - (Vector2)shotByGO.transform.position).normalized;
 		float angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg;
 		BulletBehaviour b = bullet.GetComponent<BulletBehaviour>();
-		b.Shoot(dir, angle, shotByGO, DamageZone);
+		b.Shoot(dir, angle, shotByGO, wep, DamageZone);
 	}
 
 	//public static ShootMessage Send(GameObject weapon, Vector2 endPos, string bulletName,

--- a/UnityProject/Assets/Scripts/Objects/MessageOnInteract.cs
+++ b/UnityProject/Assets/Scripts/Objects/MessageOnInteract.cs
@@ -12,9 +12,10 @@ public class MessageOnInteract : InputTrigger
 	void Update () {
 		
 	}
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		ChatRelay.Instance.AddToChatLogClient(Message, ChatChannel.Examine);
+		return true;
 	}
 
 }

--- a/UnityProject/Assets/Scripts/Objects/NetworkTabTrigger.cs
+++ b/UnityProject/Assets/Scripts/Objects/NetworkTabTrigger.cs
@@ -2,12 +2,12 @@ using UnityEngine;
 
 public abstract class NetworkTabTrigger : InputTrigger {
     public NetTabType NetTabType;
-    public override void Interact(GameObject originator, Vector3 position, string hand)
+    public override bool Interact(GameObject originator, Vector3 position, string hand)
     {
         var playerScript = originator.GetComponent<PlayerScript>();
         if (playerScript.canNotInteract() || !playerScript.IsInReach( gameObject ))
         { //check for both client and server
-            return;
+            return true;
         }
         if (!isServer)
         { 
@@ -20,5 +20,7 @@ public abstract class NetworkTabTrigger : InputTrigger {
             TabUpdateMessage.Send( originator, gameObject, NetTabType, TabAction.Open );
             
         }
+
+		return true;
     }
 }

--- a/UnityProject/Assets/Scripts/Objects/VendorTrigger.cs
+++ b/UnityProject/Assets/Scripts/Objects/VendorTrigger.cs
@@ -14,7 +14,7 @@ public class VendorTrigger : InputTrigger
 	public string deniedMessage;
 	public DispenseDirection DispenseDirection = DispenseDirection.None;
 
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		if (!allowSell && deniedMessage != null && !GameData.Instance.testServer && !GameData.IsHeadlessServer)
 		{
@@ -42,6 +42,7 @@ public class VendorTrigger : InputTrigger
 			StartCoroutine(VendorInputCoolDown());
 		}
 
+		return true;
 	}
 
 	[Server]

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.Tilemaps;
 
+/// <summary>
+/// Main entry point for handling all input events
+/// </summary>
 public class InputController : MonoBehaviour
 {
 	/// <summary>
@@ -361,8 +364,15 @@ public class InputController : MonoBehaviour
 		return Interact(_transform, _transform.position);
 	}
 
+	/// <summary>
+	/// Checks for the various interactions that can occur and delegates to the appropriate trigger classes.
+	/// Note that only one interaction is allowed to occur in this method - the first time any trigger returns true
+	/// (indicating that interaction logic has occurred), the method returns.
+	/// </summary>
 	public bool Interact(Transform _transform, Vector3 position)
 	{
+		//TODO: Wouldn't it be better to simply delegate all logic to all handlers? Have a standard interface
+		//which takes some data and returns true if an interaction occurred.
 		if (playerMove.isGhost)
 		{
 			return false;
@@ -372,7 +382,7 @@ public class InputController : MonoBehaviour
 		var localPlayer = PlayerManager.LocalPlayerScript;
 		if (localPlayer.IsInReach(Camera.main.ScreenToWorldPoint(Input.mousePosition)) || localPlayer.IsHidden)
 		{
-			//Check for melee triggers first:
+			//Check for melee triggers first. If a melee interaction occurs, stop checking for any further interactions
 			MeleeTrigger meleeTrigger = _transform.GetComponentInParent<MeleeTrigger>();
 			if (meleeTrigger != null)
 			{

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputController.cs
@@ -66,34 +66,41 @@ public class InputController : MonoBehaviour
 					CheckClick();
 				}
 			}
-		} else if (Input.GetMouseButton(0)) {
+		}
+		else if (Input.GetMouseButton(0))
+		{
 			//mouse being held down / dragged
 			CheckDrag();
-		} else {
+		}
+		else
+		{
 			CheckHover();
 		}
 	}
 	private Renderer lastHoveredThing;
 
-	private void CheckHover() {
+	private void CheckHover()
+	{
 		Renderer hitRenderer;
-		if ( RayHit(false, out hitRenderer ) ) {
-			if ( !hitRenderer ) {
+		if (RayHit(false, out hitRenderer))
+		{
+			if (!hitRenderer)
+			{
 				return;
 			}
 
-			if ( lastHoveredThing != hitRenderer )
+			if (lastHoveredThing != hitRenderer)
 			{
-				if ( lastHoveredThing )
+				if (lastHoveredThing)
 				{
-					lastHoveredThing.transform.SendMessageUpwards( "OnHoverEnd", SendMessageOptions.DontRequireReceiver );
+					lastHoveredThing.transform.SendMessageUpwards("OnHoverEnd", SendMessageOptions.DontRequireReceiver);
 				}
-				hitRenderer.transform.SendMessageUpwards( "OnHoverStart", SendMessageOptions.DontRequireReceiver );
+				hitRenderer.transform.SendMessageUpwards("OnHoverStart", SendMessageOptions.DontRequireReceiver);
 
 				lastHoveredThing = hitRenderer;
 			}
 
-			hitRenderer.transform.SendMessageUpwards( "OnHover", SendMessageOptions.DontRequireReceiver );
+			hitRenderer.transform.SendMessageUpwards("OnHover", SendMessageOptions.DontRequireReceiver);
 		}
 	}
 
@@ -102,9 +109,10 @@ public class InputController : MonoBehaviour
 		UIManager.Hands.Swap();
 	}
 
-	private void CheckClick() {
-		bool ctrlClick = Input.GetKey(KeyCode.LeftControl) || Input.GetKey( KeyCode.LeftCommand ) ||
-		                 Input.GetKey(KeyCode.RightControl) || Input.GetKey( KeyCode.RightCommand );
+	private void CheckClick()
+	{
+		bool ctrlClick = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.LeftCommand) ||
+						 Input.GetKey(KeyCode.RightControl) || Input.GetKey(KeyCode.RightCommand);
 		if (!ctrlClick)
 		{
 			//change the facingDirection of player on click
@@ -115,13 +123,17 @@ public class InputController : MonoBehaviour
 			{
 				InteractHands(false);
 			}
-		} else {
+		}
+		else
+		{
 			Renderer hitRenderer;
-			if ( RayHit(false, out hitRenderer ) ) {
-				if ( !hitRenderer ) {
+			if (RayHit(false, out hitRenderer))
+			{
+				if (!hitRenderer)
+				{
 					return;
 				}
-				hitRenderer.transform.SendMessageUpwards( "OnCtrlClick", SendMessageOptions.DontRequireReceiver );
+				hitRenderer.transform.SendMessageUpwards("OnCtrlClick", SendMessageOptions.DontRequireReceiver);
 			}
 		}
 	}
@@ -129,9 +141,11 @@ public class InputController : MonoBehaviour
 	/// <summary>
 	/// Handles events that should happen while mouse is being held down (but not when it is initially clicked down)
 	/// </summary>
-	private void CheckDrag() {
+	private void CheckDrag()
+	{
 		//if we found nothing at all to click on try to use whats in our hands (might be shooting at someone in space)
-		if (!RayHitInteract(true) && !EventSystem.current.IsPointerOverGameObject()) {
+		if (!RayHitInteract(true) && !EventSystem.current.IsPointerOverGameObject())
+		{
 			InteractHands(true);
 		}
 	}
@@ -176,7 +190,7 @@ public class InputController : MonoBehaviour
 			currentSlot.Clear();
 			//				Logger.Log( $"Requesting throw from {currentSlot.eventName} to {position}" );
 			PlayerManager.LocalPlayerScript.playerNetworkActions
-				.CmdRequestThrow(currentSlot.eventName, position, (int) UIManager.DamageZone);
+				.CmdRequestThrow(currentSlot.eventName, position, (int)UIManager.DamageZone);
 
 			//Disabling throw button
 			UIManager.Action.Throw();
@@ -208,7 +222,8 @@ public class InputController : MonoBehaviour
 	/// </summary>
 	/// <param name="isDrag">is this during (but not at the very start of) a drag?</param>
 	/// <returns>true iff there was a hit that caused an interaction</returns>
-	private bool RayHitInteract(bool isDrag) {
+	private bool RayHitInteract(bool isDrag)
+	{
 		Renderer hitRenderer;
 		return RayHit(isDrag, out hitRenderer, true);
 	}
@@ -221,7 +236,8 @@ public class InputController : MonoBehaviour
 	/// <param name="hitRenderer>renderer of the gameobject that had an interaction</param>
 	/// <param name="interact">true iff there was an interaction that occurred</param>
 	/// <returns>true iff there was a hit that caused an interaction</returns>
-	private bool RayHit(bool isDrag, out Renderer hitRenderer, bool interact = false) {
+	private bool RayHit(bool isDrag, out Renderer hitRenderer, bool interact = false)
+	{
 		hitRenderer = null;
 
 		Vector3 mousePosition = MousePosition;
@@ -256,11 +272,13 @@ public class InputController : MonoBehaviour
 				{
 					hitRenderer = _renderer;
 
-					if ( !interact ) {
+					if (!interact)
+					{
 						break;
 					}
-					
-					if (Interact(_renderer.transform, mousePosition, isDrag)) {
+
+					if (Interact(_renderer.transform, mousePosition, isDrag))
+					{
 						isInteracting = true;
 						break;
 					}
@@ -337,7 +355,7 @@ public class InputController : MonoBehaviour
 		Vector2 mousePos = Input.mousePosition;
 		Vector2 viewportPos = cam.ScreenToViewportPoint(mousePos);
 		if (viewportPos.x < 0.0f || viewportPos.x > 1.0f || viewportPos.y < 0.0f || viewportPos.y > 1.0f) return false; // out of viewport bounds
-		// Cast a ray from viewport point into world
+																														// Cast a ray from viewport point into world
 		Ray ray = cam.ViewportPointToRay(viewportPos);
 
 		// Check for intersection with sprite and get the color
@@ -362,20 +380,20 @@ public class InputController : MonoBehaviour
 		}
 		// Craete a plane so it has the same orientation as the sprite transform
 		Plane plane = new Plane(transform.forward, (Vector2)transform.position); //????????
-		// Intersect the ray and the plane
+																				 // Intersect the ray and the plane
 		float rayIntersectDist; // the distance from the ray origin to the intersection point
 		if (!plane.Raycast(ray, out rayIntersectDist)) return false; // no intersection
-		// Convert world position to sprite position
-		// worldToLocalMatrix.MultiplyPoint3x4 returns a value from based on the texture dimensions (+/- half texDimension / pixelsPerUnit) )
-		// 0, 0 corresponds to the center of the TEXTURE ITSELF, not the center of the trimmed sprite textureRect
+																	 // Convert world position to sprite position
+																	 // worldToLocalMatrix.MultiplyPoint3x4 returns a value from based on the texture dimensions (+/- half texDimension / pixelsPerUnit) )
+																	 // 0, 0 corresponds to the center of the TEXTURE ITSELF, not the center of the trimmed sprite textureRect
 		Vector3 spritePos = spriteRenderer.worldToLocalMatrix.MultiplyPoint3x4(ray.origin + (ray.direction * rayIntersectDist));
 		Rect textureRect = sprite.textureRect;
 		float pixelsPerUnit = sprite.pixelsPerUnit;
 		float halfRealTexWidth = sprite.rect.width * 0.5f;
 		float halfRealTexHeight = sprite.rect.height * 0.5f;
 
-		int texPosX = (int) (sprite.rect.x + (spritePos.x * pixelsPerUnit + halfRealTexWidth));
-		int texPosY = (int) (sprite.rect.y + (spritePos.y * pixelsPerUnit + halfRealTexHeight));
+		int texPosX = (int)(sprite.rect.x + (spritePos.x * pixelsPerUnit + halfRealTexWidth));
+		int texPosY = (int)(sprite.rect.y + (spritePos.y * pixelsPerUnit + halfRealTexHeight));
 
 		// Check if pixel is within texture
 		if (texPosX < 0 || texPosX < textureRect.x || texPosX >= Mathf.FloorToInt(textureRect.xMax)) return false;
@@ -434,10 +452,19 @@ public class InputController : MonoBehaviour
 			{
 				if (objectBehaviour.visibleState)
 				{
-					if (isDrag) {
-						inputTrigger.TriggerDrag(position);
-					} else {
-						inputTrigger.Trigger(position);
+					bool interacted = false;
+					if (isDrag)
+					{
+						interacted = inputTrigger.TriggerDrag(position);
+					}
+					else
+					{
+						interacted = inputTrigger.Trigger(position);
+					}
+
+					if (interacted)
+					{
+						return true;
 					}
 
 					//FIXME currently input controller only uses the first InputTrigger found on an object
@@ -450,22 +477,31 @@ public class InputController : MonoBehaviour
 						P2PInteractions playerInteractions = inputTrigger.gameObject.GetComponent<P2PInteractions>();
 						if (playerInteractions != null)
 						{
-							if (isDrag) {
-								playerInteractions.TriggerDrag(position);
-							} else {
-								playerInteractions.Trigger(position);
+							if (isDrag)
+							{
+								interacted = playerInteractions.TriggerDrag(position);
+							}
+							else
+							{
+								interacted = playerInteractions.Trigger(position);
 							}
 						}
 					}
-					return true;
+					if (interacted)
+					{
+						return true;
+					}
 				}
 				//Allow interact with cupboards we are inside of!
 				ClosetControl closet = inputTrigger.GetComponent<ClosetControl>();
 				//no closet interaction happens when dragging
 				if (closet && Camera2DFollow.followControl.target == closet.transform && !isDrag)
 				{
-					inputTrigger.Trigger(position);
-					return true;
+
+					if (inputTrigger.Trigger(position))
+					{
+						return true;
+					}
 				}
 				return false;
 			}
@@ -482,12 +518,19 @@ public class InputController : MonoBehaviour
 			InputTrigger inputTrigger = UIManager.Hands.CurrentSlot.Item.GetComponent<InputTrigger>();
 			if (inputTrigger != null)
 			{
-				if (isDrag) {
-					inputTrigger.TriggerDrag();
-				} else {
-					inputTrigger.Trigger();
+				bool interacted = false;
+				if (isDrag)
+				{
+					interacted = inputTrigger.TriggerDrag();
 				}
-				return true;
+				else
+				{
+					interacted = inputTrigger.Trigger();
+				}
+				if (interacted)
+				{
+					return true;
+				}
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputTrigger.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputTrigger.cs
@@ -8,8 +8,9 @@ using UnityEngine.Networking;
 /// There are 2 kinds of interactions - an interaction (defined when the mouse is initially clicked) and a drag interaction (defined as when the mouse is
 /// being dragged while held down but not during the initial click)
 ///
-/// Keep in mind that (currently) only at most one interaction will be triggered for a given update, and the interaction will first be attempted on the highest layer
-/// before checking for interactions on lower layers. The first interaction which returns true will cause no further interactions to be checked.
+/// Keep in mind that (currently) every interaction which is checked on a given update has the ability to disable futher interactions by returning true. This is
+/// what most interactions do. If an interaction returns false (meaning interaction checking should continue), the game will proceed checking
+/// the other possible interactions that can happen, going down from the top to the bottom layers.
 /// </summary>
 public abstract class InputTrigger : NetworkBehaviour
 {
@@ -17,9 +18,10 @@ public abstract class InputTrigger : NetworkBehaviour
 	/// Trigger an interaction with the position set to this transform, the originator set to the LocalPlayer
 	/// (if localplayer is not null), and the hand set to the localplayer's current hand.
 	/// </summary>
-	public void Trigger()
+	/// <returns>true if further interactions should be prevented for the current update</returns>
+	public bool Trigger()
 	{
-		Trigger(transform.position);
+		return Trigger(transform.position);
 	}
 
 	/// <summary>
@@ -27,31 +29,36 @@ public abstract class InputTrigger : NetworkBehaviour
 	/// (if localplayer is not null), and the hand set to the localplayer's current hand.
 	/// </summary>
 	/// <param name="position">position of the interaction</param>
-	public void Trigger(Vector3 position)
+	/// <returns>true if further interactions should be prevented for the current update</returns>
+	public bool Trigger(Vector3 position)
 	{
-		Interact(position);
+		return Interact(position);
 	}
 
 	/// <summary>
 	/// Trigger an interaction with the position set to this transform's position, with the specified originator and hand.
 	/// </summary>
 	/// <param name="hand">hand being used by the originator</param>
-	public void Interact(GameObject originator, string hand) {
-		Interact(originator, transform.position, hand);
+	/// <returns>true if further interactions should be prevented for the current update</returns>
+	public bool Interact(GameObject originator, string hand) {
+		return Interact(originator, transform.position, hand);
 	}
 
-	private void Interact(Vector3 position) {
+	private bool Interact(Vector3 position) {
 		if (PlayerManager.LocalPlayer != null) {
-			Interact(PlayerManager.LocalPlayerScript.gameObject, position, UIManager.Hands.CurrentSlot.eventName);
+			return Interact(PlayerManager.LocalPlayerScript.gameObject, position, UIManager.Hands.CurrentSlot.eventName);
 		}
+
+		return false;
 	}
 
 	/// <summary>
 	/// Trigger a drag interaction with the position set to this transform, the originator set to the LocalPlayer
 	/// (if localplayer is not null), and the hand set to the localplayer's current hand.
 	/// </summary>
-	public void TriggerDrag() {
-		TriggerDrag(transform.position);
+	/// <returns>true if further interactions should be prevented for the current update</returns>
+	public bool TriggerDrag() {
+		return TriggerDrag(transform.position);
 	}
 
 	/// <summary>
@@ -59,14 +66,16 @@ public abstract class InputTrigger : NetworkBehaviour
 	/// (if localplayer is not null), and the hand set to the localplayer's current hand.
 	/// </summary>
 	/// <param name="position">position of the interaction</param>
-	public void TriggerDrag(Vector3 position) {
-		DragInteract(position);
+	/// <returns>true if further interactions should be prevented for the current update</returns>
+	public bool TriggerDrag(Vector3 position) {
+		return DragInteract(position);
 	}
 
-	private void DragInteract(Vector3 position) {
+	private bool DragInteract(Vector3 position) {
 		if (PlayerManager.LocalPlayer != null) {
-			DragInteract(PlayerManager.LocalPlayerScript.gameObject, position, UIManager.Hands.CurrentSlot.eventName);
+			return DragInteract(PlayerManager.LocalPlayerScript.gameObject, position, UIManager.Hands.CurrentSlot.eventName);
 		}
+		return false;
 	}
 
 	/// <summary>
@@ -75,7 +84,8 @@ public abstract class InputTrigger : NetworkBehaviour
 	/// <param name="originator>game object that is performing the interaction upon this gameobject</param>
 	/// <param name="hand">hand of the originator which is being used to perform the interaction</param>
 	/// <param name="position">position of the interaction</param>
-	public abstract void Interact(GameObject originator, Vector3 position, string hand);
+	/// <returns>true if further interactions should be prevented for the current update</returns>
+	public abstract bool Interact(GameObject originator, Vector3 position, string hand);
 
 	//TODO: Document what "position" really is - is it always mouse position? Is it sometimes the position of the object being interacted with?
 	/// <summary>
@@ -85,7 +95,8 @@ public abstract class InputTrigger : NetworkBehaviour
 	/// <param name="originator>game object that is performing the interaction upon this gameobject</param>
 	/// <param name="hand">hand of the originator which is being used to perform the interaction</param>
 	/// <param name="position">position of the interaction</param>
-	public virtual void DragInteract(GameObject originator, Vector3 position, string hand) { }
+	/// <returns>true if further interactions should be prevented for the current update</returns>
+	public virtual bool DragInteract(GameObject originator, Vector3 position, string hand) { return false; }
 
 	/// <Summary>
 	/// This is called by the hand button on the hand slots. It can also be expanded for interaction on other slots

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/InputTrigger.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/InputTrigger.cs
@@ -1,32 +1,91 @@
+using System;
 using UnityEngine;
 using UnityEngine.Networking;
 
+/// <summary>
+/// Represents a behavior for a gameobject which can trigger reactions in response to input.
+///
+/// There are 2 kinds of interactions - an interaction (defined when the mouse is initially clicked) and a drag interaction (defined as when the mouse is
+/// being dragged while held down but not during the initial click)
+///
+/// Keep in mind that (currently) only at most one interaction will be triggered for a given update, and the interaction will first be attempted on the highest layer
+/// before checking for interactions on lower layers. The first interaction which returns true will cause no further interactions to be checked.
+/// </summary>
 public abstract class InputTrigger : NetworkBehaviour
 {
+	/// <summary>
+	/// Trigger an interaction with the position set to this transform, the originator set to the LocalPlayer
+	/// (if localplayer is not null), and the hand set to the localplayer's current hand.
+	/// </summary>
 	public void Trigger()
 	{
 		Trigger(transform.position);
 	}
 
+	/// <summary>
+	/// Trigger an interaction with the position set to the specified position, the originator set to the LocalPlayer
+	/// (if localplayer is not null), and the hand set to the localplayer's current hand.
+	/// </summary>
+	/// <param name="position">position of the interaction</param>
 	public void Trigger(Vector3 position)
 	{
 		Interact(position);
 	}
 
-	private void Interact(Vector3 position)
-	{
-		if (PlayerManager.LocalPlayer != null)
-		{
+	/// <summary>
+	/// Trigger an interaction with the position set to this transform's position, with the specified originator and hand.
+	/// </summary>
+	/// <param name="hand">hand being used by the originator</param>
+	public void Interact(GameObject originator, string hand) {
+		Interact(originator, transform.position, hand);
+	}
+
+	private void Interact(Vector3 position) {
+		if (PlayerManager.LocalPlayer != null) {
 			Interact(PlayerManager.LocalPlayerScript.gameObject, position, UIManager.Hands.CurrentSlot.eventName);
 		}
 	}
 
-	public void Interact(GameObject originator, string hand)
-	{
-		Interact(originator, transform.position, hand);
+	/// <summary>
+	/// Trigger a drag interaction with the position set to this transform, the originator set to the LocalPlayer
+	/// (if localplayer is not null), and the hand set to the localplayer's current hand.
+	/// </summary>
+	public void TriggerDrag() {
+		TriggerDrag(transform.position);
 	}
 
+	/// <summary>
+	/// Trigger an interaction with the position set to the specified position, the originator set to the LocalPlayer
+	/// (if localplayer is not null), and the hand set to the localplayer's current hand.
+	/// </summary>
+	/// <param name="position">position of the interaction</param>
+	public void TriggerDrag(Vector3 position) {
+		DragInteract(position);
+	}
+
+	private void DragInteract(Vector3 position) {
+		if (PlayerManager.LocalPlayer != null) {
+			DragInteract(PlayerManager.LocalPlayerScript.gameObject, position, UIManager.Hands.CurrentSlot.eventName);
+		}
+	}
+
+	/// <summary>
+	/// Trigger an interaction, defined as when the mouse is initially clicked (but not while it is being held down and dragged)
+	/// </summary>
+	/// <param name="originator>game object that is performing the interaction upon this gameobject</param>
+	/// <param name="hand">hand of the originator which is being used to perform the interaction</param>
+	/// <param name="position">position of the interaction</param>
 	public abstract void Interact(GameObject originator, Vector3 position, string hand);
+
+	//TODO: Document what "position" really is - is it always mouse position? Is it sometimes the position of the object being interacted with?
+	/// <summary>
+	/// Trigger a drag interaction, defined as when the mouse is currently being held (but not initially clicked) and is dragged over. The default implementation is
+	/// that nothing happens.
+	/// </summary>
+	/// <param name="originator>game object that is performing the interaction upon this gameobject</param>
+	/// <param name="hand">hand of the originator which is being used to perform the interaction</param>
+	/// <param name="position">position of the interaction</param>
+	public virtual void DragInteract(GameObject originator, Vector3 position, string hand) { }
 
 	/// <Summary>
 	/// This is called by the hand button on the hand slots. It can also be expanded for interaction on other slots
@@ -34,4 +93,6 @@ public abstract class InputTrigger : NetworkBehaviour
 	/// </Summary>
 	public virtual void UI_Interact(GameObject originator, string hand) {}
 	public virtual void UI_InteractOtherSlot(GameObject originator, GameObject otherHandItem){}
+
+	
 }

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/MeleeTrigger.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/MeleeTrigger.cs
@@ -38,18 +38,18 @@ public class MeleeTrigger : MonoBehaviour
 			}
 
 			if (handItem.itemType != ItemType.ID &&
-					handItem.itemType != ItemType.Back &&
-					handItem.itemType != ItemType.Ear &&
-					handItem.itemType != ItemType.Food &&
-					handItem.itemType != ItemType.Glasses &&
-					handItem.itemType != ItemType.Gloves &&
-					handItem.itemType != ItemType.Hat &&
-					handItem.itemType != ItemType.Mask &&
-					handItem.itemType != ItemType.Neck &&
-					handItem.itemType != ItemType.Shoes &&
-					handItem.itemType != ItemType.Suit &&
-					handItem.itemType != ItemType.Uniform &&
-					PlayerManager.LocalPlayerScript.IsInReach(mousePos))
+				handItem.itemType != ItemType.Back &&
+				handItem.itemType != ItemType.Ear &&
+				handItem.itemType != ItemType.Food &&
+				handItem.itemType != ItemType.Glasses &&
+				handItem.itemType != ItemType.Gloves &&
+				handItem.itemType != ItemType.Hat &&
+				handItem.itemType != ItemType.Mask &&
+				handItem.itemType != ItemType.Neck &&
+				handItem.itemType != ItemType.Shoes &&
+				handItem.itemType != ItemType.Suit &&
+				handItem.itemType != ItemType.Uniform &&
+				PlayerManager.LocalPlayerScript.IsInReach(mousePos))
 			{
 				if (UIManager.CurrentIntent == Intent.Attack ||
 					handItem.itemType != ItemType.Gun ||

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/MeleeTrigger.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/MeleeTrigger.cs
@@ -59,7 +59,7 @@ public class MeleeTrigger : MonoBehaviour
 					Vector2 dir = (mousePos - PlayerManager.LocalPlayer.transform.position).normalized;
 
 					//special case - when we have a gun and click ourselves, we should actually shoot ourselves rather than melee, which is handled elsewhere
-					if (handItem.itemType == ItemType.Gun && originator == gameObject)
+					if ((handItem.type == ItemType.Gun || handItem.itemType == ItemType.Gun) && originator == gameObject)
 					{
 						return false;
 					}

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/MeleeTrigger.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/MeleeTrigger.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 using UnityEngine;
 
 //Do not derive from NetworkBehaviour, this is also used on tilemap layers
+/// <summary>
+/// Checks for and handles melee interactions. Note that other interactions (such as P2PInteraction) are possible and handled in other classes.
+/// </summary>
 public class MeleeTrigger : MonoBehaviour
 {
 	//Cache these on start for checking at runtime
@@ -29,24 +32,24 @@ public class MeleeTrigger : MonoBehaviour
 			var mousePos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
 			var handItem = UIManager.Hands.CurrentSlot.Item.GetComponent<ItemAttributes>();
 
-			if(handItem.itemType == ItemType.Food){
+			if (handItem.itemType == ItemType.Food) {
 				//TODO Add medical stuff too
 				return false;
 			}
 
 			if (handItem.itemType != ItemType.ID &&
-				handItem.itemType != ItemType.Back &&
-				handItem.itemType != ItemType.Ear &&
-				handItem.itemType != ItemType.Food &&
-				handItem.itemType != ItemType.Glasses &&
-				handItem.itemType != ItemType.Gloves &&
-				handItem.itemType != ItemType.Hat &&
-				handItem.itemType != ItemType.Mask &&
-				handItem.itemType != ItemType.Neck &&
-				handItem.itemType != ItemType.Shoes &&
-				handItem.itemType != ItemType.Suit &&
-				handItem.itemType != ItemType.Uniform &&
-				PlayerManager.LocalPlayerScript.IsInReach(mousePos))
+					handItem.itemType != ItemType.Back &&
+					handItem.itemType != ItemType.Ear &&
+					handItem.itemType != ItemType.Food &&
+					handItem.itemType != ItemType.Glasses &&
+					handItem.itemType != ItemType.Gloves &&
+					handItem.itemType != ItemType.Hat &&
+					handItem.itemType != ItemType.Mask &&
+					handItem.itemType != ItemType.Neck &&
+					handItem.itemType != ItemType.Shoes &&
+					handItem.itemType != ItemType.Suit &&
+					handItem.itemType != ItemType.Uniform &&
+					PlayerManager.LocalPlayerScript.IsInReach(mousePos))
 			{
 				if (UIManager.CurrentIntent == Intent.Attack ||
 					handItem.itemType != ItemType.Gun ||
@@ -54,6 +57,12 @@ public class MeleeTrigger : MonoBehaviour
 					handItem.itemType != ItemType.Belt)
 				{
 					Vector2 dir = (mousePos - PlayerManager.LocalPlayer.transform.position).normalized;
+
+					//special case - when we have a gun and click ourselves, we should actually shoot ourselves rather than melee, which is handled elsewhere
+					if (handItem.itemType == ItemType.Gun && originator == gameObject)
+					{
+						return false;
+					}
 
 					PlayerScript lps = PlayerManager.LocalPlayerScript;
 

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/Triggers/MicrowaveTrigger.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/Triggers/MicrowaveTrigger.cs
@@ -11,7 +11,7 @@ public class MicrowaveTrigger : InputTrigger
 		microwave = GetComponent<Microwave>();
 	}
 
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		if (!isServer)
 		{
@@ -28,6 +28,8 @@ public class MicrowaveTrigger : InputTrigger
 		{
 			ValidateMicrowaveInteraction(originator, position, hand);
 		}
+
+		return true;
 	}
 
 	[Server]

--- a/UnityProject/Assets/Scripts/PlayGroups/Input/Triggers/PickUpTrigger.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/Input/Triggers/PickUpTrigger.cs
@@ -2,121 +2,136 @@ using UnityEngine;
 using UnityEngine.Networking;
 
 
-	public class PickUpTrigger : InputTrigger
+public class PickUpTrigger : InputTrigger
+{
+	private void Start()
 	{
-		private void Start()
+		CheckSpriteOrder();
+	}
+	[ContextMethod("Pick Up", "hand")]
+	public void GUIInteract()
+	{
+		Interact(
+		PlayerManager.LocalPlayerScript.gameObject,
+		PlayerManager.LocalPlayerScript.WorldPos,
+		UIManager.Instance.hands.CurrentSlot.eventName);
+	}
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
+	{
+		if (originator.GetComponent<PlayerScript>().canNotInteract())
 		{
-			CheckSpriteOrder();
+			return true;
 		}
-		[ContextMethod("Pick Up","hand")]
-		public void GUIInteract(){
-			Interact(
-			PlayerManager.LocalPlayerScript.gameObject,
-			PlayerManager.LocalPlayerScript.WorldPos,
-			UIManager.Instance.hands.CurrentSlot.eventName );
-		}
-		public override void Interact(GameObject originator, Vector3 position, string hand)
+
+		if (!isServer)
 		{
-			if (originator.GetComponent<PlayerScript>().canNotInteract())
+			UISlotObject uiSlotObject = new UISlotObject(InventoryManager.GetClientUUIDFromSlotName(hand), gameObject);
+
+			//PreCheck
+			if (UIManager.CanPutItemToSlot(uiSlotObject))
 			{
-				return;
+				//Simulation
+				gameObject.GetComponent<CustomNetTransform>().DisappearFromWorld();
+				//                    UIManager.UpdateSlot(uiSlotObject);
+
+				//Client informs server of interaction attempt
+				InteractMessage.Send(gameObject, hand);
+
+				return true;
 			}
 
-			if (!isServer)
+			return true;
+
+		}
+		else
+		{
+			//Server actions
+			if (!ValidatePickUp(originator, hand))
 			{
-				UISlotObject uiSlotObject = new UISlotObject(InventoryManager.GetClientUUIDFromSlotName(hand), gameObject);
-
-				//PreCheck
-				if (UIManager.CanPutItemToSlot(uiSlotObject))
-				{
-					//Simulation
-					gameObject.GetComponent<CustomNetTransform>().DisappearFromWorld();
-					//                    UIManager.UpdateSlot(uiSlotObject);
-
-					//Client informs server of interaction attempt
-					InteractMessage.Send(gameObject, hand);
-				}
-
+				//Rollback prediction (inform player about item's true state)
+				GetComponent<CustomNetTransform>().NotifyPlayer(originator);
 			}
 			else
 			{
-				//Server actions
-				if (!ValidatePickUp(originator, hand))
-				{
-					//Rollback prediction (inform player about item's true state)
-					GetComponent<CustomNetTransform>().NotifyPlayer(originator);
-				} else {
-					OnPickUpServer(originator.GetComponent<NetworkIdentity>().netId);
-				}
+				OnPickUpServer(originator.GetComponent<NetworkIdentity>().netId);
 			}
-		}
-		
-		//Broadcast from InventoryManager on server
-		public void OnRemoveFromInventory(){
-			OnDropItemServer();
-		}
-		public virtual void OnPickUpServer(NetworkInstanceId ownerId){}
-		public virtual void OnDropItemServer(){}
 
-		[Server]
-		public virtual bool ValidatePickUp(GameObject originator, string handSlot)
+			return true;
+		}
+
+		return true;
+	}
+
+	//Broadcast from InventoryManager on server
+	public void OnRemoveFromInventory()
+	{
+		OnDropItemServer();
+	}
+	public virtual void OnPickUpServer(NetworkInstanceId ownerId) { }
+	public virtual void OnDropItemServer() { }
+
+	[Server]
+	public virtual bool ValidatePickUp(GameObject originator, string handSlot)
+	{
+		var ps = originator.GetComponent<PlayerScript>();
+
+		if (ps == null)
 		{
-			var ps = originator.GetComponent<PlayerScript>();
+			return false;
+		}
 
-			if(ps == null){
-				return false;
-			}
+		var targetSlot = InventoryManager.GetSlotFromOriginatorHand(originator, handSlot);
+		if (targetSlot == null)
+		{
+			Logger.Log("Slot not found!", Category.Inventory);
+			return false;
+		}
 
-			var targetSlot = InventoryManager.GetSlotFromOriginatorHand(originator, handSlot);
-			if(targetSlot == null){
-				Logger.Log("Slot not found!", Category.Inventory);
-				return false;
-			}
+		if (targetSlot.Item != null)
+		{
+			Logger.Log("Slot is full!", Category.Inventory);
+			return false;
+		}
 
-			if(targetSlot.Item != null){
-				Logger.Log("Slot is full!", Category.Inventory);
-				return false;
-			}
-			
 
-			var cnt = GetComponent<CustomNetTransform>();
-			var state = cnt.ServerState;
+		var cnt = GetComponent<CustomNetTransform>();
+		var state = cnt.ServerState;
 
-			if (cnt.IsFloatingServer ? !CanReachFloating(ps, state) : !ps.IsInReach(cnt.RegisterTile))
+		if (cnt.IsFloatingServer ? !CanReachFloating(ps, state) : !ps.IsInReach(cnt.RegisterTile))
+		{
+			Logger.LogWarning($"Not in reach! server pos:{state.WorldPosition} player pos:{originator.transform.position} (floating={cnt.IsFloatingServer})", Category.Security);
+			return false;
+		}
+		Logger.LogTraceFormat("Pickup success! server pos:{0} player pos:{1} (floating={2})", Category.Security,
+			state.WorldPosition, originator.transform.position, cnt.IsFloatingServer);
+
+
+		//set ForceInform to false for simulation
+		return ps.playerNetworkActions.AddItemToUISlot(gameObject, targetSlot.SlotName, false /*, false*/);
+	}
+
+	/// <summary>
+	///     Making reach check less strict when object is flying, otherwise high ping players can never catch shit!
+	/// </summary>
+	private static bool CanReachFloating(PlayerScript ps, TransformState state)
+	{
+		return ps.IsInReach(state.WorldPosition) || ps.IsInReach(state.WorldPosition - (Vector3)state.Impulse, 2f);
+	}
+
+	/// <summary>
+	///     If a SpriteRenderer.sortingOrder is 0 then there will be difficulty
+	///     interacting with the object via the InputTrigger especially when placed on
+	///     tables. This method makes sure that it is never 0 on start
+	/// </summary>
+	private void CheckSpriteOrder()
+	{
+		SpriteRenderer sR = GetComponentInChildren<SpriteRenderer>();
+		if (sR != null)
+		{
+			if (sR.sortingLayerName == "Items" && sR.sortingOrder == 0)
 			{
-				Logger.LogWarning($"Not in reach! server pos:{state.WorldPosition} player pos:{originator.transform.position} (floating={cnt.IsFloatingServer})", Category.Security);
-				return false;
-			}
-			Logger.LogTraceFormat("Pickup success! server pos:{0} player pos:{1} (floating={2})", Category.Security,
-				state.WorldPosition, originator.transform.position, cnt.IsFloatingServer);
-
-
-			//set ForceInform to false for simulation
-			return ps.playerNetworkActions.AddItemToUISlot(gameObject, targetSlot.SlotName, false /*, false*/);
-		}
-
-		/// <summary>
-		///     Making reach check less strict when object is flying, otherwise high ping players can never catch shit!
-		/// </summary>
-		private static bool CanReachFloating(PlayerScript ps, TransformState state)
-		{
-			return ps.IsInReach(state.WorldPosition) || ps.IsInReach(state.WorldPosition - (Vector3) state.Impulse, 2f);
-		}
-
-		/// <summary>
-		///     If a SpriteRenderer.sortingOrder is 0 then there will be difficulty
-		///     interacting with the object via the InputTrigger especially when placed on
-		///     tables. This method makes sure that it is never 0 on start
-		/// </summary>
-		private void CheckSpriteOrder()
-		{
-			SpriteRenderer sR = GetComponentInChildren<SpriteRenderer>();
-			if (sR != null)
-			{
-				if (sR.sortingLayerName == "Items" && sR.sortingOrder == 0)
-				{
-					sR.sortingOrder = 1;
-				}
+				sR.sortingOrder = 1;
 			}
 		}
 	}
+}

--- a/UnityProject/Assets/Scripts/PlayGroups/P2PInteractions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/P2PInteractions.cs
@@ -73,7 +73,7 @@ public class P2PInteractions : InputTrigger
 		if (PlayerManager.LocalPlayer == gameObject)
 		{
 			//suicide
-			return weapon.AttemptSuicideShot();
+			return weapon.AttemptSuicideShot(isDrag);
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/PlayGroups/P2PInteractions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/P2PInteractions.cs
@@ -2,57 +2,62 @@
 
 
 /// <summary>
-	/// Player 2 Player interactions. Also used for clicking on yourself
-	/// </summary>
-	public class P2PInteractions : InputTrigger
-	{
-		public override void Interact(GameObject originator, Vector3 position, string hand)
-		{
-			if(UIManager.Hands.CurrentSlot.Item != null){
-				//Is the item edible?
-				if(CheckEdible(UIManager.Hands.CurrentSlot.Item)){
-					return;
-				}
-
-				//Is it a weapon/ballistic or specific hand to hand melee combat with weapons?
-				if(CheckWeapon(UIManager.Hands.CurrentSlot.Item)){
-					return;
-				}
-			}
-		}
-
-		private bool CheckEdible(GameObject itemInHand)
-		{
-			FoodBehaviour baseFood = itemInHand.GetComponent<FoodBehaviour>();
-			if (baseFood == null || UIManager.CurrentIntent == Intent.Attack){
-				return false;
-			} 
-
-			if(PlayerManager.LocalPlayer == gameObject){
-				//Clicked on yourself, try to eat the food
-				baseFood.TryEat();
-			} else {
-				//Clicked on someone else
-				//TODO create a new method on FoodBehaviour for feeding others
-				//and use that here
-			}
-			return true;
-		}
-
-		private bool CheckWeapon(GameObject itemInHand){
-			Weapon weapon = itemInHand.GetComponent<Weapon>();
-			if(weapon == null){
-				return false;
+/// Player 2 Player interactions. Also used for clicking on yourself
+/// </summary>
+public class P2PInteractions : InputTrigger {
+	public override void Interact(GameObject originator, Vector3 position, string hand) {
+		if (UIManager.Hands.CurrentSlot.Item != null) {
+			//Is the item edible?
+			if (CheckEdible(UIManager.Hands.CurrentSlot.Item)) {
+				return;
 			}
 
-			if (PlayerManager.LocalPlayer == gameObject) {
-				//You no longer have the desire to live
-				weapon.AttemptSuicideShot();
-			} else {
-				//Someone else
-				//TODO any hand to hand specifics or intent based fighting here
-				weapon.Trigger();
+			//Is it a weapon/ballistic or specific hand to hand melee combat with weapons?
+			if (CheckWeapon(UIManager.Hands.CurrentSlot.Item, false)) {
+				return;
 			}
-			return true;
 		}
 	}
+
+	public override void DragInteract(GameObject originator, Vector3 position, string hand) {
+		if (UIManager.Hands.CurrentSlot.Item != null) {
+			//while dragging, can still be firing an automatic
+			if (CheckWeapon(UIManager.Hands.CurrentSlot.Item, true)) {
+				return;
+			}
+		}
+	}
+
+	private bool CheckEdible(GameObject itemInHand) {
+		FoodBehaviour baseFood = itemInHand.GetComponent<FoodBehaviour>();
+		if (baseFood == null || UIManager.CurrentIntent == Intent.Attack) {
+			return false;
+		}
+
+		if (PlayerManager.LocalPlayer == gameObject) {
+			//Clicked on yourself, try to eat the food
+			baseFood.TryEat();
+		} else {
+			//Clicked on someone else
+			//TODO create a new method on FoodBehaviour for feeding others
+			//and use that here
+		}
+		return true;
+	}
+
+	private bool CheckWeapon(GameObject itemInHand, bool isDrag) {
+		Weapon weapon = itemInHand.GetComponent<Weapon>();
+		if (weapon == null) {
+			return false;
+		}
+
+		if (PlayerManager.LocalPlayer == gameObject) {
+			//suicide
+			weapon.AttemptSuicideShot();
+		} else {
+			weapon.Trigger();
+		}
+		
+		return true;
+	}
+}

--- a/UnityProject/Assets/Scripts/PlayGroups/P2PInteractions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/P2PInteractions.cs
@@ -4,40 +4,57 @@
 /// <summary>
 /// Player 2 Player interactions. Also used for clicking on yourself
 /// </summary>
-public class P2PInteractions : InputTrigger {
-	public override void Interact(GameObject originator, Vector3 position, string hand) {
-		if (UIManager.Hands.CurrentSlot.Item != null) {
+public class P2PInteractions : InputTrigger
+{
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
+	{
+		if (UIManager.Hands.CurrentSlot.Item != null)
+		{
 			//Is the item edible?
-			if (CheckEdible(UIManager.Hands.CurrentSlot.Item)) {
-				return;
+			if (CheckEdible(UIManager.Hands.CurrentSlot.Item))
+			{
+				return true;
 			}
 
 			//Is it a weapon/ballistic or specific hand to hand melee combat with weapons?
-			if (CheckWeapon(UIManager.Hands.CurrentSlot.Item, false)) {
-				return;
+			if (CheckWeapon(UIManager.Hands.CurrentSlot.Item, false))
+			{
+				return true;
 			}
 		}
+
+		return true;
 	}
 
-	public override void DragInteract(GameObject originator, Vector3 position, string hand) {
-		if (UIManager.Hands.CurrentSlot.Item != null) {
+	public override bool DragInteract(GameObject originator, Vector3 position, string hand)
+	{
+		if (UIManager.Hands.CurrentSlot.Item != null)
+		{
 			//while dragging, can still be firing an automatic
-			if (CheckWeapon(UIManager.Hands.CurrentSlot.Item, true)) {
-				return;
+			if (CheckWeapon(UIManager.Hands.CurrentSlot.Item, true))
+			{
+				return true;
 			}
 		}
+
+		return false;
 	}
 
-	private bool CheckEdible(GameObject itemInHand) {
+	private bool CheckEdible(GameObject itemInHand)
+	{
 		FoodBehaviour baseFood = itemInHand.GetComponent<FoodBehaviour>();
-		if (baseFood == null || UIManager.CurrentIntent == Intent.Attack) {
+		if (baseFood == null || UIManager.CurrentIntent == Intent.Attack)
+		{
 			return false;
 		}
 
-		if (PlayerManager.LocalPlayer == gameObject) {
+		if (PlayerManager.LocalPlayer == gameObject)
+		{
 			//Clicked on yourself, try to eat the food
 			baseFood.TryEat();
-		} else {
+		}
+		else
+		{
 			//Clicked on someone else
 			//TODO create a new method on FoodBehaviour for feeding others
 			//and use that here
@@ -45,19 +62,22 @@ public class P2PInteractions : InputTrigger {
 		return true;
 	}
 
-	private bool CheckWeapon(GameObject itemInHand, bool isDrag) {
+	private bool CheckWeapon(GameObject itemInHand, bool isDrag)
+	{
 		Weapon weapon = itemInHand.GetComponent<Weapon>();
-		if (weapon == null) {
+		if (weapon == null)
+		{
 			return false;
 		}
 
-		if (PlayerManager.LocalPlayer == gameObject) {
+		if (PlayerManager.LocalPlayer == gameObject)
+		{
 			//suicide
-			weapon.AttemptSuicideShot();
-		} else {
-			weapon.Trigger();
+			return weapon.AttemptSuicideShot();
 		}
-		
-		return true;
+		else
+		{
+			return weapon.Trigger();
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
@@ -117,6 +117,15 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		return true;
 	}
 
+	/// <summary>
+	/// Get the item in the player's active hand
+	/// </summary>
+	/// <returns>the gameobject item in the player's active hand, null if nothing in active hand</returns>
+	public GameObject GetActiveHandItem()
+	{
+		return Inventory[activeHand].Item;
+	}
+
 	private void PlaceInHand(GameObject item)
 	{
 		UIManager.Hands.CurrentSlot.SetItem(item);

--- a/UnityProject/Assets/Scripts/Switches/DoorSwitchTrigger.cs
+++ b/UnityProject/Assets/Scripts/Switches/DoorSwitchTrigger.cs
@@ -22,14 +22,14 @@ public class DoorSwitchTrigger : InputTrigger
 		base.OnStartClient();
 	}
 
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		if (!isServer)
 		{
 			if (!PlayerManager.LocalPlayerScript.IsInReach(spriteRenderer.transform.position, 1.2f) ||
 				PlayerManager.LocalPlayerScript.playerMove.isGhost)
 			{
-				return;
+				return true;
 			}
 
 			//if the button is idle and not animating it can be pressed
@@ -44,7 +44,7 @@ public class DoorSwitchTrigger : InputTrigger
 			if (!ps.IsInReach(spriteRenderer.transform.position, 1.2f) ||
 				ps.playerMove.isGhost)
 			{
-				return;
+				return true;
 			}
 			for (int i = 0; i < doorControllers.Length; i++)
 			{
@@ -55,6 +55,8 @@ public class DoorSwitchTrigger : InputTrigger
 			}
 			RpcPlayButtonAnim();
 		}
+
+		return true;
 	}
 
 	[ClientRpc]

--- a/UnityProject/Assets/Scripts/Switches/ShutterSwitchTrigger.cs
+++ b/UnityProject/Assets/Scripts/Switches/ShutterSwitchTrigger.cs
@@ -29,12 +29,12 @@ public class ShutterSwitchTrigger : InputTrigger
 		SyncShutters(IsClosed);
 	}
 
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		if (!PlayerManager.LocalPlayerScript.IsInReach(transform.position, 1.5f) ||
 		    PlayerManager.LocalPlayerScript.playerMove.isGhost)
 		{
-			return;
+			return true;
 		}
 
 		//if the button is idle and not animating it can be pressed
@@ -47,6 +47,8 @@ public class ShutterSwitchTrigger : InputTrigger
 		{
 			Logger.Log("DOOR NOT FINISHED CLOSING YET!", Category.Shutters); 
 		}
+
+		return true;
 	}
 
 	private void SyncShutters(bool isClosed)

--- a/UnityProject/Assets/Scripts/UI/UITileListItem.cs
+++ b/UnityProject/Assets/Scripts/UI/UITileListItem.cs
@@ -57,7 +57,7 @@ public class UITileListItem : MonoBehaviour
 			return;
 		}
 		//Interact with item. In case we picked up the item, it should no longer be on the list
-		if (PlayerManager.LocalPlayerScript.inputController.Interact(item.transform))
+		if (PlayerManager.LocalPlayerScript.inputController.Interact(item.transform, false))
 		{
 			UITileList.RemoveTileListItem(transform.gameObject);
 		}

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
@@ -77,7 +77,7 @@ public abstract class BulletBehaviour : MonoBehaviour
 		{
 			return;
 		}
-		damageable.ApplyDamage(shooter, damage, damageType, bodyAim.Randomize());
+		damageable.ApplyDamage(shooter, damage, damageType, isSuicide ? bodyAim : bodyAim.Randomize());
 		Logger.LogTraceFormat("Hit {0} for {1} with HealthBehaviour! bullet absorbed", Category.Firearms, damageable.gameObject.name, damage);
 		ReturnToPool();
 	}

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
@@ -5,6 +5,7 @@ public abstract class BulletBehaviour : MonoBehaviour
 	private BodyPartType bodyAim;
 	public int damage = 25;
 	private GameObject shooter;
+	private Weapon weapon;
 	public DamageType damageType;
 	private bool isSuicide = false;
 
@@ -20,9 +21,10 @@ public abstract class BulletBehaviour : MonoBehaviour
 	/// </summary>
 	/// <param name="controlledByPlayer">player doing the shooting</param>
 	/// <param name="targetZone">body part being targeted</param>
-	public void Suicide(GameObject controlledByPlayer, BodyPartType targetZone = BodyPartType.CHEST) {
+	/// <param name="fromWeapon">Weapon the shot is being fired from</param>
+	public void Suicide(GameObject controlledByPlayer, Weapon fromWeapon, BodyPartType targetZone = BodyPartType.CHEST) {
 		isSuicide = true;
-		StartShoot(Vector2.zero, 0, controlledByPlayer, targetZone);
+		StartShoot(Vector2.zero, 0, controlledByPlayer, fromWeapon, targetZone);
 		OnShoot();
 	}
 
@@ -33,15 +35,17 @@ public abstract class BulletBehaviour : MonoBehaviour
 	/// <param name="angle"></param>
 	/// <param name="controlledByPlayer"></param>
 	/// <param name="targetZone"></param>
-	public void Shoot(Vector2 dir, float angle, GameObject controlledByPlayer, BodyPartType targetZone = BodyPartType.CHEST)
+	/// <param name="fromWeapon">Weapon the shot is being fired from</param>
+	public void Shoot(Vector2 dir, float angle, GameObject controlledByPlayer, Weapon fromWeapon, BodyPartType targetZone = BodyPartType.CHEST)
 	{
 		isSuicide = false;
-		StartShoot(dir, angle, controlledByPlayer, targetZone);
+		StartShoot(dir, angle, controlledByPlayer, fromWeapon, targetZone);
 		OnShoot();
 	}
 
-	private void StartShoot(Vector2 dir, float angle, GameObject controlledByPlayer, BodyPartType targetZone)
+	private void StartShoot(Vector2 dir, float angle, GameObject controlledByPlayer, Weapon fromWeapon, BodyPartType targetZone)
 	{
+		weapon = fromWeapon;
 		Direction = dir;
 		bodyAim = targetZone;
 		shooter = controlledByPlayer;
@@ -77,7 +81,9 @@ public abstract class BulletBehaviour : MonoBehaviour
 		{
 			return;
 		}
-		damageable.ApplyDamage(shooter, damage, damageType, isSuicide ? bodyAim : bodyAim.Randomize());
+		var aim = isSuicide ? bodyAim : bodyAim.Randomize();
+		damageable.ApplyDamage(shooter, damage, damageType, aim);
+		PostToChatMessage.SendItemAttackMessage(weapon.gameObject, shooter, coll.gameObject, damage, aim);
 		Logger.LogTraceFormat("Hit {0} for {1} with HealthBehaviour! bullet absorbed", Category.Firearms, damageable.gameObject.name, damage);
 		ReturnToPool();
 	}

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
@@ -57,6 +57,10 @@ public abstract class BulletBehaviour : MonoBehaviour
 
 	private void OnCollisionEnter2D(Collision2D coll)
 	{
+		if (coll.gameObject == shooter && !isSuicide)
+		{
+			return;
+		}
 		ReturnToPool();
 	}
 

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
@@ -4,9 +4,9 @@ public abstract class BulletBehaviour : MonoBehaviour
 {
 	private BodyPartType bodyAim;
 	public int damage = 25;
-	public GameObject shooter;
+	private GameObject shooter;
 	public DamageType damageType;
-	public bool isSuicide = false;
+	private bool isSuicide = false;
 
 	public TrailRenderer trail;
 
@@ -15,8 +15,27 @@ public abstract class BulletBehaviour : MonoBehaviour
 
 	public Vector2 Direction { get; private set; }
 
+	/// <summary>
+	/// Shoot the controlledByPlayer
+	/// </summary>
+	/// <param name="controlledByPlayer">player doing the shooting</param>
+	/// <param name="targetZone">body part being targeted</param>
+	public void Suicide(GameObject controlledByPlayer, BodyPartType targetZone = BodyPartType.CHEST) {
+		isSuicide = true;
+		StartShoot(Vector2.zero, 0, controlledByPlayer, targetZone);
+		OnShoot();
+	}
+
+	/// <summary>
+	/// Shoot in a direction
+	/// </summary>
+	/// <param name="dir"></param>
+	/// <param name="angle"></param>
+	/// <param name="controlledByPlayer"></param>
+	/// <param name="targetZone"></param>
 	public void Shoot(Vector2 dir, float angle, GameObject controlledByPlayer, BodyPartType targetZone = BodyPartType.CHEST)
 	{
+		isSuicide = false;
 		StartShoot(dir, angle, controlledByPlayer, targetZone);
 		OnShoot();
 	}

--- a/UnityProject/Assets/Scripts/Weapons/Weapon.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Weapon.cs
@@ -304,10 +304,21 @@ public class Weapon : PickUpTrigger
 	/// <summary>
 	/// Shoot the weapon holder.
 	/// </summary>
+	/// <param name="isDrag">if this suicide is being attempted during a drag interaction</param>
 	/// <returns>true iff something happened</returns>
-	public bool AttemptSuicideShot()
+	public bool AttemptSuicideShot(bool isDrag)
 	{
-		return AttemptToFireWeapon(true);
+		//Only allow drag shot suicide if we've already started a burst
+		if (isDrag && InAutomaticAction && FireCountDown <= 0)
+		{
+			return AttemptToFireWeapon(true);
+		}
+		else if (!isDrag)
+		{
+			return AttemptToFireWeapon(true);
+		}
+
+		return false;
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Weapons/Weapon.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Weapon.cs
@@ -5,505 +5,467 @@ using UnityEngine.Networking;
 
 
 /// <summary>
-	///     Generic weapon types
+///     Generic weapon types
+/// </summary>
+public enum WeaponType {
+	Melee, //TODO: SUPPORT MELEE WEAPONS
+	SemiAutomatic,
+	FullyAutomatic,
+	Burst //TODO: SUPPORT BURST WEAPONS
+}
+
+/// <summary>
+///     Generic weapon base
+/// </summary>
+public class Weapon : PickUpTrigger {
+	/// <summary>
+	///     The type of ammo this weapon will allow, this is a string and not an enum for diversity
 	/// </summary>
-	public enum WeaponType
-	{
-		Melee, //TODO: SUPPORT MELEE WEAPONS
-		SemiAutomatic,
-		FullyAutomatic,
-		Burst //TODO: SUPPORT BURST WEAPONS
+	public string AmmoType;
+
+	[SyncVar] public NetworkInstanceId ControlledByPlayer;
+
+	/// <summary>
+	///     The current magazine for this weapon, null means empty
+	/// </summary>
+	public MagazineBehaviour CurrentMagazine { get; private set; }
+
+	/// <summary>
+	///     Checks if the weapon should spawn weapon casings
+	/// </summary>
+	public bool SpawnsCaseing = true;
+
+	/// <summary>
+	///     The the current recoil variance this weapon has reached
+	/// </summary>
+	[SyncVar] [HideInInspector] public float CurrentRecoilVariance;
+
+	/// <summary>
+	///     The countdown untill we can shoot again
+	/// </summary>
+	[HideInInspector] public double FireCountDown;
+
+	/// <summary>
+	///     The the name of the sound this gun makes when shooting
+	/// </summary>
+	public string FireingSound;
+
+	/// <summary>
+	///     The amount of times per second this weapon can fire
+	/// </summary>
+	public double FireRate;
+
+	/// <summary>
+	///     If the weapon is currently in automatic action
+	/// </summary>
+	private bool InAutomaticAction;
+	/// <summary>
+	/// If the automatic action is for a suicide
+	/// </summary>
+	private bool InAutomaticSuicideAction;
+
+
+	[SyncVar(hook = nameof(LoadUnloadAmmo))] public NetworkInstanceId MagNetID;
+
+	//TODO connect these with the actual shooting of a projectile
+	/// <summary>
+	///     The max recoil angle this weapon can reach with sustained fire
+	/// </summary>
+	public float MaxRecoilVariance;
+
+	/// <summary>
+	///     The projectile fired from this weapon
+	/// </summary>
+	public GameObject Projectile;
+
+	/// <summary>
+	///     The damage for this weapon
+	/// </summary>
+	public int ProjectileDamage;
+
+	/// <summary>
+	///     The amount of projectiles expended per shot
+	/// </summary>
+	public int ProjectilesFired;
+
+	/// <summary>
+	///     The traveling speed for this weapons projectile
+	/// </summary>
+	public int ProjectileVelocity;
+
+	/// <summary>
+	///     Current Weapon Type
+	/// </summary>
+	public WeaponType WeaponType;
+
+	private GameObject casingPrefab;
+
+	private void Start() {
+		InAutomaticAction = false;
+		//init weapon with missing settings
+		if (AmmoType == null) {
+			AmmoType = "12mm";
+		}
+		if (Projectile == null) {
+			Projectile = Resources.Load("Bullet_12mm") as GameObject;
+		}
+	}
+
+	private void Update() {
+		if (ControlledByPlayer == NetworkInstanceId.Invalid) {
+			return;
+		}
+
+		//don't start it too early:
+		if (!PlayerManager.LocalPlayer) {
+			return;
+		}
+
+		//Only update if it is inhand of localplayer
+		if (PlayerManager.LocalPlayer != ClientScene.FindLocalObject(ControlledByPlayer)) {
+			return;
+		}
+
+		if (FireCountDown > 0) {
+			FireCountDown -= Time.deltaTime;
+			//prevents the next projectile taking miliseconds longer than it should
+			if (FireCountDown < 0) {
+				FireCountDown = 0;
+			}
+		}
+
+		//Check if magazine in opposite hand or if unloading
+		if (Input.GetKeyDown(KeyCode.R) && !UIManager.IsInputFocus) {
+			//PlaceHolder for click UI
+			GameObject currentHandItem = UIManager.Hands.CurrentSlot.Item;
+			GameObject otherHandItem = UIManager.Hands.OtherSlot.Item;
+			string hand;
+
+			if ((currentHandItem != null) && (otherHandItem != null)) {
+				if (CurrentMagazine == null) {
+					//RELOAD
+					if (currentHandItem.GetComponent<MagazineBehaviour>() && otherHandItem.GetComponent<Weapon>()) {
+						string ammoType = currentHandItem.GetComponent<MagazineBehaviour>().ammoType;
+
+						if (AmmoType == ammoType) {
+							hand = UIManager.Hands.CurrentSlot.eventName;
+							Reload(currentHandItem, hand, true);
+
+						}
+
+						if (AmmoType != ammoType) {
+							ChatRelay.Instance.AddToChatLogClient("You try to load the wrong ammo into your weapon", ChatChannel.Examine);
+						}
+					}
+
+					if (otherHandItem.GetComponent<MagazineBehaviour>() && currentHandItem.GetComponent<Weapon>()) {
+						string ammoType = otherHandItem.GetComponent<MagazineBehaviour>().ammoType;
+
+						if (AmmoType == ammoType) {
+							hand = UIManager.Hands.OtherSlot.eventName;
+							Reload(otherHandItem, hand, false);
+						}
+						if (AmmoType != ammoType) {
+							ChatRelay.Instance.AddToChatLogClient("You try to load the wrong ammo into your weapon", ChatChannel.Examine);
+						}
+					}
+
+
+				} else {
+					//UNLOAD
+
+					if (currentHandItem.GetComponent<Weapon>() && otherHandItem == null) {
+						ManualUnload(CurrentMagazine);
+					} else if (currentHandItem.GetComponent<Weapon>() && otherHandItem.GetComponent<MagazineBehaviour>()) {
+						ChatRelay.Instance.AddToChatLogClient("You weapon is already loaded, you cant fit more Magazines in it, silly!", ChatChannel.Examine);
+
+					} else if (otherHandItem.GetComponent<Weapon>() && currentHandItem.GetComponent<MagazineBehaviour>()) {
+						ChatRelay.Instance.AddToChatLogClient("You weapon is already loaded, you cant fit more Magazines in it, silly!", ChatChannel.Examine);
+
+					}
+				}
+			}
+		}
+
+		if (Input.GetMouseButtonUp(0)) {
+			InAutomaticAction = false;
+
+			//remove recoil after shooting is released
+			CurrentRecoilVariance = 0;
+		}
+
+		if (InAutomaticAction && FireCountDown <= 0) {
+			AttemptToFireWeapon(InAutomaticSuicideAction);
+		}
+	}
+
+	//Do all the weapon init for connecting clients
+	public override void OnStartClient() {
+		StartCoroutine(WaitForLoad());
+		base.OnStartClient();
+	}
+
+	private IEnumerator WaitForLoad() {
+		while (MagNetID == NetworkInstanceId.Invalid) {
+			yield return YieldHelper.EndOfFrame;
+		}
+		yield return YieldHelper.EndOfFrame;
+		LoadUnloadAmmo(MagNetID);
+	}
+
+	#region Weapon Server Init
+
+	public override void OnStartServer() {
+		GameObject ammoPrefab = Resources.Load("Rifles/Magazine_" + AmmoType) as GameObject;
+
+		GameObject m = ItemFactory.SpawnItem(ammoPrefab, transform.parent);
+		var cnt = m.GetComponent<CustomNetTransform>();
+		cnt.DisappearFromWorldServer();
+
+		StartCoroutine(SetMagazineOnStart(m));
+
+		base.OnStartServer();
+	}
+
+	//Gives it a chance for weaponNetworkActions to init
+	private IEnumerator SetMagazineOnStart(GameObject magazine) {
+		yield return new WaitForSeconds(2f);
+		//			if (GameData.IsHeadlessServer || GameData.Instance.testServer) {
+		NetworkInstanceId networkID = magazine.GetComponent<NetworkIdentity>().netId;
+		MagNetID = networkID;
+		//			} else {
+		//				PlayerManager.LocalPlayerScript.weaponNetworkActions.CmdLoadMagazine(gameObject, magazine);
+		//			}
+	}
+
+	#endregion
+
+	#region Weapon Firing Mechanism
+
+	public override void Interact(GameObject originator, Vector3 position, string hand) {
+		//Currently this method is only invoked in these cases:
+		//1) We are currently doing a burst of automatic fire and are on the 2nd or later shot, OR
+		//2) We are shooting by clicking on empty space rather than directly on ourselves or a player
+
+		//todo: validate fire attempts on server
+		//shoot gun interation if its in hand
+		if (gameObject == UIManager.Hands.CurrentSlot.Item) {
+			//it will only be a suicide shot if we are bursting automatic fire on ourselves.
+			AttemptToFireWeapon(InAutomaticSuicideAction && InAutomaticAction);
+		}
+		//if the weapon is not in our hands not in hands, pick it up
+		else {
+			base.Interact(originator, position, hand);
+		}
 	}
 
 	/// <summary>
-	///     Generic weapon base
+	/// Attempt a suicide shot, targeting the holder of the weapon. Assumes that weapon is already in current hand.
 	/// </summary>
-	public class Weapon : PickUpTrigger
-	{
-		/// <summary>
-		///     The type of ammo this weapon will allow, this is a string and not an enum for diversity
-		/// </summary>
-		public string AmmoType;
+	public void AttemptSuicideShot() {
+		AttemptToFireWeapon(true);
+	}
 
-		[SyncVar] public NetworkInstanceId ControlledByPlayer;
+	/// <summary>
+	/// Attempt to fire a single shot of the weapon (this is called once per bullet for a burst of automatic fire)
+	/// </summary>
+	/// <param name="suicideShot">if the shot should be a suicide shot, striking the weapon holder</param>
+	private void AttemptToFireWeapon(bool suicideShot) {
+		//ignore if we are hovering over UI
+		if (EventSystem.current.IsPointerOverGameObject()) {
+			return;
+		}
 
-		/// <summary>
-		///     The current magazine for this weapon, null means empty
-		/// </summary>
-		public MagazineBehaviour CurrentMagazine {get; private set;}
-
-		/// <summary>
-		///     Checks if the weapon should spawn weapon casings
-		/// </summary>
-		public bool SpawnsCaseing = true;
-
-		/// <summary>
-		///     The the current recoil variance this weapon has reached
-		/// </summary>
-		[SyncVar] [HideInInspector] public float CurrentRecoilVariance;
-
-		/// <summary>
-		///     The countdown untill we can shoot again
-		/// </summary>
-		[HideInInspector] public double FireCountDown;
-
-		/// <summary>
-		///     The the name of the sound this gun makes when shooting
-		/// </summary>
-		public string FireingSound;
-
-		/// <summary>
-		///     The amount of times per second this weapon can fire
-		/// </summary>
-		public double FireRate;
-
-		/// <summary>
-		///     If the weapon is currently in automatic action
-		/// </summary>
-		[HideInInspector] public bool InAutomaticAction;
-
-		[SyncVar(hook = nameof(LoadUnloadAmmo))] public NetworkInstanceId MagNetID;
-
-		//TODO connect these with the actual shooting of a projectile
-		/// <summary>
-		///     The max recoil angle this weapon can reach with sustained fire
-		/// </summary>
-		public float MaxRecoilVariance;
-
-		/// <summary>
-		///     The projectile fired from this weapon
-		/// </summary>
-		public GameObject Projectile;
-
-		/// <summary>
-		///     The damage for this weapon
-		/// </summary>
-		public int ProjectileDamage;
-
-		/// <summary>
-		///     The amount of projectiles expended per shot
-		/// </summary>
-		public int ProjectilesFired;
-
-		/// <summary>
-		///     The traveling speed for this weapons projectile
-		/// </summary>
-		public int ProjectileVelocity;
-
-		/// <summary>
-		///     Current Weapon Type
-		/// </summary>
-		public WeaponType WeaponType;
-
-		private GameObject casingPrefab;
-
-		private void Start()
-		{
+		//if we have no mag/clip loaded play empty sound
+		if (CurrentMagazine == null) {
 			InAutomaticAction = false;
-			//init weapon with missing settings
-			if (AmmoType == null)
-			{
-				AmmoType = "12mm";
-			}
-			if (Projectile == null)
-			{
-				Projectile = Resources.Load("Bullet_12mm") as GameObject;
-			}
+			PlayEmptySFX();
 		}
+		//if we are out of ammo for this weapon eject magazine and play out of ammo sfx
+		else if (Projectile != null && CurrentMagazine.ammoRemains <= 0 && FireCountDown <= 0) {
+			InAutomaticAction = false;
+			ManualUnload(CurrentMagazine);
+			OutOfAmmoSFX();
+		} else {
+			//if we have a projectile to shoot, we have ammo and we are not waiting to be allowed to shoot again, Fire!
+			if (Projectile != null && CurrentMagazine.ammoRemains > 0 && FireCountDown <= 0) {
+				//Add too the cooldown timer to being allowed to shoot again
+				FireCountDown += 1.0 / FireRate;
+				//fire a single round if its a semi or automatic weapon
+				if (WeaponType == WeaponType.SemiAutomatic || WeaponType == WeaponType.FullyAutomatic) {
+					Vector2 dir = (Camera.main.ScreenToWorldPoint(Input.mousePosition) - PlayerManager.LocalPlayer.transform.position).normalized;
 
-		private void Update()
-		{
-			if (ControlledByPlayer == NetworkInstanceId.Invalid)
-			{
-				return;
-			}
-
-			//don't start it too early:
-			if (!PlayerManager.LocalPlayer)
-			{
-				return;
-			}
-
-			//Only update if it is inhand of localplayer
-			if (PlayerManager.LocalPlayer != ClientScene.FindLocalObject(ControlledByPlayer))
-			{
-				return;
-			}
-
-			if (FireCountDown > 0)
-			{
-				FireCountDown -= Time.deltaTime;
-				//prevents the next projectile taking miliseconds longer than it should
-				if (FireCountDown < 0)
-				{
-					FireCountDown = 0;
-				}
-			}
-
-			//Check if magazine in opposite hand or if unloading
-			if (Input.GetKeyDown(KeyCode.R) && !UIManager.IsInputFocus)
-			{
-				//PlaceHolder for click UI
-				GameObject currentHandItem = UIManager.Hands.CurrentSlot.Item;
-				GameObject otherHandItem = UIManager.Hands.OtherSlot.Item;
-				string hand;
-
-				if ((currentHandItem != null) && (otherHandItem != null))
-				{
-					if (CurrentMagazine == null)
-					{
-						//RELOAD
-						if (currentHandItem.GetComponent<MagazineBehaviour>() && otherHandItem.GetComponent<Weapon>())
-						{
-							string ammoType = currentHandItem.GetComponent<MagazineBehaviour>().ammoType;
-
-							if (AmmoType == ammoType)
-							{
-								hand = UIManager.Hands.CurrentSlot.eventName;
-								Reload(currentHandItem, hand, true);
-
-							}
-
-							if (AmmoType != ammoType)
-							{
-								ChatRelay.Instance.AddToChatLogClient( "You try to load the wrong ammo into your weapon", ChatChannel.Examine );
-							}
-						}
-
-						if (otherHandItem.GetComponent<MagazineBehaviour>() && currentHandItem.GetComponent<Weapon>())
-						{
-							string ammoType = otherHandItem.GetComponent<MagazineBehaviour>().ammoType;
-
-							if (AmmoType == ammoType)
-							{
-								hand = UIManager.Hands.OtherSlot.eventName;
-								Reload(otherHandItem, hand, false);
-							}
-							if (AmmoType != ammoType)
-							{
-								ChatRelay.Instance.AddToChatLogClient( "You try to load the wrong ammo into your weapon", ChatChannel.Examine );
-							}
-						}
-
-
+					RequestShootMessage.Send(gameObject, dir, Projectile.name, UIManager.DamageZone, suicideShot, PlayerManager.LocalPlayer);
+					if (!isServer) {
+						//Prediction (client bullets don't do any damage)
+						Shoot(PlayerManager.LocalPlayer, dir, Projectile.name, UIManager.DamageZone, suicideShot);
 					}
-					else
-					{
-						//UNLOAD
 
-						if (currentHandItem.GetComponent<Weapon>() && otherHandItem == null)
-						{
-							ManualUnload(CurrentMagazine);
-						}
-
-						else if (currentHandItem.GetComponent<Weapon>() && otherHandItem.GetComponent<MagazineBehaviour>())
-						{
-							ChatRelay.Instance.AddToChatLogClient("You weapon is already loaded, you cant fit more Magazines in it, silly!", ChatChannel.Examine);
-
-						}
-						else if (otherHandItem.GetComponent<Weapon>() && currentHandItem.GetComponent<MagazineBehaviour>())
-						{
-							ChatRelay.Instance.AddToChatLogClient("You weapon is already loaded, you cant fit more Magazines in it, silly!", ChatChannel.Examine);
-
-						}
+					if (WeaponType == WeaponType.FullyAutomatic) {
+						PlayerManager.LocalPlayerScript.inputController.OnMouseDownDir(dir);
 					}
 				}
-			}
 
-			if (Input.GetMouseButtonUp(0))
-			{
-				InAutomaticAction = false;
-
-				//remove recoil after shooting is released
-				CurrentRecoilVariance = 0;
-			}
-
-			if (InAutomaticAction && FireCountDown <= 0)
-			{
-				AttemptToFireWeapon();
-			}
-		}
-
-		//Do all the weapon init for connecting clients
-		public override void OnStartClient()
-		{
-			StartCoroutine(WaitForLoad());
-			base.OnStartClient();
-		}
-
-		private IEnumerator WaitForLoad()
-		{
-			while(MagNetID == NetworkInstanceId.Invalid){
-				yield return YieldHelper.EndOfFrame;
-			}
-			yield return YieldHelper.EndOfFrame;
-			LoadUnloadAmmo(MagNetID);
-		}
-
-		#region Weapon Server Init
-
-		public override void OnStartServer()
-		{
-			GameObject ammoPrefab = Resources.Load("Rifles/Magazine_" + AmmoType)  as GameObject;
-
-			GameObject m = ItemFactory.SpawnItem(ammoPrefab, transform.parent);
-			var cnt = m.GetComponent<CustomNetTransform>();
-			cnt.DisappearFromWorldServer();
-
-			StartCoroutine(SetMagazineOnStart(m));
-
-			base.OnStartServer();
-		}
-
-		//Gives it a chance for weaponNetworkActions to init
-		private IEnumerator SetMagazineOnStart(GameObject magazine)
-		{
-			yield return new WaitForSeconds(2f);
-			//			if (GameData.IsHeadlessServer || GameData.Instance.testServer) {
-			NetworkInstanceId networkID = magazine.GetComponent<NetworkIdentity>().netId;
-			MagNetID = networkID;
-			//			} else {
-			//				PlayerManager.LocalPlayerScript.weaponNetworkActions.CmdLoadMagazine(gameObject, magazine);
-			//			}
-		}
-
-		#endregion
-
-		#region Weapon Firing Mechanism
-
-		public override void Interact(GameObject originator, Vector3 position, string hand)
-		{
-			//todo: validate fire attempts on server
-			//shoot gun interation if its in hand
-			if (gameObject == UIManager.Hands.CurrentSlot.Item)
-			{
-				AttemptToFireWeapon();
-			}
-			//if the weapon is not in our hands not in hands, pick it up
-			else
-			{
-				base.Interact(originator, position, hand);
-			}
-		}
-
-		public void AttemptSuicideShot(){
-			//Hand slot checks are already done before calling this method (i.e. is weapon in current hand)
-			AttemptToFireWeapon(true);
-		}
-
-		private void AttemptToFireWeapon(bool suicideShot = false)
-		{
-			//ignore if we are hovering over UI
-			if (EventSystem.current.IsPointerOverGameObject())
-			{
-				return;
-			}
-
-			//if we have no mag/clip loaded play empty sound
-			if (CurrentMagazine == null)
-			{
-				InAutomaticAction = false;
-				PlayEmptySFX();
-			}
-			//if we are out of ammo for this weapon eject magazine and play out of ammo sfx
-			else if (Projectile != null && CurrentMagazine.ammoRemains <= 0 && FireCountDown <= 0)
-			{
-				InAutomaticAction = false;
-				ManualUnload(CurrentMagazine);
-				OutOfAmmoSFX();
-			}
-			else
-			{	
-				//if we have a projectile to shoot, we have ammo and we are not waiting to be allowed to shoot again, Fire!
-				if (Projectile != null && CurrentMagazine.ammoRemains > 0 && FireCountDown <= 0)
-				{
-					//Add too the cooldown timer to being allowed to shoot again
-					FireCountDown += 1.0 / FireRate;
-					//fire a single round if its a semi or automatic weapon
-					if (WeaponType == WeaponType.SemiAutomatic || WeaponType == WeaponType.FullyAutomatic)
-					{
-						Vector2 dir = (Camera.main.ScreenToWorldPoint(Input.mousePosition) - PlayerManager.LocalPlayer.transform.position).normalized;
-
-						RequestShootMessage.Send(gameObject, dir, Projectile.name, UIManager.DamageZone, suicideShot, PlayerManager.LocalPlayer);
-						if (!isServer) {
-							//Prediction (client bullets don't do any damage)
-							Shoot(PlayerManager.LocalPlayer, dir, Projectile.name, UIManager.DamageZone, suicideShot);
-						}
-
-						if (WeaponType == WeaponType.FullyAutomatic)
-						{
-							PlayerManager.LocalPlayerScript.inputController.OnMouseDownDir(dir);
-						}
-					}
-
-					if (WeaponType == WeaponType.FullyAutomatic)
-					{
-						InAutomaticAction = true;
-					}
+				if (WeaponType == WeaponType.FullyAutomatic) {
+					InAutomaticAction = true;
+					InAutomaticSuicideAction = suicideShot;
 				}
 			}
 		}
+	}
 
-		[Server]
-		public void ServerShoot(GameObject shotBy, Vector2 direction, string bulletName,
-		                        BodyPartType damageZone, bool isSuicideShot){
-			PlayerMove shooter = shotBy.GetComponent<PlayerMove>();
-			if(!shooter.allowInput || shooter.isGhost){
-				return;
-			}
+	[Server]
+	public void ServerShoot(GameObject shotBy, Vector2 direction, string bulletName,
+							BodyPartType damageZone, bool isSuicideShot) {
+		PlayerMove shooter = shotBy.GetComponent<PlayerMove>();
+		if (!shooter.allowInput || shooter.isGhost) {
+			return;
+		}
 
-			Shoot(shotBy, direction, bulletName, damageZone, isSuicideShot);
+		Shoot(shotBy, direction, bulletName, damageZone, isSuicideShot);
 
-			//This is used to determine where bullet shot should head towards on client
+		//This is used to determine where bullet shot should head towards on client
+		if (isSuicideShot) {
+			//no need for the bullet to travel if it's a suicide, just have it stay right where it is
+			ShootMessage.SendToAll(gameObject, shotBy.transform.position, bulletName, damageZone, shotBy);
+		} else {
 			Ray2D ray = new Ray2D(shotBy.transform.position, direction);
 			ShootMessage.SendToAll(gameObject, ray.GetPoint(30f), bulletName, damageZone, shotBy);
+		}
 
-			if (SpawnsCaseing) {
-				if(casingPrefab == null){
-					casingPrefab = Resources.Load("BulletCasing") as GameObject;
-				}
-				ItemFactory.SpawnItem(casingPrefab, shotBy.transform.position, shotBy.transform.parent);
+		if (SpawnsCaseing) {
+			if (casingPrefab == null) {
+				casingPrefab = Resources.Load("BulletCasing") as GameObject;
 			}
+			ItemFactory.SpawnItem(casingPrefab, shotBy.transform.position, shotBy.transform.parent);
 		}
-
-		//This is only for the shooters client and the server. Rest is done via msg
-		private void Shoot(GameObject shooter, Vector2 direction, string bulletName,
-								BodyPartType damageZone, bool isSuicideShot){
-			CurrentMagazine.ammoRemains--;
-			//get the bullet prefab being shot
-			GameObject bullet = PoolManager.Instance.PoolClientInstantiate(Resources.Load(bulletName) as GameObject,
-				shooter.transform.position, Quaternion.identity);
-			float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
-
-			//if we have recoil variance add it, and get the new attack angle
-			if (CurrentRecoilVariance > 0) {
-				direction = GetRecoilOffset(angle);
-			}
-
-			BulletBehaviour b = bullet.GetComponent<BulletBehaviour>();
-			b.isSuicide = isSuicideShot;
-			b.Shoot(direction, angle, shooter, damageZone);
-
-			//add additional recoil after shooting for the next round
-			AppendRecoil(angle);
-
-			SoundManager.PlayAtPosition(FireingSound, shooter.transform.position);
-		}
-
-		#endregion
-
-		#region Weapon Loading and Unloading
-
-		private void Reload(GameObject m, string hand, bool current)
-		{
-			Logger.LogTrace("Reloading", Category.Firearms);
-			PlayerManager.LocalPlayerScript.weaponNetworkActions.CmdLoadMagazine(gameObject, m, hand);
-			if (current)
-			{
-				UIManager.Hands.CurrentSlot.Clear();
-			}
-			else
-			{
-				UIManager.Hands.OtherSlot.Clear();
-			}
-
-		}
-
-		//atm unload with shortcut 'e'
-		//TODO dev right click unloading so it goes into the opposite hand if it is selected
-		private void ManualUnload(MagazineBehaviour m)
-		{
-			Logger.LogTrace("Unloading", Category.Firearms);
-			if (m != null)
-			{
-				//PlayerManager.LocalPlayerScript.playerNetworkActions.CmdDropItemNotInUISlot(m.gameObject);
-				PlayerManager.LocalPlayerScript.weaponNetworkActions.CmdUnloadWeapon(gameObject);
-			}
-		}
-
-		#endregion
-
-		#region Weapon Inventory Management
-
-		public void LoadUnloadAmmo(NetworkInstanceId magazineID)
-		{
-			//if the magazine ID is invalid remove the magazine
-			if (magazineID == NetworkInstanceId.Invalid)
-			{
-				CurrentMagazine = null;
-			}
-			else
-			{
-				//find the magazine by NetworkID
-				GameObject magazine = ClientScene.FindLocalObject(magazineID);
-				if (magazine != null)
-				{
-					MagazineBehaviour magazineBehavior = magazine.GetComponent<MagazineBehaviour>();
-					CurrentMagazine = magazineBehavior;
-					var cnt = magazine.GetComponent<CustomNetTransform>();
-					if(isServer){
-						cnt.DisappearFromWorldServer();
-					} else {
-						cnt.DisappearFromWorld();
-					}
-					Logger.LogTraceFormat("MagazineBehaviour found ok: {0}", Category.Firearms, magazineID);
-				}
-			}
-		}
-
-		#endregion
-
-		#region Weapon Pooling
-
-		//This is only called on the serverside
-		public override void OnPickUpServer(NetworkInstanceId ownerId)
-		{
-			ControlledByPlayer = ownerId;
-		}
-
-		public override void OnDropItemServer()
-		{
-			ControlledByPlayer = NetworkInstanceId.Invalid;
-		}
-
-		#endregion
-
-		#region Weapon Sounds
-
-		private void OutOfAmmoSFX()
-		{
-			PlayerManager.LocalPlayerScript.soundNetworkActions.CmdPlaySoundAtPlayerPos("OutOfAmmoAlarm");
-		}
-
-		private void PlayEmptySFX()
-		{
-			PlayerManager.LocalPlayerScript.soundNetworkActions.CmdPlaySoundAtPlayerPos("EmptyGunClick");
-		}
-
-		#endregion
-
-		#region Weapon Network Supporting Methods
-
-		private Vector2 GetRecoilOffset(float angle)
-		{
-			float angleVariance = Random.Range(-CurrentRecoilVariance, CurrentRecoilVariance);
-			float newAngle = angle * Mathf.Deg2Rad + angleVariance;
-			Vector2 vec2 = new Vector2(Mathf.Cos(newAngle), Mathf.Sin(newAngle)).normalized;
-			return vec2;
-		}
-
-		private void AppendRecoil(float angle)
-		{
-			if (CurrentRecoilVariance < MaxRecoilVariance) {
-				//get a random recoil
-				float randRecoil = Random.Range(CurrentRecoilVariance, MaxRecoilVariance);
-				CurrentRecoilVariance += randRecoil;
-				//make sure the recoil is not too high
-				if (CurrentRecoilVariance > MaxRecoilVariance) {
-					CurrentRecoilVariance = MaxRecoilVariance;
-				}
-			}
-		}
-
-		#endregion
 	}
+
+	//This is only for the shooters client and the server. Rest is done via msg
+	private void Shoot(GameObject shooter, Vector2 direction, string bulletName,
+							BodyPartType damageZone, bool isSuicideShot) {
+		CurrentMagazine.ammoRemains--;
+		//get the bullet prefab being shot
+		GameObject bullet = PoolManager.Instance.PoolClientInstantiate(Resources.Load(bulletName) as GameObject,
+			shooter.transform.position, Quaternion.identity);
+		float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
+
+		//if we have recoil variance add it, and get the new attack angle
+		if (CurrentRecoilVariance > 0) {
+			direction = GetRecoilOffset(angle);
+		}
+
+		BulletBehaviour b = bullet.GetComponent<BulletBehaviour>();
+		if (isSuicideShot) {
+			b.Suicide(shooter, damageZone);
+		} else {
+			b.Shoot(direction, angle, shooter, damageZone);
+		}
+
+
+		//add additional recoil after shooting for the next round
+		AppendRecoil(angle);
+
+		SoundManager.PlayAtPosition(FireingSound, shooter.transform.position);
+	}
+
+	#endregion
+
+	#region Weapon Loading and Unloading
+
+	private void Reload(GameObject m, string hand, bool current) {
+		Logger.LogTrace("Reloading", Category.Firearms);
+		PlayerManager.LocalPlayerScript.weaponNetworkActions.CmdLoadMagazine(gameObject, m, hand);
+		if (current) {
+			UIManager.Hands.CurrentSlot.Clear();
+		} else {
+			UIManager.Hands.OtherSlot.Clear();
+		}
+
+	}
+
+	//atm unload with shortcut 'e'
+	//TODO dev right click unloading so it goes into the opposite hand if it is selected
+	private void ManualUnload(MagazineBehaviour m) {
+		Logger.LogTrace("Unloading", Category.Firearms);
+		if (m != null) {
+			//PlayerManager.LocalPlayerScript.playerNetworkActions.CmdDropItemNotInUISlot(m.gameObject);
+			PlayerManager.LocalPlayerScript.weaponNetworkActions.CmdUnloadWeapon(gameObject);
+		}
+	}
+
+	#endregion
+
+	#region Weapon Inventory Management
+
+	public void LoadUnloadAmmo(NetworkInstanceId magazineID) {
+		//if the magazine ID is invalid remove the magazine
+		if (magazineID == NetworkInstanceId.Invalid) {
+			CurrentMagazine = null;
+		} else {
+			//find the magazine by NetworkID
+			GameObject magazine = ClientScene.FindLocalObject(magazineID);
+			if (magazine != null) {
+				MagazineBehaviour magazineBehavior = magazine.GetComponent<MagazineBehaviour>();
+				CurrentMagazine = magazineBehavior;
+				var cnt = magazine.GetComponent<CustomNetTransform>();
+				if (isServer) {
+					cnt.DisappearFromWorldServer();
+				} else {
+					cnt.DisappearFromWorld();
+				}
+				Logger.LogTraceFormat("MagazineBehaviour found ok: {0}", Category.Firearms, magazineID);
+			}
+		}
+	}
+
+	#endregion
+
+	#region Weapon Pooling
+
+	//This is only called on the serverside
+	public override void OnPickUpServer(NetworkInstanceId ownerId) {
+		ControlledByPlayer = ownerId;
+	}
+
+	public override void OnDropItemServer() {
+		ControlledByPlayer = NetworkInstanceId.Invalid;
+	}
+
+	#endregion
+
+	#region Weapon Sounds
+
+	private void OutOfAmmoSFX() {
+		PlayerManager.LocalPlayerScript.soundNetworkActions.CmdPlaySoundAtPlayerPos("OutOfAmmoAlarm");
+	}
+
+	private void PlayEmptySFX() {
+		PlayerManager.LocalPlayerScript.soundNetworkActions.CmdPlaySoundAtPlayerPos("EmptyGunClick");
+	}
+
+	#endregion
+
+	#region Weapon Network Supporting Methods
+
+	private Vector2 GetRecoilOffset(float angle) {
+		float angleVariance = Random.Range(-CurrentRecoilVariance, CurrentRecoilVariance);
+		float newAngle = angle * Mathf.Deg2Rad + angleVariance;
+		Vector2 vec2 = new Vector2(Mathf.Cos(newAngle), Mathf.Sin(newAngle)).normalized;
+		return vec2;
+	}
+
+	private void AppendRecoil(float angle) {
+		if (CurrentRecoilVariance < MaxRecoilVariance) {
+			//get a random recoil
+			float randRecoil = Random.Range(CurrentRecoilVariance, MaxRecoilVariance);
+			CurrentRecoilVariance += randRecoil;
+			//make sure the recoil is not too high
+			if (CurrentRecoilVariance > MaxRecoilVariance) {
+				CurrentRecoilVariance = MaxRecoilVariance;
+			}
+		}
+	}
+
+	#endregion
+}

--- a/UnityProject/Assets/Scripts/Weapons/Weapon.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Weapon.cs
@@ -272,53 +272,57 @@ public class Weapon : PickUpTrigger
 	/// <summary>
 	/// Occurs when shooting by clicking on empty space
 	/// </summary>
-	public override void Interact(GameObject originator, Vector3 position, string hand)
+	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		//todo: validate fire attempts on server
 		//shoot gun interation if its in hand
 		if (gameObject == UIManager.Hands.CurrentSlot.Item)
 		{
-			AttemptToFireWeapon(false);
+			return AttemptToFireWeapon(false);
 		}
 		//if the weapon is not in our hands not in hands, pick it up
 		else
 		{
-			base.Interact(originator, position, hand);
+			return base.Interact(originator, position, hand);
 		}
 	}
 
 	/// <summary>
 	/// Occurs when shooting by clicking on empty space
 	/// </summary>
-	public override void DragInteract(GameObject originator, Vector3 position, string hand)
+	public override bool DragInteract(GameObject originator, Vector3 position, string hand)
 	{
 		//continue automatic fire while dragging
 		if (InAutomaticAction && FireCountDown <= 0)
 		{
-			AttemptToFireWeapon(false);
+			return AttemptToFireWeapon(false);
 		}
+
+		return false;
 	}
 
 	/// <summary>
 	/// Shoot the weapon holder.
 	/// </summary>
-	public void AttemptSuicideShot()
+	/// <returns>true iff something happened</returns>
+	public bool AttemptSuicideShot()
 	{
-		AttemptToFireWeapon(true);
+		return AttemptToFireWeapon(true);
 	}
 
 	/// <summary>
 	/// Attempt to fire a single shot of the weapon (this is called once per bullet for a burst of automatic fire)
 	/// </summary>
 	/// <param name="isSuicide">if the shot should be a suicide shot, striking the weapon holder</param>
-	private void AttemptToFireWeapon(bool isSuicide)
+	/// <returns>true iff something happened</returns>
+	private bool AttemptToFireWeapon(bool isSuicide)
 	{
 		//suicide is not allowed in some cases.
 		isSuicide = isSuicide && AllowSuicide;
 		//ignore if we are hovering over UI
 		if (EventSystem.current.IsPointerOverGameObject())
 		{
-			return;
+			return false;
 		}
 
 		//if we have no mag/clip loaded play empty sound
@@ -326,6 +330,7 @@ public class Weapon : PickUpTrigger
 		{
 			StopAutomaticBurst();
 			PlayEmptySFX();
+			return true;
 		}
 		//if we are out of ammo for this weapon eject magazine and play out of ammo sfx
 		else if (Projectile != null && CurrentMagazine.ammoRemains <= 0 && FireCountDown <= 0)
@@ -333,6 +338,7 @@ public class Weapon : PickUpTrigger
 			StopAutomaticBurst();
 			ManualUnload(CurrentMagazine);
 			OutOfAmmoSFX();
+			return true;
 		}
 		else
 		{
@@ -368,8 +374,12 @@ public class Weapon : PickUpTrigger
 				{
 					ContinueBurst(isSuicide);
 				}
+
+				return true;
 			}
 		}
+
+		return true;
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Weapons/Weapon.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Weapon.cs
@@ -480,11 +480,11 @@ public class Weapon : PickUpTrigger
 		BulletBehaviour b = bullet.GetComponent<BulletBehaviour>();
 		if (isSuicideShot)
 		{
-			b.Suicide(shooter, damageZone);
+			b.Suicide(shooter, this, damageZone);
 		}
 		else
 		{
-			b.Shoot(direction, angle, shooter, damageZone);
+			b.Shoot(direction, angle, shooter, this, damageZone);
 		}
 
 


### PR DESCRIPTION
### Purpose
Restore the ability to shoot yourself with a gun. Also marked LaserGun.prefab with ItemType.Gun.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
This will probably change a bit once we refactor the weapon interaction logic, but the only reason this stopped working was just that the MeleeTrigger was handling it before P2PInteraction and returning true, which stops processing of further interactions. But this suicide check only happens in P2PInteraction. Checking for this special case and returning false from MeleeTrigger (gun in hand, clicking self should not be a melee action so we exit from MeleeTrigger in that case) solves this issue.
