### PR TITLE
Enabled the creation of water decals on mopped tiles

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Tools/MopTrigger.cs
@@ -106,7 +106,7 @@ public class MopTrigger : PickUpTrigger
 	    if (!MatrixManager.IsSpaceAt(worldPosInt))
 	    {
 		    // Create a WaterSplat Decal (visible slippery tile)
-		    // EffectsFactory.Instance.WaterSplat(targetWorldIntPos);
+		    EffectsFactory.Instance.WaterSplat(worldPosInt);
 
 		    // Sets a tile to slippery
 		    matrix.MetaDataLayer.MakeSlipperyAt(localPosInt);


### PR DESCRIPTION
### Purpose
Uncomments the code to re-enable the creation of water decals on mopped tiles<br>
Fixes #1777 

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
