### PR TITLE
Fixing player light emission, Fixing wrongly rotated wall mounts

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V3(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V3(uNet).prefab
@@ -906,6 +906,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18a28f9f9a41257418b09671ebb5c96e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isBumping: 0
   playerMove: {fileID: 114792299177679754}
 --- !u!114 &114173340621344012
 MonoBehaviour:
@@ -1015,6 +1016,7 @@ MonoBehaviour:
   visibleState: 1
   isNotPushable: 0
   closetHandlerCache: {fileID: 0}
+  parentContainer: {fileID: 0}
 --- !u!114 &114449635359748350
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1072,7 +1074,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cc835be17c750e246bed37c4406e0113, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  DefaultIntensity: 0.2
+  DefaultIntensity: 0
   DefaultColour: {r: 1, g: 1, b: 1, a: 0}
   DefaultEnumSprite: 0
   DefaultSize: 1.5
@@ -3818,6 +3820,7 @@ MonoBehaviour:
   visibleState: 1
   isNotPushable: 0
   closetHandlerCache: {fileID: 0}
+  parentContainer: {fileID: 0}
 --- !u!1 &1969254411952092
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
+++ b/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
@@ -44,8 +44,7 @@ public class WallmountBehavior : MonoBehaviour
 	void OnDrawGizmos ()
 	{
 		Gizmos.color = Color.green;
-        //Gizmos.DrawSphere(transform.position , 3);
-		Gizmos.DrawLine(transform.position,(transform.position-transform.up ));
+		GizmoUtils.DrawArrow(transform.position,(new Vector3() - transform.up) );
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
+++ b/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
@@ -44,7 +44,7 @@ public class WallmountBehavior : MonoBehaviour
 	void OnDrawGizmos ()
 	{
 		Gizmos.color = Color.green;
-		GizmoUtils.DrawArrow(transform.position,(new Vector3() - transform.up) );
+		GizmoUtils.DrawArrow(transform.position,(Vector3.zero - transform.up) );
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
+++ b/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
@@ -44,7 +44,7 @@ public class WallmountBehavior : MonoBehaviour
 	void OnDrawGizmos ()
 	{
 		Gizmos.color = Color.green;
-		GizmoUtils.DrawArrow(transform.position,(Vector3.zero - transform.up) );
+		GizmoUtils.DrawArrow(transform.position, - transform.up);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
+++ b/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEditor;
 
 /// <summary>
 /// Behavior common to all wall mounts.
@@ -37,6 +38,14 @@ public class WallmountBehavior : MonoBehaviour
 		float difference = Vector3.Angle(facing, headingToPosition);
 		//91 rather than 90 helps prevent flickering due to rounding
 		return difference >= 91 || difference <= -91;
+	}
+
+	//[DrawGizmo(GizmoType.Selected | GizmoType.NonSelected)]
+	void OnDrawGizmos ()
+	{
+		Gizmos.color = Color.green;
+        //Gizmos.DrawSphere(transform.position , 3);
+		Gizmos.DrawLine(transform.position,(transform.position-transform.up ));
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
+++ b/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs
@@ -40,7 +40,6 @@ public class WallmountBehavior : MonoBehaviour
 		return difference >= 91 || difference <= -91;
 	}
 
-	//[DrawGizmo(GizmoType.Selected | GizmoType.NonSelected)]
 	void OnDrawGizmos ()
 	{
 		Gizmos.color = Color.green;

--- a/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/WallmountBehavior.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 419385456094870383, guid: 0000000000000000d000000000000000, type: 0}
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION

### Purpose
Fixing player light emission, Fixing wrongly rotated wall mounts
, Added gizmo for direction of wallmounts, Added self powered mode, and Fixed APC detection

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer

### Notes:
if (RelatedAPC != null ) //|| SelfPowered
Technically shouldn't work but it does so Just take it out of the comment if it starts being Strange