### PR TITLE
Drop items when unconcious, fix UI not clearing while incapped

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -646,6 +646,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		}
 		else
 		{
+			//Drop items when unconcious
 			DropItem("rightHand");
 			DropItem("leftHand");
 			playerMove.allowInput = false;

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -646,6 +646,8 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		}
 		else
 		{
+			DropItem("rightHand");
+			DropItem("leftHand");
 			playerMove.allowInput = false;
 			gameObject.GetComponent<ForceRotation>().Rotation = new Vector3(0, 0, -90);
 			soundNetworkActions.RpcPlayNetworkSound("Bodyfall", transform.position);

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
@@ -145,7 +145,7 @@ public class UI_ItemSlot : MonoBehaviour, IDragHandler, IEndDragHandler
 	public GameObject Clear()
 	{
 		PlayerScript lps = PlayerManager.LocalPlayerScript;
-		if (!lps || lps.canNotInteract())
+		if (!lps)
 		{
 			return null;
 		}


### PR DESCRIPTION
### Purpose
This isn't listed as an issue but I came across it while fixing another one
If you die with something in your hand, the UI icon will [still be there on death](https://imgur.com/wAmEy9T)
This removes the interaction check when clearing a UI slot and adds dropitem upon unconcious state

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer

### Notes:
_Please enter any other relevant information here_
