### PR TITLE
Fix player sprite facing sync issue

### DIFF
--- a/UnityProject/Assets/Scripts/Player/UserControlledSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/UserControlledSprites.cs
@@ -12,7 +12,7 @@ using UnityEngine.Networking;
 /// </summary>
 public abstract class UserControlledSprites : NetworkBehaviour
 {
-	[SyncVar(hook = nameof(FaceDirectionSync))]
+	[SyncVar(hook = nameof(FaceDirectionSyncVarTrigger))]
 	protected Orientation currentDirection;
 	//cached other behaviors
 	protected PlayerMove playerMove;
@@ -79,11 +79,18 @@ public abstract class UserControlledSprites : NetworkBehaviour
 	    LocalFaceDirection(direction);
     }
 
+    // workaround to prevent IL2CPP issue while still ensuring the subclass implementation of FaceDirectionSync method
+    // is invoked
+    private void FaceDirectionSyncVarTrigger(Orientation dir)
+    {
+		FaceDirectionSync(dir);
+    }
+
     /// <summary>
     /// Invoked when currentDirection syncvar changes.
     /// </summary>
     /// <param name="dir"></param>
-    protected virtual void FaceDirectionSync( Orientation dir ){}
+    protected abstract void FaceDirectionSync(Orientation dir);
 
     /// <summary>
     /// Locally changes the direction of this player to face the specified direction but doesn't tell the server.


### PR DESCRIPTION
### Purpose
Fixes #1659 

Set up Android build and tested it with IL2CPP configured before my change. I could reproduce the IL2CPP compilation issue. After making the change in this commit the issue went away, so I'm assuming this won't reintroduce the IL2CPP error that happened when trying to build for iOS. I think IL2CPP just didn't like having a syncvar hook being an abstract method, but having the hook be a method in the base class and then invoking the abstract method in that hook is fine.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients, if applicable)
