### PR TITLE
Girder spawn at deconstructing walls

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/CraftingManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/CraftingManager.prefab
@@ -121,6 +121,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 88089395c4b1d4419b37a8390bf9b277, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wallGirderPrefab: {fileID: 0}
+  wallGirderPrefab: {fileID: 7376449702682419346, guid: 384a51cf5ff9a794e8aa15449d16f05c,
+    type: 3}
   metalPrefab: {fileID: 1645856876941636, guid: 78d9125d50217497cbcd4a18ffe2e3e4,
     type: 3}

--- a/UnityProject/Assets/Scenes/Lobby.unity
+++ b/UnityProject/Assets/Scenes/Lobby.unity
@@ -5285,7 +5285,7 @@ PrefabInstance:
     - target: {fileID: 224264904714827184, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 409.30014
+      value: 409.3001
       objectReference: {fileID: 0}
     - target: {fileID: 224816160242944980, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
@@ -5587,12 +5587,6 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 114920310630293518, guid: 829f4ca992b848d6bb4d007fb9c112e1,
-        type: 3}
-      propertyPath: wallGirderPrefab
-      value: 
-      objectReference: {fileID: 7376449702682419346, guid: 384a51cf5ff9a794e8aa15449d16f05c,
-        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 829f4ca992b848d6bb4d007fb9c112e1, type: 3}
 --- !u!1 &495160934
@@ -20363,7 +20357,7 @@ PrefabInstance:
     - target: {fileID: 224576715969102918, guid: 38ecd680d57974ffe87b4bdd8cd52589,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0.000013801039
+      value: -0.00004169943
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 38ecd680d57974ffe87b4bdd8cd52589, type: 3}

--- a/UnityProject/Assets/Scenes/Lobby.unity
+++ b/UnityProject/Assets/Scenes/Lobby.unity
@@ -5285,7 +5285,7 @@ PrefabInstance:
     - target: {fileID: 224264904714827184, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 409.3001
+      value: 409.30014
       objectReference: {fileID: 0}
     - target: {fileID: 224816160242944980, guid: 829f4ca992b848d6bb4d007fb9c112e1,
         type: 3}
@@ -5587,6 +5587,12 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 114920310630293518, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+        type: 3}
+      propertyPath: wallGirderPrefab
+      value: 
+      objectReference: {fileID: 7376449702682419346, guid: 384a51cf5ff9a794e8aa15449d16f05c,
+        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 829f4ca992b848d6bb4d007fb9c112e1, type: 3}
 --- !u!1 &495160934
@@ -20357,7 +20363,7 @@ PrefabInstance:
     - target: {fileID: 224576715969102918, guid: 38ecd680d57974ffe87b4bdd8cd52589,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0.00004169943
+      value: -0.000013801039
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 38ecd680d57974ffe87b4bdd8cd52589, type: 3}

--- a/UnityProject/Assets/Scripts/Construction/Managers/Deconstruction.cs
+++ b/UnityProject/Assets/Scripts/Construction/Managers/Deconstruction.cs
@@ -63,8 +63,8 @@ public class Deconstruction : MonoBehaviour
 		tcm.RemoveTile(cellPos, LayerType.Walls);
 		SoundManager.PlayNetworkedAtPos("Deconstruct", worldPos, 1f);
 
-        PoolManager.PoolNetworkInstantiate(metalPrefab, worldPos, tcm.transform);
-        PoolManager.PoolNetworkInstantiate(wallGirderPrefab, worldPos, tcm.transform);
+		PoolManager.PoolNetworkInstantiate(metalPrefab, worldPos, tcm.transform);
+		PoolManager.PoolNetworkInstantiate(wallGirderPrefab, worldPos, tcm.transform);
 	}
 
 }

--- a/UnityProject/Assets/Scripts/Construction/Managers/Deconstruction.cs
+++ b/UnityProject/Assets/Scripts/Construction/Managers/Deconstruction.cs
@@ -63,15 +63,8 @@ public class Deconstruction : MonoBehaviour
 		tcm.RemoveTile(cellPos, LayerType.Walls);
 		SoundManager.PlayNetworkedAtPos("Deconstruct", worldPos, 1f);
 
-		//Spawn 2 metal sheets:
-		int spawnMetalsAmt = 0;
-		while (spawnMetalsAmt < 2)
-		{
-			spawnMetalsAmt++;
-			PoolManager.PoolNetworkInstantiate(metalPrefab, worldPos, tcm.transform);
-		}
-
-		//TODO spawn wall girder!
+        PoolManager.PoolNetworkInstantiate(metalPrefab, worldPos, tcm.transform);
+        PoolManager.PoolNetworkInstantiate(wallGirderPrefab, worldPos, tcm.transform);
 	}
 
 }


### PR DESCRIPTION
### Purpose
Deconstructing walls will now only spawn one metal sheet instead of two, and spawn a girder object

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
Girders and metal walls cost 1 to make, because metal sheets don't have any stacking features yet. When they do, this should be corrected.
