### PR TITLE
#1446  Healthdoll state changes

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V3(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V3(uNet).prefab
@@ -43,17 +43,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdad2d3b11224e58b19f7f483935abc8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GrayDamageMonitorIcon: {fileID: 21300832, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+  BlueDamageMonitorIcon: {fileID: 21300912, guid: edb6a9bb8c0d64b80953e48ba732f4e9,
     type: 3}
   GreenDamageMonitorIcon: {fileID: 21300756, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
+  YellowDamageMonitorIcon: {fileID: 21300768, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
   OrangeDamageMonitorIcon: {fileID: 21300780, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  DarkOrangeDamageMonitorIcon: {fileID: 21300792, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
   RedDamageMonitorIcon: {fileID: 21300810, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
-  Type: 3
-  YellowDamageMonitorIcon: {fileID: 21300768, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+  GrayDamageMonitorIcon: {fileID: 21300832, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
+  Type: 3
   Severity: 0
 --- !u!1 &1028579746739352
 GameObject:
@@ -474,17 +478,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdad2d3b11224e58b19f7f483935abc8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GrayDamageMonitorIcon: {fileID: 21300844, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+  BlueDamageMonitorIcon: {fileID: 21300912, guid: edb6a9bb8c0d64b80953e48ba732f4e9,
     type: 3}
   GreenDamageMonitorIcon: {fileID: 21300762, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
-  OrangeDamageMonitorIcon: {fileID: 21300786, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
-    type: 3}
-  RedDamageMonitorIcon: {fileID: 21300798, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
-    type: 3}
-  Type: 4
   YellowDamageMonitorIcon: {fileID: 21300774, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
+  OrangeDamageMonitorIcon: {fileID: 21300786, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  DarkOrangeDamageMonitorIcon: {fileID: 21300798, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  RedDamageMonitorIcon: {fileID: 21300822, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  GrayDamageMonitorIcon: {fileID: 21300844, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  Type: 4
   Severity: 0
 --- !u!1 &1075270923249368
 GameObject:
@@ -972,6 +980,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6c7b6bc021c23c54d8e5410a430ca7fe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  OnRotateEnd:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: OrientationEvent, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+  OnRotateStart:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: OrientationEvent, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
   ObjectType: 2
   rotateWithMatrix: 1
 --- !u!114 &114803877374308862
@@ -1591,17 +1609,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f8b6bad0196f4cca947cdfe73fcf7ca5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GrayDamageMonitorIcon: {fileID: 21300830, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+  BlueDamageMonitorIcon: {fileID: 21300912, guid: edb6a9bb8c0d64b80953e48ba732f4e9,
     type: 3}
   GreenDamageMonitorIcon: {fileID: 21300754, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
-  OrangeDamageMonitorIcon: {fileID: 21300778, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
-    type: 3}
-  RedDamageMonitorIcon: {fileID: 21300790, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
-    type: 3}
-  Type: 1
   YellowDamageMonitorIcon: {fileID: 21300766, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
+  OrangeDamageMonitorIcon: {fileID: 21300778, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  DarkOrangeDamageMonitorIcon: {fileID: 21300790, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  RedDamageMonitorIcon: {fileID: 21300806, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  GrayDamageMonitorIcon: {fileID: 21300830, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  Type: 1
   Severity: 0
 --- !u!1 &1332325770335918
 GameObject:
@@ -2284,17 +2306,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdad2d3b11224e58b19f7f483935abc8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GrayDamageMonitorIcon: {fileID: 21300836, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+  BlueDamageMonitorIcon: {fileID: 21300912, guid: edb6a9bb8c0d64b80953e48ba732f4e9,
     type: 3}
   GreenDamageMonitorIcon: {fileID: 21300758, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
-  OrangeDamageMonitorIcon: {fileID: 21300782, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
-    type: 3}
-  RedDamageMonitorIcon: {fileID: 21300794, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
-    type: 3}
-  Type: 2
   YellowDamageMonitorIcon: {fileID: 21300770, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
+  OrangeDamageMonitorIcon: {fileID: 21300782, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  DarkOrangeDamageMonitorIcon: {fileID: 21300794, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  RedDamageMonitorIcon: {fileID: 21300814, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  GrayDamageMonitorIcon: {fileID: 21300836, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  Type: 2
   Severity: 0
 --- !u!1 &1492008254133120
 GameObject:
@@ -3069,17 +3095,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 286e2ff4e04b48b0b91e6ebfc4b212f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GrayDamageMonitorIcon: {fileID: 21300824, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+  BlueDamageMonitorIcon: {fileID: 21300912, guid: edb6a9bb8c0d64b80953e48ba732f4e9,
     type: 3}
   GreenDamageMonitorIcon: {fileID: 21300752, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
-  OrangeDamageMonitorIcon: {fileID: 21300776, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
-    type: 3}
-  RedDamageMonitorIcon: {fileID: 21300788, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
-    type: 3}
-  Type: 0
   YellowDamageMonitorIcon: {fileID: 21300764, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
+  OrangeDamageMonitorIcon: {fileID: 21300776, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  DarkOrangeDamageMonitorIcon: {fileID: 21300788, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  RedDamageMonitorIcon: {fileID: 21300802, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  GrayDamageMonitorIcon: {fileID: 21300824, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  Type: 0
   Severity: 0
 --- !u!1 &1708637642242452
 GameObject:
@@ -3124,17 +3154,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdad2d3b11224e58b19f7f483935abc8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GrayDamageMonitorIcon: {fileID: 21300840, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+  BlueDamageMonitorIcon: {fileID: 21300912, guid: edb6a9bb8c0d64b80953e48ba732f4e9,
     type: 3}
   GreenDamageMonitorIcon: {fileID: 21300760, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
-  OrangeDamageMonitorIcon: {fileID: 21300784, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
-    type: 3}
-  RedDamageMonitorIcon: {fileID: 21300816, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
-    type: 3}
-  Type: 5
   YellowDamageMonitorIcon: {fileID: 21300772, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
     type: 3}
+  OrangeDamageMonitorIcon: {fileID: 21300784, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  DarkOrangeDamageMonitorIcon: {fileID: 21300796, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  RedDamageMonitorIcon: {fileID: 21300818, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  GrayDamageMonitorIcon: {fileID: 21300840, guid: da41a78685fb46e1b8e7a41e8f9fe42e,
+    type: 3}
+  Type: 5
   Severity: 0
 --- !u!1 &1795409780741894
 GameObject:

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager.prefab
@@ -256,6 +256,80 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
+--- !u!1 &5589402897978137286
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9070108685468332042}
+  - component: {fileID: 9130090246312066318}
+  - component: {fileID: 3213158581219974412}
+  m_Layer: 5
+  m_Name: DamageMonitor_Base
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9070108685468332042
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5589402897978137286}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8477623458309051401}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -32, y: 32}
+  m_SizeDelta: {x: 64, y: 64}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9130090246312066318
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5589402897978137286}
+  m_CullTransparentMesh: 0
+--- !u!114 &3213158581219974412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5589402897978137286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300750, guid: da41a78685fb46e1b8e7a41e8f9fe42e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!1 &6602690125291050415
 GameObject:
   m_ObjectHideFlags: 0
@@ -5005,7 +5079,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8477623458309051401}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -5040,7 +5114,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300754, guid: da41a78685fb46e1b8e7a41e8f9fe42e, type: 3}
+  m_Sprite: {fileID: 21300912, guid: edb6a9bb8c0d64b80953e48ba732f4e9, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -7796,6 +7870,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1.3427055, y: 1.3427055, z: 1.3427055}
   m_Children:
+  - {fileID: 9070108685468332042}
   - {fileID: 8477486197870488179}
   - {fileID: 8477100200368465903}
   - {fileID: 8477406535623163831}
@@ -8795,7 +8870,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8477623458309051401}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -8830,7 +8905,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300760, guid: da41a78685fb46e1b8e7a41e8f9fe42e, type: 3}
+  m_Sprite: {fileID: 21300912, guid: edb6a9bb8c0d64b80953e48ba732f4e9, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -9195,7 +9270,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8477623458309051401}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -9230,7 +9305,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300758, guid: da41a78685fb46e1b8e7a41e8f9fe42e, type: 3}
+  m_Sprite: {fileID: 21300912, guid: edb6a9bb8c0d64b80953e48ba732f4e9, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -10513,7 +10588,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8477623458309051401}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -10548,7 +10623,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300756, guid: da41a78685fb46e1b8e7a41e8f9fe42e, type: 3}
+  m_Sprite: {fileID: 21300912, guid: edb6a9bb8c0d64b80953e48ba732f4e9, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -15833,7 +15908,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8477623458309051401}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -15868,7 +15943,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300762, guid: da41a78685fb46e1b8e7a41e8f9fe42e, type: 3}
+  m_Sprite: {fileID: 21300912, guid: edb6a9bb8c0d64b80953e48ba732f4e9, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -17233,7 +17308,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 409.29987}
+  m_AnchoredPosition: {x: 0, y: 409.30038}
   m_SizeDelta: {x: 0, y: 700}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &8556515118206096667
@@ -19038,8 +19113,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 8584827757962983305}
   m_HandleRect: {fileID: 8477495159653326549}
   m_Direction: 2
-  m_Value: 0.00000029824162
-  m_Size: 0.41528565
+  m_Value: 0
+  m_Size: 0.4152853
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -21115,7 +21190,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8477623458309051401}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -21150,7 +21225,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300752, guid: da41a78685fb46e1b8e7a41e8f9fe42e, type: 3}
+  m_Sprite: {fileID: 21300912, guid: edb6a9bb8c0d64b80953e48ba732f4e9, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/UnityProject/Assets/Scripts/Health/BloodHealth/BloodSystem.cs
+++ b/UnityProject/Assets/Scripts/Health/BloodHealth/BloodSystem.cs
@@ -217,6 +217,8 @@ public class BloodSystem : MonoBehaviour
 			// don't start bleeding if limb is in ok condition after it received damage
 			switch (bodyPart.Severity)
 			{
+				case DamageSeverity.Light:
+				case DamageSeverity.LightModerate:
 				case DamageSeverity.Moderate:
 				case DamageSeverity.Bad:
 				case DamageSeverity.Critical:

--- a/UnityProject/Assets/Scripts/Health/BodyParts/BodyPartBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/BodyParts/BodyPartBehaviour.cs
@@ -95,17 +95,17 @@ public class BodyPartBehaviour : MonoBehaviour
 		{
 			Severity = DamageSeverity.LightModerate;
 		}
-		else if (severity <= 0.6)
+		else if (severity <= 0.5)
 		{
 			Severity = DamageSeverity.Moderate;
 		}
-		else if (severity <= 0.75)
+		else if (severity <= 0.7)
 		{
 			Severity = DamageSeverity.Bad;
 		}
 		else if (severity <= .9)
 		{
-			severity = DamageSeverity.Critical;
+			Severity = DamageSeverity.Critical;
 		}
 		else if (severity <= 1f)
 		{

--- a/UnityProject/Assets/Scripts/Health/BodyParts/BodyPartBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/BodyParts/BodyPartBehaviour.cs
@@ -83,31 +83,38 @@ public class BodyPartBehaviour : MonoBehaviour
 	{
 		// update UI limbs depending on their severity of damage
 		float severity = (float)OverallDamage / MaxDamage;
+		// If the limb is uninjured
 		if (severity <= 0)
 		{
 			Severity = DamageSeverity.None;
 		}
-		else if (severity <= 0.2) 
+		// If the limb is under 20% damage
+		else if (severity < 0.2) 
 		{
 			Severity = DamageSeverity.Light;
 		}
-		else if (severity <= 0.4)
+		// If the limb is under 40% damage
+		else if (severity < 0.4)
 		{
 			Severity = DamageSeverity.LightModerate;
 		}
-		else if (severity <= 0.5)
+		// If the limb is under 60% damage
+		else if (severity < 0.6)
 		{
 			Severity = DamageSeverity.Moderate;
 		}
-		else if (severity <= 0.7)
+		// If the limb is under 80% damage
+		else if (severity < 0.8)
 		{
 			Severity = DamageSeverity.Bad;
 		}
-		else if (severity <= .9)
+		// If the limb is under 100% damage
+		else if (severity < 1f)
 		{
 			Severity = DamageSeverity.Critical;
 		}
-		else if (severity <= 1f)
+		// If the limb is 100% damage or over
+		else if (severity >= 1f)
 		{
 			Severity = DamageSeverity.Max;
 		}

--- a/UnityProject/Assets/Scripts/Health/BodyParts/BodyPartBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/BodyParts/BodyPartBehaviour.cs
@@ -93,15 +93,19 @@ public class BodyPartBehaviour : MonoBehaviour
 		}
 		else if (severity <= 0.4)
 		{
-			Severity = DamageSeverity.Moderate;
+			Severity = DamageSeverity.LightModerate;
 		}
 		else if (severity <= 0.6)
 		{
+			Severity = DamageSeverity.Moderate;
+		}
+		else if (severity <= 0.75)
+		{
 			Severity = DamageSeverity.Bad;
 		}
-		else if (severity <= 0.8)
+		else if (severity <= .9)
 		{
-			Severity = DamageSeverity.Critical;
+			severity = DamageSeverity.Critical;
 		}
 		else if (severity <= 1f)
 		{

--- a/UnityProject/Assets/Scripts/Health/BodyParts/BodyPartBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/BodyParts/BodyPartBehaviour.cs
@@ -7,17 +7,15 @@ public class BodyPartBehaviour : MonoBehaviour
 	private float burnDamage;
 	public float BruteDamage { get { return bruteDamage; } set { bruteDamage = Mathf.Clamp(value, 0, 101); } }
 	public float BurnDamage { get { return burnDamage; } set { burnDamage = Mathf.Clamp(value, 0, 101); } }
-
-	public Sprite GrayDamageMonitorIcon;
-
+	public Sprite BlueDamageMonitorIcon;
 	public Sprite GreenDamageMonitorIcon;
-
-	private int MaxDamage = 100;
-
-	public Sprite OrangeDamageMonitorIcon;
-	public Sprite RedDamageMonitorIcon;
-	public BodyPartType Type;
 	public Sprite YellowDamageMonitorIcon;
+	public Sprite OrangeDamageMonitorIcon;
+	public Sprite DarkOrangeDamageMonitorIcon;
+	public Sprite RedDamageMonitorIcon;
+	public Sprite GrayDamageMonitorIcon;
+	private int MaxDamage = 100;
+	public BodyPartType Type;
 
 	public DamageSeverity Severity; //{ get; private set; }
 	public float OverallDamage => BruteDamage + BurnDamage;
@@ -83,25 +81,29 @@ public class BodyPartBehaviour : MonoBehaviour
 
 	private void UpdateSeverity()
 	{
+		// update UI limbs depending on their severity of damage
 		float severity = (float)OverallDamage / MaxDamage;
-		if (severity < 0.2)
+		if (severity <= 0)
 		{
 			Severity = DamageSeverity.None;
 		}
-		else
-		if (severity >= 0.2 && severity < 0.4)
+		else if (severity <= 0.2) 
+		{
+			Severity = DamageSeverity.Light;
+		}
+		else if (severity <= 0.4)
+		{
+			Severity = DamageSeverity.LightModerate;
+		}
+		else if (severity <= 0.6)
 		{
 			Severity = DamageSeverity.Moderate;
 		}
-		else if (severity >= 0.4 && severity < 0.7)
-		{
-			Severity = DamageSeverity.Bad;
-		}
-		else if (severity >= 0.7 && severity < 1f)
+		else if (severity <= 0.8)
 		{
 			Severity = DamageSeverity.Critical;
 		}
-		else if (severity >= 1f)
+		else if (severity <= 1f)
 		{
 			Severity = DamageSeverity.Max;
 		}

--- a/UnityProject/Assets/Scripts/Health/BodyParts/BodyPartBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/BodyParts/BodyPartBehaviour.cs
@@ -93,11 +93,11 @@ public class BodyPartBehaviour : MonoBehaviour
 		}
 		else if (severity <= 0.4)
 		{
-			Severity = DamageSeverity.LightModerate;
+			Severity = DamageSeverity.Moderate;
 		}
 		else if (severity <= 0.6)
 		{
-			Severity = DamageSeverity.Moderate;
+			Severity = DamageSeverity.Bad;
 		}
 		else if (severity <= 0.8)
 		{

--- a/UnityProject/Assets/Scripts/Health/DamageStates/DamageSeverity.cs
+++ b/UnityProject/Assets/Scripts/Health/DamageStates/DamageSeverity.cs
@@ -5,8 +5,9 @@
 public enum DamageSeverity
 {
 	None = 0,
-	Moderate = 25,
-	Bad = 50,
-	Critical = 75,
-	Max = 100
+	Light = 25,
+	Moderate = 50,
+	Bad = 75,
+	Critical = 100,
+	Max = 125
 }

--- a/UnityProject/Assets/Scripts/Health/DamageStates/DamageSeverity.cs
+++ b/UnityProject/Assets/Scripts/Health/DamageStates/DamageSeverity.cs
@@ -6,8 +6,9 @@ public enum DamageSeverity
 {
 	None = 0,
 	Light = 25,
-	Moderate = 50,
-	Bad = 75,
-	Critical = 100,
-	Max = 125
+	LightModerate = 50,
+	Moderate = 75,
+	Bad = 100,
+	Critical = 125,
+	Max = 150
 }

--- a/UnityProject/Assets/Scripts/UI/PlayerHealthUI.cs
+++ b/UnityProject/Assets/Scripts/UI/PlayerHealthUI.cs
@@ -91,18 +91,24 @@ public class PlayerHealthUI : MonoBehaviour
 			switch (bodyPart.Severity)
 			{
 				case DamageSeverity.None:
+					sprite = bodyPart.BlueDamageMonitorIcon;
+					break;
+				case DamageSeverity.Light:
 					sprite = bodyPart.GreenDamageMonitorIcon;
 					break;
-				case DamageSeverity.Moderate:
+				case DamageSeverity.LightModerate:
 					sprite = bodyPart.YellowDamageMonitorIcon;
 					break;
-				case DamageSeverity.Bad:
+				case DamageSeverity.Moderate:
 					sprite = bodyPart.OrangeDamageMonitorIcon;
 					break;
+				case DamageSeverity.Bad:
+					sprite = bodyPart.DarkOrangeDamageMonitorIcon;
+					break;
 				case DamageSeverity.Critical:
-				case DamageSeverity.Max:
 					sprite = bodyPart.RedDamageMonitorIcon;
 					break;
+				case DamageSeverity.Max:
 				default:
 					sprite = bodyPart.GrayDamageMonitorIcon;
 					break;


### PR DESCRIPTION
### Purpose
Create proper limb changing health states.
Fixes #1446 

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer

### Notes:
This will make the health ui update to a new state every 20% of damage taken (or from blue to green any damage).
Currently weapon damage is pretty high so to test this I'd recommend duplicating a weapon and tuning it's damage down.