### PR TITLE
Checks for an existing job when a job is requested

### DIFF
--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -62,7 +62,27 @@ public class JoinedViewer : NetworkBehaviour
     [Command]
     public void CmdRequestJob(JobType jobType)
     {
-        SpawnHandler.RespawnPlayer(connectionToClient, playerControllerId,
+        var player = PlayerList.Instance.Get(connectionToClient);
+        /// Verifies that the player has no job
+        if (player.Job == JobType.NULL)
+        {
+            SpawnHandler.RespawnPlayer(connectionToClient, playerControllerId,
             GameManager.Instance.GetRandomFreeOccupation(jobType));
+
+        }
+        /// Spawns in player if they have a job but aren't spawned
+        else if (player.GameObject == null)
+        {
+            SpawnHandler.RespawnPlayer(connectionToClient, playerControllerId,
+            GameManager.Instance.GetRandomFreeOccupation(player.Job));
+
+        }
+        else
+        {
+            Logger.LogWarning("[Jobs] Request Job Failed: Already Has Job");
+
+
+        }
+        
     }
 }


### PR DESCRIPTION
This checks the PlayerList for a player's job when they request a job.

Ensures that no job switching can take place if a client can somehow request a job.

Fixes https://github.com/unitystation/unitystation/issues/1614