### PR TITLE
Disabled mid-round job changes fixes #1614

### DIFF
--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -11,6 +11,8 @@ using UnityEngine.Networking;
 /// </summary>
 public class JoinedViewer : NetworkBehaviour
 {
+	private bool hasJob = false;
+
     public override void OnStartServer()
     {
         base.OnStartServer();
@@ -21,7 +23,8 @@ public class JoinedViewer : NetworkBehaviour
                 GameObject = gameObject,
                 Job = JobType.NULL
         });
-    }
+		hasJob = false;
+	}
     public override void OnStartLocalPlayer()
     {
         base.OnStartLocalPlayer();
@@ -62,7 +65,11 @@ public class JoinedViewer : NetworkBehaviour
     [Command]
     public void CmdRequestJob(JobType jobType)
     {
-        SpawnHandler.RespawnPlayer(connectionToClient, playerControllerId,
-            GameManager.Instance.GetRandomFreeOccupation(jobType));
+		if (hasJob == false)
+		{
+			SpawnHandler.RespawnPlayer(connectionToClient, playerControllerId,
+				GameManager.Instance.GetRandomFreeOccupation(jobType));
+			hasJob = true;
+		}
     }
 }

--- a/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
@@ -41,6 +41,7 @@ public class ControlDisplays : MonoBehaviour
 
 	public void SetScreenForGame()
 	{
+		jobSelectWindow.SetActive(false);
 		hudRight.gameObject.SetActive(true);
 		hudBottom.gameObject.SetActive(true);
 		backGround.SetActive(false);

--- a/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
+++ b/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
@@ -19,6 +19,12 @@ public class GUI_PlayerJobs : MonoBehaviour
 		{
 			UpdateJobsList();
 		}
+
+		//If the player has spawned and they already have a job. Don't display this window.
+		if (PlayerManager.LocalPlayer != null && PlayerManager.LocalPlayerScript.JobType != JobType.NULL)
+		{
+			this.gameObject.SetActive(false);
+		}
 	}
 
 	public void BtnOk(JobType preference)

--- a/UnityProject/Assets/Scripts/UI/NukeOpsGameMode/GUI_NukeOps.cs
+++ b/UnityProject/Assets/Scripts/UI/NukeOpsGameMode/GUI_NukeOps.cs
@@ -30,6 +30,12 @@ public class GUI_NukeOps : MonoBehaviour
 		nanoActive = GameManager.Instance.GetNanoTrasenCount();
 		UpdateCounts();
 		SyndiesAllowed();
+
+		//If the player has spawned and they already have a job. Don't display this window.
+		if (PlayerManager.LocalPlayer != null && PlayerManager.LocalPlayerScript.JobType != JobType.NULL)
+		{
+			this.gameObject.SetActive(false);
+		}
 	}
 
 	bool SyndiesAllowed()


### PR DESCRIPTION
### Purpose

- ControlDisplays now ensures that the job select window is initially inactive at the start of the round. 
- Added fallback to ensure that only one of either the job select window or team select window can be visible at one time and only if the player doesn't already have a job.
- Added serverside validation. Once the player has picked a job they cannot call CmdRequestJob.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer