### PR TITLE
APCs will now load their information in OnStartClient()

### DIFF
--- a/UnityProject/Assets/Scripts/Electricity/PoweredDevices/Powered device category/APC.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PoweredDevices/Powered device category/APC.cs
@@ -244,6 +244,21 @@ public class APC : NetworkBehaviour, IElectricalNeedUpdate, IDeviceControl
 			}
 		}
 	}
+
+	public override void OnStartClient()
+	{
+		base.OnStartClient();
+		StartCoroutine(WaitForLoad());
+	}
+
+	private IEnumerator WaitForLoad()
+	{
+		yield return new WaitForSeconds(3f);
+		OnVoltageChange();
+		OnStateChange();
+	}
+
+
 	private void OnStateChange()
 	{
 		switch (State)


### PR DESCRIPTION
### Purpose
APCs will now load their information in OnStartClient(), they just had default values on a new client login. Fixes #1619
### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients, if applicable)

### Notes:
Not really a fan of using coroutines to load information inside OnStartClient(), its repeated a lot in the repo but I can see it bringing problems if this process isnt organized later on as the project grows.
Lightswitches use them to set the bulbs and tubes on/off