### PR TITLE
Fix issue where UI wasn't being fully reset upon going back to the lobby

### DIFF
--- a/UnityProject/Assets/Scenes/Lobby.unity
+++ b/UnityProject/Assets/Scenes/Lobby.unity
@@ -5285,7 +5285,7 @@ PrefabInstance:
     - target: {fileID: 224264904714827184, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 409.3001
+      value: 409.29993
       objectReference: {fileID: 0}
     - target: {fileID: 224816160242944980, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
@@ -5577,6 +5577,11 @@ PrefabInstance:
       propertyPath: RoundTime
       value: 600
       objectReference: {fileID: 0}
+    - target: {fileID: 114735544628521044, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: teamSelectionWindow
+      value: 
+      objectReference: {fileID: 1794994171}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 829f4ca992b848d6bb4d007fb9c112e1, type: 3}
 --- !u!1 &506934249
@@ -16678,7 +16683,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 22400762, guid: 67117722a812a2e46ab8cb8eafbf5f5e, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.000019073486
+      value: -0.000011444092
       objectReference: {fileID: 0}
     - target: {fileID: 22414360, guid: 67117722a812a2e46ab8cb8eafbf5f5e, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -17590,6 +17595,12 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1782858966}
   m_CullTransparentMesh: 0
+--- !u!1 &1794994171 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1091980934480710, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+    type: 3}
+  m_PrefabInstance: {fileID: 488811643}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1807554843
 GameObject:
   m_ObjectHideFlags: 0
@@ -19157,7 +19168,7 @@ PrefabInstance:
     - target: {fileID: 224576715969102918, guid: 38ecd680d57974ffe87b4bdd8cd52589,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.000037417358
+      value: 0.000030517578
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 38ecd680d57974ffe87b4bdd8cd52589, type: 3}

--- a/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
@@ -6,6 +6,7 @@ public class ControlDisplays : MonoBehaviour
 	public RectTransform hudBottom;
 	public RectTransform hudRight;
 	public GameObject jobSelectWindow;
+	public GameObject teamSelectionWindow;
 	public RectTransform panelRight;
 	public UIManager parentScript;
 
@@ -34,6 +35,8 @@ public class ControlDisplays : MonoBehaviour
 		hudBottom.gameObject.SetActive(false);
 		backGround.SetActive(true);
 		panelRight.gameObject.SetActive(false);
+		jobSelectWindow.SetActive(false);
+		teamSelectionWindow.SetActive(false);
 	}
 
 	public void SetScreenForGame()
@@ -53,7 +56,7 @@ public class ControlDisplays : MonoBehaviour
 	}
 
 	public void DetermineGameMode()
-	{ 
+	{
 		//if(GameManager.Instance.gameMode == GameMode.nukeops){
 			nukeOpsGameMode.SetActive(true);
 		//}


### PR DESCRIPTION
Fixes #1250 including the issue I brought up after being unable to reproduce the initial problem.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
Had to change Lobby scene so that ControlDisplays had a reference to the team selection window.

If there is an issue merging it, this is all that's needed to set up my change in the lobby (in Lobby > UIManager > ControlDisplays behavior):
![Annotation 2019-03-12 210633](https://user-images.githubusercontent.com/1329062/54253247-60a69f00-450b-11e9-8d4a-03a41b04ed28.png)

I think a new steam server / client build will be needed to fully test this.
