### PR TITLE
Fix users of CanUse so they send the interact message

### DIFF
--- a/UnityProject/Assets/Prefabs/GUI/Resources/ChemistryDispenser.cs
+++ b/UnityProject/Assets/Prefabs/GUI/Resources/ChemistryDispenser.cs
@@ -6,8 +6,8 @@ public class ChemistryDispenser : NetworkTabTrigger {
 
 	public ReagentContainer Container;
 	public ObjectBehaviour objectse;
-	public delegate void ChangeEvent (); 
-	public static event ChangeEvent changeEvent;  
+	public delegate void ChangeEvent ();
+	public static event ChangeEvent changeEvent;
 
 
 	public override bool Interact(GameObject originator, Vector3 position, string hand)
@@ -18,6 +18,8 @@ public class ChemistryDispenser : NetworkTabTrigger {
 		}
 		if (!isServer)
 		{
+			//ask server to perform the interaction
+			InteractMessage.Send(gameObject, position, hand);
 			return true;
 		}
 
@@ -49,7 +51,7 @@ public class ChemistryDispenser : NetworkTabTrigger {
 	public void  UpdateGUI()
 	{
 		// Change event runs updateAll in ChemistryGUI
-   		if(changeEvent!=null) 
+   		if(changeEvent!=null)
 		{
 			changeEvent();
 		}

--- a/UnityProject/Assets/Scripts/Closets/FireCabinetTrigger.cs
+++ b/UnityProject/Assets/Scripts/Closets/FireCabinetTrigger.cs
@@ -63,6 +63,8 @@ public class FireCabinetTrigger : InputTrigger
 		}
 		if (!isServer)
 		{
+			//ask server to perform the interaction
+			InteractMessage.Send(gameObject, position, hand);
 			return true;
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/MessageOnInteract.cs
+++ b/UnityProject/Assets/Scripts/Objects/MessageOnInteract.cs
@@ -13,6 +13,8 @@ public class MessageOnInteract : InputTrigger
 		}
 		if (!isServer)
 		{
+			//ask server to perform the interaction
+			InteractMessage.Send(gameObject, position, hand);
 			return true;
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/VendorTrigger.cs
+++ b/UnityProject/Assets/Scripts/Objects/VendorTrigger.cs
@@ -20,9 +20,11 @@ public class VendorTrigger : InputTrigger
 			return false;
 		}
 		if(!isServer){
+			//ask server to perform the interaction
+			InteractMessage.Send(gameObject, position, hand);
 			return true;
 		}
-		
+
 		if (!allowSell && deniedMessage != null && !GameData.Instance.testServer && !GameData.IsHeadlessServer)
 		{
 			UpdateChatMessage.Send(originator, ChatChannel.Examine, deniedMessage);
@@ -37,7 +39,7 @@ public class VendorTrigger : InputTrigger
 			ServerVendorInteraction(position);
 			StartCoroutine(VendorInputCoolDown());
 		}
-	
+
 		return true;
 	}
 


### PR DESCRIPTION
### Purpose
Fixes #1668 

There was a bug noticed by @Aranclanos in that clients could no longer interact with things that were using InputTrigger.CanUse, due to a refactoring which removed the side effect of sending an interact message. I kept CanUse as it is (because I don't think it should have that side effect) but ensured that each user of it sends the message if it is a client, after checking if CanUse returns true.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients, if applicable)
