### PR TITLE
Set matrices to 0.5 0.5 offset in order to get cross matrices atmos…

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Tilemaps.Behaviours.Meta;
 using UnityEngine;
 
@@ -114,7 +113,8 @@ public class MetaDataSystem : SubsystemBehaviour
 					Vector3Int neighbor = neighbors[i];
 					if (metaTileMap.IsSpaceAt(neighbor))
 					{
-						Vector3 worldPosition = transform.TransformPoint(neighbor);
+						Vector3 worldPosition = transform.TransformPoint(neighbor + Vector3Int.one);
+						worldPosition.z = 0;
 						if (MatrixManager.IsSpaceAt(worldPosition.RoundToInt()))
 						{
 							isSpace = true;
@@ -158,7 +158,7 @@ public class MetaDataSystem : SubsystemBehaviour
 	{
 		Vector3Int[] neighbors = MetaUtils.GetNeighbors(node.Position);
 
-		for(int i = 0; i < neighbors.Length; i++)
+		for (int i = 0; i < neighbors.Length; i++)
 		{
 			if (metaTileMap.IsSpaceAt(neighbors[i]))
 			{
@@ -167,8 +167,9 @@ public class MetaDataSystem : SubsystemBehaviour
 					externalNodes.Add(node);
 				}
 
-				Vector3 worldPosition = transform.TransformPoint(neighbors[i]);
+				Vector3 worldPosition = transform.TransformPoint(neighbors[i] + Vector3Int.one);
 				worldPosition.z = 0;
+
 				if (!MatrixManager.IsSpaceAt(worldPosition.RoundToInt()))
 				{
 					MatrixInfo matrixInfo = MatrixManager.AtPoint(worldPosition.RoundToInt());

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SubsystemManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SubsystemManager.cs
@@ -11,6 +11,7 @@ public class SubsystemManager : NetworkBehaviour
 	public override void OnStartServer()
 	{
 		systems = systems.OrderByDescending(s => s.Priority).ToList();
+
 		Initialize();
 	}
 
@@ -31,10 +32,11 @@ public class SubsystemManager : NetworkBehaviour
 
 	public void UpdateAt(Vector3Int position)
 	{
-		if ( !initialized )
+		if (!initialized)
 		{
 			return;
 		}
+
 		for (int i = 0; i < systems.Count; i++)
 		{
 			systems[i].UpdateAt(position);


### PR DESCRIPTION
… working again.

### Purpose
Make Cross-Matrices Atmos Great Again.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer