### PR TITLE
Fixes #1465

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
@@ -36,7 +36,7 @@
 				// OneDirectionRestricted is hardcoded to only be from the negative y position
 				Vector3Int v = Vector3Int.RoundToInt(transform.localRotation * Vector3.down);
 
-				// Returns false if player is bumping from the correct and restricted direction 
+				// Returns false if player is bumping door from the restricted direction 
 				return !(to - Position).y.Equals(v.y);
 			}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
@@ -33,9 +33,11 @@
 		{
 			if (isClosed && OneDirectionRestricted)
 			{
+				// OneDirectionRestricted is hardcoded to only be from the negative y position
 				Vector3Int v = Vector3Int.RoundToInt(transform.localRotation * Vector3.down);
 
-				return !(to - Position).Equals(v);
+				// Returns false if player is bumping from the correct and restricted direction 
+				return !(to - Position).y.Equals(v.y);
 			}
 
 			return !isClosed;


### PR DESCRIPTION
### Purpose
Fixes #1465 

### Open Questions and Pre-Merge TODOs
- [x] This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer

### Notes:
OneDirectionRestricted is hardcoded to only be from the negative y direction. No support currently for restricting in other directions
