### PR TITLE
#1512 fix icon still appearing after fast slot swapping

### DIFF
--- a/UnityProject/Assets/Scripts/UI/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/UIManager.cs
@@ -148,7 +148,6 @@ public class UIManager : MonoBehaviour
 			return false;
 		}
 		InventoryInteractMessage.Send(slotInfo.SlotUUID, slotInfo.FromSlotUUID, slotInfo.SlotContents, true);
-		UpdateSlot(slotInfo);
 		return true;
 	}
 
@@ -180,8 +179,7 @@ public class UIManager : MonoBehaviour
 		var fromSlot = InventorySlotCache.GetSlotByUUID(slotInfo.FromSlotUUID);
 		bool fromS = fromSlot != null;
 		bool fromSI = fromSlot?.Item != null;
-
-		if (fromSlot?.Item == slotInfo.SlotContents)
+		if (fromSlot && (fromSlot.image.enabled || fromSlot?.Item == slotInfo.SlotContents))
 		{
 			CheckStorageHandlerOnMove(fromSlot.Item);
 			fromSlot.Clear();


### PR DESCRIPTION
### Purpose
fixes issue where when swapping at breakneck speeds, the icon was still visible in the previous slot.
Fixes #1512
![pants](https://user-images.githubusercontent.com/47410468/54175877-845ddc80-445a-11e9-9ef8-0ab37d163127.gif)

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer

### Notes:
 E equipping is not currently working right now, however the issue was that the slots were swapping too quickly which can be done with just clicking too.

I removed a call to updateSlot directly after the inventoryinteractmessage was sent because UpdateSlot already gets called after the message is processed.