### PR TITLE
Fixed All characters are named 'Anonymous Spessman' #1539

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
+++ b/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
@@ -105,7 +105,7 @@ public class ConnectedPlayer
 
     public bool HasNoName()
     {
-        return name == null || name.Trim().Equals("");
+        return name == null || name.Trim().Equals("") || name == DEAFAULT_NAME;
     }
 
 	/// <summary>


### PR DESCRIPTION
### Purpose
Fixes #1539
Changed server code so it doesn't assign the default name to all users.

### Open Questions and Pre-Merge TODOs

- [x] This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:

