### PR TITLE
Prevent right click menu from displaying objects under floor tiles

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Right click/Rightclick.cs
+++ b/UnityProject/Assets/Scripts/UI/Right click/Rightclick.cs
@@ -122,6 +122,9 @@ public class Rightclick : MonoBehaviour
 		//special case, remove wallmounts that are transparent
 		objects.RemoveAll(IsHiddenWallmount);
 
+		//Objects that are under a floor tile should not be available
+		objects.RemoveAll(IsUnderFloorTile);
+
 		return objects;
 	}
 
@@ -135,6 +138,17 @@ public class Rightclick : MonoBehaviour
 		}
 
 		return wallmountBehavior.IsHiddenFromLocalPlayer();
+	}
+
+	private bool IsUnderFloorTile(GameObject obj)
+	{
+		LayerTile tile = UITileList.GetTileAtPosition(obj.WorldPos());
+
+		if (tile.LayerType != LayerType.Base && obj.layer < 1)
+		{
+			return true;
+		}
+		return false;
 	}
 
 	private void Generate(List<GameObject> objects)


### PR DESCRIPTION
### Purpose
Fixes #1500 

Previously the right click menu would show all objects that were in a location. Now if there is a floor tile present, only objects on top of the floor tile will be taken into account.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer

### Notes:
I'm having trouble with the right click menu when running from a build rather than an editor. If someone else could test my PR under that circumstance I would appreciate it. 
