### PR TITLE
"Local Position" Check and Fire Damage

### DIFF
--- a/UnityProject/Assets/Scripts/Editor/Matrix/Views/MetaDataView.cs
+++ b/UnityProject/Assets/Scripts/Editor/Matrix/Views/MetaDataView.cs
@@ -29,8 +29,9 @@ public class MetaDataView : BasicView
 
 	public override void DrawContent()
 	{
-		foreach (Check<MetaDataLayer> check in localChecks)
+		for (var i = 0; i < localChecks.Count; i++)
 		{
+			Check<MetaDataLayer> check = localChecks[i];
 			check.Active = GUILayout.Toggle(check.Active, check.Label);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Editor/Matrix/Views/MetaTileMapView.cs
+++ b/UnityProject/Assets/Scripts/Editor/Matrix/Views/MetaTileMapView.cs
@@ -22,13 +22,15 @@ public class MetaTileMapView : BasicView
 
 	public override void DrawContent()
 	{
-		foreach (Check<MetaTileMap> check in localChecks)
+		for (int i = 0; i < localChecks.Count; i++)
 		{
+			Check<MetaTileMap> check = localChecks[i];
 			check.Active = GUILayout.Toggle(check.Active, check.Label);
 		}
 
-		foreach (Check<MatrixManager> check in globalChecks)
+		for (int i = 0; i < globalChecks.Count; i++)
 		{
+			Check<MatrixManager> check = globalChecks[i];
 			check.Active = GUILayout.Toggle(check.Active, check.Label);
 		}
 	}
@@ -103,8 +105,7 @@ public class MetaTileMapView : BasicView
 
 		public override void DrawLabel(MetaTileMap source, Vector3Int position)
 		{
-//			if (!source.IsEmptyAt(position))
-			if (Selection.activeGameObject.GetComponent<MetaTileMap>() == source)
+			if (!source.IsEmptyAt(position))
 			{
 				Vector3 p = source.transform.TransformPoint(position) + GizmoUtils.HalfOne;
 				GizmoUtils.DrawText($"{position.x}, {position.y}", p, false);

--- a/UnityProject/ProjectSettings/GraphicsSettings.asset
+++ b/UnityProject/ProjectSettings/GraphicsSettings.asset
@@ -39,7 +39,6 @@ GraphicsSettings:
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 4800000, guid: 941c854b8306dab48b376ed6d37ac05f, type: 3}
-  - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}

--- a/UnityProject/ProjectSettings/ProjectSettings.asset
+++ b/UnityProject/ProjectSettings/ProjectSettings.asset
@@ -106,6 +106,11 @@ PlayerSettings:
   xboxOneDisableEsram: 0
   xboxOnePresentImmediateThreshold: 0
   switchQueueCommandMemory: 0
+  switchQueueControlMemory: 16384
+  switchQueueComputeMemory: 262144
+  switchNVNShaderPoolsGranularity: 33554432
+  switchNVNDefaultPoolsGranularity: 16777216
+  switchNVNOtherPoolsGranularity: 16777216
   vulkanEnableSetSRGBWrite: 0
   m_SupportedAspectRatios:
     4:3: 0
@@ -565,6 +570,7 @@ PlayerSettings:
   switchAllowsRuntimeAddOnContentInstall: 0
   switchDataLossConfirmation: 0
   switchUserAccountLockEnabled: 0
+  switchSystemResourceMemory: 16777216
   switchSupportedNpadStyles: 3
   switchNativeFsCacheSize: 32
   switchIsHoldTypeHorizontal: 0


### PR DESCRIPTION
### Purpose
* Fixing "Local Positions" matrix check ( fixes #1548 )
* Adding first damage on fire to LivingHealthBehaviours (not finished)

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
Also changes to GraphicsSettings.asset and ProjectSettings.asset added accidentally, but they shouldn't do any damage.