### PR TITLE
Fixes #1455

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager.cs
@@ -110,7 +110,7 @@ public class MatrixManager : MonoBehaviour
 		{
 			return BumpType.Push;
 		}
-		else if (GetClosedDoorAt(targetPos) != null)
+		else if (GetClosedDoorAt(worldOrigin, targetPos) != null)
 		{
 			return BumpType.ClosedDoor;
 		}
@@ -135,26 +135,29 @@ public class MatrixManager : MonoBehaviour
 	}
 
 	/// <summary>
-	/// Gets a closed door (if there is one) at the specified position
+	/// Gets the closest door to worldOrigin on the path from worldOrigin to targetPos (if there is one)
+	/// Assumes that 
 	/// </summary>
+	/// <param name="worldOrigin">Origin World position to check from. This is required because e.g. Windoors may not appear closed from certain positions.</param>
 	/// <param name="targetPos">target world position to check</param>
-	/// <returns>the DoorTrigger of the closed door object at that position, null if no such object
+	/// <returns>The DoorTrigger of the closed door object specified in the summary, null if no such object
 	/// exists at that location</returns>
-	public static DoorTrigger GetClosedDoorAt(Vector3Int targetPos)
+	public static DoorTrigger GetClosedDoorAt(Vector3Int worldOrigin, Vector3Int targetPos)
 	{
-		DoorTrigger door = Instance.GetFirst<DoorTrigger>(targetPos);
-		if (door)
-		{
-			RegisterDoor registerDoor = door.GetComponent<RegisterDoor>();
-			Vector3Int localPos = Instance.WorldToLocalInt(targetPos, AtPoint(targetPos).Matrix);
+		// Check door on the local tile first
+		Vector3Int localTarget = Instance.WorldToLocalInt(targetPos, AtPoint(targetPos).Matrix);
+		DoorTrigger originDoor = Instance.GetFirst<DoorTrigger>(worldOrigin);
+		if (originDoor && !originDoor.GetComponent<RegisterDoor>().IsPassableTo(localTarget))
+			return originDoor;
 
-			if (registerDoor.IsPassable(localPos))
-			{
-				door = null;
-			}
-		}
+		// No closed door on local tile, check target tile
+		Vector3Int localOrigin = Instance.WorldToLocalInt(worldOrigin, AtPoint(worldOrigin).Matrix);
+		DoorTrigger targetDoor = Instance.GetFirst<DoorTrigger>(targetPos);
+		if (targetDoor && !targetDoor.GetComponent<RegisterDoor>().IsPassable(localOrigin))
+			return targetDoor;
 
-		return door;
+		// No closed doors on either tile
+		return null;
 	}
 
 	/// <summary>
@@ -425,7 +428,7 @@ public class MatrixManager : MonoBehaviour
 		}
 
 		return matrix.MatrixMove.ClientState.Orientation.EulerInverted * (worldPos - matrix.Offset - matrix.MatrixMove.Pivot) +
-		       matrix.MatrixMove.Pivot;
+			matrix.MatrixMove.Pivot;
 	}
 }
 

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -489,7 +489,7 @@ public partial class PlayerSync
 	private void InteractDoor(Vector3Int currentPos, Vector3Int targetPos)
 	{
 		// Make sure there is a door which can be interacted with
-		DoorTrigger door = MatrixManager.GetClosedDoorAt(targetPos);
+		DoorTrigger door = MatrixManager.GetClosedDoorAt(currentPos, targetPos);
 
 		// Attempt to open door
 		if (door != null)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
@@ -43,6 +43,7 @@
 
 		public override bool IsPassable( Vector3Int from )
 		{
+			// Entering and leaving is the same check
 			return IsPassableTo( from );
 		}
 


### PR DESCRIPTION
### Purpose
Fixes #1455 
Also adds 2 Windoors to make testing easier

![Windoors in action](https://cdn.discordapp.com/attachments/316360839290421252/538730953208758272/windoors.gif)
(Windoors in the gif weren't actually added to the map in this PR, they were just for testing purposes)

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer

### Notes:
Windoors don't yet open when you approach them diagonally, I highly suspect IsPassableTo in RegisterDoor.cs is the cause of that.
