### PR TITLE
More convenient and secure Client Message

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/Client/ClientHealthMessages/RequestHealthMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/ClientHealthMessages/RequestHealthMessage.cs
@@ -12,9 +12,9 @@ public class RequestHealthMessage : ClientMessage
 
 	public override IEnumerator Process()
 	{
-		yield return WaitFor(LivingEntity, SentBy);
+		yield return WaitFor(LivingEntity);
 
-		NetworkObjects[0].GetComponent<HealthStateMonitor>().ProcessClientUpdateRequest(NetworkObjects[1]);
+		NetworkObject.GetComponent<HealthStateMonitor>().ProcessClientUpdateRequest(SentByPlayer.GameObject);
 	}
 
 	public static RequestHealthMessage Send(GameObject entity)

--- a/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs
@@ -1,41 +1,33 @@
-﻿using UnityEngine.Networking;
+﻿using System.Collections;
+using UnityEngine.Networking;
 
 public abstract class ClientMessage : GameMessageBase
 {
-	public NetworkInstanceId SentBy;
+/// <summary>
+/// Player that sent this ClientMessage.
+/// Returns ConnectedPlayer.Invalid if there are issues finding one from PlayerList (like, player already left)
+/// </summary>
+	public ConnectedPlayer SentByPlayer;
+	public override IEnumerator Process( NetworkConnection sentBy )
+	{
+		SentByPlayer = PlayerList.Instance.Get( sentBy );
+		return base.Process( sentBy );
+	}
 
 	public void Send()
 	{
-		if (PlayerManager.LocalPlayer)
-		{
-			SentBy = LocalPlayerId();
-		}
-
 		CustomNetworkManager.Instance.client.connection.Send(GetMessageType(), this);
 //		Logger.Log($"Sent {this}");
 	}
 
 	public void SendUnreliable()
 	{
-		SentBy = LocalPlayerId();
 		CustomNetworkManager.Instance.client.connection.SendUnreliable(GetMessageType(), this);
 	}
 
 	private static NetworkInstanceId LocalPlayerId()
 	{
-		
+
 		return PlayerManager.LocalPlayer.GetComponent<NetworkIdentity>().netId;
-	}
-
-	public override void Deserialize(NetworkReader reader)
-	{
-		base.Deserialize(reader);
-		SentBy = reader.ReadNetworkId();
-	}
-
-	public override void Serialize(NetworkWriter writer)
-	{
-		base.Serialize(writer);
-		writer.Write(SentBy);
 	}
 }

--- a/UnityProject/Assets/Scripts/Messages/Client/InteractMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/InteractMessage.cs
@@ -17,14 +17,14 @@ public class InteractMessage : ClientMessage
 	{
 		//		Logger.Log("Processed " + ToString());
 
-		yield return WaitFor(Subject, SentBy);
+		yield return WaitFor(Subject);
 		if (!UITrigger)
 		{
-			NetworkObjects[0].GetComponent<InputTrigger>().Interact(NetworkObjects[1], Position, decodeHand(Hand));
+			NetworkObject.GetComponent<InputTrigger>().Interact(SentByPlayer.GameObject, Position, decodeHand(Hand));
 		}
 		else
 		{
-			NetworkObjects[0].GetComponent<InputTrigger>().UI_Interact(NetworkObjects[1], decodeHand(Hand));
+			NetworkObject.GetComponent<InputTrigger>().UI_Interact(SentByPlayer.GameObject, decodeHand(Hand));
 		}
 	}
 
@@ -92,7 +92,7 @@ public class InteractMessage : ClientMessage
 
 	public override string ToString()
 	{
-		return $"[InteractMessage Subject={Subject} Hand={decodeHand( Hand )} Type={MessageType} SentBy={SentBy}]";
+		return $"[InteractMessage Subject={Subject} Hand={decodeHand( Hand )} Type={MessageType} SentBy={SentByPlayer}]";
 	}
 
 	public override void Deserialize(NetworkReader reader)

--- a/UnityProject/Assets/Scripts/Messages/Client/InventoryInteractMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/InventoryInteractMessage.cs
@@ -20,20 +20,18 @@ public class InventoryInteractMessage : ClientMessage
 		if (Subject.Equals(NetworkInstanceId.Invalid))
 		{
 			//Drop item message
-			yield return WaitFor(SentBy);
-			ProcessFurther(NetworkObject);
+			ProcessFurther(SentByPlayer);
 		}
 		else
 		{
-			yield return WaitFor(SentBy, Subject);
-			ProcessFurther(NetworkObjects[0], NetworkObjects[1]);
+			yield return WaitFor(Subject);
+			ProcessFurther(SentByPlayer, NetworkObject);
 		}
 	}
 
-	private void ProcessFurther(GameObject player, GameObject item = null)
+	private void ProcessFurther(ConnectedPlayer player, GameObject item = null)
 	{
-		GameObject clientPlayer = player;
-		PlayerNetworkActions pna = clientPlayer.GetComponent<PlayerNetworkActions>();
+		PlayerNetworkActions pna = player.Script.playerNetworkActions;
 		if (string.IsNullOrEmpty(SlotUUID))
 		{
 			//To drop

--- a/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs
@@ -13,10 +13,9 @@ public class PostToChatMessage : ClientMessage
 
 	public override IEnumerator Process()
 	{
-		yield return WaitFor(SentBy);
-		if (NetworkObject)
+		if (SentByPlayer != ConnectedPlayer.Invalid)
 		{
-			if (ValidRequest(NetworkObject)) {
+			if (ValidRequest(SentByPlayer)) {
 				ChatEvent chatEvent = new ChatEvent(ChatMessageText, NetworkObject, Channels);
 				ChatRelay.Instance.AddToChatLogServer(chatEvent);
 			}
@@ -26,9 +25,10 @@ public class PostToChatMessage : ClientMessage
 			ChatEvent chatEvent = new ChatEvent(ChatMessageText, Channels);
 			ChatRelay.Instance.AddToChatLogServer(chatEvent);
 		}
+		yield return null;
 	}
 
-	public static void SendThrowHitMessage( GameObject item, GameObject victim, int damage, BodyPartType hitZone = BodyPartType.None ) 
+	public static void SendThrowHitMessage( GameObject item, GameObject victim, int damage, BodyPartType hitZone = BodyPartType.None )
 	{
 		var player = victim.Player();
 		if ( player == null ) {
@@ -53,7 +53,7 @@ public class PostToChatMessage : ClientMessage
 	/// <param name="victim">GameObject of the player hat was the victim</param>
 	/// <param name="damage">damage done</param>
 	/// <param name="hitZone">zone that was damaged</param>
-	public static void SendItemAttackMessage( GameObject item, GameObject attacker, GameObject victim, int damage, BodyPartType hitZone = BodyPartType.None ) 
+	public static void SendItemAttackMessage( GameObject item, GameObject attacker, GameObject victim, int damage, BodyPartType hitZone = BodyPartType.None )
 	{
 		var itemAttributes = item.GetComponent<ItemAttributes>();
 
@@ -61,14 +61,14 @@ public class PostToChatMessage : ClientMessage
 		if ( player == null ) {
 			hitZone = BodyPartType.None;
 		}
-		
+
 		string victimName;
 		if ( attacker == victim ) {
 			victimName = "self";
 		} else {
 			victimName = victim.ExpensiveName();
 		}
-		
+
 		var attackVerb = itemAttributes.attackVerb.GetRandom() ?? "attacked";
 
 		var message = $"{attacker.Player()?.Name} has {attackVerb} {victimName}{InTheZone( hitZone )} with {itemAttributes.itemName}!";
@@ -99,9 +99,9 @@ public class PostToChatMessage : ClientMessage
 		return msg;
 	}
 
-	public bool ValidRequest(GameObject player)
+	public bool ValidRequest(ConnectedPlayer player)
 	{
-		PlayerScript playerScript = player.GetComponent<PlayerScript>();
+		PlayerScript playerScript = player.Script;
 		//Need to add system channel here so player can transmit system level events but not select it in the UI
 		ChatChannel availableChannels = playerScript.GetAvailableChannelsMask() | ChatChannel.System;
 		if ((availableChannels & Channels) == Channels)

--- a/UnityProject/Assets/Scripts/Messages/Client/RequestAuthMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/RequestAuthMessage.cs
@@ -12,31 +12,29 @@ public class RequestAuthMessage : ClientMessage
 	public override IEnumerator Process()
 	{
 		//	Logger.Log("Processed " + ToString());
-		yield return WaitFor(SentBy);
+//		yield return WaitFor(SentBy);
 
 //		if ( !Managers.instance.isForRelease )
 //		{
 //			Logger.Log($"Ignoring {this}, not for release");
 //			yield break;
 //		}
-		
-		var connectedPlayer = PlayerList.Instance.Get( NetworkObject );
 
-		if ( PlayerList.IsConnWhitelisted(connectedPlayer) )
-		{ 
-			Logger.Log( $"Player whitelisted: {connectedPlayer}", Category.Steam);
-			yield break;
-		}
-		if ( connectedPlayer.SteamId != 0 )
+		if ( PlayerList.IsConnWhitelisted(SentByPlayer) )
 		{
-			Logger.Log( $"Player already authenticated: {connectedPlayer}", Category.Steam );
+			Logger.Log( $"Player whitelisted: {SentByPlayer}", Category.Steam);
 			yield break;
 		}
-		
+		if ( SentByPlayer.SteamId != 0 )
+		{
+			Logger.Log( $"Player already authenticated: {SentByPlayer}", Category.Steam );
+			yield break;
+		}
+
 //		Logger.Log("Server Starting Auth for User:" + SteamID);
 		if (Server.Instance != null && SteamID != 0 && TicketBinary != null)
 		{
-			
+
 			//This results in a callback in CustomNetworkManager
 			if (!Server.Instance.Auth.StartSession(TicketBinary, SteamID))
 			{
@@ -44,24 +42,24 @@ public class RequestAuthMessage : ClientMessage
 				// More info: http://projectzomboid.com/modding//net/puppygames/steam/BeginAuthSessionResult.html
 				// if triggered does prevent the authchange callback.
 //				Logger.Log("Start Session returned false, kicking");
-				CustomNetworkManager.Kick( connectedPlayer, "Steam auth failed" );
+				CustomNetworkManager.Kick( SentByPlayer, "Steam auth failed" );
 			}
 			else
 			{
-				connectedPlayer.SteamId = SteamID;
+				SentByPlayer.SteamId = SteamID;
 			}
 		}
 
 	}
-	
+
 	public static RequestAuthMessage Send(ulong steamid, byte[] ticketBinary)
 	{
 		RequestAuthMessage msg = new RequestAuthMessage
 		{
 			SteamID = steamid,
-			TicketBinary = ticketBinary			
+			TicketBinary = ticketBinary
 		};
-		
+
 		msg.Send();
 		return msg;
 	}
@@ -69,7 +67,7 @@ public class RequestAuthMessage : ClientMessage
 
 	public override string ToString()
 	{
-		return $"[RequestAuthMessage SteamID={SteamID} TicketBinary={TicketBinary} Type={MessageType} SentBy={SentBy}]";
+		return $"[RequestAuthMessage SteamID={SteamID} TicketBinary={TicketBinary} Type={MessageType} SentBy={SentByPlayer}]";
 	}
 
 	public override void Deserialize(NetworkReader reader)

--- a/UnityProject/Assets/Scripts/Messages/Client/RequestMoveMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/RequestMoveMessage.cs
@@ -12,10 +12,8 @@ public class RequestMoveMessage : ClientMessage
 	public override IEnumerator Process()
 	{
 //		Logger.Log("Processed " + ToString());
-
-		yield return WaitFor(SentBy);
-
-		NetworkObject.GetComponent<PlayerSync>().ProcessAction(Action);
+		SentByPlayer.Script.PlayerSync.ProcessAction(Action);
+		yield return null;
 	}
 
 	public static RequestMoveMessage Send(PlayerAction action)
@@ -30,7 +28,7 @@ public class RequestMoveMessage : ClientMessage
 
 	public override string ToString()
 	{
-		return $"[RequestMoveMessage Action={Action} SentBy={SentBy}]";
+		return $"[RequestMoveMessage Action={Action} SentBy={SentByPlayer}]";
 	}
 
 	public override void Deserialize(NetworkReader reader)

--- a/UnityProject/Assets/Scripts/Messages/Client/RequestShootMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/RequestShootMessage.cs
@@ -25,18 +25,18 @@ public class RequestShootMessage : ClientMessage {
 
 	public override IEnumerator Process()
 	{
-		if (SentBy.Equals(NetworkInstanceId.Invalid)) {
+		if (SentByPlayer == ConnectedPlayer.Invalid) {
 			//Failfast
 			Logger.LogWarning($"Shoot request invalid, processing stopped: {ToString()}", Category.Firearms);
 			yield break;
 		}
 
 
-		yield return WaitFor(SentBy);
 		//get the currently equipped weapon in the player's active hand
-		PlayerNetworkActions pna = NetworkObject.GetComponent<PlayerNetworkActions>();
+		PlayerNetworkActions pna = SentByPlayer.Script.playerNetworkActions;
 		Weapon wep = pna.GetActiveHandItem().GetComponent<Weapon>();
 		wep.ServerShoot(NetworkObject,Target, DamageZone, IsSuicideShot);
+		yield return null;
 	}
 
 	public static RequestShootMessage Send(GameObject weapon, Vector2 direction, string bulletName,

--- a/UnityProject/Assets/Scripts/Messages/Client/RequestSyncMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/RequestSyncMessage.cs
@@ -12,21 +12,18 @@ public class RequestSyncMessage : ClientMessage
 	public override IEnumerator Process()
 	{
 //		Logger.Log("Processed " + ToString());
-
-		yield return WaitFor(SentBy);
-
-		ConnectedPlayer connectedPlayer = PlayerList.Instance.Get( NetworkObject );
-		Logger.Log($"{connectedPlayer} requested sync", Category.Connections);
+		Logger.Log($"{SentByPlayer} requested sync", Category.Connections);
 
 		//not sending out sync data for players not ingame
-		if ( connectedPlayer.Job != JobType.NULL && !connectedPlayer.Synced ) {
-			CustomNetworkManager.Instance.SyncPlayerData(NetworkObject);
+		if ( SentByPlayer.Job != JobType.NULL && !SentByPlayer.Synced ) {
+			CustomNetworkManager.Instance.SyncPlayerData(SentByPlayer.GameObject);
 
 			//marking player as synced to avoid sending that data pile again
-			connectedPlayer.Synced = true;
+			SentByPlayer.Synced = true;
 
-			AnnounceNewPlayer( connectedPlayer );
+			AnnounceNewPlayer( SentByPlayer );
 		}
+		yield return null;
 	}
 
 	private static void AnnounceNewPlayer( ConnectedPlayer newPlayer ) {
@@ -41,7 +38,7 @@ public class RequestSyncMessage : ClientMessage
 
 	public override string ToString()
 	{
-		return $"[RequestSyncMessage Type={MessageType} SentBy={SentBy}]";
+		return $"[RequestSyncMessage Type={MessageType} SentBy={SentByPlayer}]";
 	}
 
 	public override void Deserialize(NetworkReader reader)

--- a/UnityProject/Assets/Scripts/Messages/Client/UIInteractMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/UIInteractMessage.cs
@@ -15,9 +15,9 @@ public class UIInteractMessage : ClientMessage
 	{
 //		Logger.Log("Processed " + ToString());
 
-		yield return WaitFor(Subject, SentBy);
+		yield return WaitFor(Subject);
 
-		NetworkObjects[0].GetComponent<InputTrigger>().UI_Interact(NetworkObjects[1], decodeHand(Hand));
+		NetworkObject.GetComponent<InputTrigger>().UI_Interact(SentByPlayer.GameObject, decodeHand(Hand));
 	}
 
 	public static UIInteractMessage Send(GameObject subject, string hand)
@@ -61,7 +61,7 @@ public class UIInteractMessage : ClientMessage
 
 	public override string ToString()
 	{
-		return $"[InteractMessage Subject={Subject} Hand={decodeHand( Hand )} Type={MessageType} SentBy={SentBy}]";
+		return $"[InteractMessage Subject={Subject} Hand={decodeHand( Hand )} Type={MessageType} SentBy={SentByPlayer}]";
 	}
 
 	public override void Deserialize(NetworkReader reader)

--- a/UnityProject/Assets/Scripts/Messages/Client/UpdateHeadsetKeyMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/UpdateHeadsetKeyMessage.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 using UnityEngine.Networking;
 
 /// <summary>
-///     Requests a Headset Encryption Key update 
+///     Requests a Headset Encryption Key update
 /// </summary>
 public class UpdateHeadsetKeyMessage : ClientMessage
 {
@@ -24,9 +24,9 @@ public class UpdateHeadsetKeyMessage : ClientMessage
 		if ( EncryptionKey.Equals(NetworkInstanceId.Invalid) )
 		{
 			//No key passed in message -> Removes EncryptionKey from a headset
-			yield return WaitFor(SentBy, HeadsetItem);
-			var player = NetworkObjects[0];
-			var headsetGO = NetworkObjects[1];
+			yield return WaitFor(HeadsetItem);
+			var player = SentByPlayer;
+			var headsetGO = NetworkObject;
 			if ( ValidRemoval(headsetGO) )
 			{
 				detachKey(headsetGO, player);
@@ -35,10 +35,10 @@ public class UpdateHeadsetKeyMessage : ClientMessage
 		else
 		{
 			//Key was passed -> Puts it into headset
-			yield return WaitFor(SentBy, HeadsetItem, EncryptionKey);
-			var player = NetworkObjects[0];
-			var headsetGO = NetworkObjects[1];
-			var keyGO = NetworkObjects[2];
+			yield return WaitFor(HeadsetItem, EncryptionKey);
+			var player = SentByPlayer;
+			var headsetGO = NetworkObjects[0];
+			var keyGO = NetworkObjects[1];
 			if ( ValidUpdate(headsetGO, keyGO) )
 			{
 				setKey(player, headsetGO, keyGO);
@@ -46,9 +46,9 @@ public class UpdateHeadsetKeyMessage : ClientMessage
 		}
 	}
 
-	private static void setKey(GameObject player, GameObject headsetGO, GameObject keyGO)
+	private static void setKey(ConnectedPlayer player, GameObject headsetGO, GameObject keyGO)
 	{
-		var pna = player.GetComponent<PlayerNetworkActions>();
+		var pna = player.Script.playerNetworkActions;
 		if ( pna.HasItem(keyGO) )
 		{
 			Headset headset = headsetGO.GetComponent<Headset>();
@@ -58,27 +58,27 @@ public class UpdateHeadsetKeyMessage : ClientMessage
 		}
 	}
 
-	private static void detachKey(GameObject headsetGO, GameObject player)
+	private static void detachKey(GameObject headsetGO, ConnectedPlayer player)
 	{
 		Headset headset = headsetGO.GetComponent<Headset>();
 		GameObject encryptionKey =
-		Object.Instantiate(Resources.Load("EncryptionKey", typeof( GameObject )), 
-			headsetGO.transform.position, 
-			headsetGO.transform.rotation, 
+		Object.Instantiate(Resources.Load("EncryptionKey", typeof( GameObject )),
+			headsetGO.transform.position,
+			headsetGO.transform.rotation,
 			headsetGO.transform.parent) as GameObject;
 		if ( encryptionKey == null )
 		{
-			Logger.LogError($"Headset key instantiation for {PlayerList.Instance.Get(player).Name} failed, spawn aborted",Category.Telecoms);
+			Logger.LogError($"Headset key instantiation for {player.Name} failed, spawn aborted",Category.Telecoms);
 			return;
 		}
 
 		encryptionKey.GetComponent<EncryptionKey>().Type = headset.EncryptionKey;
 //		Logger.Log($"Spawning headset key {encryptionKey} with type {headset.EncryptionKey}");
-		
+
 		//TODO when added interact with dropped headset, add encryption key to empty hand
 		headset.EncryptionKey = EncryptionKeyType.None;
-		
-		ItemFactory.SpawnItem(encryptionKey, player.transform.position, player.transform.parent);
+
+		ItemFactory.SpawnItem(encryptionKey, player.Script.WorldPos, player.GameObject.transform.parent);
 	}
 
 	public static UpdateHeadsetKeyMessage Send(GameObject headsetItem, GameObject encryptionkey = null)
@@ -121,7 +121,7 @@ public class UpdateHeadsetKeyMessage : ClientMessage
 
 	public override string ToString()
 	{
-		return $"[UpdateHeadsetKeyMessage SentBy={SentBy} HeadsetItem={HeadsetItem} EncryptionKey={EncryptionKey}]";
+		return $"[UpdateHeadsetKeyMessage SentBy={SentByPlayer} HeadsetItem={HeadsetItem} EncryptionKey={EncryptionKey}]";
 	}
 
 	public override void Deserialize(NetworkReader reader)

--- a/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs
+++ b/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Reflection;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -10,11 +11,16 @@ public abstract class GameMessageBase : MessageBase
 
 	public abstract IEnumerator Process();
 
+	public virtual IEnumerator Process( NetworkConnection sentBy )
+	{
+		yield return Process();
+	}
+
 	protected IEnumerator WaitFor(NetworkInstanceId id)
 	{
 		if (id.IsEmpty())
 		{
-			Logger.LogWarning($"{this} tried to wait on an empty (0) id", Category.NetMessage);
+			Logger.LogWarningFormat( "{0} tried to wait on an empty (0) id", Category.NetMessage, this.GetType().Name );
 			yield break;
 		}
 
@@ -23,7 +29,7 @@ public abstract class GameMessageBase : MessageBase
 		{
 			if (tries++ > 10)
 			{
-				Logger.LogWarning($"{this} could not find object with id {id}", Category.NetMessage);
+				Logger.LogWarningFormat( "{0} could not find object with id {1}", Category.NetMessage, this.GetType().Name, id );
 				yield break;
 			}
 

--- a/UnityProject/Assets/Scripts/NetworkManagerExtensions.cs
+++ b/UnityProject/Assets/Scripts/NetworkManagerExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using UnityEditor;
 using UnityEngine.Networking;
 
 public static class NetworkManagerExtensions
@@ -40,10 +41,12 @@ public static class NetworkManagerExtensions
 		where T : GameMessageBase, new()
 	{
 		// In normal C# this would just be `T.MessageType` but it seems unity's compiler has some stipulations about that...
-		FieldInfo field = typeof(T).GetField("MessageType",
-			BindingFlags.Static | BindingFlags.FlattenHierarchy | BindingFlags.Public);
+		FieldInfo field = typeof(T).GetField("MessageType",BindingFlags.Static | BindingFlags.FlattenHierarchy | BindingFlags.Public);
 		short msgType = (short) field.GetValue(null);
-		NetworkMessageDelegate cb = delegate(NetworkMessage msg) { manager.StartCoroutine(msg.ReadMessage<T>().Process()); };
+		NetworkMessageDelegate cb = delegate( NetworkMessage msg )
+		{
+			manager.StartCoroutine(msg.ReadMessage<T>().Process( msg.conn ));
+		};
 
 		if (conn != null)
 		{
@@ -60,7 +63,7 @@ public static class NetworkManagerExtensions
 	/// </summary>
 	private static MethodInfo GetHandlerInfo()
 	{
-		return typeof(NetworkManagerExtensions).GetMethod("RegisterHandler", BindingFlags.Static | BindingFlags.Public);
+		return typeof(NetworkManagerExtensions).GetMethod(nameof(RegisterHandler), BindingFlags.Static | BindingFlags.Public);
 	}
 
 	/// <summary>


### PR DESCRIPTION
### Purpose
Fixes #1433 – client can no longer fake `SentBy` 
You no longer have to `WaitFor(SentBy)` in `Process()`, as `SentBy` has been replaced with `SentByPlayer` (`ConnectedPlayer` class) and is resolved implicitly.
`SentByPlayer` is way more convenient to use because you no longer have to `GetComponent<>()` for basic things like `PlayerNetworkActions` and have all `ConnectedPlayer` data (including Name, PlayerScript, even Job) at your fingertips.
Existing ClientMessages have been refactored to support this change.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
This might slightly increase allocations due to invocation of `PlayerList.Instance.Get()` for every received ClientMessage on server. But in practice these are sparse and I don't really see it ever becoming a problem.