### PR TITLE
#1630 optionally stop momentum upon disappearing

### DIFF
--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
@@ -410,11 +410,15 @@ public partial class CustomNetTransform : ManagedNetworkBehaviour, IPushable //s
 	#region Hiding/Unhiding
 
 	[Server]
-	public void DisappearFromWorldServer()
+	public void DisappearFromWorldServer(bool stopInertia = true)
 	{
 		OnPullInterrupt().Invoke();
 		serverState.Position = TransformState.HiddenPos;
 		serverLerpState.Position = TransformState.HiddenPos;
+		if (CheckFloatingServer() && stopInertia )
+		{
+			Stop();
+		}
 		NotifyPlayers();
 	}
 


### PR DESCRIPTION
### Purpose
Stop saved momentum unless desired with optional bool
Fixes #1630 

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer

### Notes:
Item Momentum after disappearing will definitely have a use later and this should default it to stopping if it has disappeared now. I didn't see anything else this should affect currently other than closets.