### PR TITLE
#1612 fix null reference exception when taking down walls

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -60,10 +60,13 @@ public abstract class RegisterTile : NetworkBehaviour
 		get => matrix;
 		private set
 		{
-			matrix = value;
-			//update matrix move as well
-			//if it exists
-			MatrixMove = matrix.transform.root.GetComponent<MatrixMove>();
+			if (value)
+			{
+				matrix = value;
+				//update matrix move as well
+				//if it exists
+				MatrixMove = matrix.transform.root.GetComponent<MatrixMove>();
+			}
 		}
 	}
 	private Matrix matrix;


### PR DESCRIPTION
### Purpose
fix null reference exception
Fixes #1612 

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer

### Notes:
When the metal tiles were being Instantiated after a wall went down, the parent's matrix didn't exist so when it's value was being set it gave a null reference exception.
This seems to have fixed the issue but if there's something else to look into for this one let me know