### PR TITLE
#1606 Change swap to check for item interaction first

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager.prefab
@@ -2072,7 +2072,6 @@ GameObject:
   - component: {fileID: 8479207382714481023}
   - component: {fileID: 8587403945929970393}
   - component: {fileID: 8587432192721568523}
-  - component: {fileID: 8587769863163809915}
   - component: {fileID: 8587712180830150811}
   m_Layer: 5
   m_Name: itemSlot
@@ -2155,59 +2154,6 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
---- !u!114 &8587769863163809915
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8554630399048325915}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 8587432192721568523}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 8587403945929970393}
-        m_MethodName: TryItemInteract
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &8587712180830150811
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4045,7 +3991,6 @@ GameObject:
   - component: {fileID: 8479215583570524191}
   - component: {fileID: 8584864879229433161}
   - component: {fileID: 8587584011139510611}
-  - component: {fileID: 8587588272172980873}
   - component: {fileID: 8587846072417712687}
   m_Layer: 5
   m_Name: itemSlot
@@ -4128,59 +4073,6 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
---- !u!114 &8587588272172980873
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8554723427290520107}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 8587584011139510611}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 8584864879229433161}
-        m_MethodName: TryItemInteract
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &8587846072417712687
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -17634,7 +17526,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 409.30002}
+  m_AnchoredPosition: {x: 0, y: 409.29993}
   m_SizeDelta: {x: 0, y: 700}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &8556515118206096667
@@ -19440,8 +19332,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 8584827757962983305}
   m_HandleRect: {fileID: 8477495159653326549}
   m_Direction: 2
-  m_Value: 0.0000000745604
-  m_Size: 0.41528562
+  m_Value: 0.00000022368125
+  m_Size: 0.41528568
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -26046,6 +25938,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 255477921449369631}
     m_Modifications:
+    - target: {fileID: 6473321260040441807, guid: 115eda0ce16984116b796d3f1138c4a3,
+        type: 3}
+      propertyPath: m_Name
+      value: Top
+      objectReference: {fileID: 0}
     - target: {fileID: 8124694636446102824, guid: 115eda0ce16984116b796d3f1138c4a3,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -26151,11 +26048,6 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6473321260040441807, guid: 115eda0ce16984116b796d3f1138c4a3,
-        type: 3}
-      propertyPath: m_Name
-      value: Top
-      objectReference: {fileID: 0}
     - target: {fileID: 2371396193203315087, guid: 115eda0ce16984116b796d3f1138c4a3,
         type: 3}
       propertyPath: Keys.Array.size
@@ -26181,6 +26073,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 255477921449369631}
     m_Modifications:
+    - target: {fileID: 6473321260040441807, guid: 115eda0ce16984116b796d3f1138c4a3,
+        type: 3}
+      propertyPath: m_Name
+      value: Center
+      objectReference: {fileID: 0}
     - target: {fileID: 8124694636446102824, guid: 115eda0ce16984116b796d3f1138c4a3,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -26285,11 +26182,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6473321260040441807, guid: 115eda0ce16984116b796d3f1138c4a3,
-        type: 3}
-      propertyPath: m_Name
-      value: Center
       objectReference: {fileID: 0}
     - target: {fileID: 2371396193203315087, guid: 115eda0ce16984116b796d3f1138c4a3,
         type: 3}
@@ -26433,15 +26325,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1be41ad698bc54230b6354fed0d26a9c, type: 3}
---- !u!224 &8891954396708566947 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5324971781104245395, guid: 1be41ad698bc54230b6354fed0d26a9c,
-    type: 3}
-  m_PrefabInstance: {fileID: 3639059092237708592}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &4050590157662293267 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 771838192555679779, guid: 1be41ad698bc54230b6354fed0d26a9c,
+    type: 3}
+  m_PrefabInstance: {fileID: 3639059092237708592}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &8891954396708566947 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5324971781104245395, guid: 1be41ad698bc54230b6354fed0d26a9c,
     type: 3}
   m_PrefabInstance: {fileID: 3639059092237708592}
   m_PrefabAsset: {fileID: 0}
@@ -26452,6 +26344,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 255477921449369631}
     m_Modifications:
+    - target: {fileID: 6473321260040441807, guid: 115eda0ce16984116b796d3f1138c4a3,
+        type: 3}
+      propertyPath: m_Name
+      value: MidHigh
+      objectReference: {fileID: 0}
     - target: {fileID: 8124694636446102824, guid: 115eda0ce16984116b796d3f1138c4a3,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -26572,11 +26469,6 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 0.9999981
       objectReference: {fileID: 0}
-    - target: {fileID: 6473321260040441807, guid: 115eda0ce16984116b796d3f1138c4a3,
-        type: 3}
-      propertyPath: m_Name
-      value: MidHigh
-      objectReference: {fileID: 0}
     - target: {fileID: 2371396193203315087, guid: 115eda0ce16984116b796d3f1138c4a3,
         type: 3}
       propertyPath: Keys.Array.size
@@ -26602,6 +26494,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 255477921449369631}
     m_Modifications:
+    - target: {fileID: 6473321260040441807, guid: 115eda0ce16984116b796d3f1138c4a3,
+        type: 3}
+      propertyPath: m_Name
+      value: Bottom
+      objectReference: {fileID: 0}
     - target: {fileID: 8124694636446102824, guid: 115eda0ce16984116b796d3f1138c4a3,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -26707,11 +26604,6 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6473321260040441807, guid: 115eda0ce16984116b796d3f1138c4a3,
-        type: 3}
-      propertyPath: m_Name
-      value: Bottom
-      objectReference: {fileID: 0}
     - target: {fileID: 2371396193203315087, guid: 115eda0ce16984116b796d3f1138c4a3,
         type: 3}
       propertyPath: Keys.Array.size
@@ -26737,6 +26629,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 255477921449369631}
     m_Modifications:
+    - target: {fileID: 6473321260040441807, guid: 115eda0ce16984116b796d3f1138c4a3,
+        type: 3}
+      propertyPath: m_Name
+      value: MidLow
+      objectReference: {fileID: 0}
     - target: {fileID: 8124694636446102824, guid: 115eda0ce16984116b796d3f1138c4a3,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -26856,11 +26753,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 0.9999981
-      objectReference: {fileID: 0}
-    - target: {fileID: 6473321260040441807, guid: 115eda0ce16984116b796d3f1138c4a3,
-        type: 3}
-      propertyPath: m_Name
-      value: MidLow
       objectReference: {fileID: 0}
     - target: {fileID: 2371396193203315087, guid: 115eda0ce16984116b796d3f1138c4a3,
         type: 3}

--- a/UnityProject/Assets/Scripts/Clothing/BackPack/BackPackTrigger.cs
+++ b/UnityProject/Assets/Scripts/Clothing/BackPack/BackPackTrigger.cs
@@ -11,7 +11,7 @@ public class BackPackTrigger : PickUpTrigger
 	{
 		storageObj = GetComponent<StorageObject>();
 	}
-	public override void UI_InteractOtherSlot(GameObject originator, GameObject item)
+	public override bool UI_InteractOtherSlot(GameObject originator, GameObject item)
 	{
 		if (item != null)
 		{
@@ -36,6 +36,7 @@ public class BackPackTrigger : PickUpTrigger
 				UIManager.StorageHandler.CloseStorageUI();
 			}
 		}
+		return false;
 	}
 
 	public override void UI_Interact(GameObject originator, string hand)

--- a/UnityProject/Assets/Scripts/Input System/KeyboardInputManager.cs
+++ b/UnityProject/Assets/Scripts/Input System/KeyboardInputManager.cs
@@ -203,7 +203,7 @@ public class KeyboardInputManager : MonoBehaviour
 
 		{  KeyAction.HandSwap, 		() => { UIManager.Hands.Swap(); }},
 		{  KeyAction.HandActivate,	() => { UIManager.Hands.Activate(); }},
-		{  KeyAction.HandEquip, 	() => { UIManager.Hands.Equip(); }},
+		// {  KeyAction.HandEquip, 	() => { UIManager.Hands.Equip(); }},
 
 		// Intents
 		{ KeyAction.IntentLeft,		() => { UIManager.Intent.CycleIntent(true); }},

--- a/UnityProject/Assets/Scripts/Input System/Triggers/InputTrigger.cs
+++ b/UnityProject/Assets/Scripts/Input System/Triggers/InputTrigger.cs
@@ -104,7 +104,7 @@ public abstract class InputTrigger : NetworkBehaviour
 	/// Just add a button to the slot and GetComponent<InputTrigger>().UI_Interact(PlayerManager.LocalPlayer, UIManager.CurrentSlot.eventName)
 	/// </Summary>
 	public virtual void UI_Interact(GameObject originator, string hand) {}
-	public virtual void UI_InteractOtherSlot(GameObject originator, GameObject otherHandItem){}
+	public virtual bool UI_InteractOtherSlot(GameObject originator, GameObject otherHandItem){ return true; }
 
 
 }

--- a/UnityProject/Assets/Scripts/Items/Others/PaperTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/PaperTrigger.cs
@@ -23,7 +23,7 @@ public class PaperTrigger : PickUpTrigger
 		}
 	}
 
-	public override void UI_InteractOtherSlot(GameObject originator, GameObject otherHandItem)
+	public override bool UI_InteractOtherSlot(GameObject originator, GameObject otherHandItem)
 	{
 		if (otherHandItem != null)
 		{
@@ -33,5 +33,6 @@ public class PaperTrigger : PickUpTrigger
 				UI_Interact(originator, UIManager.Hands.OtherSlot.eventName);
 			}
 		}
+		return false;
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
@@ -100,6 +100,8 @@ public class Hands : MonoBehaviour
 
 	/// <summary>
 	/// General function to try to equip the item in the active hand
+	/// NOTE: This method isn't being used right now and should should possibly
+	/// be changed/called by clothing's UI_Interact
 	/// </summary>
 	public void Equip()
 	{

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
@@ -226,19 +226,35 @@ public class UI_ItemSlot : MonoBehaviour, IDragHandler, IEndDragHandler
 		return allowed;
 	}
 
+
+	/// <summary>
+	/// Check if item has an interaction with a an item in a slot
+	/// If not or if bool returned is true, swap items
+	/// </summary>
 	public void TryItemInteract()
 	{
+		// Clicked on another slot other than hands
 		if (eventName != "leftHand" && eventName != "rightHand")
 		{
-			//Clicked on item in another slot other then hands
+			// If full, attempt to interact the two, otherwise swap
 			if (Item != null)
 			{
+				// If there is an an interaction, run and check if it wants to swap
 				var inputTrigger = Item.GetComponent<InputTrigger>();
-				inputTrigger.UI_InteractOtherSlot(PlayerManager.LocalPlayer, UIManager.Hands.CurrentSlot.Item);
+				bool response = inputTrigger.UI_InteractOtherSlot(PlayerManager.LocalPlayer, UIManager.Hands.CurrentSlot.Item);
+				if (response)
+				{
+					UIManager.Hands.SwapItem(this);
+				}
+				return;
+			}
+			else
+			{
+				UIManager.Hands.SwapItem(this);
 				return;
 			}
 		}
-
+		// If there is an item and the hand is interacting in the same slot
 		if (Item != null && UIManager.Hands.CurrentSlot.eventName == eventName)
 		{
 			var inputTrigger = Item.GetComponent<InputTrigger>();
@@ -254,8 +270,14 @@ public class UI_ItemSlot : MonoBehaviour, IDragHandler, IEndDragHandler
 					var trig = UIManager.Hands.OtherSlot.Item.GetComponent<InputTrigger>();
 					if (trig != null)
 					{
-						trig.UI_InteractOtherSlot(PlayerManager.LocalPlayer,
+						// If there is an an interaction, run and check if it wants to swap
+						bool response = trig.UI_InteractOtherSlot(PlayerManager.LocalPlayer,
 							UIManager.Hands.CurrentSlot.Item);
+						if (response)
+						{
+							UIManager.Hands.SwapItem(this);
+						}
+						return;
 					}
 				}
 			}

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSwap.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSwap.cs
@@ -14,7 +14,7 @@ public class UI_ItemSwap : MonoBehaviour, IPointerClickHandler, IDropHandler
 		if (eventData.button == PointerEventData.InputButton.Left)
 		{
 			SoundManager.Play("Click01");
-			UIManager.Hands.SwapItem(itemSlot);
+			itemSlot.TryItemInteract();
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Weapons/Weapon.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Weapon.cs
@@ -311,9 +311,9 @@ public class Weapon : PickUpTrigger
 	/// <summary>
 	/// Occurs when a user uses another slot to interact with the weapon
 	/// </summary>
-	public override void UI_InteractOtherSlot(GameObject originator, GameObject item)
+	public override bool UI_InteractOtherSlot(GameObject originator, GameObject item)
 	{
-		TryReload(item);
+		return TryReload(item);
 	}
 
 	/// <summary>
@@ -331,38 +331,42 @@ public class Weapon : PickUpTrigger
 	/// <summary>
 	/// attempt to reload the weapon with the item given
 	/// </summary>
-	public void TryReload(GameObject item)
+	public bool TryReload(GameObject item)
 	{
 		string hand;
 		if (item != null)
 		{
 			MagazineBehaviour magazine = item.GetComponent<MagazineBehaviour>();
-			if (CurrentMagazine == null)
+			if (magazine)
 			{
-				//RELOAD
-				// If the item used on the gun is a magazine, check type and reload
-				if (magazine)
+				if (CurrentMagazine == null)
 				{
+					//RELOAD
+					// If the item used on the gun is a magazine, check type and reload
 					string ammoType = magazine.ammoType;		
 					if (AmmoType == ammoType)
 					{
 						hand = UIManager.Hands.CurrentSlot.eventName;
 						RequestReload(item, hand, true);
 					}
-
 					if (AmmoType != ammoType)
 					{
 						ChatRelay.Instance.AddToChatLogClient("You try to load the wrong ammo into your weapon",
 							ChatChannel.Examine);
 					}
 				}
+				else  if (AmmoType == magazine.ammoType)
+				{
+					ChatRelay.Instance.AddToChatLogClient(
+						"You weapon is already loaded, you can't fit more Magazines in it, silly!",
+						ChatChannel.Examine);
+				}
 			}
-			else  if (AmmoType == magazine.ammoType)
-			{
-				ChatRelay.Instance.AddToChatLogClient(
-					"You weapon is already loaded, you can't fit more Magazines in it, silly!",
-					ChatChannel.Examine);
-			}
+			return false;
+		}
+		else
+		{
+			return true;
 		}
 	}
 


### PR DESCRIPTION
### Purpose
This changes itemswap to always use tryItemInteract first.
UI_intereactOther is now a bool which determines if swapItem will be run.
(true means SwapItem)
Fixes #1606 

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer

### Notes:
I am using "this" in itemSlot for swapping item. if that's an issue an issue I can correct it. I just figured I'd post everything for feedback.
The change to the UI_Manager.prefab is the removal of the button on hands which directly runs tryItemInteract since swapItem is still run on slots regardless
It seems to be working without issue in multiplayer.

I rolled back the previous commit to rebase uiManager over it.