### PR TITLE
Shutters should be already closed from start #1437

### DIFF
--- a/UnityProject/Assets/Animations/Doors/Shutters/04_shuttersClosed.anim
+++ b/UnityProject/Assets/Animations/Doors/Shutters/04_shuttersClosed.anim
@@ -6,7 +6,7 @@ AnimationClip:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: 04_shuttersClose
+  m_Name: 04_shuttersClosed
   serializedVersion: 6
   m_Legacy: 0
   m_Compressed: 0
@@ -20,26 +20,12 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300030, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.1
-      value: {fileID: 21300002, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.2
-      value: {fileID: 21300004, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.3
-      value: {fileID: 21300006, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.4
-      value: {fileID: 21300008, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.5
-      value: {fileID: 21300010, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.6
-      value: {fileID: 21300012, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.7
       value: {fileID: 21300014, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
     attribute: m_Sprite
     path: Sprite
     classID: 212
     script: {fileID: 0}
-  m_SampleRate: 20
+  m_SampleRate: 60
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
@@ -54,20 +40,13 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300030, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300002, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300004, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300006, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300008, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300010, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300012, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
     - {fileID: 21300014, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.75
+    m_StopTime: 0.016666668
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/UnityProject/Assets/Animations/Doors/Shutters/04_shuttersClosed.anim.meta
+++ b/UnityProject/Assets/Animations/Doors/Shutters/04_shuttersClosed.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 283afc4795688aa4aa3b37ce3156a251
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Animations/Doors/Shutters/04_shuttersOpen.anim
+++ b/UnityProject/Assets/Animations/Doors/Shutters/04_shuttersOpen.anim
@@ -3,8 +3,9 @@
 --- !u!74 &7400000
 AnimationClip:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: 04_shuttersOpen
   serializedVersion: 6
   m_Legacy: 0
@@ -45,10 +46,11 @@ AnimationClip:
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
     genericBindings:
-    - path: 850496168
+    - serializedVersion: 2
+      path: 850496168
       attribute: 0
       script: {fileID: 0}
-      classID: 212
+      typeID: 212
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
@@ -84,6 +86,4 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_GenerateMotionCurves: 0
-  m_IsEmpty: 0
   m_Events: []

--- a/UnityProject/Assets/Animations/Doors/Shutters/04_shuttersOpened.anim
+++ b/UnityProject/Assets/Animations/Doors/Shutters/04_shuttersOpened.anim
@@ -6,7 +6,7 @@ AnimationClip:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: 04_shuttersClose
+  m_Name: 04_shuttersOpened
   serializedVersion: 6
   m_Legacy: 0
   m_Compressed: 0
@@ -21,25 +21,11 @@ AnimationClip:
   - curve:
     - time: 0
       value: {fileID: 21300030, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.1
-      value: {fileID: 21300002, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.2
-      value: {fileID: 21300004, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.3
-      value: {fileID: 21300006, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.4
-      value: {fileID: 21300008, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.5
-      value: {fileID: 21300010, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.6
-      value: {fileID: 21300012, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - time: 0.7
-      value: {fileID: 21300014, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
     attribute: m_Sprite
     path: Sprite
     classID: 212
     script: {fileID: 0}
-  m_SampleRate: 20
+  m_SampleRate: 60
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
@@ -55,19 +41,12 @@ AnimationClip:
       isPPtrCurve: 1
     pptrCurveMapping:
     - {fileID: 21300030, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300002, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300004, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300006, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300008, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300010, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300012, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
-    - {fileID: 21300014, guid: 3126d5359b7d4eb0944012e91bd4be16, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.75
+    m_StopTime: 0.016666668
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/UnityProject/Assets/Animations/Doors/Shutters/04_shuttersOpened.anim.meta
+++ b/UnityProject/Assets/Animations/Doors/Shutters/04_shuttersOpened.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a2d831c5c1357e4283666cdbfc2dce2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Animations/Doors/Shutters/ShutterController.controller
+++ b/UnityProject/Assets/Animations/Doors/Shutters/ShutterController.controller
@@ -3,8 +3,9 @@
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: ShutterController
   serializedVersion: 5
   m_AnimatorParameters:
@@ -13,7 +14,7 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -30,12 +31,13 @@ AnimatorController:
 --- !u!1101 &1101088304269419632
 AnimatorStateTransition:
   m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions: []
   m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 1102077905879437370}
+  m_DstState: {fileID: 0}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
@@ -48,32 +50,12 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1101 &1101286361557389202
+--- !u!1101 &1101259473788531846
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 1102077905879437370}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.1
-  m_TransitionOffset: 0
-  m_ExitTime: 0.9
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1101 &1101538034784719696
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 2
@@ -85,19 +67,45 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &1101340421395031930
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: close
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102356932772858182}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
   m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.75409836
+  m_ExitTime: 0.75
   m_HasExitTime: 0
   m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1101 &1101770483771704654
+--- !u!1101 &1101391082009556916
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
@@ -109,25 +117,95 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &1101548201804954794
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102356932772858182}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.7916667
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &1101742515148771498
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: close
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102042990982339594}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
   m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.9
+  m_ExitTime: 0.75
   m_HasExitTime: 0
   m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1102 &1102077905879437370
+--- !u!1101 &1101984741005283842
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102042990982339594}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.6666666
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &1102042990982339594
 AnimatorState:
   serializedVersion: 5
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Idle
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 04_shuttersClosed
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: 1101770483771704654}
+  - {fileID: 1101259473788531846}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -136,22 +214,25 @@ AnimatorState:
   m_SpeedParameterActive: 0
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
-  m_Motion: {fileID: 0}
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 283afc4795688aa4aa3b37ce3156a251, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &1102139167169081238
 AnimatorState:
   serializedVersion: 5
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: 04_shuttersOpen
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: 1101286361557389202}
+  - {fileID: 1101548201804954794}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -160,22 +241,25 @@ AnimatorState:
   m_SpeedParameterActive: 0
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: ad4ec73bec53c914eb433f85af7bc678, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &1102177941112428184
 AnimatorState:
   serializedVersion: 5
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: 04_shuttersClose
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: 1101538034784719696}
+  - {fileID: 1101984741005283842}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -184,35 +268,99 @@ AnimatorState:
   m_SpeedParameterActive: 0
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 3142134727de9a54b9e16948d5283ca5, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &1102356932772858182
+AnimatorState:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 04_shuttersOpened
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 1101391082009556916}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 8a2d831c5c1357e4283666cdbfc2dce2, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &1102603725289777994
+AnimatorState:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: IsClosed
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 1101742515148771498}
+  - {fileID: 1101340421395031930}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 1
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1107 &1107148729554176944
 AnimatorStateMachine:
   serializedVersion: 5
   m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: Base Layer
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 1102139167169081238}
     m_Position: {x: 528, y: -36, z: 0}
   - serializedVersion: 1
-    m_State: {fileID: 1102077905879437370}
-    m_Position: {x: 372, y: 108, z: 0}
-  - serializedVersion: 1
     m_State: {fileID: 1102177941112428184}
     m_Position: {x: 240, y: -36, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1102042990982339594}
+    m_Position: {x: 528, y: -156, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1102356932772858182}
+    m_Position: {x: 528, y: 84, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1102603725289777994}
+    m_Position: {x: 804, y: -36, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: 50, y: 20, z: 0}
-  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_EntryPosition: {x: 1080, y: -36, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 1102077905879437370}
+  m_DefaultState: {fileID: 1102603725289777994}

--- a/UnityProject/Assets/Scripts/Doors/ShutterController.cs
+++ b/UnityProject/Assets/Scripts/Doors/ShutterController.cs
@@ -30,12 +30,11 @@ public class ShutterController : ObjectTrigger
 		closedSortingLayer = SortingLayer.NameToID("Doors Open");
 		openLayer = LayerMask.NameToLayer("Door Open");
 		openSortingLayer = SortingLayer.NameToID("Doors Closed");
-		SetLayer(openLayer, openSortingLayer);
 	}
 
 	public void Start()
 	{
-		gameObject.SendMessage("TurnOffDoorFov", null, SendMessageOptions.DontRequireReceiver);
+		Trigger(registerTile.IsClosed);
 	}
 
 	public override void Trigger(bool iState)


### PR DESCRIPTION
### Purpose
_Fixes #1437_<br>
_Allows the opening/closing of shutters at game start up by ticking is Closed flag of Shutter's Register Door script_

Example of running in edit mode, the left two shutters have IsClosed to *false*, the right two to *true*
![](https://i.imgur.com/oCqskUh.gif)  
  
The below example has two switches. One is set to open the two shutters on the left (set to isClosed = true). The set at the bottom left is a switch set to close a shutter (set to isClosed = false)

![](https://i.imgur.com/ELlZHgR.gif)





### Open Questions and Pre-Merge TODOs

* [x]   This fix is tested on the same branch it is PR'ed to.
* [x]  I correctly commented my code
* [x]  My code is indented with tabs and not spaces
* [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
* [x]  This PR does not bring up any new compile errors
* [x]  This PR has been tested in editor
* [x]  This PR has been tested in multiplayer

### Notes:
_The only odd change needed to be done was having to move animator.SetBool("close", isClosed). There was only a single Shutter that would not close, and for some reason would not reach the animator.SetBool("close", isClosed) line when it was below the if{} else{} block within SetState() method_
