### PR TITLE
Updated Trail Render API and meta files

### DIFF
--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletColliderBehavior.cs.meta
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletColliderBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ea8ddb9c64877944b91d5d8c9bff7d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/LocalTrailRenderer.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/LocalTrailRenderer.cs
@@ -73,7 +73,7 @@ public class LocalTrailRenderer : MonoBehaviour
 
 	private void Reset() {
         // Wipe out any old positions in the LineRenderer
-        lineRenderer.numPositions = 0;
+        lineRenderer.positionCount = 0;
         secondsSinceLastSegment = 0;
         // Then set the first position to our object's current local position
         AddPoint(objToFollow.localPosition);
@@ -83,12 +83,12 @@ public class LocalTrailRenderer : MonoBehaviour
     private void AddPoint(Vector3 newPoint) {
 	    secondsSinceLastSegment = 0;
         // Increase the number of positions to render by 1
-        lineRenderer.numPositions += 1;
+        lineRenderer.positionCount += 1;
         // Set the new, last item in the Vector3 list to our new point
-        lineRenderer.SetPosition(lineRenderer.numPositions - 1, newPoint);
+        lineRenderer.SetPosition(lineRenderer.positionCount - 1, newPoint);
 
         // Check to see if the list is too long
-        if (limitTrailLength && lineRenderer.numPositions > maxPositions) {
+        if (limitTrailLength && lineRenderer.positionCount > maxPositions) {
             // ...and discard old positions if necessary
             TruncatePositions(maxPositions);
         }
@@ -103,7 +103,7 @@ public class LocalTrailRenderer : MonoBehaviour
         // Create a temporary list of the desired length
         Vector3[] tempList = new Vector3[newLength];
         // Calculate how many extra items will need to be cut out from the original list
-        int nExtraItems = lineRenderer.numPositions - newLength;
+        int nExtraItems = lineRenderer.positionCount - newLength;
         // Loop through original list and add newest X items to temp list
         for (int i=0; i<newLength; i++) {
             // shift index by nExtraItems... e.g., if 2 extras, start at index 2 instead of index 0
@@ -111,7 +111,7 @@ public class LocalTrailRenderer : MonoBehaviour
         }
 
         // Set the LineRenderer's position list length to the appropriate amount
-        lineRenderer.numPositions = newLength;
+        lineRenderer.positionCount = newLength;
         // ...and use our tempList to fill it's positions appropriately
         lineRenderer.SetPositions(tempList);
     }

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/LocalTrailRenderer.cs.meta
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/LocalTrailRenderer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d9753a64261245d45b627f287951be7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Updates the trail API to stop the update prompt from happening, and adds the missing meta files.
Bullet trails were already broken before this.
