### PR TITLE
Update WindowDrag.cs

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager.prefab
@@ -16079,7 +16079,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -184, y: -122.700195}
+  m_AnchoredPosition: {x: -184, y: -260}
   m_SizeDelta: {x: 429.3, y: 53.6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8479790989508148053
@@ -17634,7 +17634,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 409.3002}
+  m_AnchoredPosition: {x: 0, y: 409.30002}
   m_SizeDelta: {x: 0, y: 700}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &8556515118206096667
@@ -19440,8 +19440,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 8584827757962983305}
   m_HandleRect: {fileID: 8477495159653326549}
   m_Direction: 2
-  m_Value: 0
-  m_Size: 0.41528553
+  m_Value: 0.0000000745604
+  m_Size: 0.41528562
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -25265,7 +25265,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -41.09961}
+  m_AnchoredPosition: {x: 0, y: -190}
   m_SizeDelta: {x: 580, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8479689637447853149
@@ -26433,15 +26433,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1be41ad698bc54230b6354fed0d26a9c, type: 3}
---- !u!1 &4050590157662293267 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 771838192555679779, guid: 1be41ad698bc54230b6354fed0d26a9c,
-    type: 3}
-  m_PrefabInstance: {fileID: 3639059092237708592}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &8891954396708566947 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5324971781104245395, guid: 1be41ad698bc54230b6354fed0d26a9c,
+    type: 3}
+  m_PrefabInstance: {fileID: 3639059092237708592}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4050590157662293267 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 771838192555679779, guid: 1be41ad698bc54230b6354fed0d26a9c,
     type: 3}
   m_PrefabInstance: {fileID: 3639059092237708592}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Scripts/UI/WindowDrag.cs
+++ b/UnityProject/Assets/Scripts/UI/WindowDrag.cs
@@ -7,10 +7,12 @@
 		private float offsetX;
 		private float offsetY;
 		private Vector3 startPositon;
-		
+		private RectTransform rectTransform;
+
 		void Start () {
 			// Save initial window start positon
 			startPositon = gameObject.transform.position;
+			rectTransform = GetComponent<RectTransform>();
 		}
 		void OnDisable () {
 			// Reset window to start position
@@ -19,14 +21,40 @@
 				gameObject.transform.position = startPositon;
 			}
 		}
+
+		/// <summary>
+		/// Sets the windowDrag fields offsetX and offsetY from the window position and the mouse position.
+        /// The fields offsetX and offsetY are the mouse position's offset from the window's top-left corner.
+		/// In onDrag(), these offsets are used to "hook" the window to the cursor as it is dragged.
+		/// </summary>
 		public void BeginDrag()
 		{
-			offsetX = transform.position.x - Input.mousePosition.x;
-			offsetY = transform.position.y - Input.mousePosition.y;
+			var windowTransformPosition = transform.position;
+
+			offsetX = windowTransformPosition.x - Input.mousePosition.x;
+			offsetY = windowTransformPosition.y - Input.mousePosition.y;
 		}
 
+		/// <summary>
+		/// Moves the window with the cursor within the screen bounds when called.
+		/// </summary>
 		public void OnDrag()
 		{
-			transform.position = new Vector3(offsetX + Input.mousePosition.x, offsetY + Input.mousePosition.y);
+			var windowSize = rectTransform.sizeDelta;
+			var windowScale = rectTransform.lossyScale;
+
+			var windowWidth = windowSize.x;
+			var windowHeight = windowSize.y;
+
+			var widthScale = windowScale.x;
+			var heightScale = windowScale.y;
+
+			transform.position = new Vector3(
+				Mathf.Clamp(offsetX + Input.mousePosition.x,
+					windowWidth * widthScale / 2f,
+					Screen.width - windowWidth * widthScale / 2f),
+				Mathf.Clamp(offsetY + Input.mousePosition.y,
+					windowHeight * heightScale / 2f,
+					Screen.height - windowHeight * heightScale / 2f));
 		}
 	}


### PR DESCRIPTION
Updates BeginDrag() to make it more efficient.
Updates OnDrag() to make it more efficient, and to clamp the dragged window within the screen.
Adds summaries to BeginDrag() and OnDrag().

### Purpose
Prevents the window from going out of the screen bounds.
Fixes #1609 
![47bsh3a](https://user-images.githubusercontent.com/28093344/53880659-6a955180-4076-11e9-8485-2c634bca6bf3.png)

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer

### Notes:
When the resolution changes, the windows do not move with the new resolution and may end up out of bounds: 
![i9lhx3n](https://user-images.githubusercontent.com/28093344/53880719-9adcf000-4076-11e9-95ff-990525552c7e.png)
Although, when an out of bound window gets dragged again the position is fixed.

All window's bounds are correct except for the "Alliance" select window's bounds: 
![fxdgj5s](https://user-images.githubusercontent.com/28093344/53880925-2ce4f880-4077-11e9-857d-ed2bb5a29aed.png)
Not sure why.
