### PR TITLE
#1506 Restrict chat in crit

### DIFF
--- a/UnityProject/Assets/Scripts/UI/ControlChat.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlChat.cs
@@ -120,6 +120,11 @@ public class ControlChat : MonoBehaviour
         }
         else
         {
+            if (PlayerManager.LocalPlayerScript.playerHealth.IsCrit)
+            {
+                //Player in crit, message not sent
+                return;
+            }
             if (PlayerManager.LocalPlayerScript.playerMove.isGhost)
             {
                 //dead chat only


### PR DESCRIPTION
### Purpose
This removes player ability to speak while in a critical condition

Fixes #1506

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer

### Notes:
I'd like to implement it as a chat modifier however in it's current form when modifiers are applied they cannot be returned if empty.  I'll look into other changes in the system but will just add a fix for this right now.