### PR TITLE
#1521 Fixes various issues related to rotating matrices / rotations

### DIFF
--- a/UnityProject/Assets/Scripts/Camera/Camera2DFollow.cs
+++ b/UnityProject/Assets/Scripts/Camera/Camera2DFollow.cs
@@ -10,7 +10,7 @@ public class Camera2DFollow : MonoBehaviour
 	private readonly float lookAheadMoveThreshold = 0.1f;
 	private readonly float lookAheadReturnSpeed = 0.5f;
 
-	private readonly float yOffSet = -0.5f; 
+	private readonly float yOffSet = -0.5f;
 
 	private Vector3 cachePos;
 	private Vector3 currentVelocity;
@@ -82,7 +82,7 @@ public class Camera2DFollow : MonoBehaviour
 		if(!PlayerManager.LocalPlayerScript.weaponNetworkActions){
 			return;
 		}
-		if (target != null && !isShaking && !PlayerManager.LocalPlayerScript.weaponNetworkActions.lerping)
+		if (target != null && !isShaking)
 		{
 			// only update lookahead pos if accelerating or changed direction
 			float xMoveDelta = (target.position - lastTargetPosition).x;
@@ -106,7 +106,7 @@ public class Camera2DFollow : MonoBehaviour
 			//aheadTargetPos.x += xOffset;
 
 			Vector3 newPos = Vector3.SmoothDamp(transform.position, aheadTargetPos, ref currentVelocity, damping);
-	
+
 			if (adjustPixel)
 			{
 				newPos.x = Mathf.RoundToInt(newPos.x * pixelAdjustment) / pixelAdjustment;

--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -8,6 +8,7 @@ public class ClosetControl : InputTrigger
 {
 	private Sprite doorClosed;
 	public Sprite doorOpened;
+
 	[Header("Contents that will spawn inside every locker of type")]
 	public List<GameObject> DefaultContents;
 
@@ -44,9 +45,9 @@ public class ClosetControl : InputTrigger
 		StartCoroutine(WaitForServerReg());
 		base.OnStartServer();
 
-		foreach ( GameObject itemPrefab in DefaultContents )
+		foreach (GameObject itemPrefab in DefaultContents)
 		{
-			ItemFactory.SpawnItem( itemPrefab, transform.position, transform.parent );
+			ItemFactory.SpawnItem(itemPrefab, transform.position, transform.parent);
 		}
 	}
 
@@ -78,6 +79,7 @@ public class ClosetControl : InputTrigger
 				return true;
 			}
 		}
+
 		foreach (var item in heldItems)
 		{
 			if (item.gameObject == gameObject)
@@ -110,6 +112,7 @@ public class ClosetControl : InputTrigger
 					IsLocked = false;
 					return;
 				}
+
 				IsClosed = false;
 				SetItems(true);
 			}
@@ -146,6 +149,7 @@ public class ClosetControl : InputTrigger
 		{
 			return;
 		}
+
 		if (lockIt)
 		{
 		}
@@ -176,12 +180,14 @@ public class ClosetControl : InputTrigger
 			lockLight.Hide();
 		}
 	}
+
 	[ContextMethod("Open/close", "hand")]
 	public void GUIInteract()
 	{
 		//don't put your hand contents on open/close rmb action!
 		InteractInternal(false);
 	}
+
 	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
 		return InteractInternal();
@@ -217,8 +223,10 @@ public class ClosetControl : InputTrigger
 			{
 				localPlayer.playerNetworkActions.CmdToggleCupboard(gameObject);
 			}
+
 			return true;
 		}
+
 		return true;
 	}
 
@@ -254,7 +262,8 @@ public class ClosetControl : InputTrigger
 				netTransform.AppearAtPosition(pos);
 				if (pushPull && pushPull.Pushable.IsMovingServer)
 				{
-					netTransform.InertiaDrop(pos, pushPull.Pushable.MoveSpeedServer, pushPull.InheritedImpulse.To2Int());
+					netTransform.InertiaDrop(pos, pushPull.Pushable.MoveSpeedServer,
+						pushPull.InheritedImpulse.To2Int());
 				}
 				else
 				{
@@ -287,7 +296,8 @@ public class ClosetControl : InputTrigger
 				playerSync.AppearAtPositionServer(registerTile.WorldPosition);
 				if (pushPull && pushPull.Pushable.IsMovingServer)
 				{
-					playerScript.pushPull.TryPush(pushPull.InheritedImpulse.To2Int(), pushPull.Pushable.MoveSpeedServer);
+					playerScript.pushPull.TryPush(pushPull.InheritedImpulse.To2Int(),
+						pushPull.Pushable.MoveSpeedServer);
 				}
 			}
 
@@ -303,6 +313,25 @@ public class ClosetControl : InputTrigger
 					ClosetHandlerMessage.Send(player.gameObject, gameObject);
 				}
 			}
+		}
+	}
+
+
+	/// <summary>
+	/// Invoked when the parent net ID of this closet's RegisterCloset changes. Updates the parent net ID of the player / items
+	/// in the closet, passing the update on to their RegisterTile behaviors.
+	/// </summary>
+	/// <param name="parentNetId">new parent net ID</param>
+	public void OnParentChangeComplete(NetworkInstanceId parentNetId)
+	{
+		foreach (ObjectBehaviour objectBehaviour in heldItems)
+		{
+			objectBehaviour.registerTile.ParentNetId = parentNetId;
+		}
+
+		foreach (ObjectBehaviour objectBehaviour in heldPlayers)
+		{
+			objectBehaviour.registerTile.ParentNetId = parentNetId;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Editor/Matrix/Views/MetaTileMapView.cs
+++ b/UnityProject/Assets/Scripts/Editor/Matrix/Views/MetaTileMapView.cs
@@ -17,6 +17,7 @@ public class MetaTileMapView : BasicView
 		globalChecks.Add(new SpaceCheck());
 		globalChecks.Add(new ShowGlobalPositionsCheck());
 		globalChecks.Add(new ShowPositionsCheck());
+		globalChecks.Add(new AtPointCheck());
 	}
 
 	public override void DrawContent()
@@ -137,6 +138,21 @@ public class MetaTileMapView : BasicView
 			else
 			{
 				GizmoUtils.DrawText($"{position.x}, {position.y}", position, Color.gray, false);
+			}
+		}
+	}
+
+	private class AtPointCheck : Check<MatrixManager>
+	{
+		public override string Label { get; } = "Matrix ID At Point";
+
+		public override void DrawLabel(MatrixManager source, Vector3Int position)
+		{
+			if (!MatrixManager.IsSpaceAt(position))
+			{
+				MatrixInfo matrix = MatrixManager.AtPoint(position);
+
+				GizmoUtils.DrawText($"{matrix.Id}", position, false);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -323,7 +323,7 @@ public class CustomNetworkManager : NetworkManager
 		CustomNetTransform[] scripts = FindObjectsOfType<CustomNetTransform>();
 		for (var i = 0; i < scripts.Length; i++)
 		{
-			scripts[i].NotifyPlayer(playerGameObject, true);
+			scripts[i].NotifyPlayer(playerGameObject);
 		}
 		//All players
 		List<ConnectedPlayer> players = PlayerList.Instance.InGamePlayers;

--- a/UnityProject/Assets/Scripts/Player/PlayerManager.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerManager.cs
@@ -80,7 +80,7 @@ public class PlayerManager : MonoBehaviour
 
 		PlayerScript =
 			LocalPlayerScript; // Set this on the manager so it can be accessed by other components/managers
-		Camera2DFollow.followControl.target = LocalPlayer.transform.Find("Sprites");
+		Camera2DFollow.followControl.target = LocalPlayer.transform;
 
 		HasSpawned = true;
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
@@ -112,7 +112,6 @@ using UnityEngine.Tilemaps;
 		public virtual bool HasTile(Vector3Int position)
 		{
 			return tilemap.HasTile( position );
-//			return GetTile(position);
 		}
 
 		public virtual void RemoveTile(Vector3Int position, bool removeAll=false)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 
-
+/// <summary>
+/// Holds and provides functionality for all the MetaDataTiles for a given matrix.
+/// </summary>
 public class MetaDataLayer : MonoBehaviour
 {
 	private MetaDataDictionary nodes = new MetaDataDictionary();

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosManager.cs
@@ -3,8 +3,10 @@ using UnityEngine;
 
 public class AtmosManager : MonoBehaviour
 {
+	[Tooltip("frequency of atmos simulation updates (seconds between each update)")]
 	public float Speed = 0.1f;
 
+	[Tooltip("not currently implemented, thread count is always locked at one regardless of this setting")]
 	public int NumberThreads = 1;
 
 	private void OnValidate()

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
@@ -4,16 +4,45 @@ using UnityEngine;
 
 namespace Atmospherics
 {
+	/// <summary>
+	/// Main class which runs the atmospheric simulation for a given atmos thread. Since there is currently only
+	/// one thread (At the time of writing), this means AtmosSimulation runs the simulation for the entire map.
+	///
+	/// AtmosSimulation operates on MetaDataNodes. There is one MetaDataNode per tile. The metadatanode describes
+	/// the current state of the tile and is updated when AtmosSimulation updates it.
+	///
+	/// AtmosSimulation works by updating only what MetaDataNodes it is told to update, via AddToUpdateList. Once
+	/// it updates, it doesn't do anything else to that MetaDataNode until it is told to again.
+	/// </summary>
 	public class AtmosSimulation
 	{
+		/// <summary>
+		/// Interval (seconds) between updates of the simulation.
+		/// </summary>
 		public float Speed = 0.1f;
 
+		/// <summary>
+		/// True iff atmossimulation has updates to perform
+		/// </summary>
 		public bool IsIdle => updateList.IsEmpty;
 
+		/// <summary>
+		/// Number of updates remaining for atmossimulation to process
+		/// </summary>
 		public int UpdateListCount => updateList.Count;
 
+		/// <summary>
+		/// determines how much things change during an update, calculated based on the Speed and number of
+		/// updates that currently need processing.
+		/// </summary>
 		private float factor;
+		/// <summary>
+		/// Holds the nodes which are being processed during the current Update
+		/// </summary>
 		private List<MetaDataNode> nodes = new List<MetaDataNode>(5);
+		/// <summary>
+		/// MetaDataNodes that we are requested to update but haven't yet
+		/// </summary>
 		private UniqueQueue<MetaDataNode> updateList = new UniqueQueue<MetaDataNode>();
 
 		public void AddToUpdateList(MetaDataNode node)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -3,6 +3,9 @@ using System.Linq;
 
 namespace Atmospherics
 {
+	/// <summary>
+	/// Represents a mix of gases
+	/// </summary>
 	public struct GasMix
 	{
 		public readonly float[] Gases;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Hotspot.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Hotspot.cs
@@ -3,12 +3,25 @@ using UnityEngine;
 
 namespace Atmospherics
 {
+	/// <summary>
+	/// Represents the potential for a MetaDataNode to ignite the gases on it, and provides logic related to igniting the actual
+	/// gases.
+	/// </summary>
 	public class Hotspot
 	{
+		/// <summary>
+		/// Current temperature on the tile
+		/// </summary>
 		public float Temperature { get; private set; }
 
+		/// <summary>
+		/// Current volume of the tile
+		/// </summary>
 		public float Volume { get; private set; }
 
+		/// <summary>
+		/// Node this hotspot lives on.
+		/// </summary>
 		private MetaDataNode node;
 
 		public Hotspot(MetaDataNode node, float temperature, float volume)
@@ -42,6 +55,9 @@ namespace Atmospherics
 			return true;
 		}
 
+		/// <summary>
+		/// Exposes the hotspot, igniting gases on the tile
+		/// </summary>
 		private void Expose()
 		{
 			if ((Volume / node.GasMix.Volume) > 0.95f)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -4,6 +4,9 @@ using Atmospherics;
 using Objects;
 using UnityEngine;
 
+/// <summary>
+/// Handles performing the various reactions that can occur in atmospherics simulation.
+/// </summary>
 public class ReactionManager : MonoBehaviour
 {
 	private TileChangeManager tileChangeManager;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
@@ -7,25 +7,56 @@ using UnityEngine;
 public enum NodeType
 {
 	None,
+	/// <summary>
+	/// Node out in space
+	/// </summary>
 	Space,
+	/// <summary>
+	/// Node in a room on a tile that is not occupied.
+	/// </summary>
 	Room,
+	/// <summary>
+	/// Node occupied by something such that it is not passable.
+	/// </summary>
 	Occupied
 }
 
+/// <summary>
+/// Holds all of the metadata associated with an individual tile, such as for atmospherics simulation, damage.
+/// </summary>
 public class MetaDataNode: IGasMixContainer
 {
 	public static readonly MetaDataNode None;
 
+	/// <summary>
+	/// Local position of this tile in its parent matrix.
+	/// </summary>
 	public readonly Vector3Int Position;
 
+	/// <summary>
+	/// Type of this node.
+	/// </summary>
 	public NodeType Type;
 
+	/// <summary>
+	/// The mixture of gases currently on this node.
+	/// </summary>
 	public GasMix GasMix { get; set; }
 
+	/// <summary>
+	/// The hotspot state of this node - indicates a potential to ignite gases, and
+	/// ignites them if conditions are met. Null if no potential exists on this tile.
+	/// </summary>
 	public Hotspot Hotspot;
 
+	/// <summary>
+	/// Current damage inflicted on this tile.
+	/// </summary>
 	public int Damage;
 
+	/// <summary>
+	/// Number of neighboring MetaDataNodes
+	/// </summary>
 	public int NeighborCount
 	{
 		get
@@ -37,6 +68,9 @@ public class MetaDataNode: IGasMixContainer
 		}
 	}
 
+	/// <summary>
+	/// The current neighbor nodes.
+	/// </summary>
 	public MetaDataNode[] Neighbors
 	{
 		get
@@ -50,6 +84,10 @@ public class MetaDataNode: IGasMixContainer
 
 	private List<MetaDataNode> neighbors;
 
+	/// <summary>
+	/// Create a new MetaDataNode on the specified local position (within the parent matrix)
+	/// </summary>
+	/// <param name="position">local position (within the matrix) the node exists on</param>
 	public MetaDataNode(Vector3Int position)
 	{
 		Position = position;
@@ -62,8 +100,17 @@ public class MetaDataNode: IGasMixContainer
 		None = new MetaDataNode(Vector3Int.one * -1000000);
 	}
 
+	/// <summary>
+	/// Is this tile in space
+	/// </summary>
 	public bool IsSpace => Type == NodeType.Space;
+	/// <summary>
+	/// Is this tile in a room
+	/// </summary>
 	public bool IsRoom => Type == NodeType.Room;
+	/// <summary>
+	/// Is this tile occupied by something impassable
+	/// </summary>
 	public bool IsOccupied => Type == NodeType.Occupied;
 
 	public bool Exists => this != None;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -3,9 +3,18 @@ using System.Diagnostics;
 using Tilemaps.Behaviours.Meta;
 using UnityEngine;
 
+/// <summary>
+/// Subsystem behavior which manages updating the MetaDataNodes and simulation that affects them for a given matrix.
+/// </summary>
 public class MetaDataSystem : SubsystemBehaviour
 {
+	/// <summary>
+	/// Nodes which exist in space next to room tiles of the matrix.
+	/// </summary>
 	private HashSet<MetaDataNode> externalNodes;
+	/// <summary>
+	/// Matrix this system is managing the MetaDataNodes for.
+	/// </summary>
 	private Matrix matrix;
 
 	// Set higher priority to ensure that it is executed before other systems

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
@@ -60,7 +60,7 @@ public class TileChangeManager : NetworkBehaviour
 	{
 		LayerTile layerTile = TileManager.GetTile(tileType, tileName);
 
-		if (tileType == TileType.Damaged)
+		if (tileType == TileType.WindowDamaged)
 		{
 			position.z -= 1;
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterCloset.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterCloset.cs
@@ -1,15 +1,37 @@
 ﻿using UnityEngine;
 
 
-	[ExecuteInEditMode]
-	public class RegisterCloset : RegisterObject
+[ExecuteInEditMode]
+[RequireComponent(typeof(ClosetControl))]
+public class RegisterCloset : RegisterObject
+{
+	/// <summary>
+	/// Cached closet control for this closet
+	/// </summary>
+	private ClosetControl closetControl;
+	private bool isClosed = true;
+
+	public bool IsClosed
 	{
-		private bool isClosed = true;
-		public bool IsClosed {
-			set {
-				isClosed = value;
-				Passable = !isClosed;
-			}
-			get { return isClosed; }
+		set
+		{
+			isClosed = value;
+			Passable = !isClosed;
+		}
+		get { return isClosed; }
+	}
+
+	private void Awake()
+	{
+		closetControl = GetComponent<ClosetControl>();
+	}
+
+	protected override void OnParentChangeComplete()
+	{
+		if (closetControl != null)
+		{
+			// update the parent of each of the items in the closet
+			closetControl.OnParentChangeComplete(ParentNetId);
 		}
 	}
+}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -125,19 +125,19 @@ public class TilemapDamage : MonoBehaviour
 		data.Damage += damage;
 		if (data.Damage >= 20 && data.Damage < 50 && data.WindowDmgType != "crack01")
 		{
-			tileChangeManager.UpdateTile(cellPos, TileType.Damaged, "crack01");
+			tileChangeManager.UpdateTile(cellPos, TileType.WindowDamaged, "crack01");
 			data.WindowDmgType = "crack01";
 		}
 
 		if (data.Damage >= 50 && data.Damage < 75 && data.WindowDmgType != "crack02")
 		{
-			tileChangeManager.UpdateTile(cellPos, TileType.Damaged, "crack02");
+			tileChangeManager.UpdateTile(cellPos, TileType.WindowDamaged, "crack02");
 			data.WindowDmgType = "crack02";
 		}
 
 		if (data.Damage >= 75 && data.Damage < 100 && data.WindowDmgType != "crack03")
 		{
-			tileChangeManager.UpdateTile(cellPos, TileType.Damaged, "crack03");
+			tileChangeManager.UpdateTile(cellPos, TileType.WindowDamaged, "crack03");
 			data.WindowDmgType = "crack03";
 		}
 
@@ -164,7 +164,7 @@ public class TilemapDamage : MonoBehaviour
 		if (data.Damage >= 60)
 		{
 			tileChangeManager.RemoveTile(cellPos, LayerType.Grills);
-			tileChangeManager.UpdateTile(cellPos, TileType.Damaged, "GrillDestroyed");
+			tileChangeManager.UpdateTile(cellPos, TileType.WindowDamaged, "GrillDestroyed");
 
 			PlaySoundMessage.SendToAll("GrillHit", bulletHitTarget, 1f);
 

--- a/UnityProject/Assets/Scripts/Tilemaps/TileManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/TileManager.cs
@@ -14,7 +14,7 @@ public static class TilePaths
 		{TileType.Wall, "Tiles/Walls"},
 		{TileType.Grill, "Tiles/Objects"}, // TODO remove
 		{TileType.Object, "Tiles/Objects"},
-		{TileType.Damaged, "Tiles/Damaged"},
+		{TileType.WindowDamaged, "Tiles/WindowDamage"},
 		{TileType.Effects, "Tiles/Effects"}
 	};
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Utils/Types.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Utils/Types.cs
@@ -10,7 +10,7 @@ public enum TileType
 	Object,
 	Grill,
 	Base,
-	Damaged,
+	WindowDamaged,
 	Effects
 }
 

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
@@ -483,7 +483,7 @@ public partial class CustomNetTransform {
 			serverState.Speed = 0;
 		}
 		serverState.Impulse = Vector2.zero;
-		serverState.Rotation = transform.rotation.eulerAngles.z;
+		serverState.SpinRotation = transform.localRotation.eulerAngles.z;
 		serverState.SpinFactor = 0;
 		serverState.ActiveThrow = ThrowInfo.NoThrow;
 		NotifyPlayers();

--- a/UnityProject/Assets/Scripts/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Weapons/WeaponNetworkActions.cs
@@ -193,7 +193,7 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 		{
 			playerScript.hitIcon.ShowHitIcon(stabDir, lerpSprite);
 		}
-		lerpFrom = transform.position;
+		lerpFrom = Vector3.zero;
 		Vector3 newDir = stabDir * 0.5f;
 		newDir.z = lerpFrom.z;
 		lerpTo = lerpFrom + newDir;
@@ -221,8 +221,8 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 		if (lerping)
 		{
 			lerpProgress += Time.deltaTime;
-			spritesObj.transform.position = Vector3.Lerp(lerpFrom, lerpTo, lerpProgress * speed);
-			if (spritesObj.transform.position == lerpTo || lerpProgress > 2f)
+			spritesObj.transform.localPosition = Vector3.Lerp(lerpFrom, lerpTo, lerpProgress * speed);
+			if (spritesObj.transform.localPosition == lerpTo || lerpProgress > 2f)
 			{
 				if (!isForLerpBack)
 				{
@@ -241,7 +241,7 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 					//To lerp back from knife attack
 					ResetLerp();
 					lerpTo = lerpFrom;
-					lerpFrom = spritesObj.transform.position;
+					lerpFrom = spritesObj.transform.localPosition;
 					lerping = true;
 				}
 			}


### PR DESCRIPTION
### Purpose
Fixes #1521 

Fix issue where rotated objects are not quite precisely at
90 degree increments.

When object is hidden, preserve everything else in its
transformstate but set only its position to HiddenPos. Fixes
issue where closets dragged to a different matrix were parented
to outpost station and got stuck in world space.

Also sets uninitialized transform state matrix IDs to -1 so uninitialized
transforms no longer parent to outpost station by default and we can
detect the error earlier (fail fast)

Fix missing key exception when trying to show damaged window tile

Fix issue where player gets stuck in world position
when lerping during the melee attack animation

Fix issue where doors were not rotating and clients were
not getting rotated matrices when joining

Fix issue where locker and other stuff rotates when
on a rotated matrix and pushed / pulled

Fix NRE on load related to closets.


### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
Also note that I changed TransformState so that IsLocalRotation is no longer there and clarified the purpose of the Rotation float by renaming it to SpinRotation, and that it is always used for localRotation only as it is only used for spinning objects.