### PR TITLE
Fixed wallmouts visiblility on 1x zoom

### DIFF
--- a/UnityProject/Assets/Materials/PostProcess/POst-PPRT Transform Material.mat
+++ b/UnityProject/Assets/Materials/PostProcess/POst-PPRT Transform Material.mat
@@ -7,7 +7,7 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Post-PPRT Transform Material
+  m_Name: POst-PPRT Transform Material
   m_Shader: {fileID: 4800000, guid: c812736daeccca7439b94c819cadb594, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4

--- a/UnityProject/Assets/Resources/Effects/Light2D/Minimal Player Light Material.mat
+++ b/UnityProject/Assets/Resources/Effects/Light2D/Minimal Player Light Material.mat
@@ -7,7 +7,7 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Default Light Material
+  m_Name: Minimal Player Light Material
   m_Shader: {fileID: 4800000, guid: 3dbf6073efd087147bb6625a1a2b5cc3, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4

--- a/UnityProject/Assets/Scripts/Lighting System/LightingSystem.cs
+++ b/UnityProject/Assets/Scripts/Lighting System/LightingSystem.cs
@@ -39,6 +39,7 @@ public class LightingSystem : MonoBehaviour
 	private TextureDataRequest mTextureDataRequest;
 	//used for FOV checking is async readback is NOT supported
 	private Texture2D mTex2DWallFloorOcclusionMask;
+	private OperationParameters mOperationParameters;
 
 	public bool matrixRotationMode
 	{
@@ -155,7 +156,19 @@ public class LightingSystem : MonoBehaviour
 		}
 	}
 
-	private OperationParameters operationParameters { get; set; }
+	private OperationParameters operationParameters
+	{
+		get
+		{
+			return mOperationParameters;
+		}
+		set
+		{
+			mOperationParameters = value;
+
+			Shader.SetGlobalFloat("_LightingTilePixelsPerUnit", value.pixelsPerUnit);
+		}
+	}
 
 	/// <summary>
 	/// Transforms provided movement data to match pixel perfect space of lighting system.
@@ -314,11 +327,12 @@ public class LightingSystem : MonoBehaviour
 
 	private void Update()
 	{
-		//don't run lighting system on headless
+		// Don't run lighting system on headless.
 		if (GameData.IsHeadlessServer)
 		{
 			return;
 		}
+
 		// Monitor state to detect when we should trigger reinitialization of rendering textures.
 		var _newParameters = new OperationParameters(mMainCamera, renderSettings, matrixRotationMode);
 

--- a/UnityProject/Assets/Scripts/Lighting System/OperationParameters.cs
+++ b/UnityProject/Assets/Scripts/Lighting System/OperationParameters.cs
@@ -38,7 +38,11 @@ public struct OperationParameters : IEquatable<OperationParameters>
 		fovPPRTParameter = new PixelPerfectRTParameter(occlusionPPRTParameter.units, _initialSampleDetail);
 		lightPPRTParameter = new PixelPerfectRTParameter(cameraViewportUnitsCeiled, _initialSampleDetail * (int)iRenderSettings.lightResample);
 		obstacleLightPPRTParameter = new PixelPerfectRTParameter(lightPPRTParameter.units, Mathf.Clamp(_initialSampleDetail, 2, int.MaxValue));
+
+		pixelsPerUnit = _occlusionDetail;
 	}
+
+	public int pixelsPerUnit { get; }
 
 	public static bool operator ==(OperationParameters iLeftHand, OperationParameters iRightHand)
 	{

--- a/UnityProject/Assets/Shaders/Post Process/PostProcess FovGenerator.shader
+++ b/UnityProject/Assets/Shaders/Post Process/PostProcess FovGenerator.shader
@@ -41,6 +41,7 @@ Shader "PostProcess/Fov Generator"
 
 			sampler2D _MainTex;
 			float4 _PositionOffset;
+			float _LightingTilePixelsPerUnit;
 
             //how detailed to make wall occlusion checks. Too low = wall occlusion looks messier and jaggier. Too high = performance impact.
             static const int LERP_ITERATIONS = 25;
@@ -93,7 +94,7 @@ Shader "PostProcess/Fov Generator"
                 }                
 
                 //look up to one tile width away from the current pixel in each direction and check if green is touching red.
-                float2 TILE_WIDTH = float2(_MainTex_TexelSize.x, _MainTex_TexelSize.y) * 14.5f; // use pixel size as "step" and scale as required.
+                float2 TILE_WIDTH = float2(_MainTex_TexelSize.x, _MainTex_TexelSize.y) * (_LightingTilePixelsPerUnit + 0.5f); // use pixel size as "step" and scale as required.
 
                 float up = checkVisibility(xy, xy + float2(0, TILE_WIDTH.y));
                 float down = checkVisibility(xy, xy + float2(0, -TILE_WIDTH.y));


### PR DESCRIPTION
Fixed wallmouts visible when they should not be on 1x zoom.

Problem: I'm cheating a little in the lighting system to improve performance. When zoom is set to 1x I'm reducing lighting texture by half from 14 pixels per unit to 6. It helps a lot since jump form 2x to 1x requires a doubling of lighting texture size which leads to a bad performance at 1x zoom. New wallmount shader had tile to pixel ratio hardcoded, so it would not be able to catch the change. I've changed lighting system to set global property _LightingTilePixelsPerUnit to be available to all the shaders if needed, and replaced hardcoded pixel ration with it.