### PR TITLE
Player preferences reset fix

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerManager.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerManager.cs
@@ -62,7 +62,6 @@ public class PlayerManager : MonoBehaviour
 	{
 		SceneManager.sceneLoaded -= OnLevelFinishedLoading;
 		EventManager.RemoveHandler(EVENT.PlayerDied, OnPlayerDeath);
-		PlayerPrefs.SetString("currentcharacter", JsonUtility.ToJson(new CharacterSettings()));
 		PlayerPrefs.Save();
 	}
 


### PR DESCRIPTION
### Purpose
Removes the reset of preferences on PlayerManager OnDisable(), being called on scene changes
Fixes #1395 

### Open Questions and Pre-Merge TODOs
- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients, if applicable)

### Notes:

