### PR TITLE
LogLevel settings: Saves prefs to json. Allows level settings via console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ UnityProject/Assets/UI/Fonts/Font_Awesome_4.7.0.meta
 *.DotSettings
 UnityProject/Assets/StreamingAssets/changelog.json
 UnityProject/Assets/StreamingAssets/changelog.json.meta
+UnityProject/Assets/StreamingAssets/LogLevelDefaults/custom.json
+UnityProject/Assets/StreamingAssets/LogLevelDefaults/custom.json.meta

--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -83,6 +84,40 @@ namespace IngameDebugConsole
 			{
 				Logger.Log("Escape shuttle already called.", Category.DebugConsole);
 			}
+		}
+
+		[ConsoleMethod("log", "Adjust individual log levels\nUsage:\nloglevel <category> <level> \nExample: loglevel Health 0\n-1 = Off \n0 = Error \n1 = Warning \n2 = Info \n 3 = Trace")]
+		public static void SetLogLevel(string logCategory, int level)
+		{
+			bool catFound = false;
+			Category category = Category.Unknown;
+			foreach (Category c in Enum.GetValues(typeof(Category)))
+			{
+				if (c.ToString().ToLower() == logCategory.ToLower())
+				{
+					catFound = true;
+					category = c;
+				}
+			}
+
+			if (!catFound)
+			{
+				Logger.Log("Category not found", Category.DebugConsole);
+				return;
+			}
+
+			LogLevel logLevel = LogLevel.Info;
+
+			if (level > (int)LogLevel.Trace)
+			{
+				logLevel = LogLevel.Trace;
+			}
+			else
+			{
+				logLevel = (LogLevel)level;
+			}
+
+			Logger.SetLogLevel(category, logLevel);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/EventManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/EventManager.cs
@@ -22,7 +22,8 @@ public enum EVENT
 	EnableInternals,
 	PlayerSpawned,
 	PlayerDied,
-	GhostSpawned
+	GhostSpawned,
+	LogLevelAdjusted,
 } // + other events. Add them as you need them
 
 [ExecuteInEditMode]


### PR DESCRIPTION
As per the title.

To use via console type: `log <(string)category> <(int)level> `

It does not matter about capitalization, use all lower case if you want. Saves any changes to custom.json in loglevelsettings folder and it will include it in your builds. 