### PR TITLE
Prevent hovering / interacting with hidden stuff

### DIFF
--- a/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.Experimental.UIElements;
+using UnityEngine.SceneManagement;
 using UnityEngine.Tilemaps;
 
 /// <summary>
@@ -25,6 +28,8 @@ public class MouseInputController : MonoBehaviour
 	private ObjectBehaviour objectBehaviour;
 	private PlayerMove playerMove;
 	private PlayerSprites playerSprites;
+	/// reference to the global lighting system, used to check occlusion
+	private LightingSystem lightingSystem;
 
 	public static readonly Vector3 sz = new Vector3(0.02f, 0.02f, 0.02f);
 
@@ -45,6 +50,8 @@ public class MouseInputController : MonoBehaviour
 		playerSprites = gameObject.GetComponent<PlayerSprites>();
 		playerMove = GetComponent<PlayerMove>();
 		objectBehaviour = GetComponent<ObjectBehaviour>();
+
+		lightingSystem = Camera.main.GetComponent<LightingSystem>();
 
 		//Do not include the Default layer! Assign your object to one of the layers below:
 		layerMask = LayerMask.GetMask("Furniture", "Walls", "Windows", "Machines", "Players", "Items", "Door Open", "Door Closed", "WallMounts",
@@ -238,6 +245,13 @@ public class MouseInputController : MonoBehaviour
 
 		Vector3 mousePosition = MousePosition;
 
+		//sample the FOV mask under current mouse position
+		if (lightingSystem.IsFovOccluded(Input.mousePosition))
+		{
+			return false;
+		}
+
+
 		//for debug purpose, mark the most recently touched tile location
 		//	LastTouchedTile = new Vector2(Mathf.Round(mousePosition.x), Mathf.Round(mousePosition.y));
 
@@ -319,7 +333,7 @@ public class MouseInputController : MonoBehaviour
 			SpriteRenderer spriteRenderer = bySortingOrder[i];
 			Sprite sprite = spriteRenderer.sprite;
 
-			if (spriteRenderer.enabled && sprite)
+			if (spriteRenderer.enabled && sprite && spriteRenderer.color.a > 0)
 			{
 				Color pixelColor = new Color();
 				GetSpritePixelColorUnderMousePointer(spriteRenderer, out pixelColor);

--- a/UnityProject/Assets/Scripts/Lighting System/PostProcessingStack.cs
+++ b/UnityProject/Assets/Scripts/Lighting System/PostProcessingStack.cs
@@ -76,7 +76,7 @@ public class PostProcessingStack
 		}
 	}
 
-	/// <summary>	
+	/// <summary>
 	/// Processes provided Mask thru post processing stack.
 	/// </summary>
 	/// <param name="iMask">Raw Occlusion mask with R and G channels.</param>
@@ -96,7 +96,7 @@ public class PostProcessingStack
 	{
 		// In case of matrix rotation we want to blur more to hide quirks.
 		float _interpolation = Mathf.Lerp(iRenderSettings.lightBlurInterpolation, iRenderSettings.lightBlurInterpolation * 4, iMatrixRotationModeBlend);
- 
+
 		Blur(iMask, mMaterialContainer.lightBlurMaterial, _interpolation, iRenderSettings.lightBlurIterations, blurRenderTextureLight, iCameraSize);
 	}
 
@@ -183,7 +183,7 @@ public class PostProcessingStack
 		mMaterialContainer.fovMaterial.SetVector("_PositionOffset", iFovCenterInViewSpace);
 		iFloorOcclusionMask.renderTexture.filterMode = FilterMode.Bilinear;
 		PixelPerfectRT.Blit(iFloorOcclusionMask, iWallFloorOcclusionMask, mMaterialContainer.fovMaterial);
-	
+
 	}
 
 	public void CreateWallLightMask(
@@ -193,7 +193,7 @@ public class PostProcessingStack
 		float iCameraSize)
 	{
 		// Down Scale light mask and blur it.
-		PixelPerfectRT.Transform(iLightMask, iObstacleLightMask, mMaterialContainer.PPRTTransformMaterial);
+		PixelPerfectRT.Transform(iLightMask, iObstacleLightMask, mMaterialContainer);
 
 		mMaterialContainer.lightWallBlurMaterial.SetVector("_MultiLimit", new Vector4(iRenderSettings.occlusionMaskMultiplier,iRenderSettings.occlusionMaskLimit,0,0));
 

--- a/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
+++ b/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
@@ -17,4 +17,18 @@ public class WallmountBehavior : MonoBehaviour {
 			renderer.gameObject.AddComponent<WallmountSpriteBehavior>();
 		}
 	}
+
+	/// <summary>
+	/// Checks if the wallmount is facing the specified position
+	/// </summary>
+	/// <param name="worldPosition">position to check</param>
+	/// <returns>true iff it is facing the position</returns>
+	public bool IsFacingPosition(Vector3 worldPosition)
+	{
+		Vector3 headingToPosition = worldPosition - transform.position;
+		Vector3 facing = transform.up;
+		float difference = Vector3.Angle(facing, headingToPosition);
+		//91 rather than 90 helps prevent flickering due to rounding
+		return difference >= 91 || difference <= -91;
+	}
 }

--- a/UnityProject/Assets/Scripts/Objects/WallmountSpriteBehavior.cs
+++ b/UnityProject/Assets/Scripts/Objects/WallmountSpriteBehavior.cs
@@ -19,10 +19,13 @@ using UnityEngine;
 public class WallmountSpriteBehavior : MonoBehaviour {
 	// This sprite's renderer
 	private SpriteRenderer spriteRenderer;
+	//parent wallmount behavior
+	private WallmountBehavior wallmountBehavior;
 
 	private void Start()
 	{
 		spriteRenderer = GetComponent<SpriteRenderer>();
+		wallmountBehavior = GetComponentInParent<WallmountBehavior>();
 	}
 
 	// Handles rendering logic, only runs when this sprite is on camera
@@ -35,11 +38,7 @@ public class WallmountSpriteBehavior : MonoBehaviour {
 		}
 
 		//recalculate if it is facing the player
-		Vector3 headingToPlayer = PlayerManager.LocalPlayer.transform.position - transform.parent.position;
-		Vector3 facing = transform.parent.up;
-		float difference = Vector3.Angle(facing, headingToPlayer);
-		//91 rather than 90 helps prevent flickering due to rounding
-		bool visible = difference >= 91 || difference <= -91;
+		bool visible = wallmountBehavior.IsFacingPosition(PlayerManager.LocalPlayer.transform.position);
 		spriteRenderer.color = new Color(spriteRenderer.color.r, spriteRenderer.color.g, spriteRenderer.color.b, visible ? 1 : 0);
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -554,58 +554,82 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	[Command]
 	public void CmdToggleShutters(GameObject switchObj)
 	{
-		ShutterSwitchTrigger s = switchObj.GetComponent<ShutterSwitchTrigger>();
-		if (s.IsClosed)
+		if (CanInteractWallmount(switchObj.GetComponent<WallmountBehavior>()))
 		{
-			s.IsClosed = false;
+			ShutterSwitchTrigger s = switchObj.GetComponent<ShutterSwitchTrigger>();
+			if (s.IsClosed)
+			{
+				s.IsClosed = false;
+			}
+			else
+			{
+				s.IsClosed = true;
+			}
 		}
 		else
 		{
-			s.IsClosed = true;
+			Logger.LogWarning("player attempted to interact with shutter switch through wall," +
+			                  " this could indicate a hacked client.");
 		}
 	}
 
 	[Command]
 	public void CmdToggleLightSwitch(GameObject switchObj)
 	{
-		LightSwitchTrigger s = switchObj.GetComponent<LightSwitchTrigger>();
-		s.isOn = !s.isOn;
+		if (CanInteractWallmount(switchObj.GetComponent<WallmountBehavior>()))
+		{
+			LightSwitchTrigger s = switchObj.GetComponent<LightSwitchTrigger>();
+			s.isOn = !s.isOn;
+		}
+		else
+		{
+			Logger.LogWarning("player attempted to interact with light switch through wall," +
+			                  " this could indicate a hacked client.");
+		}
 	}
 
 	[Command]
 	public void CmdToggleFireCabinet(GameObject cabObj, bool forItemInteract, string currentSlotName)
 	{
-		FireCabinetTrigger c = cabObj.GetComponent<FireCabinetTrigger>();
+		if (CanInteractWallmount(cabObj.GetComponent<WallmountBehavior>()))
+		{
+			FireCabinetTrigger c = cabObj.GetComponent<FireCabinetTrigger>();
 
-		if (!forItemInteract)
-		{
-			if (c.IsClosed)
+			if (!forItemInteract)
 			{
-				c.IsClosed = false;
-			}
-			else
-			{
-				c.IsClosed = true;
-			}
-		}
-		else
-		{
-			if (c.isFull)
-			{
-				c.isFull = false;
-				if (AddItemToUISlot(c.storedObject.gameObject, currentSlotName))
+				if (c.IsClosed)
 				{
-					c.storedObject.visibleState = true;
-					c.storedObject = null;
+					c.IsClosed = false;
+				}
+				else
+				{
+					c.IsClosed = true;
 				}
 			}
 			else
 			{
-				c.storedObject = Inventory[currentSlotName].Item.GetComponent<ObjectBehaviour>();
-				ClearInventorySlot(currentSlotName);
-				c.storedObject.visibleState = false;
-				c.isFull = true;
+				if (c.isFull)
+				{
+					c.isFull = false;
+					if (AddItemToUISlot(c.storedObject.gameObject, currentSlotName))
+					{
+						c.storedObject.visibleState = true;
+						c.storedObject = null;
+					}
+				}
+				else
+				{
+					c.storedObject = Inventory[currentSlotName].Item.GetComponent<ObjectBehaviour>();
+					ClearInventorySlot(currentSlotName);
+					c.storedObject.visibleState = false;
+					c.isFull = true;
+				}
 			}
+		}
+		else
+		{
+			Logger.LogWarning("player attempted to interact with fire cabinet through wall," +
+			                  " this could indicate a hacked client.");
 		}
 	}
 
@@ -615,9 +639,21 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		item.transform.position = newPos;
 	}
 
+	/// <summary>
+	/// Validates that the player can interact with the specified wallmount
+	/// </summary>
+	/// <param name="wallmount">wallmount to check</param>
+	/// <returns>true iff interaction is allowed</returns>
+	[Server]
+	private bool CanInteractWallmount(WallmountBehavior wallmount)
+	{
+		//can only interact if the player is facing the wallmount
+		return wallmount.IsFacingPosition(transform.position);
+	}
+
 	[Server]
 	public void SetConsciousState(bool conscious)
-	{	
+	{
 		if (conscious)
 		{
 			playerMove.allowInput = true;


### PR DESCRIPTION
### Purpose
Fixes #1063 
Fixes #1426 

Prevents interaction with FOV-occluded stuff as well as wallmounts on the wrong side of the wall. Also adds server-side checks for interacting with wrong side of wallmount.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer
