### PR TITLE
Fixes #1406 - clean up inventory better when player disconnects

### DIFF
--- a/UnityProject/Assets/Scripts/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Equipment/Equipment.cs
@@ -5,344 +5,362 @@ using UnityEngine;
 using UnityEngine.Networking;
 
 
-	public class Equipment : NetworkBehaviour
+public class Equipment : NetworkBehaviour
+{
+	public ClothingItem[] clothingSlots;
+
+	private bool isInit;
+	private PlayerNetworkActions playerNetworkActions;
+	private PlayerScript playerScript;
+	public SyncListInt syncEquipSprites = new SyncListInt();
+
+	public NetworkIdentity networkIdentity { get; set; }
+
+	private void Start()
 	{
-		public ClothingItem[] clothingSlots;
+		networkIdentity = GetComponent<NetworkIdentity>();
+		playerNetworkActions = gameObject.GetComponent<PlayerNetworkActions>();
+		playerScript = gameObject.GetComponent<PlayerScript>();
+	}
 
-		private bool isInit;
-		private PlayerNetworkActions playerNetworkActions;
-		private PlayerScript playerScript;
-		public SyncListInt syncEquipSprites = new SyncListInt();
+	public override void OnStartServer()
+	{
+		InitEquipment();
+		base.OnStartServer();
+	}
 
-		public NetworkIdentity networkIdentity { get; set; }
+	public override void OnStartClient()
+	{
+		InitEquipment();
+		base.OnStartClient();
+	}
 
-		private void Start()
+	private void InitEquipment()
+	{
+		if (isInit)
 		{
-			networkIdentity = GetComponent<NetworkIdentity>();
-			playerNetworkActions = gameObject.GetComponent<PlayerNetworkActions>();
-			playerScript = gameObject.GetComponent<PlayerScript>();
+			return;
 		}
 
-		public override void OnStartServer()
+		syncEquipSprites.Callback = SyncSprites;
+		for (int i = 0; i < clothingSlots.Length; i++)
 		{
-			InitEquipment();
-			base.OnStartServer();
-		}
-
-		public override void OnStartClient()
-		{
-			InitEquipment();
-			base.OnStartClient();
-		}
-
-		private void InitEquipment()
-		{
-			if (isInit)
-			{
-				return;
-			}
-
-			syncEquipSprites.Callback = SyncSprites;
-			for (int i = 0; i < clothingSlots.Length; i++)
-			{
-				//All the other slots:
-				clothingSlots[i].Reference = -1;
-				if (isServer)
-				{
-					syncEquipSprites.Add(-1);
-				}
-				else
-				{
-					clothingSlots[i].Reference = syncEquipSprites[i];
-				}
-			}
-			isInit = true;
+			//All the other slots:
+			clothingSlots[i].Reference = -1;
 			if (isServer)
 			{
-				StartCoroutine(SetPlayerLoadOuts());
+				syncEquipSprites.Add(-1);
+			}
+			else
+			{
+				clothingSlots[i].Reference = syncEquipSprites[i];
 			}
 		}
-
-		public void SyncSprites(SyncList<int>.Operation op, int index)
+		isInit = true;
+		if (isServer)
 		{
-			clothingSlots[index].Reference = syncEquipSprites[index];
+			StartCoroutine(SetPlayerLoadOuts());
 		}
+	}
 
-		/// Wait until client gains control of this player before proceeding further
-		/// (Could be moved into some more generic place in the future)
-		private IEnumerator WaitUntilInControl(int maxTries = 50)
+	public void SyncSprites(SyncList<int>.Operation op, int index)
+	{
+		clothingSlots[index].Reference = syncEquipSprites[index];
+	}
+
+	/// Wait until client gains control of this player before proceeding further
+	/// (Could be moved into some more generic place in the future)
+	private IEnumerator WaitUntilInControl(int maxTries = 50)
+	{
+		int tries = 0;
+		while (!PlayerList.Instance.ContainsGameObject(gameObject))
 		{
-			int tries = 0;
-			while (!PlayerList.Instance.ContainsGameObject(gameObject))
+			if (tries++ > maxTries)
 			{
-				if (tries++ > maxTries)
-				{
-					Logger.LogError($"{this} not in control after {maxTries} tries", Category.Equipment);
-					yield break;
-				}
-
-				yield return YieldHelper.DeciSecond;
-			}
-		}
-
-
-		public IEnumerator SetPlayerLoadOuts()
-		{
-			//Waiting for player name resolve
-			yield return WaitUntilInControl();
-
-			// Null Job players dont get a loadout
-			if (playerScript.JobType == JobType.NULL)
-			{
+				Logger.LogError($"{this} not in control after {maxTries} tries", Category.Equipment);
 				yield break;
 			}
 
-			PlayerScript pS = GetComponent<PlayerScript>();
-			pS.JobType = playerScript.JobType;
-
-			JobOutfit standardOutfit = GameManager.Instance.StandardOutfit.GetComponent<JobOutfit>();
-			JobOutfit jobOutfit = GameManager.Instance.GetOccupationOutfit(playerScript.JobType);
-
-			Dictionary<string, string> gear = new Dictionary<string, string>();
-
-			gear.Add("uniform", standardOutfit.uniform);
-			gear.Add("ears", standardOutfit.ears);
-			gear.Add("belt", standardOutfit.belt);
-			gear.Add("back", standardOutfit.backpack);
-			gear.Add("shoes", standardOutfit.shoes);
-			gear.Add("glasses", standardOutfit.glasses);
-			gear.Add("gloves", standardOutfit.gloves);
-			gear.Add("suit", standardOutfit.suit);
-			gear.Add("head", standardOutfit.head);
-			//gear.Add("accessory", standardOutfit.accessory);
-			gear.Add("mask", standardOutfit.mask);
-			//gear.Add("backpack", standardOutfit.backpack);
-			//gear.Add("satchel", standardOutfit.satchel);
-			//gear.Add("duffelbag", standardOutfit.duffelbag);
-			//gear.Add("box", standardOutfit.box);
-			//gear.Add("l_hand", standardOutfit.l_hand);
-			//gear.Add("l_pocket", standardOutfit.l_pocket);
-			//gear.Add("r_pocket", standardOutfit.r_pocket);
-			//gear.Add("suit_store", standardOutfit.suit_store);
-
-			if (!string.IsNullOrEmpty(jobOutfit.uniform))
-			{
-				gear["uniform"] = jobOutfit.uniform;
-			}
-			/*if (!String.IsNullOrEmpty(jobOutfit.id))
-			    gear["id"] = jobOutfit.id;*/
-			if (!string.IsNullOrEmpty(jobOutfit.ears))
-			{
-				gear["ears"] = jobOutfit.ears;
-			}
-			if (!string.IsNullOrEmpty(jobOutfit.belt))
-			{
-				gear["belt"] = jobOutfit.belt;
-			}
-			if (!string.IsNullOrEmpty(jobOutfit.backpack))
-			{
-				gear["back"] = jobOutfit.backpack;
-			}
-			if (!string.IsNullOrEmpty(jobOutfit.shoes))
-			{
-				gear["shoes"] = jobOutfit.shoes;
-			}
-			if (!string.IsNullOrEmpty(jobOutfit.glasses))
-			{
-				gear["glasses"] = jobOutfit.glasses;
-			}
-			if (!string.IsNullOrEmpty(jobOutfit.gloves))
-			{
-				gear["gloves"] = jobOutfit.gloves;
-			}
-			if (!string.IsNullOrEmpty(jobOutfit.suit))
-			{
-				gear["suit"] = jobOutfit.suit;
-			}
-			if (!string.IsNullOrEmpty(jobOutfit.head))
-			{
-				gear["head"] = jobOutfit.head;
-			}
-			/*if (!String.IsNullOrEmpty(jobOutfit.accessory))
-			    gear["accessory"] = jobOutfit.accessory;*/
-			if (!string.IsNullOrEmpty(jobOutfit.mask))
-			{
-				gear["mask"] = jobOutfit.mask;
-			}
-			/*if (!String.IsNullOrEmpty(jobOutfit.backpack))
-			    gear["backpack"] = jobOutfit.backpack;
-			if (!String.IsNullOrEmpty(jobOutfit.satchel))
-			    gear["satchel"] = jobOutfit.satchel;
-			if (!String.IsNullOrEmpty(jobOutfit.duffelbag))
-			    gear["duffelbag"] = jobOutfit.duffelbag;
-			if (!String.IsNullOrEmpty(jobOutfit.box))
-			    gear["box"] = jobOutfit.box;
-			if (!String.IsNullOrEmpty(jobOutfit.l_hand))
-			    gear["l_hand"] = jobOutfit.l_hand;
-			if (!String.IsNullOrEmpty(jobOutfit.l_pocket))
-			    gear["l_pocket"] = jobOutfit.l_pocket;
-			if (!String.IsNullOrEmpty(jobOutfit.r_pocket))
-			    gear["r_pocket"] = jobOutfit.r_pocket;
-			if (!String.IsNullOrEmpty(jobOutfit.suit_store))
-			    gear["suit_store"] = jobOutfit.suit_store;*/
-
-			foreach (KeyValuePair<string, string> gearItem in gear)
-			{
-				if (gearItem.Value.Contains(ClothFactory.ClothingHierIdentifier) || gearItem.Value.Contains(ClothFactory.HeadsetHierIdentifier)||
-				gearItem.Value.Contains(ClothFactory.BackPackHierIdentifier) || gearItem.Value.Contains(ClothFactory.BagHierIdentifier))
-				{
-					GameObject obj = ClothFactory.Instance.CreateCloth(gearItem.Value, TransformState.HiddenPos, transform.parent);
-					//if ClothFactory does not return an object then move on to the next clothing item
-					if (!obj)
-					{
-						Logger.LogWarning("Trying to instantiate clothing item " + gearItem.Value + " failed!", Category.Equipment);
-						continue;
-					}
-					ItemAttributes itemAtts = obj.GetComponent<ItemAttributes>();
-					SetItem(GetLoadOutEventName(gearItem.Key), itemAtts.gameObject);
-				}
-				else if (!string.IsNullOrEmpty(gearItem.Value))
-				{
-//					Logger.Log(gearItem.Value + " creation not implemented yet.");
-				}
-			}
-			SpawnID(jobOutfit);
-
-			yield return new WaitForSeconds(3f); //Wait a bit for headset to be fully setup and player to be fully spawned.
-			if (playerScript.JobType == JobType.SYNDICATE)
-			{
-				//Check to see if there is a nuke and communicate the nuke code:
-				NukeInteract nuke = FindObjectOfType<NukeInteract>();
-				if (nuke != null)
-				{
-					UpdateChatMessage.Send(gameObject, ChatChannel.Syndicate,
-														"We have intercepted the code for the nuclear weapon: " + nuke.NukeCode);
-				}
-			}	
-		}
-
-		private void SpawnID(JobOutfit outFit)
-		{
-			GameObject idObj;
-			var realName = PlayerList.Instance.Get( gameObject ).Name;
-			if (outFit.jobType == JobType.CAPTAIN)
-			{
-				idObj = ItemFactory.Instance.SpawnIDCard(IDCardType.captain, outFit.jobType, outFit.allowedAccess, realName, transform.parent);
-			}
-			else if (outFit.jobType == JobType.HOP || outFit.jobType == JobType.HOS || outFit.jobType == JobType.CMO || outFit.jobType == JobType.RD ||
-			         outFit.jobType == JobType.CHIEF_ENGINEER)
-			{
-				idObj = ItemFactory.Instance.SpawnIDCard(IDCardType.command, outFit.jobType, outFit.allowedAccess, realName, transform.parent);
-			}
-			else
-			{
-				idObj = ItemFactory.Instance.SpawnIDCard(IDCardType.standard, outFit.jobType, outFit.allowedAccess, realName, transform.parent);
-			}
-
-			SetItem("id", idObj);
-		}
-
-		// //Hand item sprites after picking up an item (server)
-		// public void SetHandItem(string slotName, GameObject obj)
-		// {
-		// 	ItemAttributes att = obj.GetComponent<ItemAttributes>();
-		// 	SetHandItemSprite(att);
-		// 	RpcSendMessage(slotName, obj);
-		// }
-
-		// [ClientRpc]
-		// private void RpcSendMessage(string eventName, GameObject obj)
-		// {
-		// 	obj.BroadcastMessage("OnAddToInventory", eventName, SendMessageOptions.DontRequireReceiver);
-		// }
-
-		public string GetLoadOutEventName(string uniformPosition)
-		{
-			switch (uniformPosition)
-			{
-				case "glasses":
-					return "eyes";
-				case "head":
-					return "head";
-				case "neck":
-					return "neck";
-				case "mask":
-					return "mask";
-				case "ears":
-					return "ear";
-				case "suit":
-					return "suit";
-				case "uniform":
-					return "uniform";
-				case "gloves":
-					return "hands";
-				case "shoes":
-					return "feet";
-				case "belt":
-					return "belt";
-				case "back":
-					return "back";
-				case "id":
-					return "id";
-				case "l_pocket":
-					return "storage02";
-				case "r_pocket":
-					return "storage01";
-				case "l_hand":
-					return "leftHand";
-				case "r_hand":
-					return "rightHand";
-				default:
-					Logger.LogWarning("GetLoadOutEventName: Unknown uniformPosition:" + uniformPosition, Category.Equipment);
-					return null;
-			}
-		}
-
-		//To set the actual sprite on the player obj
-		public void SetHandItemSprite(ItemAttributes att, string hand)
-		{
-			Epos enumA = (Epos) Enum.Parse(typeof(Epos), hand);
-			if (hand == "leftHand")
-			{
-				syncEquipSprites[(int) enumA] = att.NetworkInHandRefLeft();
-			}
-			else
-			{
-				syncEquipSprites[(int) enumA] = att.NetworkInHandRefRight();
-			}
-		}
-
-		//Clear any sprite slot with -1 via the slotName (server)
-		public void ClearItemSprite(string eventName)
-		{
-			Epos enumA = (Epos) Enum.Parse(typeof(Epos), eventName);
-			syncEquipSprites[(int) enumA] = -1;
-		}
-
-		private void SetItem(string slotName, GameObject obj)
-		{
-			StartCoroutine(SetItemPatiently(slotName, obj));
-
-			/*			if (String.IsNullOrEmpty(slotName) || itemAtts == null) {
-				return;
-				Logger.LogError("Error with item attribute for object: " + itemAtts.gameObject.name);
-			}
-
-			EquipmentPool.AddGameObject(gameObject, itemAtts.gameObject);
-
-			playerNetworkActions.TrySetItem(slotName, itemAtts.gameObject);
-			//Sync all clothing items across network using SyncListInt syncEquipSprites
-			if (itemAtts.spriteType == SpriteType.Clothing)
-			{
-			    Epos enumA = (Epos)Enum.Parse(typeof(Epos), slotName);
-			    syncEquipSprites[(int)enumA] = itemAtts.clothingReference;
-			}*/
-		}
-
-		private IEnumerator SetItemPatiently(string slotName, GameObject obj)
-		{
-			//Waiting for hier name resolve
-			yield return new WaitForSeconds(0.2f);
-			playerNetworkActions.AddItemToUISlot(obj, slotName, true);
+			yield return YieldHelper.DeciSecond;
 		}
 	}
+
+
+	public IEnumerator SetPlayerLoadOuts()
+	{
+		//Waiting for player name resolve
+		yield return WaitUntilInControl();
+
+		// Null Job players dont get a loadout
+		if (playerScript.JobType == JobType.NULL)
+		{
+			yield break;
+		}
+
+		PlayerScript pS = GetComponent<PlayerScript>();
+		pS.JobType = playerScript.JobType;
+
+		JobOutfit standardOutfit = GameManager.Instance.StandardOutfit.GetComponent<JobOutfit>();
+		JobOutfit jobOutfit = GameManager.Instance.GetOccupationOutfit(playerScript.JobType);
+
+		Dictionary<string, string> gear = new Dictionary<string, string>();
+
+		gear.Add("uniform", standardOutfit.uniform);
+		gear.Add("ears", standardOutfit.ears);
+		gear.Add("belt", standardOutfit.belt);
+		gear.Add("back", standardOutfit.backpack);
+		gear.Add("shoes", standardOutfit.shoes);
+		gear.Add("glasses", standardOutfit.glasses);
+		gear.Add("gloves", standardOutfit.gloves);
+		gear.Add("suit", standardOutfit.suit);
+		gear.Add("head", standardOutfit.head);
+		//gear.Add("accessory", standardOutfit.accessory);
+		gear.Add("mask", standardOutfit.mask);
+		//gear.Add("backpack", standardOutfit.backpack);
+		//gear.Add("satchel", standardOutfit.satchel);
+		//gear.Add("duffelbag", standardOutfit.duffelbag);
+		//gear.Add("box", standardOutfit.box);
+		//gear.Add("l_hand", standardOutfit.l_hand);
+		//gear.Add("l_pocket", standardOutfit.l_pocket);
+		//gear.Add("r_pocket", standardOutfit.r_pocket);
+		//gear.Add("suit_store", standardOutfit.suit_store);
+
+		if (!string.IsNullOrEmpty(jobOutfit.uniform))
+		{
+			gear["uniform"] = jobOutfit.uniform;
+		}
+		/*if (!String.IsNullOrEmpty(jobOutfit.id))
+			gear["id"] = jobOutfit.id;*/
+		if (!string.IsNullOrEmpty(jobOutfit.ears))
+		{
+			gear["ears"] = jobOutfit.ears;
+		}
+		if (!string.IsNullOrEmpty(jobOutfit.belt))
+		{
+			gear["belt"] = jobOutfit.belt;
+		}
+		if (!string.IsNullOrEmpty(jobOutfit.backpack))
+		{
+			gear["back"] = jobOutfit.backpack;
+		}
+		if (!string.IsNullOrEmpty(jobOutfit.shoes))
+		{
+			gear["shoes"] = jobOutfit.shoes;
+		}
+		if (!string.IsNullOrEmpty(jobOutfit.glasses))
+		{
+			gear["glasses"] = jobOutfit.glasses;
+		}
+		if (!string.IsNullOrEmpty(jobOutfit.gloves))
+		{
+			gear["gloves"] = jobOutfit.gloves;
+		}
+		if (!string.IsNullOrEmpty(jobOutfit.suit))
+		{
+			gear["suit"] = jobOutfit.suit;
+		}
+		if (!string.IsNullOrEmpty(jobOutfit.head))
+		{
+			gear["head"] = jobOutfit.head;
+		}
+		/*if (!String.IsNullOrEmpty(jobOutfit.accessory))
+			gear["accessory"] = jobOutfit.accessory;*/
+		if (!string.IsNullOrEmpty(jobOutfit.mask))
+		{
+			gear["mask"] = jobOutfit.mask;
+		}
+		/*if (!String.IsNullOrEmpty(jobOutfit.backpack))
+			gear["backpack"] = jobOutfit.backpack;
+		if (!String.IsNullOrEmpty(jobOutfit.satchel))
+			gear["satchel"] = jobOutfit.satchel;
+		if (!String.IsNullOrEmpty(jobOutfit.duffelbag))
+			gear["duffelbag"] = jobOutfit.duffelbag;
+		if (!String.IsNullOrEmpty(jobOutfit.box))
+			gear["box"] = jobOutfit.box;
+		if (!String.IsNullOrEmpty(jobOutfit.l_hand))
+			gear["l_hand"] = jobOutfit.l_hand;
+		if (!String.IsNullOrEmpty(jobOutfit.l_pocket))
+			gear["l_pocket"] = jobOutfit.l_pocket;
+		if (!String.IsNullOrEmpty(jobOutfit.r_pocket))
+			gear["r_pocket"] = jobOutfit.r_pocket;
+		if (!String.IsNullOrEmpty(jobOutfit.suit_store))
+			gear["suit_store"] = jobOutfit.suit_store;*/
+
+		foreach (KeyValuePair<string, string> gearItem in gear)
+		{
+			if (gearItem.Value.Contains(ClothFactory.ClothingHierIdentifier) || gearItem.Value.Contains(ClothFactory.HeadsetHierIdentifier) ||
+			gearItem.Value.Contains(ClothFactory.BackPackHierIdentifier) || gearItem.Value.Contains(ClothFactory.BagHierIdentifier))
+			{
+				GameObject obj = ClothFactory.Instance.CreateCloth(gearItem.Value, TransformState.HiddenPos, transform.parent);
+				//if ClothFactory does not return an object then move on to the next clothing item
+				if (!obj)
+				{
+					Logger.LogWarning("Trying to instantiate clothing item " + gearItem.Value + " failed!", Category.Equipment);
+					continue;
+				}
+				ItemAttributes itemAtts = obj.GetComponent<ItemAttributes>();
+				SetItem(GetLoadOutEventName(gearItem.Key), itemAtts.gameObject);
+			}
+			else if (!string.IsNullOrEmpty(gearItem.Value))
+			{
+				//					Logger.Log(gearItem.Value + " creation not implemented yet.");
+			}
+		}
+		SpawnID(jobOutfit);
+
+		yield return new WaitForSeconds(3f); //Wait a bit for headset to be fully setup and player to be fully spawned.
+		if (playerScript.JobType == JobType.SYNDICATE)
+		{
+			//Check to see if there is a nuke and communicate the nuke code:
+			NukeInteract nuke = FindObjectOfType<NukeInteract>();
+			if (nuke != null)
+			{
+				UpdateChatMessage.Send(gameObject, ChatChannel.Syndicate,
+													"We have intercepted the code for the nuclear weapon: " + nuke.NukeCode);
+			}
+		}
+	}
+
+	private void SpawnID(JobOutfit outFit)
+	{
+		GameObject idObj;
+		var realName = PlayerList.Instance.Get(gameObject).Name;
+		if (outFit.jobType == JobType.CAPTAIN)
+		{
+			idObj = ItemFactory.Instance.SpawnIDCard(IDCardType.captain, outFit.jobType, outFit.allowedAccess, realName, transform.parent);
+		}
+		else if (outFit.jobType == JobType.HOP || outFit.jobType == JobType.HOS || outFit.jobType == JobType.CMO || outFit.jobType == JobType.RD ||
+				 outFit.jobType == JobType.CHIEF_ENGINEER)
+		{
+			idObj = ItemFactory.Instance.SpawnIDCard(IDCardType.command, outFit.jobType, outFit.allowedAccess, realName, transform.parent);
+		}
+		else
+		{
+			idObj = ItemFactory.Instance.SpawnIDCard(IDCardType.standard, outFit.jobType, outFit.allowedAccess, realName, transform.parent);
+		}
+
+		SetItem("id", idObj);
+	}
+
+	// //Hand item sprites after picking up an item (server)
+	// public void SetHandItem(string slotName, GameObject obj)
+	// {
+	// 	ItemAttributes att = obj.GetComponent<ItemAttributes>();
+	// 	SetHandItemSprite(att);
+	// 	RpcSendMessage(slotName, obj);
+	// }
+
+	// [ClientRpc]
+	// private void RpcSendMessage(string eventName, GameObject obj)
+	// {
+	// 	obj.BroadcastMessage("OnAddToInventory", eventName, SendMessageOptions.DontRequireReceiver);
+	// }
+
+	public string GetLoadOutEventName(string uniformPosition)
+	{
+		switch (uniformPosition)
+		{
+			case "glasses":
+				return "eyes";
+			case "head":
+				return "head";
+			case "neck":
+				return "neck";
+			case "mask":
+				return "mask";
+			case "ears":
+				return "ear";
+			case "suit":
+				return "suit";
+			case "uniform":
+				return "uniform";
+			case "gloves":
+				return "hands";
+			case "shoes":
+				return "feet";
+			case "belt":
+				return "belt";
+			case "back":
+				return "back";
+			case "id":
+				return "id";
+			case "l_pocket":
+				return "storage02";
+			case "r_pocket":
+				return "storage01";
+			case "l_hand":
+				return "leftHand";
+			case "r_hand":
+				return "rightHand";
+			default:
+				Logger.LogWarning("GetLoadOutEventName: Unknown uniformPosition:" + uniformPosition, Category.Equipment);
+				return null;
+		}
+	}
+
+	//To set the actual sprite on the player obj
+	public void SetHandItemSprite(ItemAttributes att, string hand)
+	{
+		Epos enumA = (Epos)Enum.Parse(typeof(Epos), hand);
+		if (hand == "leftHand")
+		{
+			syncEquipSprites[(int)enumA] = att.NetworkInHandRefLeft();
+		}
+		else
+		{
+			syncEquipSprites[(int)enumA] = att.NetworkInHandRefRight();
+		}
+	}
+
+	//
+	/// <summary>
+	///  Clear any sprite slot by setting the slot to -1 via the slotName (server). If the
+	///  specified slot has no associated player sprite, nothing will be done.
+	/// </summary>
+	/// <param name="slotName">name of the slot (should match an Epos enum)</param>
+	public void ClearItemSprite(string slotName)
+	{
+		Epos enumA = (Epos)Enum.Parse(typeof(Epos), slotName);
+		if (hasPlayerSprite(enumA))
+		{
+			syncEquipSprites[(int)enumA] = -1;
+		}
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <param name="slot"></param>
+	/// <returns>true iff the specified Epos has an associated player sprite.</returns>
+	private bool hasPlayerSprite(Epos slot)
+	{
+		return slot != Epos.id && slot == Epos.storage01 && slot == Epos.storage02 && slot == Epos.suitStorage;
+	}
+
+	private void SetItem(string slotName, GameObject obj)
+	{
+		StartCoroutine(SetItemPatiently(slotName, obj));
+
+		/*			if (String.IsNullOrEmpty(slotName) || itemAtts == null) {
+			return;
+			Logger.LogError("Error with item attribute for object: " + itemAtts.gameObject.name);
+		}
+
+		EquipmentPool.AddGameObject(gameObject, itemAtts.gameObject);
+
+		playerNetworkActions.TrySetItem(slotName, itemAtts.gameObject);
+		//Sync all clothing items across network using SyncListInt syncEquipSprites
+		if (itemAtts.spriteType == SpriteType.Clothing)
+		{
+			Epos enumA = (Epos)Enum.Parse(typeof(Epos), slotName);
+			syncEquipSprites[(int)enumA] = itemAtts.clothingReference;
+		}*/
+	}
+
+	private IEnumerator SetItemPatiently(string slotName, GameObject obj)
+	{
+		//Waiting for hier name resolve
+		yield return new WaitForSeconds(0.2f);
+		playerNetworkActions.AddItemToUISlot(obj, slotName, true);
+	}
+}

--- a/UnityProject/Assets/Scripts/Inventory/InventoryManager.cs
+++ b/UnityProject/Assets/Scripts/Inventory/InventoryManager.cs
@@ -55,36 +55,53 @@ public class InventoryManager : MonoBehaviour
 		}
 	}
 
+	/// <summary>
+	/// Updates the inventory slot list, transferring an item out of / into an inventory slot (or ground).
+	/// </summary>
+	/// <param name="isServer">whether to update this client's inventory slots or the server's inventory slots</param>
+	/// <param name="UUID">UUID of the destination inventory slot, empty string if item is not going into an inventory slot (such as when dropping it)</param>
+	/// <param name="item">gameobject representing the item being transferred</param>
+	/// <param name="FromUUID">UUID of the previous inventory slot that item is coming from, empty string if it's not coming from
+	/// another inventory slot</param>
 	public static void UpdateInvSlot(bool isServer, string UUID, GameObject item, string FromUUID = "")
 	{
 		bool uiSlotChanged = false;
 		string toSlotName = "";
-		GameObject owner = null;
+		GameObject fromOwner = null;
+		GameObject toOwner = null;
+		//TODO: DropItem is not called during disconnect
+		//find the inventory slot with the given UUID
 		var index = InventorySlotList(isServer).FindIndex(
 			x => x.UUID == UUID);
 		if (index != -1)
 		{
 			var invSlot = InventorySlotList(isServer)[index];
+			//put the item in the slot
 			invSlot.Item = item;
 			if (invSlot.IsUISlot)
 			{
+				//if this is a UI slot, mark that it has been changed and keep track of the new owner so we can send the update
+				//message
 				uiSlotChanged = true;
 				toSlotName = invSlot.SlotName;
-				owner = invSlot.Owner.gameObject;
+				toOwner = invSlot.Owner.gameObject;
 			}
 		}
 		if (!string.IsNullOrEmpty(FromUUID))
 		{
+			//if this came from another slot, find it
 			index = InventorySlotList(isServer).FindIndex(
 				x => x.UUID == FromUUID);
 			if (index != -1)
 			{
 				var invSlot = InventorySlotList(isServer)[index];
+				//remove the item from the previous slot
 				invSlot.Item = null;
 				if (invSlot.IsUISlot)
 				{
+					//if the previous slot had an owner, track the owner so we can include it in the update message
 					uiSlotChanged = true;
-					owner = invSlot.Owner.gameObject;
+					fromOwner = invSlot.Owner.gameObject;
 				}
 			}
 		}
@@ -92,7 +109,17 @@ public class InventoryManager : MonoBehaviour
 		//Only ever sync UI slots straight away, storage slots will sync when they are being observed (picked up and inspected)
 		if (isServer && uiSlotChanged)
 		{
-			UpdateSlotMessage.Send(owner, UUID, FromUUID, item);
+			//send the update to the player who the item was taken from and the player it was
+			//given to
+			if (fromOwner != null)
+			{
+				UpdateSlotMessage.Send(fromOwner, UUID, FromUUID, item);
+			}
+			if (toOwner != null)
+			{
+				UpdateSlotMessage.Send(toOwner, UUID, FromUUID, item);
+			}
+
 		}
 
 		if (!isServer && uiSlotChanged)
@@ -153,7 +180,7 @@ public class InventoryManager : MonoBehaviour
 	//Server only:
 	public static InventorySlot GetSlotFromOriginatorHand(GameObject originator, string hand)
 	{
-		InventorySlot slot = null;
+		InventorySlot slot = null;		
 
 		var index = AllServerInventorySlots.FindLastIndex(x => x.Owner?.gameObject == originator && x.SlotName == hand);
 		if(index != -1){
@@ -215,6 +242,21 @@ public class InventoryManager : MonoBehaviour
 
 		DropItem(GetSlotFromItem(item), pos);
 	}
+
+	/// <summary>
+	/// Performs cleanup needed when a player disconnects. Drops their items at their current location and removes all the inventory slots.
+	/// </summary>
+	/// <param name="owner">gameobject of the player that is disconnecting, which should still be present wherever it was prior to disconnecting.</param>
+	public static void HandleDisconnect(GameObject owner)
+	{
+		//drop everything
+		AllServerInventorySlots
+			.FindAll(x => x.Owner?.gameObject == owner && x.Item)
+			.ForEach(x => DropGameItem(owner, x.Item, owner.transform.position));
+
+		//remove their slots
+		AllServerInventorySlots.RemoveAll(x => x.Owner?.gameObject == owner);
+	}
 }
 
 //Helps identify the position in syncEquip list
@@ -233,5 +275,9 @@ public enum Epos
 	back,
 	hands,
 	ear,
-	neck
+	neck,
+	id,
+	storage01,
+	storage02,
+	suitStorage
 }

--- a/UnityProject/Assets/Scripts/Inventory/InventoryManager.cs
+++ b/UnityProject/Assets/Scripts/Inventory/InventoryManager.cs
@@ -69,7 +69,7 @@ public class InventoryManager : MonoBehaviour
 		string toSlotName = "";
 		GameObject fromOwner = null;
 		GameObject toOwner = null;
-		//TODO: DropItem is not called during disconnect
+
 		//find the inventory slot with the given UUID
 		var index = InventorySlotList(isServer).FindIndex(
 			x => x.UUID == UUID);

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -361,8 +361,10 @@ public class CustomNetworkManager : NetworkManager
 		var player = PlayerList.Instance.Get(conn);
 		if (player.GameObject)
 		{
-			player.GameObject.GetComponent<PlayerNetworkActions>().DropAll(true);
+			//Tell the inventorymanager about the disconnect so it can perform whatever cleanup is needed
+			InventoryManager.HandleDisconnect(player.GameObject);
 		}
+		
 		Logger.Log($"Player Disconnected: {player.Name}", Category.Connections);
 		PlayerList.Instance.Remove(conn);
 	}

--- a/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/PlayGroups/PlayerNetworkActions.cs
@@ -273,14 +273,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		for (int i = 0; i < slotNames.Length; i++)
 		{
 			Inventory[slotNames[i]].Item = null;
-			if (slotNames[i] == "id" || slotNames[i] == "storage01" || slotNames[i] == "storage02" || slotNames[i] == "suitStorage")
-			{
-				//Not clearing onPlayer sprites for these as they don't have any
-			}
-			else
-			{
-				equipment.ClearItemSprite(slotNames[i]);
-			}
+			equipment.ClearItemSprite(slotNames[i]);			
 			InventoryManager.UpdateInvSlot(true, slotNames[i], null);
 		}
 
@@ -415,40 +408,22 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 			}
 		}
 		InventoryManager.DropGameItem(gameObject, Inventory[slot].Item, transform.position);
+
 		equipment.ClearItemSprite(slot);
 	}
 
-	//Drop all items. Use onQuit only if player has left server
+	/// <summary>
+	/// Drops all items.
+	/// </summary>
 	[Server]
-	public void DropAll(bool onQuit = false)
+	public void DropAll()
 	{
-		//Dropping whatever player has got
-		if (!onQuit)
+		//fixme: modified collectionz
+		foreach (var key in Inventory.Keys)
 		{
-			//fixme: modified collectionz
-			foreach (var key in Inventory.Keys)
+			if (Inventory[key].Item)
 			{
-				if (Inventory[key].Item)
-				{
-					DropItem(key);
-				}
-			}
-		}
-		else
-		// Drop all shit from player's inventory when he's leaving, ignoring pools
-		{
-			foreach (var item in Inventory.Values)
-			{
-				if (!item.Item)
-				{
-					continue;
-				}
-
-				var objTransform = item.Item.GetComponent<CustomNetTransform>();
-				if (objTransform)
-				{
-					objTransform.ForceDrop(gameObject.transform.position);
-				}
+				DropItem(key);
 			}
 		}
 	}


### PR DESCRIPTION
### Purpose
Fixes #1406 by adding a "HandleDisconnect" method to InventoryManager, allowing the manager to be notified when a disconnect occurs so that it can drop the player's items and remove their inventory slots.

Added some more documentation / small refactorings.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer
