### PR TITLE
Client can mop, refactor FinishProgressAction to delegate to component

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Tools/Resources/Mop.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Resources/Mop.prefab
@@ -202,15 +202,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   clothingReference: -1
   hierarchy: 
-  inHandReferenceLeft: 984
-  inHandReferenceRight: 996
+  inHandReferenceLeft: 312
+  inHandReferenceRight: 324
   itemDescription: A Mop
   itemName: mop
   itemType: 0
   size: 2
   spriteType: 0
   type: 0
-  ConnectedToTank: 0
+  CanConnectToTank: 0
   throwDamage: 7
   throwSpeed: 2
   throwRange: 7

--- a/UnityProject/Assets/Scripts/Construction/Managers/Deconstruction.cs
+++ b/UnityProject/Assets/Scripts/Construction/Managers/Deconstruction.cs
@@ -34,12 +34,14 @@ public class Deconstruction : MonoBehaviour
 		{
 			//Set up the action to be invoked when progress bar finishes:
 			var progressFinishAction = new FinishProgressAction(
-				FinishProgressAction.Action.TileDeconstruction,
-				matrixRoot.GetComponent<TileChangeManager>(),
-				tileType,
-				cellPos,
-				worldCellPos,
-				player
+				finishReason =>
+				{
+					if (finishReason == FinishProgressAction.FinishReason.COMPLETED)
+					{
+						CraftingManager.Deconstruction.TryTileDeconstruct(
+							matrixRoot.GetComponent<TileChangeManager>(), tileType, cellPos, worldCellPos);
+					}
+				}
 			);
 
 			//Start the progress bar:
@@ -48,6 +50,12 @@ public class Deconstruction : MonoBehaviour
 
 			SoundManager.PlayNetworkedAtPos("Weld", worldCellPos, Random.Range(0.9f, 1.1f));
 		}
+	}
+
+	//does the deconstruction when deconstruction progress finishes
+	private void DoTileDeconstruction()
+	{
+
 	}
 
 	private void DoWallDeconstruction(Vector3Int cellPos, TileChangeManager tcm, Vector3 worldPos)

--- a/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
@@ -480,16 +480,18 @@ public class MouseInputController : MonoBehaviour
 		if (UIManager.Hands.CurrentSlot.Item != null && objectBehaviour.visibleState)
 		{
 			InputTrigger inputTrigger = UIManager.Hands.CurrentSlot.Item.GetComponent<InputTrigger>();
+
 			if (inputTrigger != null)
 			{
 				bool interacted = false;
+				var interactPosition = Camera.main.ScreenToWorldPoint(CommonInput.mousePosition);
 				if (isDrag)
 				{
-					interacted = inputTrigger.TriggerDrag();
+					interacted = inputTrigger.TriggerDrag(interactPosition);
 				}
 				else
 				{
-					interacted = inputTrigger.Trigger();
+					interacted = inputTrigger.Trigger(interactPosition);
 				}
 				if (interacted)
 				{

--- a/UnityProject/Assets/Scripts/Input System/Triggers/InputTrigger.cs
+++ b/UnityProject/Assets/Scripts/Input System/Triggers/InputTrigger.cs
@@ -82,7 +82,7 @@ public abstract class InputTrigger : NetworkBehaviour
 	/// <summary>
 	/// Trigger an interaction, defined as when the mouse is initially clicked (but not while it is being held down and dragged)
 	/// </summary>
-	/// <param name="originator">game object that is performing the interaction upon this gameobject</param>
+	/// <param name="originator">game object of the player that is performing the interaction upon this gameobject</param>
 	/// <param name="hand">hand of the originator which is being used to perform the interaction</param>
 	/// <param name="position">position of the interaction</param>
 	/// <returns>true if further interactions should be prevented for the current update</returns>
@@ -93,7 +93,7 @@ public abstract class InputTrigger : NetworkBehaviour
 	/// Trigger a drag interaction, defined as when the mouse is currently being held (but not initially clicked) and is dragged over. The default implementation is
 	/// that nothing happens.
 	/// </summary>
-	/// <param name="originator">game object that is performing the interaction upon this gameobject</param>
+	/// <param name="originator">game object of the player that is performing the interaction upon this gameobject</param>
 	/// <param name="hand">hand of the originator which is being used to perform the interaction</param>
 	/// <param name="position">position of the interaction</param>
 	/// <returns>true if further interactions should be prevented for the current update</returns>
@@ -107,9 +107,9 @@ public abstract class InputTrigger : NetworkBehaviour
 	public virtual bool UI_InteractOtherSlot(GameObject originator, GameObject otherHandItem){ return true; }
 
 	/// <Summary>
-	/// This is called by the Interact() of objects twice, one by the client and then by the server if the first call returns true
+	/// Checks if originator is able to actually use the item in their hand
 	/// </Summary>
-	/// <param name="originator">game object that is performing the interaction upon this gameobject</param>
+	/// <param name="originator">game object of the player that is performing the interaction upon this gameobject</param>
 	/// <param name="hand">hand of the originator which is being used to perform the interaction</param>
 	/// <param name="position">position of the interaction</param>
 	/// <param name="allowSoftCrit">if true it allows mobs in soft crit perform the action</param>
@@ -124,11 +124,6 @@ public abstract class InputTrigger : NetworkBehaviour
 
 		if(!playerScript.IsInReach(position)){
 			return false;
-		}
-
-		if (!isServer)
-		{
-			InteractMessage.Send(gameObject, position, hand);
 		}
 
 		return true;

--- a/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
@@ -68,11 +68,18 @@ public class MopTrigger : PickUpTrigger
 		{
 			//server is performing server-side logic for the interaction
 			//do the mopping
-			//TODO: Refactor to use a callback / interface for the completion actions
 			var progressFinishAction = new FinishProgressAction(
-				FinishProgressAction.Action.CleanTile,
-				position.RoundToInt(),
-				this
+				reason =>
+				{
+					if (reason == FinishProgressAction.FinishReason.INTERRUPTED)
+					{
+						CancelCleanTile();
+					}
+					else if (reason == FinishProgressAction.FinishReason.COMPLETED)
+					{
+						CleanTile(position);
+					}
+				}
 			);
 			isCleaning = true;
 
@@ -84,7 +91,7 @@ public class MopTrigger : PickUpTrigger
 
 
 	[Server]
-	public void CleanTile (Vector3 worldPos)
+	private void CleanTile (Vector3 worldPos)
     {
 	    var worldPosInt = worldPos.CutToInt();
 	    var matrix = MatrixManager.AtPoint( worldPosInt );
@@ -109,7 +116,7 @@ public class MopTrigger : PickUpTrigger
     }
 
 	[Server]
-	public void CancelCleanTile()
+	private void CancelCleanTile()
 	{
 		//stop the in progress cleaning
 		isCleaning = false;

--- a/UnityProject/Assets/Scripts/Messages/Client/InteractMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/InteractMessage.cs
@@ -3,14 +3,27 @@ using UnityEngine;
 using UnityEngine.Networking;
 
 /// <summary>
-///     Informs server of interaction
+///     Informs server of interaction. Implied that the sender of the message is the player performing the interaciton.
 /// </summary>
 public class InteractMessage : ClientMessage
 {
+
 	public static short MessageType = (short) MessageTypes.InteractMessage;
+	/// <summary>
+	/// Which hand is performing the interaction
+	/// </summary>
 	public byte Hand;
+	/// <summary>
+	/// Position being targeted by interaction
+	/// </summary>
 	public Vector3 Position;
+	/// <summary>
+	/// Varies. Sometimes subject is the netid of the object being used to interact at the
+	/// specified position. Other times subject is the object being targeted by interaction. Regardless,
+	/// Subject will always be the game object whose InputTrigger is invoked when this message is processed.
+	/// </summary>
 	public NetworkInstanceId Subject;
+	//if true, indicates this interaction is happening in the subject's UI
 	public bool UITrigger;
 
 	public override IEnumerator Process()
@@ -29,13 +42,22 @@ public class InteractMessage : ClientMessage
 	}
 
 	/// <summary>
-	/// Send the object being interacted with and the hand variable
+	/// Request an interaction on the specified subject via the specified hand
 	/// </summary>
+	/// <param name="subject">thing whose inputtrigger should be invoked</param>
+	/// <param name="hand">hand performing the interaction</param>
 	public static InteractMessage Send(GameObject subject, string hand)
 	{
 		return Send(subject, subject.transform.position, hand);
 	}
 
+	/// <summary>
+	/// Request an interaction on the specified subject via the specified hand
+	/// </summary>
+	/// <param name="subject">thing whose inputtrigger should be invoked</param>
+	/// <param name="hand">hand performing the interaction</param>
+	/// <param name="UITrigger">true if this is a UI interaction, false if an interaction on the map</param>
+	/// <returns></returns>
 	public static InteractMessage Send(GameObject subject, string hand, bool UITrigger)
 	{
 		InteractMessage msg = new InteractMessage
@@ -50,6 +72,13 @@ public class InteractMessage : ClientMessage
 		return msg;
 	}
 
+	/// <summary>
+	/// Request an interaction on the specified position using the specified subject
+	/// </summary>
+	/// <param name="subject">thing whose inputtrigger should be invoked</param>
+	/// <param name="position">position targeted by the interaction</param>
+	/// <param name="hand">hand performing the interaction</param>
+	/// <returns></returns>
 	public static InteractMessage Send(GameObject subject, Vector3 position, string hand)
 	{
 		InteractMessage msg = new InteractMessage

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TileTrigger.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TileTrigger.cs
@@ -62,10 +62,7 @@ public class TileTrigger : InputTrigger
 		{
 			return false;
 		}
-		if (!isServer)
-		{
-			return true;
-		}
+
 		return DetermineTileAction(originator, position, hand);
 	}
 
@@ -81,7 +78,28 @@ public class TileTrigger : InputTrigger
 
 		LayerTile tile = metaTileMap.GetTile(pos);
 
-		GameObject handObj = pna.Inventory[hand].Item;
+		GameObject handObj;
+		//if we are client, our pna.Inventory is always empty so we should get the hand item a different way
+		if (!isServer)
+		{
+			if (originator != PlayerManager.LocalPlayer)
+			{
+				Logger.LogError("Client is attempting to determine the tile actions of a player other than" +
+				                " themselves. This should not happen and should be fixed. Client should only determine their own" +
+				                " actions.");
+				return false;
+			}
+			else
+			{
+				handObj = UIManager.InventorySlots[hand].Item;
+			}
+		}
+		else
+		{
+			handObj = pna.Inventory[hand].Item;
+		}
+
+
 
 		// Nothing in hand, do nothing
 		if (handObj == null)

--- a/UnityProject/Assets/Scripts/UI/ProgressBar/ProgressBar.cs
+++ b/UnityProject/Assets/Scripts/UI/ProgressBar/ProgressBar.cs
@@ -99,6 +99,7 @@ public class ProgressBar : NetworkBehaviour
 			//Cancel the progress bar if the player moves away or faces another direction:
 			if (playerProgress[i].HasMovedAway())
 			{
+				playerProgress[i].completedAction.InterruptAction();
 				CloseProgressBar(playerProgress[i]);
 				continue;
 			}
@@ -158,6 +159,9 @@ public class PlayerProgressEntry
 	}
 }
 
+/// <summary>
+/// Defines what to do when finishing or quitting the action early - pretty sure this runs only on the server.
+/// </summary>
 public class FinishProgressAction
 {
 	public enum Action
@@ -207,7 +211,18 @@ public class FinishProgressAction
 				DoTileDeconstruction();
 				break;
 			case Action.CleanTile:
-				DoCleanTile();
+				DoCleanTile(false);
+				break;
+		}
+	}
+
+	//invoked when action is interrupted before completing
+	public void InterruptAction()
+	{
+		switch (actionType)
+		{
+			case Action.CleanTile:
+				DoCleanTile(true);
 				break;
 		}
 	}
@@ -223,8 +238,16 @@ public class FinishProgressAction
 			tileChangeManager, tileType, cellPos, worldPos);
 	}
 
-	private void DoCleanTile()
+	private void DoCleanTile(bool cancel)
 	{
-		theMop.CleanTile(worldPos);
+		if (!cancel)
+		{
+			theMop.CleanTile(worldPos);
+		}
+		else
+		{
+			theMop.CancelCleanTile();
+		}
+
 	}
 }


### PR DESCRIPTION
### Purpose
Fixes #1668 

Refactors FinishProgressAction so that it isn't doing all of the actual logic of what happens at the end of every different kind of progress action. Instead, it invokes a callback so that the component that originally started the action can decide what to do - better separation of responsibility that way IMO.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients, if applicable)

### Notes:
I noticed an issue with tool->floor interactions where TileTrigger was "eating" interactions on the client side without doing anything - returning true from Interact even in cases where an interaction would've have actually occurred, and thus false should've been returned. I made a change to avoid that issue. I tested to see if interaction is still working fine but I'm not sure why that code was there to begin with and it seemed like it might've been a hack for something I'm unaware of. The code I changed seems to pertain to #1681 if you happen to know what the purpose of it was.
