### PR TITLE
Flickering wall items

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/ObjectBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Objects/ObjectBehaviour.cs
@@ -14,15 +14,23 @@ public class ObjectBehaviour : PushPull
 
 	//The object that this object is contained inside
 	public ObjectBehaviour parentContainer = null;
+	private Vector3 lastNonHiddenPosition = new Vector3();
+	//Location where objects are sent to when hidden
+	private readonly Vector3Int HiddenPos = new Vector3Int(0, 0, -100);
 	//returns position of highest object this object is contained in
     public Vector3 AssumedLocation()
     {
 		//If this object is contained in another, run until highest layer layer is reached
         if (parentContainer != null)
         {
-            return parentContainer.AssumedLocation();
+            lastNonHiddenPosition = parentContainer.AssumedLocation();
         }
-        return transform.position;
+		else if (transform.position != HiddenPos)
+		{
+			lastNonHiddenPosition = transform.position;
+		}
+
+        return lastNonHiddenPosition;
     }
 
 	public override void OnVisibilityChange(bool state)

--- a/UnityProject/Assets/Scripts/Objects/ObjectBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Objects/ObjectBehaviour.cs
@@ -15,8 +15,6 @@ public class ObjectBehaviour : PushPull
 	//The object that this object is contained inside
 	public ObjectBehaviour parentContainer = null;
 	private Vector3 lastNonHiddenPosition = new Vector3();
-	//Location where objects are sent to when hidden
-	private readonly Vector3Int HiddenPos = new Vector3Int(0, 0, -100);
 	//returns position of highest object this object is contained in
     public Vector3 AssumedLocation()
     {
@@ -25,7 +23,7 @@ public class ObjectBehaviour : PushPull
         {
             lastNonHiddenPosition = parentContainer.AssumedLocation();
         }
-		else if (transform.position != HiddenPos)
+		else if (transform.position != TransformState.HiddenPos)
 		{
 			lastNonHiddenPosition = transform.position;
 		}

--- a/UnityProject/Assets/Scripts/Objects/WallmountSpriteBehavior.cs
+++ b/UnityProject/Assets/Scripts/Objects/WallmountSpriteBehavior.cs
@@ -36,9 +36,11 @@ public class WallmountSpriteBehavior : MonoBehaviour {
 		{
 			return;
 		}
+		//Allows getting parent's assumed position if inside object
+		objectBehaviour = PlayerManager.LocalPlayer.GetComponent<ObjectBehaviour>();
 
 		//recalculate if it is facing the player
-		bool visible = wallmountBehavior.IsFacingPosition(PlayerManager.LocalPlayer.transform.position);
+		bool visible = wallmountBehavior.IsFacingPosition(objectBehaviour.AssumedLocation());
 		spriteRenderer.color = new Color(spriteRenderer.color.r, spriteRenderer.color.g, spriteRenderer.color.b, visible ? 1 : 0);
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/WallmountSpriteBehavior.cs
+++ b/UnityProject/Assets/Scripts/Objects/WallmountSpriteBehavior.cs
@@ -37,7 +37,7 @@ public class WallmountSpriteBehavior : MonoBehaviour {
 			return;
 		}
 		//Allows getting parent's assumed position if inside object
-		objectBehaviour = PlayerManager.LocalPlayer.GetComponent<ObjectBehaviour>();
+		ObjectBehaviour objectBehaviour = PlayerManager.LocalPlayerScript.pushPull;
 
 		//recalculate if it is facing the player
 		bool visible = wallmountBehavior.IsFacingPosition(objectBehaviour.AssumedLocation());

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -30,7 +30,7 @@ public class PlayerScript : ManagedNetworkBehaviour
 
 	public PlayerMove playerMove { get; set; }
 
-	public PushPull pushPull { get; set; }
+	public ObjectBehaviour pushPull { get; set; }
 
 	public PlayerSprites playerSprites { get; set; }
 
@@ -93,7 +93,7 @@ public class PlayerScript : ManagedNetworkBehaviour
 		playerNetworkActions = GetComponent<PlayerNetworkActions>();
 		registerTile = GetComponent<RegisterTile>();
 		playerHealth = GetComponent<PlayerHealth>();
-		pushPull = GetComponent<PushPull>();
+		pushPull = GetComponent<ObjectBehaviour>();
 		weaponNetworkActions = GetComponent<WeaponNetworkActions>();
 		soundNetworkActions = GetComponent<SoundNetworkActions>();
 		mouseInputController = GetComponent<MouseInputController>();


### PR DESCRIPTION
Implemented solution to issue #1571 by preventing use of the HiddenPos for position calculations

### Purpose
Fixes #1571 
Uses parent ObjectBehavior to set valid position.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
PR creates a "lastNonHiddenPosition" that is used to rectify intermittent transform.position sets to the HiddenPos when the position is updated after exiting a locker.
