### PR TITLE
Players with help intent can swap places

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/ObjectBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Objects/ObjectBehaviour.cs
@@ -15,6 +15,7 @@ public class ObjectBehaviour : PushPull
 	//The object that this object is contained inside
 	public ObjectBehaviour parentContainer = null;
 	private Vector3 lastNonHiddenPosition = new Vector3();
+
 	//returns position of highest object this object is contained in
     public Vector3 AssumedLocation()
     {

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -19,6 +19,48 @@ public class PlayerMove : NetworkBehaviour
 
 	[SyncVar] public bool allowInput = true;
 
+	/// <summary>
+	/// Tracks the server's idea of whether we have help intent
+	/// </summary>
+	[SyncVar] private bool serverIsHelpIntent = true;
+	/// <summary>
+	/// Tracks our idea of whether we have help intent so we can use it for client prediction
+	/// </summary>
+	private bool localIsHelpIntent = true;
+
+	/// <summary>
+	/// True iff this player is set to help intent, thus should swap places with players
+	/// that they collide with if the other player also has help intent
+	/// </summary>
+	public bool IsHelpIntent
+	{
+		get
+		{
+			if (isLocalPlayer)
+			{
+				return localIsHelpIntent;
+			}
+			else
+			{
+				return serverIsHelpIntent;
+			}
+		}
+		set
+		{
+			if (isLocalPlayer)
+			{
+				localIsHelpIntent = value;
+				//tell the server we want this to be our setting
+				CmdChangeHelpIntent(value);
+			}
+			else
+			{
+				//accept what the server is telling us about someone other than our local player
+				serverIsHelpIntent = value;
+			}
+		}
+	}
+
 	private readonly List<MoveAction> moveActionList = new List<MoveAction>();
 
 	public MoveAction[] moveList =
@@ -47,6 +89,12 @@ public class PlayerMove : NetworkBehaviour
 
 		registerTile = GetComponent<RegisterTile>();
 		pna = gameObject.GetComponent<PlayerNetworkActions>();
+	}
+
+	[Command]
+	private void CmdChangeHelpIntent(bool isHelpIntent)
+	{
+		serverIsHelpIntent = isHelpIntent;
 	}
 
 	public PlayerAction SendAction()

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -123,6 +123,27 @@ public partial class PlayerSync
 					LastDirection = action.Direction();
 					UpdatePredictedState();
 				}
+				else if (clientBump == BumpType.HelpIntent)
+				{
+					if (!isServer)
+					{
+						//check if a swap should happen - client prediction only (hence !isServer, otherwise it would swap twice on the server)
+						PlayerMove other = MatrixManager.GetHelpIntentAt(((Vector2)predictedState.WorldPosition + action.Direction()).RoundToInt(), gameObject);
+						if (other != null)
+						{
+							if (!other.PlayerScript.PlayerSync.IsMovingClient)
+							{
+								//they've stopped there, so let's swap them
+								InitiateSwap(other, action.Direction() * -1);
+							}
+						}
+					}
+
+					//move freely
+					pendingActions.Enqueue(action);
+					LastDirection = action.Direction();
+					UpdatePredictedState();
+				}
 				else
 				{
 					//cannot move -> tell server we're just bumping in that direction

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -60,7 +60,7 @@ public partial class PlayerSync
 			{
 				return false;
 			}
-			GameObject[] context = pushPull.IsPullingSomething ? new[]{gameObject, pushPull.PulledObject.gameObject} : new[]{gameObject};
+			GameObject[] context = pushPull.IsPullingSomethingServer ? new[]{gameObject, pushPull.PulledObjectServer.gameObject} : new[]{gameObject};
 			return MatrixManager.IsFloatingAt( context, Vector3Int.RoundToInt( serverState.WorldPosition ) );
 		}
 	}

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -191,7 +191,7 @@ public partial class PlayerSync
 			MatrixId = newMatrix.Id,
 			WorldPosition = roundedPos,
 			ResetClientQueue = true,
-			Speed = serverState.Speed
+			Speed = SpeedServer
 		};
 		serverLerpState = newState;
 		serverState = newState;

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -386,16 +386,7 @@ public partial class PlayerSync
 		//check if a swap should occur
 		if (serverBump == BumpType.HelpIntent)
 		{
-			PlayerMove other = MatrixManager.GetHelpIntentAt(nextState.WorldPosition.RoundToInt(), gameObject);
-			if (other != null)
-			{
-				if (!other.PlayerScript.PlayerSync.IsMovingServer)
-				{
-					//they've stopped there, so let's swap them
-					InitiateSwap(other, action.Direction() * -1);
-				}
-			}
-
+			CheckAndDoSwap(nextState.WorldPosition.RoundToInt(), action.Direction() * -1);
 		}
 
 		nextState.Speed = SpeedServer;
@@ -609,6 +600,8 @@ public partial class PlayerSync
 		}
 		if ( serverLerpState.WorldPosition == targetPos ) {
 			OnTileReached().Invoke( targetPos.RoundToInt() );
+			// Check for swap once movement is done, to prevent us and another player moving into the same tile
+			CheckAndDoSwap(targetPos.RoundToInt(), serverLastDirection*-1);
 		}
 		if ( TryNotifyPlayers() ) {
 			TryUpdateServerTarget();

--- a/UnityProject/Assets/Scripts/UI/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/UIManager.cs
@@ -100,7 +100,18 @@ public class UIManager : MonoBehaviour
 	/// <summary>
 	///     Current Intent status
 	/// </summary>
-	public static Intent CurrentIntent { get; set; }
+	public static Intent CurrentIntent
+	{
+		get => currentIntent;
+		set
+		{
+			currentIntent = value;
+			//update the intent of the player so it can be synced
+			PlayerManager.LocalPlayerScript.playerMove.IsHelpIntent = value == global::Intent.Help;
+		}
+	}
+
+	private static Intent currentIntent;
 
 	/// <summary>
 	///     What is DamageZoneSeclector currently set at

--- a/UnityProject/Assets/Scripts/UI/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/UIManager.cs
@@ -107,7 +107,10 @@ public class UIManager : MonoBehaviour
 		{
 			currentIntent = value;
 			//update the intent of the player so it can be synced
-			PlayerManager.LocalPlayerScript.playerMove.IsHelpIntent = value == global::Intent.Help;
+			if (PlayerManager.LocalPlayerScript != null)
+			{
+				PlayerManager.LocalPlayerScript.playerMove.IsHelpIntent = value == global::Intent.Help;
+			}
 		}
 	}
 


### PR DESCRIPTION
### Purpose
Fixes #1596 

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients, if applicable)

### Notes:
Had to make a few design decisions about how things worked, so these are up for debate (not like you all need any prompting for that 😄 ). Here's the logic that swapping has:

- If a player with help intent begins to move into a tile occupied by another stopped player (with help intent), they will swap. This is the basic functionality described in the ticket.
- Players with help intent can pass through each other when they are both moving. This is intended to make movement smooth when 2 players move through each other even if the swap logic doesn't catch this case and explicitly initiate a swap. Also I think this just makes movement less of a hassle when players are trying to move around in the same area.
- If 2 players with help intent end up on the same tile, the swap will be performed with the player who last reached the tile initiating it (this is a failsafe for the above logic to prevent 2 players from being able to stop on the same tile and remain there)
- When a player is pulling something, they cannot swap or be swapped with. They revert back to the normal behavior of being pushable. I just don't see a way where it would make sense. If they were pulling an impassable object, for example, where would the swapee go? Or what if they were against a wall and already pulling someone behind them? 
- The exception to the above is that if a player is pulling another player and both have help intent, they can swap places and the pull will not be broken. I think this is more convenient than having to do a circle when trying to turn around and still maintain a pull.
- A player who is BEING pulled can be swapped with by another player, thus breaking the pull.

