### PR TITLE
Refactor ShowTab to take into account NetTab.isPopOut

### DIFF
--- a/UnityProject/Assets/Scripts/UI/ControlTabs.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlTabs.cs
@@ -420,13 +420,10 @@ public class ControlTabs : MonoBehaviour
 			return;
 		}
 
-		bool isPopOut = false;
+		NetTab thisTab = NetworkTabManager.Instance.Get(tabProvider, type);
 
-		//Add the popout types here:
-		if ((type == NetTabType.Paper) || (type == NetTabType.ChemistryDispenser))
-		{
-			isPopOut = true;
-		}
+		//Make use of NetTab's fancy isPopOut bool instead of depending on the NetTabType.
+		bool isPopOut = thisTab.isPopOut;
 
 		if (!Instance.rolledOut && !isPopOut)
 		{

--- a/UnityProject/Assets/Scripts/UI/ControlTabs.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlTabs.cs
@@ -420,16 +420,12 @@ public class ControlTabs : MonoBehaviour
 			return;
 		}
 
-		// Need to spawn a local instance of the NetTab to obtain its isPopOut property.
-		// thisTab is entirely ephemeral. The real instance is used or created later on.
+		// Need to spawn a local instance of the NetTab to obtain its isPopOut property first. Parent is changed later.
 		var openedTab = new NetTabDescriptor(tabProvider, type);
-		NetTab thisTab = openedTab.Spawn(tabProvider.transform);
+		NetTab tabInfo = openedTab.Spawn(tabProvider.transform);
 
 		//Make use of NetTab's fancy isPopOut bool instead of depending on the NetTabType.
-		bool isPopOut = thisTab.isPopOut;
-
-		// We don't need the temporarily spawned NetTab any more, get rid of it.
-		Destroy(thisTab);
+		bool isPopOut = tabInfo.isPopOut;
 
 
 		if (!Instance.rolledOut && !isPopOut)
@@ -446,7 +442,7 @@ public class ControlTabs : MonoBehaviour
 		if (!Instance.OpenedNetTabs.ContainsKey(openedTab))
 		{
 			Transform newParent = !isPopOut ? Instance.TabStorage : Instance.TabStoragePopOut;
-			NetTab tabInfo = openedTab.Spawn(newParent);
+			tabInfo.transform.SetParent(newParent, false);
 			GameObject tabObject = tabInfo.gameObject;
 
 			//putting into the right place

--- a/UnityProject/Assets/Scripts/UI/ControlTabs.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlTabs.cs
@@ -420,17 +420,23 @@ public class ControlTabs : MonoBehaviour
 			return;
 		}
 
-		NetTab thisTab = NetworkTabManager.Instance.Get(tabProvider, type);
+		// Need to spawn a local instance of the NetTab to obtain its isPopOut property.
+		// thisTab is entirely ephemeral. The real instance is used or created later on.
+		var openedTab = new NetTabDescriptor(tabProvider, type);
+		NetTab thisTab = openedTab.Spawn(tabProvider.transform);
 
 		//Make use of NetTab's fancy isPopOut bool instead of depending on the NetTabType.
 		bool isPopOut = thisTab.isPopOut;
+
+		// We don't need the temporarily spawned NetTab any more, get rid of it.
+		Destroy(thisTab);
+
 
 		if (!Instance.rolledOut && !isPopOut)
 		{
 			Instance.StartCoroutine(Instance.AnimTabRoll());
 		}
 
-		var openedTab = new NetTabDescriptor(tabProvider, type);
 		//try to dig out a hidden tab with matching parameters and enable it:
 		if (Instance.HiddenNetTabs.ContainsKey(openedTab))
 		{


### PR DESCRIPTION
### Purpose
Fixes #1533 

ShowTab used to rely on a static list of tab types, it's been refactored to instead rely on the tab's isPopout variable.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
If there's a better way to do this please let me know and I'll work on changing it. I'm not too familiar with Unity just yet. 
