### PR TITLE
Sync doors when player joins.

### DIFF
--- a/UnityProject/Assets/Scripts/Doors/DoorAnimator.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorAnimator.cs
@@ -6,20 +6,26 @@
 		public DoorController doorController;
 
 
-		public abstract void OpenDoor();
-		public abstract void CloseDoor();
-		public abstract void AccessDenied();
+		public abstract void OpenDoor(bool skipAnimation);
+		public abstract void CloseDoor(bool skipAnimation);
+		public abstract void AccessDenied(bool skipAnimation);
 
-		public void PlayAnimation( DoorUpdateType type ) {
+		/// <summary>
+		/// Play the specified animation
+		/// </summary>
+		/// <param name="type">animation to play</param>
+		/// <param name="skipAnimation">if true, animation should be skipped to the end and no sound should be
+		/// 	played - currently only used for when players are joining and there are open doors to sync.</param>
+		public void PlayAnimation( DoorUpdateType type, bool skipAnimation ) {
 			switch ( type ) {
 				case DoorUpdateType.Open:
-					OpenDoor();
+					OpenDoor(skipAnimation);
 					break;
 				case DoorUpdateType.Close:
-					CloseDoor();
+					CloseDoor(skipAnimation);
 					break;
 				case DoorUpdateType.AccessDenied:
-					AccessDenied();
+					AccessDenied(skipAnimation);
 					break;
 			}
 		}

--- a/UnityProject/Assets/Scripts/Doors/DoorController.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorController.cs
@@ -254,4 +254,16 @@ using UnityEngine.Networking;
 		}
 
 		#endregion
+
+		/// <summary>
+		/// Used when player is joining, tells player to open the door if it is opened.
+		/// </summary>
+		/// <param name="playerGameObject">game object of the player to inform</param>
+		public void NotifyPlayer(GameObject playerGameObject)
+		{
+			if (IsOpened)
+			{
+				DoorUpdateMessage.Send(playerGameObject, gameObject, DoorUpdateType.Open, true);
+			}
+		}
 	}

--- a/UnityProject/Assets/Scripts/Doors/WinDoorAnimator.cs
+++ b/UnityProject/Assets/Scripts/Doors/WinDoorAnimator.cs
@@ -40,23 +40,33 @@ using UnityEngine;
 			doorbase.sprite = sprites[closeFrame + (int) direction];
 		}
 
-		public override void OpenDoor()
+		public override void OpenDoor(bool skipAnimation)
 		{
-			doorController.isPerformingAction = true;
-			doorController.PlayOpenSound();
-			doorController.isPerformingAction = false;
-			StartCoroutine(PlayOpenAnim());
+			if (!skipAnimation)
+			{
+				doorController.isPerformingAction = true;
+				doorController.PlayOpenSound();
+				doorController.isPerformingAction = false;
+			}
+			StartCoroutine(PlayOpenAnim(skipAnimation));
 		}
 
-		public override void CloseDoor()
+		public override void CloseDoor(bool skipAnimation)
 		{
-			doorController.isPerformingAction = true;
-			doorController.PlayCloseSound();
-			StartCoroutine(PlayCloseAnim());
+			if (!skipAnimation)
+			{
+				doorController.isPerformingAction = true;
+				doorController.PlayCloseSound();
+			}
+			StartCoroutine(PlayCloseAnim(skipAnimation));
 		}
 
-		public override void AccessDenied()
+		public override void AccessDenied(bool skipAnimation)
 		{
+			if (skipAnimation)
+			{
+				return;
+			}
 			doorController.isPerformingAction = true;
 			SoundManager.PlayAtPosition("AccessDenied", transform.position);
 			StartCoroutine(PlayDeniedAnim());
@@ -68,33 +78,49 @@ using UnityEngine;
 			doorController.isPerformingAction = false;
 		}
 
-		private IEnumerator PlayCloseAnim()
+		private IEnumerator PlayCloseAnim(bool skipAnimation)
 		{
-			for (int i = animFrames.Length - 1; i >= 0; i--)
+			if (skipAnimation)
 			{
-				doorbase.sprite = sprites[animFrames[i] + (int) direction];
-				//Stop movement half way through door opening to sync up with sortingOrder layer change
-				if (i == 3)
-				{
-					doorController.BoxCollToggleOn();
-				}
-				yield return new WaitForSeconds(0.1f);
+				doorController.BoxCollToggleOn();
 			}
+			else
+			{
+				for (int i = animFrames.Length - 1; i >= 0; i--)
+				{
+					doorbase.sprite = sprites[animFrames[i] + (int) direction];
+					//Stop movement half way through door opening to sync up with sortingOrder layer change
+					if (i == 3)
+					{
+						doorController.BoxCollToggleOn();
+					}
+					yield return new WaitForSeconds(0.1f);
+				}
+			}
+
 			doorbase.sprite = sprites[closeFrame + (int) direction];
 			doorController.OnAnimationFinished();
 		}
 
-		private IEnumerator PlayOpenAnim()
+		private IEnumerator PlayOpenAnim(bool skipAnimation)
 		{
-			for (int j = 0; j < animFrames.Length; j++)
+			if (skipAnimation)
 			{
-				doorbase.sprite = sprites[animFrames[j] + (int) direction];
-				//Allow movement half way through door opening to sync up with sortingOrder layer change
-				if (j == 3)
+				doorbase.sprite = sprites[animFrames[animFrames.Length-1] + (int) direction];
+				doorController.BoxCollToggleOff();
+			}
+			else
+			{
+				for (int j = 0; j < animFrames.Length; j++)
 				{
-					doorController.BoxCollToggleOff();
+					doorbase.sprite = sprites[animFrames[j] + (int) direction];
+					//Allow movement half way through door opening to sync up with sortingOrder layer change
+					if (j == 3)
+					{
+						doorController.BoxCollToggleOff();
+					}
+					yield return new WaitForSeconds(0.1f);
 				}
-				yield return new WaitForSeconds(0.1f);
 			}
 
 			doorbase.sprite = sprites[openFrame + (int) direction];

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -336,13 +336,22 @@ public class CustomNetworkManager : NetworkManager
 		{
 			storageObjs[i].SyncUUIDsWithPlayer(playerGameObject);
 		}
-    
+
 		//TileChange Data
 		TileChangeManager[] tcManagers = FindObjectsOfType<TileChangeManager>();
 		for (var i = 0; i < tcManagers.Length; i++)
 		{
 			tcManagers[i].NotifyPlayer(playerGameObject);
 		}
+
+		//Doors
+		DoorController[] doors = FindObjectsOfType<DoorController>();
+		for (var i = 0; i < doors.Length; i++)
+		{
+			doors[i].NotifyPlayer(playerGameObject);
+		}
+
+
 
 		Logger.Log($"Sent sync data ({matrices.Length} matrices, {scripts.Length} transforms, {playerBodies.Length} players) to {playerGameObject.name}", Category.Connections);
 	}


### PR DESCRIPTION
### Purpose
Fixes #1599 

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer

### Notes:
Adds the capability to play a door animation but skip to the end of it (while still preserving any state changes / logic effects that should've happened by the end), and uses this capability to update the door state when a player joins.
