### PR TITLE
APC Tab Adjustments

### DIFF
--- a/UnityProject/Assets/Scripts/UI/APC/GUI_APC.cs
+++ b/UnityProject/Assets/Scripts/UI/APC/GUI_APC.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.UI;
 
 public class GUI_APC : NetTab
 {
@@ -15,18 +13,12 @@ public class GUI_APC : NetTab
 	/// <summary>
 	/// Colours which will be used for foregrounds and backgrounds (in hex format)
 	/// </summary>
-	// private Color 	greenBackground = new Color(0.509804f, 1f, 0.2980392f), // 82FF4C
-	// 				blueBackground = new Color(0.6588235f, 0.6901961f, 0.9725491f), // A8B0F8
-	// 				redBackground = new Color(0.9725491f, 0.3764706f, 0.3764706f), // F86060
-	// 				greenForeground = new Color(0f, 0.8000001f, 0f), // 00CC00
-	// 				blueForeground = new Color(0.3764706f, 0.4392157f, 0.9725491f), // 6070F8
-	// 				redForeground = new Color(0.9411765f, 0.9725491f, 0.6588235f); // F0F8A8
-	private string 	fullBackground = "82FF4C",
-					chargingBackground = "A8B0F8",
-					criticalBackground = "F86060",
-					fullForeground = "00CC00",
-					chargingForeground = "6070F8",
-					criticalForeground = "F0F8A8";
+	private const string fullBackground 	= "82FF4C",
+						 chargingBackground = "A8B0F8",
+						 criticalBackground = "F86060",
+						 fullForeground 	= "00CC00",
+						 chargingForeground = "6070F8",
+						 criticalForeground = "F0F8A8";
 
 	// Elements that we want to visually update:
 	private NetColorChanger _backgroundColor;
@@ -218,9 +210,9 @@ public class GUI_APC : NetTab
 	private void CalculateMaxCapacity()
 	{
 		float newCapacity = 0;
-		for (int i = 0; i < LocalAPC.ConnectedDepartmentBatteries.Count; i++)
+		foreach (DepartmentBattery battery in LocalAPC.ConnectedDepartmentBatteries)
 		{
-			newCapacity += LocalAPC.ConnectedDepartmentBatteries[i].CapacityMax;
+			newCapacity += battery.CapacityMax;
 		}
 		MaxCapacity = newCapacity;
 	}
@@ -230,16 +222,15 @@ public class GUI_APC : NetTab
 		CalculateMaxCapacity ();
 		if (MaxCapacity == 0)
 		{
-			return "???%";
+			return "N/A";
 		}
 
 		float newCapacity = 0;
-		for (int i = 0; i < LocalAPC.ConnectedDepartmentBatteries.Count; i++)
+		foreach (DepartmentBattery battery in LocalAPC.ConnectedDepartmentBatteries)
 		{
-			newCapacity += LocalAPC.ConnectedDepartmentBatteries[i].CurrentCapacity;
+			newCapacity += battery.CurrentCapacity;
 		}
-		//Logger.Log(((int)((newCapacity / MaxCapacity) * 100)).ToString());
-		//ChargeBar.SetValue = ((newCapacity / MaxCapacity) * 100).ToString()); yeah Doesn't work for some reason
+
 		return (newCapacity / MaxCapacity).ToString("P0");
 	}
 
@@ -266,19 +257,17 @@ public class GUI_APC : NetTab
 			StartCoroutine( Refresh() );
 		}
 	}
-
 	private void UpdateScreenDisplay()
 	{
 		if (LocalAPC.State != APC.APCState.Dead)
 		{
 			OffOverlayColor.SetValue = DebugTools.ColorToHex(Color.clear);
 			Logger.LogTrace("Updating APC display", Category.NetUI);
-			// Update the electrical values
-			float voltage = LocalAPC.Voltage;
-			float current = LocalAPC.Current;
-			float resistance = LocalAPC.Resistance;
-			float power = voltage * current;
-			ElectricalValues.SetValue = $"{voltage:G4} V\n{current:G4} A\n{power:G4} W";
+			// Display the electrical values using engineering notation
+			string voltage = LocalAPC.Voltage.ToEngineering("V");
+			string current = LocalAPC.Current.ToEngineering("A");
+			string power = (LocalAPC.Voltage * LocalAPC.Current).ToEngineering("W");
+			ElectricalValues.SetValue = $"{voltage}\n{current}\n{power}";
 			StatusText.SetValue = LocalAPC.State.ToString();
 			ChargePercentage.SetValue = CalculateChargePercentage();
 			// State specific updates
@@ -321,15 +310,6 @@ public class GUI_APC : NetTab
 	{
 		int chargeVal = int.Parse(ChargeBar.Value) + 10;
 		// Update the charge bar animation
-		if (chargeVal > 100)
-		{
-			ChargeBar.SetValue = "0";
-		}
-		else
-		{
-			ChargeBar.SetValue = chargeVal.ToString();
-		}
+		ChargeBar.SetValue = chargeVal > 100 ? "0" : chargeVal.ToString();
 	}
-
-
 }

--- a/UnityProject/Assets/Scripts/Util/NumberFormatExtension.cs
+++ b/UnityProject/Assets/Scripts/Util/NumberFormatExtension.cs
@@ -1,5 +1,4 @@
 using System;
-using WebSocketSharp;
 
 // Many thanks to StackOverflow for a lot of this code. Used the best parts of various answers
 
@@ -37,22 +36,25 @@ public static class NumberFormatExtension
 		    double.IsPositiveInfinity(value))
 		{
 			// This should return the infinity symbol with the optional unit
-			return unit.IsNullOrEmpty() ? "\u221E" : $"\u221E {unit}";
+			return string.IsNullOrEmpty(unit) ? "\u221E" : $"\u221E {unit}";
 		}
 
 		// Calculate the exponent
-		int exp = (int)(Math.Floor( Math.Log10(value) / 3.0 ) * 3.0);
-		double newValue = value * Math.Pow(10.0, -exp);
-		if (newValue >= 1000.0) {
+		int exponent = (int)(Math.Floor( Math.Log10(value) / 3.0 ) * 3.0);
+
+		// Calculate the new value after accounting for the exponent
+		double newValue = value * Math.Pow(10.0, -exponent);
+		if (newValue >= 1000.0)
+		{
 			newValue = newValue / 1000.0;
-			exp      = exp + 3;
+			exponent      = exponent + 3;
 		}
 
 		// Determine the appropriate SI unit prefix
 		string prefix = " ";
-		if (exp >= 0)
+		if (exponent >= 0)
 		{
-			switch (exp)
+			switch (exponent)
 			{
 				case 0: case 1: case 2:
 					break;
@@ -82,9 +84,9 @@ public static class NumberFormatExtension
 					break;
 			}
 		}
-		else if (exp < 0)
+		else if (exponent < 0)
 		{
-			switch (exp)
+			switch (exponent)
 			{
 				case -1: case -2: case -3:
 					prefix = "m";

--- a/UnityProject/Assets/Scripts/Util/NumberFormatExtension.cs
+++ b/UnityProject/Assets/Scripts/Util/NumberFormatExtension.cs
@@ -1,0 +1,118 @@
+using System;
+using WebSocketSharp;
+
+// Many thanks to StackOverflow for a lot of this code. Used the best parts of various answers
+
+public static class NumberFormatExtension
+{
+	/// <summary>
+	/// Converts a number to a string with an SI unit prefix and an optional unit e.g. k, M, G, μ etc...
+	/// </summary>
+	/// <param name="value">The number to convert</param>
+	/// <param name="unit">The unit to use</param>
+	public static string ToEngineering(this int value, string unit = "")
+	{
+		return ToEngineering((double)value, unit);
+	}
+	/// <summary>
+	/// Converts a number to a string with an SI unit prefix and an optional unit e.g. k, M, G, μ etc...
+	/// </summary>
+	/// <param name="value">The number to convert</param>
+	/// <param name="unit">The unit to use</param>
+	public static string ToEngineering(this float value, string unit = "")
+	{
+		return ToEngineering((double)value, unit);
+	}
+
+	/// <summary>
+	/// Converts a number to a string with an SI unit prefix and an optional unit e.g. k, M, G, μ etc...
+	/// </summary>
+	/// <param name="value">The number to convert</param>
+	/// <param name="unit">The unit to use</param>
+	public static string ToEngineering(this double value, string unit = "")
+	{
+		if (double.IsNaN(value) ||
+		    double.IsInfinity(value) ||
+		    double.IsNegativeInfinity(value) ||
+		    double.IsPositiveInfinity(value))
+		{
+			// This should return the infinity symbol with the optional unit
+			return unit.IsNullOrEmpty() ? "\u221E" : $"\u221E {unit}";
+		}
+
+		// Calculate the exponent
+		int exp = (int)(Math.Floor( Math.Log10(value) / 3.0 ) * 3.0);
+		double newValue = value * Math.Pow(10.0, -exp);
+		if (newValue >= 1000.0) {
+			newValue = newValue / 1000.0;
+			exp      = exp + 3;
+		}
+
+		// Determine the appropriate SI unit prefix
+		string prefix = " ";
+		if (exp >= 0)
+		{
+			switch (exp)
+			{
+				case 0: case 1: case 2:
+					break;
+				case 3: case 4: case 5:
+					prefix = "k";
+					break;
+				case 6: case 7: case 8:
+					prefix = "M";
+					break;
+				case 9: case 10: case 11:
+					prefix = "G";
+					break;
+				case 12: case 13: case 14:
+					prefix = "T";
+					break;
+				case 15: case 16: case 17:
+					prefix = "P";
+					break;
+				case 18: case 19: case 20:
+					prefix = "E";
+					break;
+				case 21: case 22: case 23:
+					prefix = "Z";
+					break;
+				default:
+					prefix = "Y";
+					break;
+			}
+		}
+		else if (exp < 0)
+		{
+			switch (exp)
+			{
+				case -1: case -2: case -3:
+					prefix = "m";
+					break;
+				case -4: case -5: case -6:
+					prefix = "μ";
+					break;
+				case -7: case -8: case -9:
+					prefix = "n";
+					break;
+				case -10: case -11: case -12:
+					prefix = "p";
+					break;
+				case -13: case -14: case -15:
+					prefix = "f";
+					break;
+				case -16: case -17: case -18:
+					prefix = "a";
+					break;
+				case -19: case -20: case -21:
+					prefix = "z";
+					break;
+				default:
+					prefix = "y";
+					break;
+			}
+		}
+
+		return $"{newValue:##0.#} {prefix}{unit}";
+	}
+}

--- a/UnityProject/Assets/Scripts/Util/NumberFormatExtension.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/NumberFormatExtension.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7189d67e6a52472e858c8196e9846c3d
+timeCreated: 1554756648


### PR DESCRIPTION
### Purpose
- Fixes #1709 
- Adds NumberFormatExtension with ToEngineering() method, to convert numbers to engineering notation (could be useful for multitool and other devices)
- Makes APC tab use SI unit prefixes
- Changed charge value to be N/A when department battery isn't detected
- APC GUI script cleanup (thanks rider!)

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients, if applicable)
