### PR TITLE
#389 - only check visibility of onscreen wallmounts

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
+++ b/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
@@ -5,53 +5,16 @@ using UnityEngine;
 /// <summary>
 /// Behavior common to all wall mounts.
 ///
-/// Looks at the way a wallmount is facing by using the gameobject's transform.up (NOT the sprite's transform). Make sure the gameobject is set up so
-/// the transform.up properly points in the direction the object is facing (modify the z coordinate of the rotation to adjust facing).
-/// You may need to adjust the sprite rotation as well as the parent game object rotation if the object has unusual facing behavior such as
-/// the Request Console.
-///
-/// Wallmount sprites are occluded like all the other objects, however they should only be visible on the
-/// side of the wall that they are on. The occlusion logic keeps the nearest wall visible so we must
-/// check which side of the wall the mount is on so we can hide it if it's on the wrong side.
-/// This behavior makes the wallmount invisible if it is not facing towards the player.
-/// Facing is calculated based
+/// Adds a WallmountSpriteBehavior to all child objects that have SpriteRenderers. Facing / visibility checking is handled in
+/// there. See <see cref="WallmountSpriteBehavior"/>
 /// </summary>
 public class WallmountBehavior : MonoBehaviour {
-	private bool mHiddenByFacing = false;
-
-	// Update is called once per frame
-	void Update () {
-		//don't run check until player is created
-		if (PlayerManager.LocalPlayer == null)
+	private void Start()
+	{
+		//add the behavior to all child spriterenderers
+		foreach (SpriteRenderer renderer in GetComponentsInChildren<SpriteRenderer>())
 		{
-			return;
-		}
-
-		//check if we even need to update the visibility
-		//are any sprite renderers visible?
-		bool renderersVisible = false;
-		foreach (SpriteRenderer spriteRenderer in GetComponentsInChildren<SpriteRenderer>())
-		{
-			if (spriteRenderer.enabled)
-			{
-				renderersVisible = true;
-				break;
-			}
-		}
-
-		if (renderersVisible || !renderersVisible && mHiddenByFacing)
-		{
-			//sprites are visible currently or are invisible but only due to this component,
-			//re-calculate if the sprite should be hidden due to facing
-			Vector3 headingToPlayer = PlayerManager.LocalPlayer.transform.position - transform.position;
-			Vector3 facing = transform.up;
-			float difference = Vector3.Angle(facing, headingToPlayer);
-			mHiddenByFacing = !(difference > 90 || difference < -90);
-
-			foreach (SpriteRenderer spriteRenderer in GetComponentsInChildren<SpriteRenderer>())
-			{
-				spriteRenderer.enabled = !mHiddenByFacing;
-			}
+			renderer.gameObject.AddComponent<WallmountSpriteBehavior>();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/WallmountSpriteBehavior.cs
+++ b/UnityProject/Assets/Scripts/Objects/WallmountSpriteBehavior.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Behavior for wallmount sprites.
+///
+/// Looks at the way a wallmount is facing by using the parent gameobject's transform.up (NOT the sprite's transform). Make sure the parent gameobject is set up so
+/// the transform.up properly points in the direction the object is facing (modify the z coordinate of the rotation to adjust facing).
+/// You may need to adjust the sprite rotation as well as the parent game object rotation if the object has unusual facing behavior such as
+/// the Request Console.
+///
+/// Wallmount sprites are occluded like all the other objects, however they should only be visible on the
+/// side of the wall that they are on. The occlusion logic keeps the nearest wall visible so we must
+/// check which side of the wall the mount is on so we can hide it if it's on the wrong side.
+/// This behavior makes the wallmount invisible if it is not facing towards the player.
+/// Facing is calculated based
+/// </summary>
+public class WallmountSpriteBehavior : MonoBehaviour {
+	// This sprite's renderer
+	private SpriteRenderer spriteRenderer;
+
+	private void Start()
+	{
+		spriteRenderer = GetComponent<SpriteRenderer>();
+	}
+
+	// Handles rendering logic, only runs when this sprite is on camera
+	private void OnWillRenderObject()
+	{
+		//don't run check until player is created
+		if (PlayerManager.LocalPlayer == null)
+		{
+			return;
+		}
+
+		//recalculate if it is facing the player
+		Vector3 headingToPlayer = PlayerManager.LocalPlayer.transform.position - transform.parent.position;
+		Vector3 facing = transform.parent.up;
+		float difference = Vector3.Angle(facing, headingToPlayer);
+		bool visible = difference > 90 || difference < -90;
+		spriteRenderer.color = new Color(spriteRenderer.color.r, spriteRenderer.color.g, spriteRenderer.color.b, visible ? 1 : 0);
+	}
+}

--- a/UnityProject/Assets/Shaders/Sprite Fov Masked.shader
+++ b/UnityProject/Assets/Shaders/Sprite Fov Masked.shader
@@ -72,7 +72,7 @@ Shader "Stencil/Unlit background masked" {
 		fixed4 final = textureSample * i.color;
 
 		float maskChennel = maskSample.g + maskSample.r;
-		final.a = textureSample.a * clamp(maskChennel * 3 - 0.33333f, 0, 10);
+        final.a = textureSample.a * clamp(maskChennel * 3 - 0.33333f, 0, 10) * i.color.a;
 
 		return final;
 	}


### PR DESCRIPTION
### Purpose
Fixes #389 - a performance issue noted by @MrMeatpie with wallmount checking.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
On creation, WallmountBehavior now adds a WallmountSpriteBehavior to all child spriteRenderers. This new behavior checks facing only when the sprite is onscreen using OnWillRenderObject, but rather than disabling the spriteRenderer to make the wallmount invisible it just sets the alpha channel to make it transparent.

Sprite Fov Mask had to be updated to use the alpha channel of the spriterenderer color to adjust the final alpha value.
