### PR TITLE
Fixes a crash to do with a null reference on Shutter switched trigger and Fixed missing references on outpost

### DIFF
--- a/UnityProject/Assets/Scripts/Switches/ShutterSwitchTrigger.cs
+++ b/UnityProject/Assets/Scripts/Switches/ShutterSwitchTrigger.cs
@@ -55,7 +55,9 @@ public class ShutterSwitchTrigger : InputTrigger
 	{
 		foreach (ObjectTrigger s in TriggeringObjects)
 		{
-			s.Trigger(isClosed);
+			if (s != null) { 
+				s.Trigger(isClosed);
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Switches/ShutterSwitchTrigger.cs
+++ b/UnityProject/Assets/Scripts/Switches/ShutterSwitchTrigger.cs
@@ -55,8 +55,12 @@ public class ShutterSwitchTrigger : InputTrigger
 	{
 		foreach (ObjectTrigger s in TriggeringObjects)
 		{
-			if (s != null) { //Apparently unity can't handle the null reference Properly for this case
-				s.Trigger(isClosed); 
+			if (s != null)
+			{ //Apparently unity can't handle the null reference Properly for this case
+				s.Trigger(isClosed);
+			}
+			else {
+				Logger.LogError("you Have a null reference You have a missing reference for a shutter");
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Switches/ShutterSwitchTrigger.cs
+++ b/UnityProject/Assets/Scripts/Switches/ShutterSwitchTrigger.cs
@@ -55,8 +55,8 @@ public class ShutterSwitchTrigger : InputTrigger
 	{
 		foreach (ObjectTrigger s in TriggeringObjects)
 		{
-			if (s != null) { 
-				s.Trigger(isClosed);
+			if (s != null) { //Apparently unity can't handle the null reference Properly for this case
+				s.Trigger(isClosed); 
 			}
 		}
 	}


### PR DESCRIPTION
### Purpose
Manage to get a stack trace of the crash  so modified the code appropriately
Could be related to #1497 
### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer
