### PR TITLE
Bug/fixes04

### DIFF
--- a/UnityProject/Assets/Prefabs/Electricity/VIR_APC.prefab
+++ b/UnityProject/Assets/Prefabs/Electricity/VIR_APC.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: 114795609584507792}
   m_Layer: 19
   m_Name: VIR_APC
-  m_TagString: Untagged
+  m_TagString: APC
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 967620e59e52cc14c89c22c4176bac09, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mIntensity: 0.5
+  mIntensity: 0.223
   mAdditionalEmission: 0
   mScale: 1.7
 --- !u!1 &1795295551953532

--- a/UnityProject/Assets/Prefabs/SceneConstruction/Camera.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/Camera.prefab
@@ -28,7 +28,7 @@ Transform:
   m_GameObject: {fileID: 1917856994}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.5, z: 0}
-  m_LocalScale: {x: 3.5, y: 3.5, z: 3.5}
+  m_LocalScale: {x: 1.8, y: 1.8, z: 3.5}
   m_Children: []
   m_Father: {fileID: 4568765046733910}
   m_RootOrder: 7
@@ -45,8 +45,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61930e16e81db5c43a4ecc22422a0953, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Color: {r: 0.3773585, g: 0.3773585, b: 0.3773585, a: 0.8}
-  Sprite: {fileID: 21300000, guid: d3d68d996fdfe89458fb2adb538670aa, type: 3}
+  Color: {r: 0.990566, g: 0.990566, b: 0.990566, a: 0.29411766}
+  Sprite: {fileID: 21300000, guid: 7d4ab37af9168d243a3eead2ef5b5758, type: 3}
   SortingOrder: 0
   Material: {fileID: 2100000, guid: bb638c523f5b7064b9a032025a8db0a5, type: 2}
   LightOrigin: {x: 0, y: 0, z: 1}

--- a/UnityProject/Assets/Scripts/Lighting System/LightEmissionBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Lighting System/LightEmissionBehaviour.cs
@@ -12,7 +12,7 @@ public class LightEmissionBehaviour : MonoBehaviour
 	[SerializeField]
 	[Range(0, 1)]
 	[Tooltip("Controls how much of sprite color bleeds in to light mask.")]
-	private float mIntensity = 0.5f;
+	private float mIntensity = 0.25f;
 
 	[SerializeField]
 	[Range(0, 1)]

--- a/UnityProject/Assets/Scripts/Objects/VisibleBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Objects/VisibleBehaviour.cs
@@ -74,10 +74,7 @@ public class VisibleBehaviour : NetworkBehaviour
 
 		MonoBehaviour[] scripts = GetComponentsInChildren<MonoBehaviour>(true);
 		Collider2D[] colliders = GetComponentsInChildren<Collider2D>();
-		Renderer[] getRenderers = GetComponentsInChildren<Renderer>(true);
-		MeshRenderer[] meshRend = GetComponentsInChildren<MeshRenderer>(true);
-		//Ignore all MeshRenderers
-		Renderer[] renderers = getRenderers.Except(meshRend).ToArray();
+		Renderer[] renderers = GetComponentsInChildren<Renderer>(true);
 
 		for (int i = 0; i < scripts.Length; i++)
 		{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
@@ -19,7 +19,7 @@ public class MetaDataNode: IGasMixContainer
 	/// <summary>
 	/// If this node is in a closed room, it's assigned to it by the room's number
 	/// </summary>
-	public int RoomNumber;
+	public int RoomNumber = -1;
 
 	/// <summary>
 	/// Type of this node.

--- a/UnityProject/ProjectSettings/ProjectSettings.asset
+++ b/UnityProject/ProjectSettings/ProjectSettings.asset
@@ -381,7 +381,7 @@ PlayerSettings:
     m_APIs: 0b000000
     m_Automatic: 0
   - m_BuildTarget: MacStandaloneSupport
-    m_APIs: 1000000011000000
+    m_APIs: 11000000
     m_Automatic: 0
   m_BuildTargetVRSettings:
   - m_BuildTarget: Android


### PR DESCRIPTION
### Purpose
- Mesh renderers are now toggled in VisibleBehaviour
- Removed Metal API for the time being from macOS builds
- Auto assign APC to light switches on start
- Adjusted visible player area
- Reduced Default intensity of LightEmissionBehaviour

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
_Please enter any other relevant information here_
