### PR TITLE
ghosts can no longer spookily swap places with alive players

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -532,7 +532,7 @@ public partial class PlayerSync
 			{
 				OnClientTileReached().Invoke(Vector3Int.RoundToInt(worldPos));
 				// Check for swap once movement is done, to prevent us and another player moving into the same tile
-				if (!isServer)
+				if (!isServer && !playerScript.IsGhost)
 				{
 					//only check on client otherwise server would check this twice
 					CheckAndDoSwap(worldPos.RoundToInt(), lastDirection*-1);

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -606,10 +606,13 @@ public partial class PlayerSync
 			                   $"Target    :{serverState}", Category.Movement );
 			serverLerpState.WorldPosition = targetPos;
 		}
-		if ( serverLerpState.WorldPosition == targetPos ) {
+		if ( serverLerpState.WorldPosition == targetPos) {
 			OnTileReached().Invoke( targetPos.RoundToInt() );
 			// Check for swap once movement is done, to prevent us and another player moving into the same tile
-			CheckAndDoSwap(targetPos.RoundToInt(), serverLastDirection*-1);
+			if (!playerScript.IsGhost)
+			{
+				CheckAndDoSwap(targetPos.RoundToInt(), serverLastDirection * -1);
+			}
 		}
 		if ( TryNotifyPlayers() ) {
 			TryUpdateServerTarget();


### PR DESCRIPTION
### Purpose
Fixes #1691 

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients, if applicable)