### PR TITLE
Adds mop functionality to clean bloodsplats

### DIFF
--- a/UnityProject/Assets/Scripts/UI/ProgressBar/ProgressBar.cs
+++ b/UnityProject/Assets/Scripts/UI/ProgressBar/ProgressBar.cs
@@ -164,6 +164,7 @@ public class FinishProgressAction
 	{
 		TileConstruction,
 		TileDeconstruction,
+		CleanTile,
 		//Add whatever else you need here
 	}
 
@@ -174,6 +175,7 @@ public class FinishProgressAction
 	private TileType tileType;
 	private Vector3 cellPos;
 	private Vector3 worldPos; //worldPos of the action or tile
+	private MopTrigger theMop;
 
 	private GameObject originator;
 
@@ -188,7 +190,12 @@ public class FinishProgressAction
 		worldPos = _worldPos;
 		originator = _originator;
 	}
-
+	public FinishProgressAction(FinishProgressAction.Action cleanTile, Vector3 splatsPos, MopTrigger mop)
+	{
+		actionType = cleanTile;
+		worldPos = splatsPos;
+		theMop = mop;
+	}
 	public void DoAction()
 	{
 		switch (actionType)
@@ -198,6 +205,9 @@ public class FinishProgressAction
 				break;
 			case Action.TileDeconstruction:
 				DoTileDeconstruction();
+				break;
+			case Action.CleanTile:
+				DoCleanTile();
 				break;
 		}
 	}
@@ -211,5 +221,10 @@ public class FinishProgressAction
 	{
 		CraftingManager.Deconstruction.TryTileDeconstruct(
 			tileChangeManager, tileType, cellPos, worldPos);
+	}
+
+	private void DoCleanTile()
+	{
+		theMop.CleanTile(worldPos);
 	}
 }

--- a/UnityProject/Assets/Tilemaps/Palettes/Items.prefab
+++ b/UnityProject/Assets/Tilemaps/Palettes/Items.prefab
@@ -486,6 +486,15 @@ Tilemap:
       m_ObjectToInstantiate: {fileID: 0}
       m_TileFlags: 0
       m_ColliderType: 0
+  - first: {x: -10, y: -2, z: 0}
+    second:
+      m_TileIndex: 52
+      m_TileSpriteIndex: 52
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_ObjectToInstantiate: {fileID: 0}
+      m_TileFlags: 0
+      m_ColliderType: 2
   - first: {x: -9, y: -2, z: 0}
     second:
       m_TileIndex: 50
@@ -1060,6 +1069,8 @@ Tilemap:
     m_Data: {fileID: 11400000, guid: 1fafbd356933a48abb12c6b63043837c, type: 2}
   - m_RefCount: 1
     m_Data: {fileID: 11400000, guid: 75fe8a883597c4d1585564779847b78e, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 5d0de82a44068b04ca09c037099993e5, type: 2}
   m_TileSpriteArray:
   - m_RefCount: 1
     m_Data: {fileID: 21300000, guid: b5cfc574a66284efabd47154679abfc6, type: 3}
@@ -1165,8 +1176,10 @@ Tilemap:
     m_Data: {fileID: 21300000, guid: ee71be68434f34eeb95904a4656ad9e9, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300000, guid: 2bdd91ec232d54ea58732b19d52dc4a1, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300000, guid: dcb448b4fb7b8ce449cc68283a352689, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 90
+  - m_RefCount: 91
     m_Data:
       e00: 1
       e01: 0
@@ -1185,12 +1198,12 @@ Tilemap:
       e32: 0
       e33: 1
   m_TileColorArray:
-  - m_RefCount: 90
+  - m_RefCount: 91
     m_Data: {r: 1, g: 1, b: 1, a: 1}
   m_AnimationFrameRate: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Origin: {x: -9, y: -8, z: 0}
-  m_Size: {x: 12, y: 13, z: 1}
+  m_Origin: {x: -10, y: -8, z: 0}
+  m_Size: {x: 13, y: 13, z: 1}
   m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
   m_TileOrientation: 0
   m_TileOrientationMatrix:


### PR DESCRIPTION
### Purpose
Adds cleaning functionality to the mop item.
Fixes #1158 

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [ ]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
I added a new tilemap to map the mop for bugtesting purpose, but I did not commit the actual scene since it'd be unnecessary and outside the PR's scope.
There's a var called canBeUsed in MopTrigger.cs which i believe it is some leftover from the old inventory system in use, I'd prefer to have this confirmed before proceeding to remove it, I may be wrong;