### PR TITLE
Lockers can be clicked when open

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterCloset.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterCloset.cs
@@ -14,8 +14,6 @@ public class RegisterCloset : RegisterObject
 	/// </summary>
 	private ClosetControl closetControl;
 	private bool isClosed = true;
-	// cached colliders so they can be disabled
-	private Collider2D[] colliders;
 
 	public bool IsClosed
 	{
@@ -24,12 +22,18 @@ public class RegisterCloset : RegisterObject
 			isClosed = value;
 			if (closetType == ClosetType.LOCKER)
 			{
-				//disable colliders and make passable when open, for lockers only
+				//become passable to bullets and people when open
 				Passable = !isClosed;
-				foreach (var collider in colliders)
+				//switching to item layer if open so bullets pass through it
+				if (Passable)
 				{
-					collider.enabled = !Passable;
+					gameObject.layer = LayerMask.NameToLayer("Items");
 				}
+				else
+				{
+					gameObject.layer = LayerMask.NameToLayer("Machines");
+				}
+
 			}
 		}
 		get => isClosed;
@@ -37,7 +41,6 @@ public class RegisterCloset : RegisterObject
 
 	private void Awake()
 	{
-		colliders = GetComponents<Collider2D>();
 		closetControl = GetComponent<ClosetControl>();
 	}
 

--- a/UnityProject/Assets/Tests/Tilemaps/Behaviours/Objects/ClosetFixture.cs
+++ b/UnityProject/Assets/Tests/Tilemaps/Behaviours/Objects/ClosetFixture.cs
@@ -14,6 +14,8 @@ namespace Tests.Tilemaps.Behaviours.Objects
 		    obj.AddComponent<BoxCollider2D>();
 		    obj.AddComponent<BoxCollider2D>();
 		    var closet = obj.AddComponent<RegisterCloset>();
+		    //always starts in machines layer
+		    obj.layer = LayerMask.NameToLayer("Machines");
 
 		    closet.closetType = type;
 		    closet.Passable = false;
@@ -24,14 +26,14 @@ namespace Tests.Tilemaps.Behaviours.Objects
 
 	    private static readonly object[] Cases =
 	    {
-		    new object[] {ClosetType.LOCKER, true, true, true, false},
-		    new object[] {ClosetType.LOCKER, true, false, false, true},
-		    new object[] {ClosetType.LOCKER, false, true, true, false},
-		    new object[] {ClosetType.LOCKER, false, false, false, true},
-		    new object[] {ClosetType.CRATE, true, false, true, false},
-		    new object[] {ClosetType.CRATE, false, true, true, false},
-		    new object[] {ClosetType.CRATE, true, true, true, false},
-		    new object[] {ClosetType.CRATE, false, false, true, false}
+		    new object[] {ClosetType.LOCKER, true, true, LayerMask.NameToLayer("Machines"), false},
+		    new object[] {ClosetType.LOCKER, true, false, LayerMask.NameToLayer("Items"), true},
+		    new object[] {ClosetType.LOCKER, false, true, LayerMask.NameToLayer("Machines"), false},
+		    new object[] {ClosetType.LOCKER, false, false, LayerMask.NameToLayer("Items"), true},
+		    new object[] {ClosetType.CRATE, true, false, LayerMask.NameToLayer("Machines"), false},
+		    new object[] {ClosetType.CRATE, false, true, LayerMask.NameToLayer("Machines"), false},
+		    new object[] {ClosetType.CRATE, true, true, LayerMask.NameToLayer("Machines"), false},
+		    new object[] {ClosetType.CRATE, false, false, LayerMask.NameToLayer("Machines"), false}
 	    };
 
 	    private static void AssertCollidersEnabled(RegisterCloset closet, bool shouldEnableColliders)
@@ -43,22 +45,25 @@ namespace Tests.Tilemaps.Behaviours.Objects
 	    }
 
         [TestCaseSource(nameof(Cases))]
-        public void GivenClosetOfTypeAndOpenCloseState_WhenOpenOrClose_ThenHasCorrectCollidersAndPassabilityStatus(ClosetType type, bool isInitiallyClosed, bool thenIsClosed, bool shouldEnableColliders, bool shouldBePassable)
+        public void GivenClosetOfTypeAndOpenCloseState_WhenOpenOrClose_ThenHasCorrectLayerAndPassabilityStatus(ClosetType type, bool isInitiallyClosed, bool thenIsClosed, int shouldBeInLayer, bool shouldBePassable)
         {
 	        var closet = GetRegisterCloset(type, isInitiallyClosed);
 	        if (isInitiallyClosed == thenIsClosed)
 	        {
 		        //check right away
-		        AssertCollidersEnabled(closet, shouldEnableColliders);
+		        Assert.AreEqual(closet.gameObject.layer, shouldBeInLayer);
 		        Assert.AreEqual(closet.Passable, shouldBePassable);
 	        }
 	        else
 	        {
 		        //change and check
 		        closet.IsClosed = thenIsClosed;
-		        AssertCollidersEnabled(closet, shouldEnableColliders);
+		        Assert.AreEqual(closet.gameObject.layer, shouldBeInLayer);
 		        Assert.AreEqual(closet.Passable, shouldBePassable);
 	        }
+
+	        //collider should always be one no matter what
+	        AssertCollidersEnabled(closet, true);
         }
     }
 }


### PR DESCRIPTION
### Purpose
Fixes #1715 while still ensuring bullets and people pass through open lockers.

Previously this was accomplished by turning off colliders. That doesn't work because colliders are used for clicking. Now, it moves the lockers down into the items layer (since it basically functions as an item when it is open and the Items layer does not collide with projectiles).

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients, if applicable)
