### PR TITLE
CustomNetTransform idle optimisation (zero CPU usage)

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager.cs
@@ -313,7 +313,8 @@ public class MatrixManager : MonoBehaviour
 	/// Get MatrixInfo by matrix id
 	public static MatrixInfo Get(int id)
 	{
-		return getInternal(mat => mat.Id == id);
+		return Instance.activeMatrices[id];
+		//return getInternal(mat => mat.Id == id);
 	}
 
 	/// Get MatrixInfo by gameObject containing Matrix component

--- a/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
@@ -31,23 +31,27 @@ public class UpdateManager : MonoBehaviour
 	public void Add(ManagedNetworkBehaviour updatable)
 	{
 		if (updatable.GetType().GetMethod(nameof(ManagedNetworkBehaviour.UpdateMe))?.DeclaringType == updatable.GetType())
-		{
+		{ //Avoiding duplicates:
+			UpdateMe -= updatable.UpdateMe;
 			UpdateMe += updatable.UpdateMe;
 		}
 
 		if (updatable.GetType().GetMethod(nameof(ManagedNetworkBehaviour.FixedUpdateMe))?.DeclaringType == updatable.GetType())
 		{
+			FixedUpdateMe -= updatable.FixedUpdateMe;
 			FixedUpdateMe += updatable.FixedUpdateMe;
 		}
 
 		if (updatable.GetType().GetMethod(nameof(ManagedNetworkBehaviour.LateUpdateMe))?.DeclaringType == updatable.GetType())
 		{
+			LateUpdateMe -= updatable.LateUpdateMe;
 			LateUpdateMe += updatable.LateUpdateMe;
 		}
 	}
 
 	public void Add(Action updatable)
 	{
+		UpdateAction -= updatable;
 		UpdateAction += updatable;
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
@@ -45,7 +45,7 @@ using UnityEngine.Tilemaps;
 
 		public virtual bool IsPassableAt( Vector3Int from, Vector3Int to, bool inclPlayers = true, GameObject context = null )
 		{
-			return TileUtils.IsPassable(tilemap.GetTile<BasicTile>(to));
+			return !tilemap.HasTile(to) || TileUtils.IsPassable(tilemap.GetTile<BasicTile>(to));
 		}
 
 		public virtual bool IsAtmosPassableAt(Vector3Int from, Vector3Int to)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -12,18 +12,31 @@ public class MetaTileMap : MonoBehaviour
 	//Lists for speed
 	private List<LayerType> LayersKeys { get; set; }
 	private List<Layer> LayersValues { get; set; }
+	/// <summary>
+	/// List of layers that can definitely contain solid stuff
+	/// </summary>
+	private List<Layer> SolidLayersValues { get; set; }
 
 	private void OnEnable()
 	{
 		Layers = new Dictionary<LayerType, Layer>();
 		LayersKeys = new List<LayerType>();
 		LayersValues = new List<Layer>();
+		SolidLayersValues = new List<Layer>();
 
 		foreach (Layer layer in GetComponentsInChildren<Layer>(true))
 		{
-			Layers[layer.LayerType] = layer;
-			LayersKeys.Add(layer.LayerType);
+			var type = layer.LayerType;
+			Layers[type] = layer;
+			LayersKeys.Add(type);
 			LayersValues.Add(layer);
+			if ( type != LayerType.Effects
+			  && type != LayerType.Base
+			  && type != LayerType.Floors
+			  && type != LayerType.None)
+			{
+				SolidLayersValues.Add(layer);
+			}
 		}
 	}
 
@@ -43,9 +56,9 @@ public class MetaTileMap : MonoBehaviour
 
 	private bool _IsPassableAt(Vector3Int origin, Vector3Int to, bool inclPlayers = true, GameObject context = null)
 	{
-		for (var i = 0; i < LayersValues.Count; i++)
+		for (var i = 0; i < SolidLayersValues.Count; i++)
 		{
-			if (!LayersValues[i].IsPassableAt(origin, to, inclPlayers, context))
+			if (!SolidLayersValues[i].IsPassableAt(origin, to, inclPlayers, context))
 			{
 				return false;
 			}

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
@@ -388,7 +388,7 @@ public partial class CustomNetTransform {
 				StopFloating();
 				return;
 			}
-			serverState.Speed = serverState.Speed - ( serverState.Speed * 0.10f ) - 0.5f;
+			serverState.Speed = serverState.Speed - (serverState.Speed * (Time.deltaTime*10));
 			if ( serverState.Speed <= 0.05f ) {
 				StopFloating();
 			} else {

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
@@ -125,6 +125,7 @@ public partial class CustomNetTransform {
 	}
 
 	public bool PredictivePush( Vector2Int target, float speed = Single.NaN, bool followMode = false ) {
+		Poke();
 		Vector3Int target3int = target.To3Int();
 
 		Vector3Int currentPos = ClientPosition;
@@ -158,17 +159,23 @@ public partial class CustomNetTransform {
 		StopFloating();
 	}
 
+	/// <summary>
 	/// Predictive client movement
 	/// Mimics server collision checks for obviously impassable things.
 	/// That prevents objects going through walls if server doesn't respond in time
-	private void CheckFloatingClient() {
-		CheckFloatingClient(TransformState.HiddenPos);
+	/// </summary>
+	/// <returns>true if transform has changed</returns>
+	private bool CheckFloatingClient() {
+		return CheckFloatingClient(TransformState.HiddenPos);
 	}
-	private void CheckFloatingClient(Vector3 goal) {
-		if ( !IsFloatingClient ) {
-			return;
-		}
+	/// <summary>
+	/// internal method, called recursively if more than one tile has passed within one frame
+	/// </summary>
+	private bool CheckFloatingClient(Vector3 goal) {
 		bool isRecursive = goal != TransformState.HiddenPos;
+		if ( !IsFloatingClient ) {
+			return isRecursive;
+		}
 		Vector3 worldPos = predictedState.WorldPosition;
 		Vector3Int intOrigin = Vector3Int.RoundToInt( worldPos );
 
@@ -205,6 +212,8 @@ public partial class CustomNetTransform {
 		if ( distance > 1 ) {
 			CheckFloatingClient(isRecursive ? goal : newGoal);
 		}
+
+		return true;
 	}
 
 	/// Clientside lerping (transform to clientState position)
@@ -305,17 +314,23 @@ public partial class CustomNetTransform {
 		NotifyPlayers();
 	}
 
+	/// <summary>
 	/// Server movement checks
+	/// </summary>
+	/// <returns>true if transform has changed</returns>
 	[Server]
-	private void CheckFloatingServer() {
-		CheckFloatingServer(TransformState.HiddenPos);
+	private bool CheckFloatingServer() {
+		return CheckFloatingServer(TransformState.HiddenPos);
 	}
+	/// <summary>
+	/// internal method, called recursively if more than one tile has passed within one frame
+	/// </summary>
 	[Server]
-	private void CheckFloatingServer(Vector3 goal) {
-		if ( !IsFloatingServer || matrix == null ) {
-			return;
-		}
+	private bool CheckFloatingServer(Vector3 goal) {
 		bool isRecursive = goal != TransformState.HiddenPos;
+		if ( !IsFloatingServer || matrix == null ) {
+			return isRecursive;
+		}
 
 		Vector3 worldPosition = serverState.WorldPosition;
 		Vector3 moveDelta;
@@ -348,6 +363,8 @@ public partial class CustomNetTransform {
 		if ( distance > 1 ) {
 			CheckFloatingServer(isRecursive ? goal : newGoal);
 		}
+
+		return true;
 	}
 
 	[Server]

--- a/UnityProject/Assets/Scripts/YieldHelper.cs
+++ b/UnityProject/Assets/Scripts/YieldHelper.cs
@@ -5,4 +5,5 @@ public static class YieldHelper
 	public static readonly WaitForEndOfFrame EndOfFrame = new WaitForEndOfFrame();
 	public static readonly WaitForSeconds DeciSecond = new WaitForSeconds(0.1f);
 	public static readonly WaitForSeconds Second = new WaitForSeconds(1f);
+	public static readonly WaitForSeconds FiveSecs = new WaitForSeconds(5f);
 }


### PR DESCRIPTION
### Purpose
Part of #1442 optimisation task.
CNT only subscribes to updates when it gets moved and unsubscribes back in 5 secs of inactivity. 
Results in zero CPU and GC usage when nothing is moving.
![screenshot_29](https://user-images.githubusercontent.com/10403536/51464302-27e51780-1d5d-11e9-973b-d5f0a5e5aee0.png)


### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer
