### PR TITLE
adjust bullet trails to start a little bit closer to the shooter

### DIFF
--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/BulletBehaviour.cs
@@ -80,7 +80,7 @@ public abstract class BulletBehaviour : MonoBehaviour
 		shooter = controlledByPlayer;
 
 		transform.parent = controlledByPlayer.transform.parent;
-		Vector3 startPos = new Vector3(dir.x, dir.y, transform.position.z);
+		Vector3 startPos = new Vector3(dir.x, dir.y, transform.position.z) / 2;
 		transform.position += startPos;
 		rigidBody.transform.rotation = Quaternion.AngleAxis(Mathf.Atan2(dir.x, dir.y) * Mathf.Rad2Deg, Vector3.forward);
 		rigidBody.transform.localPosition = Vector3.zero;


### PR DESCRIPTION
### Purpose
adjust bullet trails to start a little bit closer to the shooter

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
going to merge, it's just a one line change
