### PR TITLE
Fixes facing direction bump glitch on high ping

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -13,6 +13,7 @@ public class PlayerSprites : NetworkBehaviour
 	private string characterData;
 
 	public PlayerMove playerMove;
+	private PlayerSync playerSync;
 
 	public ClothingItem[] characterSprites; //For character customization
 	private CharacterSettings characterSettings;
@@ -22,6 +23,7 @@ public class PlayerSprites : NetworkBehaviour
 
 	private void Awake()
 	{
+		playerSync = GetComponent<PlayerSync>();
 		foreach (ClothingItem c in GetComponentsInChildren<ClothingItem>())
 		{
 			clothes[c.name] = c;
@@ -143,6 +145,11 @@ public class PlayerSprites : NetworkBehaviour
 	//turning character input and sprite update for local only! (prediction)
 	public void FaceDirection(Orientation direction)
 	{
+		if(playerSync.isBumping)
+		{
+			//Don't face while bumping is occuring on this frame
+			return;
+		}
 		SetDir(direction);
 	}
 

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -48,6 +48,8 @@ public partial class PlayerSync
 	/// Does ghosts's transform pos match state pos? Ignores Z-axis.
 	private bool GhostPositionReady => (Vector2)ghostPredictedState.WorldPosition == (Vector2)playerScript.ghost.transform.position;
 
+	// Is true on the frame that the player is bumping into something
+	public bool isBumping;
 	private bool IsWeightlessClient
 	{
 		get
@@ -93,7 +95,7 @@ public partial class PlayerSync
 			StartCoroutine(DoProcess(action));
 		}
 	}
-
+    
 	private IEnumerator DoProcess(PlayerAction action)
 	{
 		MoveCooldown = true;
@@ -134,6 +136,7 @@ public partial class PlayerSync
 						playerSprites.CmdChangeDirection(Orientation.From(action.Direction()));
 						// Prediction:
 						playerSprites.FaceDirection(Orientation.From(action.Direction()));
+						isBumping = true;
 					}
 					//cooldown is longer when humping walls or pushables
 					//					yield return YieldHelper.DeciSecond;
@@ -150,6 +153,7 @@ public partial class PlayerSync
 
 		yield return YieldHelper.DeciSecond;
 		MoveCooldown = false;
+		isBumping = false;
 	}
 
 	/// Predictive interaction with object you can't move through


### PR DESCRIPTION
### Purpose
Fixes the bug where a player would switch between facing directions really fast when bumping on a high ping client. Added a bumping check to the frame that a bump is occurring so only one facing direction change can happen. The conflict occurs because there are still pending actions in the queue when player is bumping and FacingDirection tries to process both at the same time.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

