### PR TITLE
Fixes trapped in the locker void

### DIFF
--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -312,9 +312,9 @@ public class ClosetControl : InputTrigger
 			{
 				player.parentContainer = objectBehaviour;
 				playerSync.DisappearFromWorldServer();
-				//Make sure a ClosetPlayerHandler is created on the client to monitor
-				//the players input inside the storage. The handler also controls the camera follow targets:
-				if (!PlayerManager.LocalPlayerScript.IsGhost)
+                //Make sure a ClosetPlayerHandler is created on the client to monitor
+                //the players input inside the storage. The handler also controls the camera follow targets:
+				if (!playerScript.IsGhost)
 				{
 					ClosetHandlerMessage.Send(player.gameObject, gameObject);
 				}


### PR DESCRIPTION
### Purpose
Fixes lockers asking if the server player is a ghost instead of the current client mob on the closet tile when closing, resulting in a runtime if the server wasn't ingame causing the "trapped in void" issue and other unintended behaivour
Fixes #1660

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients, if applicable)

### Notes:
the other unintended behaivour would be ghosts inside lockers or humans not being able to enter lockers because the server player is currently a ghost
