### PR TITLE
Fixed typo in IsControlPressed function to check both(left and right) control/command keys as its supposed to

### DIFF
--- a/UnityProject/Assets/Scripts/Input System/KeyboardInputManager.cs
+++ b/UnityProject/Assets/Scripts/Input System/KeyboardInputManager.cs
@@ -118,8 +118,8 @@ public class KeyboardInputManager : MonoBehaviour
 	/// </summary>
 	public static bool IsControlPressed()
 	{
-		return CommonInput.GetKey(KeyCode.LeftControl) || CommonInput.GetKey(KeyCode.LeftControl) ||
-		       CommonInput.GetKey(KeyCode.LeftCommand) || CommonInput.GetKey(KeyCode.LeftCommand);
+		return CommonInput.GetKey(KeyCode.LeftControl) || CommonInput.GetKey(KeyCode.RightControl) ||
+		       CommonInput.GetKey(KeyCode.LeftCommand) || CommonInput.GetKey(KeyCode.RightCommand);
 	}
 
 	/// <summary>


### PR DESCRIPTION
### Purpose
Fixed typo in IsControlPressed function to check both(left and right) control/command keys as its supposed to<br>
Fixes #1746 

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
