### PR TITLE
Fixes #1631 Players will now die if they lose too much blood

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -429,10 +429,11 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour
 	/// Blood Loss and Toxin damage:
 	int CalculateOverallBloodLossDamage()
 	{
+		float maxBloodDmg = Mathf.Abs(HealthThreshold.Dead) + maxHealth;
 		float bloodDmg = 0f;
 		if (bloodSystem.BloodLevel < (int)BloodVolume.SAFE)
 		{
-			bloodDmg = (1f - ((float)bloodSystem.BloodLevel / (float)BloodVolume.NORMAL)) * 100f;
+			bloodDmg = Mathf.Lerp(0f, maxBloodDmg, 1f - (bloodSystem.BloodLevel / (float)BloodVolume.NORMAL));
 		}
 
 		if (bloodSystem.ToxinLevel > 1f)
@@ -441,7 +442,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour
 			//There will need to be some kind of blood / toxin ratio and severity limits determined
 		}
 
-		return Mathf.RoundToInt(Mathf.Clamp(bloodDmg, 0f, 101f));
+		return Mathf.RoundToInt(Mathf.Clamp(bloodDmg, 0f, maxBloodDmg));
 	}
 
 	/// ---------------------------


### PR DESCRIPTION
### Purpose
Changes how damage from blood loss is calculated to ensure that too much blood loss will apply enough damage to be fatal.
Fixes #1631 

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer
