### PR TITLE
#1506 Player speaking while in critical state

### DIFF
--- a/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
@@ -33,6 +33,7 @@ public enum ChatModifier
 	None = 0,
 	Drunk = 1,
 	Stutter = 2,
+	Crit = 3,
 	Hiss = 4,
 	Clown = 8
 }
@@ -139,6 +140,10 @@ public class ChatEvent
 		}
 
 		message = ApplyModifiers(message, modifiers);
+		if (message.Length < 1)
+		{
+			this.channels = ChatChannel.None;
+		}
 		message = "<b>" + speaker + "</b> says: \"" + message + "\"";
 
 		return message;
@@ -204,6 +209,10 @@ public class ChatEvent
 			{
 				output = output + " ...hic!...";
 			}
+		}
+		if ((modifiers & ChatModifier.Crit) == ChatModifier.Crit)
+		{
+			output = "";
 		}
 
 		return output;

--- a/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
@@ -142,6 +142,7 @@ public class ChatEvent
 		message = ApplyModifiers(message, modifiers);
 		if (message.Length < 1)
 		{
+			// if message + modifiers leads to no text, do not display
 			this.channels = ChatChannel.None;
 		}
 		message = "<b>" + speaker + "</b> says: \"" + message + "\"";
@@ -212,6 +213,8 @@ public class ChatEvent
 		}
 		if ((modifiers & ChatModifier.Crit) == ChatModifier.Crit)
 		{
+			//If user is in critical state remove text
+			//This can be changed later to other status effects
 			output = "";
 		}
 

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -318,6 +318,9 @@ public class PlayerScript : ManagedNetworkBehaviour
 			{
 				return ChatModifier.None;
 			}
+			if (playerHealth.IsCrit) {
+				return ChatModifier.Crit;
+			}
 
 			//TODO add missing modifiers
 			//TODO add if for being drunk

--- a/UnityProject/Assets/Scripts/UI/ControlChat.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlChat.cs
@@ -131,11 +131,26 @@ public class ControlChat : MonoBehaviour
             }
         }
 
-        if (InputFieldChat.text != "")
+        if (PlayerChatShown())
         {
             PlayerManager.LocalPlayerScript.playerNetworkActions.CmdToggleChatIcon (true);
         }
         InputFieldChat.text = "";
+    }
+    //Check cases where player should not have chat icon
+    public bool PlayerChatShown ()
+    {
+        // case where player is in crit
+        if (PlayerManager.LocalPlayerScript.playerHealth.IsCrit)
+        {
+            return false;
+        }
+        // case where text is empty
+        if (InputFieldChat.text == "")
+        {
+            return false;
+        }
+        return true;
     }
 
     public void OnChatCancel ()


### PR DESCRIPTION
### Purpose
When a user was in critical state, they were still able to communicate
Fixes #1506

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer

### Notes:
I chose the method of adding it as a modifier over a simple fix ignore talk because I believe this would make any future changes to critical state easier (death whisper or such). I added a check just after modifiers that if the message is empty after modifiers are applied that there shouldn't be any message. If this is too much I can just go with the simple block text chat in ControlChat.cs