### PR TITLE
Better clicks

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Tools/Resources/Screwdriver.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Resources/Screwdriver.prefab
@@ -1,21 +1,11 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1519710982558066}
-  m_IsPrefabAsset: 1
 --- !u!1 &1467501759831148
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4070804113322926}
@@ -27,215 +17,26 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1519710982558066
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4949321775558472}
-  - component: {fileID: 61000259733276454}
-  - component: {fileID: 114009608666145778}
-  - component: {fileID: 114287030664492144}
-  - component: {fileID: 50080775290529754}
-  - component: {fileID: 114909773131868738}
-  - component: {fileID: 114072330335640904}
-  - component: {fileID: 114998062039538404}
-  - component: {fileID: 114484434474911270}
-  m_Layer: 10
-  m_Name: Screwdriver
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &4070804113322926
 Transform:
-  m_ObjectHideFlags: 1
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1467501759831148}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: 0.00000014901144, w: 1}
+  m_LocalPosition: {x: 0, y: 0.25, z: 0}
   m_LocalScale: {x: 0.8, y: 0.8, z: 1}
   m_Children: []
   m_Father: {fileID: 4949321775558472}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &4949321775558472
-Transform:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1519710982558066}
-  m_LocalRotation: {x: -0, y: -0, z: -0.00000014901144, w: 1}
-  m_LocalPosition: {x: 16, y: 60, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 4070804113322926}
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!50 &50080775290529754
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1519710982558066}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_Interpolate: 1
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 4
---- !u!61 &61000259733276454
-BoxCollider2D:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!114 &114009608666145778
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 372142912, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SceneId:
-    m_Value: 0
-  m_AssetId:
-    i0: 218
-    i1: 169
-    i2: 37
-    i3: 174
-    i4: 51
-    i5: 234
-    i6: 181
-    i7: 212
-    i8: 152
-    i9: 143
-    i10: 129
-    i11: 130
-    i12: 161
-    i13: 206
-    i14: 51
-    i15: 172
-  m_ServerOnly: 0
-  m_LocalPlayerAuthority: 0
---- !u!114 &114072330335640904
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9511e80319bea6e47946f97051ff2b00, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &114287030664492144
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &114484434474911270
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ObjectType: 0
---- !u!114 &114909773131868738
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  clothingReference: -1
-  hierarchy: 
-  inHandReferenceLeft: 1024
-  inHandReferenceRight: 1036
-  itemDescription: A screwdriver
-  itemName: yellow screwdriver
-  itemType: 0
-  size: 0
-  spriteType: 0
-  type: 0
-  throwDamage: 21
-  throwSpeed: 2
-  throwRange: 7
-  hitDamage: 32
-  hitSound: GenericHit
-  attackVerb: []
---- !u!114 &114998062039538404
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ignoredSpriteRenderers: []
-  registerTile: {fileID: 0}
-  visibleState: 1
-  isNotPushable: 0
-  closetHandlerCache: {fileID: 0}
 --- !u!212 &212351652085156724
 SpriteRenderer:
-  m_ObjectHideFlags: 1
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1467501759831148}
   m_Enabled: 1
   m_CastShadows: 0
@@ -245,6 +46,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
   m_StaticBatchInfo:
@@ -277,3 +79,230 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &1519710982558066
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4949321775558472}
+  - component: {fileID: 61000259733276454}
+  - component: {fileID: 114009608666145778}
+  - component: {fileID: 114287030664492144}
+  - component: {fileID: 50080775290529754}
+  - component: {fileID: 114909773131868738}
+  - component: {fileID: 114072330335640904}
+  - component: {fileID: 114998062039538404}
+  - component: {fileID: 114484434474911270}
+  - component: {fileID: 2621837288423225324}
+  m_Layer: 10
+  m_Name: Screwdriver
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4949321775558472
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_LocalRotation: {x: -0, y: -0, z: -0.00000014901144, w: 1}
+  m_LocalPosition: {x: 16, y: 60, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4070804113322926}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &61000259733276454
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &114009608666145778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 372142912, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SceneId:
+    m_Value: 0
+  m_AssetId:
+    i0: 0
+    i1: 0
+    i2: 0
+    i3: 0
+    i4: 0
+    i5: 0
+    i6: 0
+    i7: 0
+    i8: 0
+    i9: 0
+    i10: 0
+    i11: 0
+    i12: 0
+    i13: 0
+    i14: 0
+    i15: 0
+  m_ServerOnly: 0
+  m_LocalPlayerAuthority: 0
+--- !u!114 &114287030664492144
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!50 &50080775290529754
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 1
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!114 &114909773131868738
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  clothingReference: -1
+  hierarchy: 
+  inHandReferenceLeft: 1024
+  inHandReferenceRight: 1036
+  itemDescription: A screwdriver
+  itemName: yellow screwdriver
+  itemType: 0
+  size: 0
+  spriteType: 0
+  type: 0
+  ConnectedToTank: 0
+  throwDamage: 21
+  throwSpeed: 2
+  throwRange: 7
+  hitDamage: 32
+  hitSound: GenericHit
+  attackVerb: []
+--- !u!114 &114072330335640904
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9511e80319bea6e47946f97051ff2b00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114998062039538404
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ignoredSpriteRenderers: []
+  registerTile: {fileID: 0}
+  visibleState: 1
+  isNotPushable: 0
+  closetHandlerCache: {fileID: 0}
+  parentContainer: {fileID: 0}
+--- !u!114 &114484434474911270
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnRotateEnd:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: OrientationEvent, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+  OnRotateStart:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: OrientationEvent, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+  ObjectType: 0
+  rotateWithMatrix: 0
+--- !u!114 &2621837288423225324
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e0036bd5aae14571835232bc33ddaf2e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
@@ -302,7 +302,8 @@ public class MouseInputController : MonoBehaviour
 		//check which of the sprite renderers we hit and pixel checked is the highest
 		if (renderers.Count > 0)
 		{
-			foreach ( Renderer _renderer in renderers.OrderByDescending(r => r.GetType() == TilemapType ? 0 : 1).ThenByDescending(r => r.sortingOrder) )
+			foreach ( Renderer _renderer in renderers.OrderByDescending(r => r.GetType() == TilemapType ? 0 : 1)
+													 .ThenByDescending(r => SortingLayer.GetLayerValueFromID(r.sortingLayerID)) )
 			{
 				// If the ray hits a FOVTile, we can continue down (don't count it as an interaction)
 				// Matrix is the base Tilemap layer. It is used for matrix detection but gets in the way

--- a/UnityProject/Assets/Scripts/Input System/Triggers/PickUpTrigger.cs
+++ b/UnityProject/Assets/Scripts/Input System/Triggers/PickUpTrigger.cs
@@ -1,5 +1,7 @@
+using System;
 using UnityEngine;
 using UnityEngine.Networking;
+using Random = UnityEngine.Random;
 
 
 public class PickUpTrigger : InputTrigger
@@ -100,7 +102,26 @@ public class PickUpTrigger : InputTrigger
 
 		if (cnt.IsFloatingServer ? !CanReachFloating(ps, state) : !ps.IsInReach(cnt.RegisterTile))
 		{
-			Logger.LogWarning($"Not in reach! server pos:{state.WorldPosition} player pos:{originator.transform.position} (floating={cnt.IsFloatingServer})", Category.Security);
+			//Long arms perk
+			if ( !cnt.IsFloatingServer && CanReachFloating(ps, state) )
+			{
+				var worldPosition = cnt.RegisterTile.WorldPosition;
+				cnt.Nudge( new NudgeInfo
+				{
+					OriginPos = worldPosition - ((Vector3)ps.WorldPos-worldPosition)/ Random.Range( 10, 31 ),
+					TargetPos = worldPosition,
+					SpinMode = SpinMode.Clockwise,
+					SpinMultiplier = 15,
+					InitialSpeed = 2
+				} );
+				Logger.LogTraceFormat( "Nudging! server pos:{0} player pos:{1}", Category.Security,
+					state.WorldPosition, originator.transform.position);
+			}
+			else
+			{
+				Logger.LogTraceFormat( "Not in reach! server pos:{0} player pos:{1} (floating={2})", Category.Security,
+					state.WorldPosition, originator.transform.position, cnt.IsFloatingServer);
+			}
 			return false;
 		}
 		Logger.LogTraceFormat("Pickup success! server pos:{0} player pos:{1} (floating={2})", Category.Security,
@@ -116,7 +137,7 @@ public class PickUpTrigger : InputTrigger
 	/// </summary>
 	private static bool CanReachFloating(PlayerScript ps, TransformState state)
 	{
-		return ps.IsInReach(state.WorldPosition) || ps.IsInReach(state.WorldPosition - (Vector3)state.Impulse, 2f);
+		return ps.IsInReach(state.WorldPosition) || ps.IsInReach(state.WorldPosition - (Vector3)state.Impulse, 1.75f);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Input System/Triggers/PickUpTrigger.cs
+++ b/UnityProject/Assets/Scripts/Input System/Triggers/PickUpTrigger.cs
@@ -20,7 +20,8 @@ public class PickUpTrigger : InputTrigger
 	}
 	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
-		if (originator.GetComponent<PlayerScript>().canNotInteract())
+		var player = originator.GetComponent<PlayerScript>();
+		if (player.canNotInteract())
 		{
 			return true;
 		}
@@ -32,9 +33,11 @@ public class PickUpTrigger : InputTrigger
 			//PreCheck
 			if (UIManager.CanPutItemToSlot(uiSlotObject))
 			{
-				//Simulation
-				gameObject.GetComponent<CustomNetTransform>().DisappearFromWorld();
-				//                    UIManager.UpdateSlot(uiSlotObject);
+				if ( player.IsInReach( this.gameObject ) )
+				{
+					//Predictive disappear only if item is within normal range
+					gameObject.GetComponent<CustomNetTransform>().DisappearFromWorld();
+				}
 
 				//Client informs server of interaction attempt
 				InteractMessage.Send(gameObject, hand);

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -4,11 +4,8 @@ using UnityEngine.Networking;
 
 public class PlayerScript : ManagedNetworkBehaviour
 {
-	// the maximum distance the player needs to be to an object to interact with it
-	//1.75 is the optimal distance to now have any direction click too far
-	//NOTE FOR ANYONE EDITING THIS IN THE FUTURE: Character's head is slightly below the top of the tile
-	//hence top reach is slightly lower than bottom reach, where the legs go exactly to the bottom of the tile.
-	public const float interactionDistance = 1.75f;
+	/// maximum distance the player needs to be to an object to interact with it
+	public const float interactionDistance = 1.5f;
 
 	public GameObject ghost;
 
@@ -228,17 +225,8 @@ public class PlayerScript : ManagedNetworkBehaviour
 
 	public static bool IsInReach(Vector3 from, Vector3 to, float interactDist = interactionDistance)
 	{
-		//If click is in diagonal direction, extend reach slightly
-		int distanceX = Mathf.FloorToInt(Mathf.Abs(from.x - to.x));
-		int distanceY = Mathf.FloorToInt(Mathf.Abs(from.y - to.y));
 		var distanceVector = from - to;
-		if (distanceX == 1 && distanceY == 1)
-		{
-			return distanceVector.magnitude <= interactDist + 0.4f;
-		}
-
-		//if cardinal direction, use regular reach
-		return Mathf.Max(distanceVector.x, distanceVector.y) <= interactDist;
+		return Mathf.Max( Mathf.Abs(distanceVector.x), Mathf.Abs(distanceVector.y) ) < interactDist;
 	}
 
 	public ChatChannel GetAvailableChannelsMask(bool transmitOnly = true)

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -231,13 +231,14 @@ public class PlayerScript : ManagedNetworkBehaviour
 		//If click is in diagonal direction, extend reach slightly
 		int distanceX = Mathf.FloorToInt(Mathf.Abs(from.x - to.x));
 		int distanceY = Mathf.FloorToInt(Mathf.Abs(from.y - to.y));
+		var distanceVector = from - to;
 		if (distanceX == 1 && distanceY == 1)
 		{
-			return (from - to).magnitude <= interactDist + 0.4f;
+			return distanceVector.magnitude <= interactDist + 0.4f;
 		}
 
 		//if cardinal direction, use regular reach
-		return (from - to).magnitude <= interactDist;
+		return Mathf.Max(distanceVector.x, distanceVector.y) <= interactDist;
 	}
 
 	public ChatChannel GetAvailableChannelsMask(bool transmitOnly = true)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -259,18 +259,8 @@ public abstract class RegisterTile : NetworkBehaviour
 
 	public void UpdatePosition()
 	{
-		bool wasHidden = Position == TransformState.HiddenPos;
 		Position = Vector3Int.RoundToInt(transform.localPosition);
-		if (wasHidden && Position != TransformState.HiddenPos && !rotateWithMatrix && spriteRenderers != null)
-		{
-			//if we just appeared, reorient ourselves
-			foreach (SpriteRenderer renderer in spriteRenderers)
-			{
-				renderer.transform.rotation = Quaternion.identity;
-			}
-		}
 	}
-
 
 	/// <summary>
 	/// Invoked when receiving rotation event from our current matrix's matrixmove

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
@@ -278,7 +278,7 @@ public partial class CustomNetTransform {
 			serverState.SpinFactor = ( sbyte ) ( Mathf.Clamp( info.InitialSpeed * info.SpinMultiplier, sbyte.MinValue, sbyte.MaxValue )
 			                                     * ( info.SpinMode == SpinMode.Clockwise ? 1 : -1 ) );
 		}
-		Logger.LogWarning( $"Nudge:{info} {serverState}", Category.Transform );
+		Logger.LogTraceFormat( "Nudge:{0} {1}", Category.Transform, info, serverState);
 		NotifyPlayers();
 	}
 

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
@@ -12,44 +12,6 @@ public enum SpinMode {
 	CounterClockwise
 }
 
-public struct ThrowInfo
-{
-	/// Null object, means that there's no throw in progress
-	public static readonly ThrowInfo NoThrow =
-		new ThrowInfo{ OriginPos = TransformState.HiddenPos, TargetPos = TransformState.HiddenPos };
-	public Vector3 OriginPos;
-	public Vector3 TargetPos;
-	public GameObject ThrownBy;
-	public BodyPartType Aim;
-	public float InitialSpeed;
-	public SpinMode SpinMode;
-	public Vector3 Trajectory => TargetPos - OriginPos;
-
-	public override string ToString() {
-		return Equals(NoThrow) ? "[No throw]" :
-			$"[{nameof( OriginPos )}: {OriginPos}, {nameof( TargetPos )}: {TargetPos}, {nameof( ThrownBy )}: {ThrownBy}, " +
-			$"{nameof( Aim )}: {Aim}, {nameof( InitialSpeed )}: {InitialSpeed}, {nameof( SpinMode )}: {SpinMode}]";
-	}
-
-	public bool Equals( ThrowInfo other ) {
-		return OriginPos.Equals( other.OriginPos ) && TargetPos.Equals( other.TargetPos );
-	}
-
-	public override bool Equals( object obj ) {
-		if ( ReferenceEquals( null, obj ) ) {
-			return false;
-		}
-
-		return obj is ThrowInfo && Equals( ( ThrowInfo ) obj );
-	}
-
-	public override int GetHashCode() {
-		unchecked {
-			return ( OriginPos.GetHashCode() * 397 ) ^ TargetPos.GetHashCode();
-		}
-	}
-}
-
 public partial class CustomNetTransform {
 	private PushPull pushPull;
 	public PushPull PushPull => pushPull ? pushPull : ( pushPull = GetComponent<PushPull>() );
@@ -294,6 +256,29 @@ public partial class CustomNetTransform {
 		}
 		serverState.ActiveThrow = correctedInfo;
 //		Logger.Log( $"Throw:{correctedInfo} {serverState}" );
+		NotifyPlayers();
+	}
+
+	/// <summary>
+	/// Experimental.
+	/// Nudge object (sliding on the ground, not in the air)
+	/// </summary>
+	[Server]
+	public void Nudge( NudgeInfo info ) {
+		Vector2 impulse = info.Trajectory.normalized;
+
+		serverState.Speed = info.InitialSpeed;
+
+		serverState.Impulse = impulse;
+		if ( info.SpinMode != SpinMode.None ) {
+			if ( info.SpinMultiplier <= 0 )
+			{
+				info.SpinMultiplier = 1;
+			}
+			serverState.SpinFactor = ( sbyte ) ( Mathf.Clamp( info.InitialSpeed * info.SpinMultiplier, sbyte.MinValue, sbyte.MaxValue )
+			                                     * ( info.SpinMode == SpinMode.Clockwise ? 1 : -1 ) );
+		}
+		Logger.LogWarning( $"Nudge:{info} {serverState}", Category.Transform );
 		NotifyPlayers();
 	}
 

--- a/UnityProject/Assets/Scripts/Transform/NudgeInfo.cs
+++ b/UnityProject/Assets/Scripts/Transform/NudgeInfo.cs
@@ -1,5 +1,8 @@
 using UnityEngine;
 
+/// <summary>
+/// Describes info required for a nudge
+/// </summary>
 public struct NudgeInfo
 {
 	/// Null object, means that there's no nudge in progress

--- a/UnityProject/Assets/Scripts/Transform/NudgeInfo.cs
+++ b/UnityProject/Assets/Scripts/Transform/NudgeInfo.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+public struct NudgeInfo
+{
+	/// Null object, means that there's no nudge in progress
+	public static readonly NudgeInfo NoNudge =
+		new NudgeInfo{ OriginPos = TransformState.HiddenPos, TargetPos = TransformState.HiddenPos };
+	public Vector3 OriginPos;
+	public Vector3 TargetPos;
+	public float SpinMultiplier;
+	public float InitialSpeed;
+	public SpinMode SpinMode;
+	public Vector3 Trajectory => TargetPos - OriginPos;
+
+	public override string ToString() {
+		return Equals(NoNudge) ? "[No nudge]" :
+			$"[{nameof( OriginPos )}: {OriginPos}, {nameof( TargetPos )}: {TargetPos}, " +
+			$"{nameof( SpinMultiplier )}: {SpinMultiplier}, {nameof( InitialSpeed )}: {InitialSpeed}, {nameof( SpinMode )}: {SpinMode}]";
+	}
+
+	public bool Equals( ThrowInfo other ) {
+		return OriginPos.Equals( other.OriginPos ) && TargetPos.Equals( other.TargetPos );
+	}
+
+	public override bool Equals( object obj ) {
+		if ( ReferenceEquals( null, obj ) ) {
+			return false;
+		}
+
+		return obj is ThrowInfo && Equals( ( ThrowInfo ) obj );
+	}
+
+	public override int GetHashCode() {
+		unchecked {
+			return ( OriginPos.GetHashCode() * 397 ) ^ TargetPos.GetHashCode();
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Transform/NudgeInfo.cs.meta
+++ b/UnityProject/Assets/Scripts/Transform/NudgeInfo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3cbde10228984c10b07ea8ebd720663b
+timeCreated: 1552479141

--- a/UnityProject/Assets/Scripts/Transform/ThrowInfo.cs
+++ b/UnityProject/Assets/Scripts/Transform/ThrowInfo.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+public struct ThrowInfo
+{
+	/// Null object, means that there's no throw in progress
+	public static readonly ThrowInfo NoThrow =
+		new ThrowInfo{ OriginPos = TransformState.HiddenPos, TargetPos = TransformState.HiddenPos };
+	public Vector3 OriginPos;
+	public Vector3 TargetPos;
+	public GameObject ThrownBy;
+	public BodyPartType Aim;
+	public float InitialSpeed;
+	public SpinMode SpinMode;
+	public Vector3 Trajectory => TargetPos - OriginPos;
+
+	public override string ToString() {
+		return Equals(NoThrow) ? "[No throw]" :
+			$"[{nameof( OriginPos )}: {OriginPos}, {nameof( TargetPos )}: {TargetPos}, {nameof( ThrownBy )}: {ThrownBy}, " +
+			$"{nameof( Aim )}: {Aim}, {nameof( InitialSpeed )}: {InitialSpeed}, {nameof( SpinMode )}: {SpinMode}]";
+	}
+
+	public bool Equals( ThrowInfo other ) {
+		return OriginPos.Equals( other.OriginPos ) && TargetPos.Equals( other.TargetPos );
+	}
+
+	public override bool Equals( object obj ) {
+		if ( ReferenceEquals( null, obj ) ) {
+			return false;
+		}
+
+		return obj is ThrowInfo && Equals( ( ThrowInfo ) obj );
+	}
+
+	public override int GetHashCode() {
+		unchecked {
+			return ( OriginPos.GetHashCode() * 397 ) ^ TargetPos.GetHashCode();
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Transform/ThrowInfo.cs
+++ b/UnityProject/Assets/Scripts/Transform/ThrowInfo.cs
@@ -1,5 +1,8 @@
 using UnityEngine;
 
+/// <summary>
+/// Describes info required for a throw
+/// </summary>
 public struct ThrowInfo
 {
 	/// Null object, means that there's no throw in progress

--- a/UnityProject/Assets/Scripts/Transform/ThrowInfo.cs.meta
+++ b/UnityProject/Assets/Scripts/Transform/ThrowInfo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ee4fd6780f5c4bde91e78be7cbb19c4e
+timeCreated: 1552479104


### PR DESCRIPTION
### Purpose
Fixes #1634 
 - Fixed renderer hit priority (reason for most click weirdness):
i.e. you could click that pixel, but ctrl+clicking wouldn't work on the exact same spot
![fixed1](https://user-images.githubusercontent.com/10403536/54344110-33a3da80-4638-11e9-9bd0-a83fef41edea.png)
 - Fixed player reach methods as they were flawed (couldn't click objects in their far corners):
![fixed2](https://user-images.githubusercontent.com/10403536/54344333-85e4fb80-4638-11e9-860f-b4b66e2395dc.png)
 - Fixed clicking objects that are registered within reach but have parts out of reach:
![fixed3](https://user-images.githubusercontent.com/10403536/54344431-bf1d6b80-4638-11e9-8b71-1ae8a6e77b48.png)
 - Experimental: clicking items that are barely out of reach will nudge them towards you
![fixed4](https://user-images.githubusercontent.com/10403536/54344762-803be580-4639-11e9-9999-ce2d65979cc1.gif)
 - Fixed trigger colliders rotation being out of sync with sprites and introducing deadzones

also centered screwdriver sprite and added pixel highlight gizmo for easier click issues debugging

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer
