### PR TITLE
Consolidate activate and tryinteract

### DIFF
--- a/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
@@ -85,8 +85,8 @@ public class Hands : MonoBehaviour
 	}
 
 	/// <summary>
-	/// General function to activate the item depending on the object.
-	/// E.g. eat food, clean floor with mop etc
+	/// General function to activate the item's UIInteract
+	/// This is the same as clicking the item with the same item's hand
 	/// </summary>
 	public void Activate()
 	{

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
@@ -95,18 +95,7 @@ public class Hands : MonoBehaviour
 		{
 			return;
 		}
-
-		//Is the item edible?
-		if (isEdible())
-		{
-			return;
-		}
-
-		// Is the item a weapon?
-		if (isWeapon())
-		{
-			return;
-		}
+		CurrentSlot.TryItemInteract();
 	}
 
 	/// <summary>
@@ -158,31 +147,6 @@ public class Hands : MonoBehaviour
 			}
 		}
 		return true;
-	}
-
-	/// <summary>
-	/// Check if the item is edible and eat it (true if it is)
-	/// </summary>
-	private bool isEdible()
-	{
-		FoodBehaviour baseFood = CurrentSlot.Item.GetComponent<FoodBehaviour>();
-		if (baseFood != null)
-		{
-			baseFood.TryEat();
-			return true;
-		}
-		return false;
-	}
-
-	private bool isWeapon()
-	{
-		Weapon baseWeapon = CurrentSlot.Item.GetComponent<Weapon>();
-		if (baseWeapon != null)
-		{
-			baseWeapon.TryReload();
-			return true;
-		}
-		return false;
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Weapons/Weapon.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Weapon.cs
@@ -303,43 +303,46 @@ public class Weapon : PickUpTrigger
 		return false;
 	}
 
-	public void TryReload()
+	/// <summary>
+	/// Occurs when a user uses another slot to interact with the weapon
+	/// </summary>
+	public override void UI_InteractOtherSlot(GameObject originator, GameObject item)
 	{
-		//PlaceHolder for click UI
-		GameObject currentHandItem = UIManager.Hands.CurrentSlot.Item;
-		GameObject otherHandItem = UIManager.Hands.OtherSlot.Item;
-		string hand;
+		TryReload(item);
+	}
 
-		if ((currentHandItem != null) && (otherHandItem != null))
+	/// <summary>
+	/// Occurs when a user interacts with the slot using the same hand
+	/// </summary>
+	public override void UI_Interact(GameObject originator, string hand)
+	{
+		if(CurrentMagazine != null)
 		{
+			StopAutomaticBurst();
+			RequestUnload(CurrentMagazine);
+		}
+	}
+	
+	/// <summary>
+	/// attempt to reload the weapon with the item given
+	/// </summary>
+	public void TryReload(GameObject item)
+	{
+		string hand;
+		if (item != null)
+		{
+			MagazineBehaviour magazine = item.GetComponent<MagazineBehaviour>();
 			if (CurrentMagazine == null)
 			{
 				//RELOAD
-				if (currentHandItem.GetComponent<MagazineBehaviour>() && otherHandItem.GetComponent<Weapon>())
+				// If the item used on the gun is a magazine, check type and reload
+				if (magazine)
 				{
-					string ammoType = currentHandItem.GetComponent<MagazineBehaviour>().ammoType;
-
+					string ammoType = magazine.ammoType;		
 					if (AmmoType == ammoType)
 					{
 						hand = UIManager.Hands.CurrentSlot.eventName;
-						RequestReload(currentHandItem, hand, true);
-					}
-
-					if (AmmoType != ammoType)
-					{
-						ChatRelay.Instance.AddToChatLogClient("You try to load the wrong ammo into your weapon",
-							ChatChannel.Examine);
-					}
-				}
-
-				if (otherHandItem.GetComponent<MagazineBehaviour>() && currentHandItem.GetComponent<Weapon>())
-				{
-					string ammoType = otherHandItem.GetComponent<MagazineBehaviour>().ammoType;
-
-					if (AmmoType == ammoType)
-					{
-						hand = UIManager.Hands.OtherSlot.eventName;
-						RequestReload(otherHandItem, hand, false);
+						RequestReload(item, hand, true);
 					}
 
 					if (AmmoType != ammoType)
@@ -349,26 +352,11 @@ public class Weapon : PickUpTrigger
 					}
 				}
 			}
-			else
+			else  if (AmmoType == magazine.ammoType)
 			{
-				//UNLOAD
-
-				if (currentHandItem.GetComponent<Weapon>() && otherHandItem == null)
-				{
-					RequestUnload(CurrentMagazine);
-				}
-				else if (currentHandItem.GetComponent<Weapon>() && otherHandItem.GetComponent<MagazineBehaviour>())
-				{
-					ChatRelay.Instance.AddToChatLogClient(
-						"You weapon is already loaded, you can't fit more Magazines in it, silly!",
-						ChatChannel.Examine);
-				}
-				else if (otherHandItem.GetComponent<Weapon>() && currentHandItem.GetComponent<MagazineBehaviour>())
-				{
-					ChatRelay.Instance.AddToChatLogClient(
-						"You weapon is already loaded, you can't fit more Magazines in it, silly!",
-						ChatChannel.Examine);
-				}
+				ChatRelay.Instance.AddToChatLogClient(
+					"You weapon is already loaded, you can't fit more Magazines in it, silly!",
+					ChatChannel.Examine);
 			}
 		}
 	}


### PR DESCRIPTION
### Purpose
This PR changes the Z keybind's activate to use clicking's tryItemInteract instead.
this means using welders and other items can both work by clicking and pressing z.
Reloading guns is changed to use UI_Interact. interacting with it will eject the magazine and you have to use the magazine with your offhand to load it.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer

### Notes:
I removed several lines checking for equipment types in hands from tryReload.
They seemed redundant but if there are issues I can add them back.
