### PR TITLE
#1110 - fix issue where client can get stuck in door

### DIFF
--- a/UnityProject/Assets/Scripts/Doors/AirLockAnimator.cs
+++ b/UnityProject/Assets/Scripts/Doors/AirLockAnimator.cs
@@ -39,7 +39,7 @@ using UnityEditor;
 				{
 					StartCoroutine(PlayAnim(overlay_Lights, overlayLights, doorController.DoorLightSpriteOffset + 2, 1));
 				}
-				else 
+				else
 				{
 					StartCoroutine(PlayAnim(overlay_Lights, overlayLights, doorController.DoorDeniedSpriteOffset, animSize, true, false, true));
 				}
@@ -57,8 +57,8 @@ using UnityEditor;
 			{
 				StartCoroutine(PlaySimpleLightAnim());
 			}
-			else 
-			{			
+			else
+			{
 				if (doorController.openingDirection == DoorController.OpeningDirection.Vertical)
 				{
 					StartCoroutine(PlayAnim(overlay_Lights, overlayLights, doorController.DoorLightSpriteOffset, 1));
@@ -69,7 +69,7 @@ using UnityEditor;
 				}
 			}
 			StartCoroutine(PlayAnim(overlay_Glass, overlaySprites, doorController.DoorCoverSpriteOffset));
-			//mabe the boxColliderStuff should be on the DoorController. 
+			//mabe the boxColliderStuff should be on the DoorController.
 			StartCoroutine(MakePassable());
 		}
 
@@ -83,13 +83,13 @@ using UnityEditor;
 			doorController.isPerformingAction = true;
 			doorController.PlayCloseSound();
 			StartCoroutine(PlayAnim(doorbase, doorBaseSprites, doorController.DoorSpriteOffset + animSize, animSize, false, true, true));
-			
+
 			// check if door uses a simple light animation (turn on 1 frame, turn it off at the end)
 			if (doorController.useSimpleLightAnimation)
 			{
 				StartCoroutine(PlaySimpleLightAnim());
 			}
-			else 
+			else
 			{
 				if (doorController.openingDirection == DoorController.OpeningDirection.Vertical)
 				{
@@ -103,7 +103,7 @@ using UnityEditor;
 			StartCoroutine(PlayAnim(overlay_Glass, overlaySprites, doorController.DoorCoverSpriteOffset + 6));
 			StartCoroutine(MakeSolid());
 		}
-		
+
 		private IEnumerator MakeSolid() {
 			yield return new WaitForSeconds( 0.15f );
 			doorController.BoxCollToggleOn();
@@ -143,7 +143,7 @@ using UnityEditor;
 				}
 				if (updateAction)
 				{
-					doorController.isPerformingAction = false;
+					doorController.OnAnimationFinished();
 				}
 			}
 			else
@@ -180,7 +180,7 @@ using UnityEditor;
 				else
 				{
 					overlay_Lights.sprite = null;
-					
+
 				}
 				light = !light;
 				yield return new WaitForSeconds(0.05f);

--- a/UnityProject/Assets/Scripts/Doors/DoorController.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -69,6 +70,40 @@ using UnityEngine.Networking;
 
 
 			registerTile = gameObject.GetComponent<RegisterDoor>();
+		}
+
+		/// <summary>
+		/// Invoked by doorAnimator once a door animation finishes
+		/// </summary>
+		public void OnAnimationFinished()
+		{
+			isPerformingAction = false;
+			//check if the door is closing on something, and reopen it if so.
+
+			//When the door first closes, it checks if anything is blocking it, but it is still possible
+			//for a laggy client to go into the door while it is closing. There are 2 cases:
+			// 1. Client enters door after server knows the door is impassable, but before client knows it is impassable.
+			// 2. Client enters door after the close begins but before server marks the door as impassable and before
+			// 		the client knows it is impassable. This is rare but there is a slight delay (.15 s) between when the door close
+			//		begins and when the server registers the door as impassable, so it is possible (See AirLockAnimator.MakeSolid)
+			// Case 1 is handled by our rollback code - the client will be lerp'd back to their previous position.
+			// Case 2 won't be handled by the rollback code because the client enters the passable tile while the
+			//	server still thinks its passable. So, for the rare situation that case 2 occurs, we will apply
+			// the below logic and reopen the door if the client got stuck in the door in the .15 s gap.
+
+			//only do this check when door is closing, and only for doors that block all directions (like airlocks)
+			if (isServer && !IsOpened && !registerTile.OneDirectionRestricted)
+			{
+				if (!MatrixManager.IsPassableAt(registerTile.WorldPosition, registerTile.WorldPosition, true,
+					this.gameObject))
+				{
+					//something is in the way, open back up
+					//set this field to false so open command will actually work
+					isPerformingAction = false;
+					Open();
+				}
+			}
+
 		}
 
 		public void BoxCollToggleOn()

--- a/UnityProject/Assets/Scripts/Doors/WinDoorAnimator.cs
+++ b/UnityProject/Assets/Scripts/Doors/WinDoorAnimator.cs
@@ -81,7 +81,7 @@ using UnityEngine;
 				yield return new WaitForSeconds(0.1f);
 			}
 			doorbase.sprite = sprites[closeFrame + (int) direction];
-			doorController.isPerformingAction = false;
+			doorController.OnAnimationFinished();
 		}
 
 		private IEnumerator PlayOpenAnim()
@@ -98,7 +98,7 @@ using UnityEngine;
 			}
 
 			doorbase.sprite = sprites[openFrame + (int) direction];
-			doorController.isPerformingAction = false;
+			doorController.OnAnimationFinished();
 		}
 
 
@@ -119,6 +119,6 @@ using UnityEngine;
 				yield return new WaitForSeconds(0.05f);
 			}
 			doorbase.sprite = sprites[closeFrame + (int) direction];
-			doorController.isPerformingAction = false;
+			doorController.OnAnimationFinished();
 		}
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
@@ -53,7 +53,7 @@ using UnityEngine;
 			//Targeting windoors here
 			List<RegisterTile> objectsOrigin = Objects.Get<RegisterTile>(origin);
 			for ( var i = 0; i < objectsOrigin.Count; i++ ) {
-				if ( !objectsOrigin[i].IsPassableTo( to ) ) {
+				if ( !objectsOrigin[i].IsPassableTo( to ) && ( !context || objectsOrigin[i].gameObject != context ) ) {
 					//Can't get outside the tile because windoor doesn't allow us
 					return false;
 				}


### PR DESCRIPTION
### Purpose
Fixes #1110 - an issue where the client can get stuck in the door in the .15 s window between when the door close begins and the door is registered as impassable.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
See my long comment in DoorController. In order to reproduce this, you have to have very precise timing on the client. Basically you need to enter the door right when the door close animation starts but before the server registers it as impassable. Otherwise you will get the normal lerpback behavior where it kicks you back out of the door. You know you've reproduced it if the character stays where they are in the door and the door reopens once it's done closing.

I originally implemented this check the entire time the door is closing (so it reopens as soon as it detects a player in it rather than once the door is finished closing), but I didn't like what I saw in the profiler with that approach (since it runs in UpdateManager.Update and checks the RegisterTiles every Update), and considering this is a very rare event I think it's fine to just have a simple behavior of reopening the door only once it's done closing.