### PR TITLE
Delaying Subsystem Initialization

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SubsystemManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SubsystemManager.cs
@@ -8,11 +8,13 @@ public class SubsystemManager : NetworkBehaviour
 	private List<SubsystemBehaviour> systems = new List<SubsystemBehaviour>();
 	private bool initialized;
 
-	public override void OnStartServer()
+	private void Start()
 	{
-		systems = systems.OrderByDescending(s => s.Priority).ToList();
-
-		Initialize();
+		if (isServer)
+		{
+			systems = systems.OrderByDescending(s => s.Priority).ToList();
+			Initialize();
+		}
 	}
 
 	private void Initialize()


### PR DESCRIPTION
…

### Purpose
Changing Subsystem Init to Start() instead of StartOnServer(), otherwise Cross-matrices might not work correctly due to somethings not being initialized yet.

Fixes #1452

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer
