### PR TITLE
Adds rejoin system

### DIFF
--- a/UnityProject/Assets/Scripts/Inventory/InventoryManager.cs
+++ b/UnityProject/Assets/Scripts/Inventory/InventoryManager.cs
@@ -325,20 +325,6 @@ public class InventoryManager : MonoBehaviour
 		DropItem(GetSlotFromItem(item), pos);
 	}
 
-	/// <summary>
-	/// Performs cleanup needed when a player disconnects. Drops their items at their current location and removes all the inventory slots.
-	/// </summary>
-	/// <param name="owner">gameobject of the player that is disconnecting, which should still be present wherever it was prior to disconnecting.</param>
-	public static void HandleDisconnect(GameObject owner)
-	{
-		//drop everything
-		AllServerInventorySlots
-			.FindAll(x => x.Owner && x.Owner.gameObject == owner && x.Item)
-			.ForEach(x => DropGameItem(owner, x.Item, owner.transform.position));
-
-		//remove their slots
-		AllServerInventorySlots.RemoveAll(x => x.Owner && x.Owner.gameObject == owner);
-	}
 }
 
 //Helps identify the position in syncEquip list

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -371,12 +371,6 @@ public class CustomNetworkManager : NetworkManager
 	public override void OnServerDisconnect(NetworkConnection conn)
 	{
 		var player = PlayerList.Instance.Get(conn);
-		if (player.GameObject)
-		{
-			//Tell the inventorymanager about the disconnect so it can perform whatever cleanup is needed
-			InventoryManager.HandleDisconnect(player.GameObject);
-		}
-
 		Logger.Log($"Player Disconnected: {player.Name}", Category.Connections);
 		PlayerList.Instance.Remove(conn);
 	}

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -109,6 +109,12 @@ public static class SpawnHandler
 		return spawnPoints.Count == 0 ? null : spawnPoints.PickRandom().transform;
 	}
 
+	/// <summary>
+	/// Connects a client to a character.
+	/// </summary>
+	/// <param name="conn">The client's NetworkConnection.</param>
+	/// <param name="playerControllerId">ID of the client player to be transfered.</param>
+	/// <param name="player">The player's character gameobject to be transfered into.</param>
 	public static void TransferPlayer(NetworkConnection conn, short playerControllerId, GameObject player){
 		var connectedPlayer = PlayerList.Instance.Get(conn);
 		PlayerList.Instance.UpdatePlayer(conn, player);

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -27,13 +27,7 @@ public static class SpawnHandler
 	public static void RespawnPlayer(NetworkConnection conn, short playerControllerId, JobType jobType)
 	{
 		GameObject player = CreatePlayer(jobType);
-		var connectedPlayer = PlayerList.Instance.Get(conn);
-		PlayerList.Instance.UpdatePlayer(conn, player);
-		NetworkServer.ReplacePlayerForConnection(conn, player, playerControllerId);
-		TriggerEventMessage.Send(player, EVENT.PlayerSpawned);
-		if (connectedPlayer.Script.PlayerSync != null) {
-			connectedPlayer.Script.PlayerSync.NotifyPlayers(true);
-		}
+		TransferPlayer(conn, playerControllerId, player);
 	}
 
 	/// <summary>
@@ -114,4 +108,16 @@ public static class SpawnHandler
 
 		return spawnPoints.Count == 0 ? null : spawnPoints.PickRandom().transform;
 	}
+
+	public static void TransferPlayer(NetworkConnection conn, short playerControllerId, GameObject player){
+		var connectedPlayer = PlayerList.Instance.Get(conn);
+		PlayerList.Instance.UpdatePlayer(conn, player);
+		NetworkServer.ReplacePlayerForConnection(conn, player, playerControllerId);
+		TriggerEventMessage.Send(player, EVENT.PlayerSpawned);
+		if (connectedPlayer.Script.PlayerSync != null)
+		{
+			connectedPlayer.Script.PlayerSync.NotifyPlayers(true);
+		}
+	}
+
 }

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -13,6 +13,9 @@ public class PlayerList : NetworkBehaviour
 	private static List<ConnectedPlayer> values = new List<ConnectedPlayer>();
 	private static List<ConnectedPlayer> oldValues = new List<ConnectedPlayer>();
 
+	private static List<ConnectedPlayer> loggedOff = new List<ConnectedPlayer>();
+
+
 	//For client needs: updated via UpdateConnectedPlayersMessage, useless for server
 	public List<ClientConnectedPlayer> ClientConnectedPlayers = new List<ClientConnectedPlayer>();
 
@@ -272,10 +275,10 @@ public class PlayerList : NetworkBehaviour
 	[Server]
 	private void TryRemove(ConnectedPlayer player)
 	{
-		Logger.Log($"Removed {player}",Category.Connections);
+		Logger.Log($"Removed {player}", Category.Connections);
+		loggedOff.Add(player);
 		values.Remove(player);
 		AddPrevious( player );
-		NetworkServer.Destroy(player.GameObject);
 		UpdateConnectedPlayersMessage.Send();
 		CheckRcon();
 	}
@@ -367,6 +370,20 @@ public class PlayerList : NetworkBehaviour
 		if(RconManager.Instance != null){
 			RconManager.UpdatePlayerListRcon();
 		}
+	}
+
+	[Server]
+	public GameObject TakeLoggedOffPlayer(ulong steamId)
+	{
+		foreach (var player in loggedOff)
+		{
+			if (player.SteamId == steamId)
+			{
+				loggedOff.Remove(player);
+				return player.GameObject;
+			}
+		}
+		return null;
 	}
 }
 

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using Facepunch.Steamworks;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -11,50 +12,86 @@ using UnityEngine.Networking;
 /// </summary>
 public class JoinedViewer : NetworkBehaviour
 {
-    public override void OnStartServer()
-    {
-        base.OnStartServer();
-        //Add player to player list
-        PlayerList.Instance.Add(new ConnectedPlayer
-        {
-            Connection = connectionToClient,
-                GameObject = gameObject,
-                Job = JobType.NULL
-        });
-    }
-    public override void OnStartLocalPlayer()
-    {
-        base.OnStartLocalPlayer();
-        PlayerManager.SetViewerForControl(this);
-        UIManager.ResetAllUI();
-        UIManager.Display.DetermineGameMode();
-        UIManager.SetDeathVisibility(true);
+	public override void OnStartServer()
+	{
+		base.OnStartServer();
+	}
 
-        if (BuildPreferences.isSteamServer)
-        {
-            //Send request to be authenticated by the server
-            StartCoroutine(WaitUntilServerInit());
-        }
-    }
+	public override void OnStartLocalPlayer()
+	{
+		base.OnStartLocalPlayer();
 
-    //Just ensures connected player record is set on the server first before Auth req is sent
-    IEnumerator WaitUntilServerInit()
-    {
-        yield return YieldHelper.EndOfFrame;
-        if (Client.Instance != null)
-        {
-            Logger.Log("Client Requesting Auth", Category.Steam);
-            // Generate authentication Ticket
-            var ticket = Client.Instance.Auth.GetAuthSessionTicket();
-            var ticketBinary = ticket.Data;
-            // Send Clientmessage to authenticate
-            RequestAuthMessage.Send(Client.Instance.SteamId, ticketBinary);
-        }
-        else
-        {
-            Logger.Log("Client NOT requesting auth", Category.Steam);
-        }
-    }
+		// Send steamId to server for player setup.
+		if (BuildPreferences.isSteamServer)
+		{
+			CmdServerSetupPlayer(Client.Instance.SteamId);
+		}
+		else
+		{
+			CmdServerSetupPlayer(0);
+		}
+	}
+
+	[Command]
+	private void CmdServerSetupPlayer(ulong steamId)
+	{
+		//Add player to player list
+		PlayerList.Instance.Add(new ConnectedPlayer
+		{
+			Connection = connectionToClient,
+			GameObject = gameObject,
+			Job = JobType.NULL,
+			SteamId = steamId
+		});
+
+		// If they have a player to rejoin send the client the player to rejoin, otherwise send a null gameobject.
+		TargetLocalPlayerSetupPlayer(connectionToClient, PlayerList.Instance.TakeLoggedOffPlayer(steamId));
+	}
+
+	[TargetRpc]
+	private void TargetLocalPlayerSetupPlayer(NetworkConnection target, GameObject loggedOffPlayer)
+	{
+		PlayerManager.SetViewerForControl(this);
+		UIManager.ResetAllUI();
+		UIManager.SetDeathVisibility(true);
+
+		if (BuildPreferences.isSteamServer)
+		{
+			//Send request to be authenticated by the server
+			StartCoroutine(WaitUntilServerInit());
+		}
+
+		// If player is joining for the first time let them pick faction and job, otherwise rejoin character.
+		if (loggedOffPlayer == null)
+		{
+			UIManager.Display.DetermineGameMode();
+		}
+		else
+		{
+			CmdRejoin(loggedOffPlayer);
+			loggedOffPlayer.GetComponent<PlayerSync>().setLocalPlayer();
+			loggedOffPlayer.GetComponent<PlayerScript>().Init();
+		}
+	}
+
+	//Just ensures connected player record is set on the server first before Auth req is sent
+	IEnumerator WaitUntilServerInit()
+	{
+		yield return YieldHelper.EndOfFrame;
+		if (Client.Instance != null)
+		{
+			Logger.Log("Client Requesting Auth", Category.Steam);
+			// Generate authentication Ticket
+			var ticket = Client.Instance.Auth.GetAuthSessionTicket();
+			var ticketBinary = ticket.Data;
+			// Send Clientmessage to authenticate
+			RequestAuthMessage.Send(Client.Instance.SteamId, ticketBinary);
+		}
+		else
+		{
+			Logger.Log("Client NOT requesting auth", Category.Steam);
+		}
+	}
 
     /// <summary>
     /// At the moment players can choose their jobs on round start:
@@ -85,4 +122,11 @@ public class JoinedViewer : NetworkBehaviour
         }
         
     }
+
+	[Command]
+	public void CmdRejoin(GameObject loggedOffPlayer)
+	{
+		SpawnHandler.TransferPlayer(connectionToClient, playerControllerId, loggedOffPlayer);
+		loggedOffPlayer.GetComponent<PlayerScript>().playerNetworkActions.ReenterBodyUpdates(loggedOffPlayer);
+	}
 }

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -123,6 +123,10 @@ public class JoinedViewer : NetworkBehaviour
         
     }
 
+    /// <summary>
+    /// Asks the server to let the client rejoin into a logged off character.
+    /// </summary>
+    /// <param name="loggedOffPlayer">The character to be rejoined into.</param>
 	[Command]
 	public void CmdRejoin(GameObject loggedOffPlayer)
 	{

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -88,14 +88,24 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		base.OnStartServer();
 	}
 
+	/// <summary>
+	/// Sync the player with the server.
+	/// </summary>
+	/// <param name="recipient">The player to be synced.</param>
 	[Server]
-	public void ReenterBodyUpdates(GameObject recipient){
+	public void ReenterBodyUpdates(GameObject recipient)
+	{
 		SendSyncMessage(recipient);
 		UpdateInventorySlots(recipient);
 	}
 
+	/// <summary>
+	/// Sends a message to sync the clientside player's inventory with the serverside inventory.
+	/// </summary>
+	/// <param name="recipient">The player to be synced.</param>
 	[Server]
-	public void SendSyncMessage(GameObject recipient){
+	public void SendSyncMessage(GameObject recipient)
+	{
 		SyncPlayerInventoryGuidMessage.Send(recipient, initSync);
 	}
 
@@ -325,6 +335,10 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		UpdatePlayerEquipSprites(fromSlot, toSlot);
 	}
 
+	/// <summary>
+	/// Sends messages to a client to update every slot in the player's clientside inventory.
+	/// </summary>
+	/// <param name="recipient">The player to have their inventory updated.</param>
 	[Server]
 	public void UpdateInventorySlots(GameObject recipient)
 	{

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -100,7 +100,7 @@ public class PlayerScript : ManagedNetworkBehaviour
 		playerSprites = GetComponent<UserControlledSprites>();
 	}
 
-	private void Init()
+	public void Init()
 	{
 		if (isLocalPlayer)
 		{

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -21,7 +21,7 @@ public partial class PlayerSync
 	/// Client predicted state
 	private PlayerState predictedState;
 
-	private Queue<PlayerAction> pendingActions;
+	public Queue<PlayerAction> pendingActions;
 	private Vector2 lastDirection;
 
 	/// Last move direction, used for space walking simulation

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -21,7 +21,7 @@ public partial class PlayerSync
 	/// Client predicted state
 	private PlayerState predictedState;
 
-	public Queue<PlayerAction> pendingActions;
+	private Queue<PlayerAction> pendingActions;
 	private Vector2 lastDirection;
 
 	/// Last move direction, used for space walking simulation

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -360,9 +360,7 @@ public partial class PlayerSync : NetworkBehaviour, IPushable
 		//Init pending actions queue for your local player
 		if (isLocalPlayer)
 		{
-			pendingActions = new Queue<PlayerAction>();
-			UpdatePredictedState();
-			predictedSpeedClient = UIManager.WalkRun.running ? playerMove.RunSpeed : playerMove.WalkSpeed;
+			setLocalPlayer();
 		}
 		//Init pending actions queue for server
 		if (isServer)
@@ -374,6 +372,12 @@ public partial class PlayerSync : NetworkBehaviour, IPushable
 		healthBehaviorScript = GetComponent<LivingHealthBehaviour>();
 		registerTile = GetComponent<RegisterTile>();
 		pushPull = GetComponent<PushPull>();
+	}
+
+	public void setLocalPlayer(){
+		pendingActions = new Queue<PlayerAction>();
+		UpdatePredictedState();
+		predictedSpeedClient = UIManager.WalkRun.running ? playerMove.RunSpeed : playerMove.WalkSpeed;
 	}
 
 	private void Update()

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -374,7 +374,11 @@ public partial class PlayerSync : NetworkBehaviour, IPushable
 		pushPull = GetComponent<PushPull>();
 	}
 
-	public void setLocalPlayer(){
+	/// <summary>
+	/// Sets up the action queue for the local player.
+	/// </summary>
+	public void setLocalPlayer()
+	{
 		pendingActions = new Queue<PlayerAction>();
 		UpdatePredictedState();
 		predictedSpeedClient = UIManager.WalkRun.running ? playerMove.RunSpeed : playerMove.WalkSpeed;


### PR DESCRIPTION
Removes HandleDisconnect() and it's call in CustomNetworkManager.cs.
Moves part of RespawnPlayer() to a new function: TransferPlayer().
Adds List<ConnectedPlayer> loggedOff in PlayerList.cs. When players are removed in TryRemove() they are added to the LoggedOff list to be retrieved when they relog.
Added TakeLoggedOffPlayer() in PlayerList.cs which returns a logged player with a certain steamId and removes them from the list.
Refactored JoinedViewer's player setup so the client sends a steamId to the server, the server does serverside player setup with the steamId, then tells the client to do clientside player setup with the character they logged out with (if they logged out).
Added CmdRejoin() in JoinedViewer which lets the player rejoin their character.
Adds ReenterBodyUpdates(), SendSyncMessage(), and UpdateInventorySlots() to PlayerNetworkActions.cs, which are used to sync a rejoined player.
Creates setLocalPlayer() in PlayerSync.cs from existing setLocalPlayer code so it can be used with the rejoin system.
Stops the player gameobject from being destroyed on logout.
Gives CmdServerSetupPlayer() "0" (ConnectedPlayer.steamId's default value) as an argument if it is not a steam server.

### Purpose
Lets players rejoin their character after logging out and logging back in.
Fixes #1429 

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients, if applicable)

### Notes:
Should be tested on steam to make sure Client.Instance.SteamId works.
