### PR TITLE
Fixes job slots lock after player dc

### DIFF
--- a/UnityProject/Assets/Scripts/Inventory/InventoryManager.cs
+++ b/UnityProject/Assets/Scripts/Inventory/InventoryManager.cs
@@ -333,11 +333,11 @@ public class InventoryManager : MonoBehaviour
 	{
 		//drop everything
 		AllServerInventorySlots
-			.FindAll(x => x.Owner?.gameObject == owner && x.Item)
+			.FindAll(x => x.Owner && x.Owner.gameObject == owner && x.Item)
 			.ForEach(x => DropGameItem(owner, x.Item, owner.transform.position));
 
 		//remove their slots
-		AllServerInventorySlots.RemoveAll(x => x.Owner?.gameObject == owner);
+		AllServerInventorySlots.RemoveAll(x => x.Owner && x.Owner.gameObject == owner);
 	}
 }
 


### PR DESCRIPTION
### Purpose
Fixes the logout item dropping process runtiming, locking jobs for new logins
Fixes #1663 

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients, if applicable)

### Notes:
lambda expressions and null propagation operators dont get along 
