### PR TITLE
fixed vending

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/Resources.meta
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22be88e59a8eb264c8ab3c2bffa2ef92
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/Resources.meta
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive/Resources.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 22be88e59a8eb264c8ab3c2bffa2ef92
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/BODA.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/BODA.prefab
@@ -204,7 +204,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!212 &212917313431182876
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_0.prefab
@@ -169,7 +169,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114744021291581812
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_100.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_100.prefab
@@ -143,7 +143,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114410048841761286
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_104.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_104.prefab
@@ -175,7 +175,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114548594117427474
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_110.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_110.prefab
@@ -202,7 +202,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!212 &212653665075570876
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_126.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_126.prefab
@@ -170,7 +170,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: 
   deniedMessage: 
-  DispenseDirection: 0
+  EjectDirection: 2
 --- !u!114 &114896506477870920
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -221,7 +221,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!212 &212235302915095170
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_133.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_133.prefab
@@ -157,7 +157,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114874788732671660
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_140.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_140.prefab
@@ -143,7 +143,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114497646148759208
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_151.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_151.prefab
@@ -188,7 +188,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114889659920394128
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_159.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_159.prefab
@@ -202,7 +202,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!212 &212886119991487396
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_16.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_16.prefab
@@ -142,7 +142,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114932710023623188
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_175.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_175.prefab
@@ -189,7 +189,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114710026204977004
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_185.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_185.prefab
@@ -189,7 +189,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114999616005251050
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_188.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_188.prefab
@@ -157,7 +157,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114360152240670150
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_190.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_190.prefab
@@ -202,7 +202,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!212 &212952225858091546
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_192.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_192.prefab
@@ -156,7 +156,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114642676927889516
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_194.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_194.prefab
@@ -188,7 +188,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114960973216336980
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_199.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_199.prefab
@@ -156,7 +156,7 @@ MonoBehaviour:
   stock: 3
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114886149982349940
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_20.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_20.prefab
@@ -144,7 +144,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114122618821075794
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_203.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_203.prefab
@@ -156,7 +156,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114708347885198788
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_24.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_24.prefab
@@ -157,7 +157,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114686181477237930
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_28.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_28.prefab
@@ -142,7 +142,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114780440889617882
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_34.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_34.prefab
@@ -236,7 +236,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114994836355027986
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_49.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_49.prefab
@@ -141,7 +141,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114108621238303254
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_51.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_51.prefab
@@ -221,7 +221,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114778853778945220
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -266,7 +266,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: 
   deniedMessage: 
-  DispenseDirection: 0
+  EjectDirection: 2
 --- !u!114 &114862503678879326
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_69.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_69.prefab
@@ -142,7 +142,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114734017414174382
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_73.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_73.prefab
@@ -170,7 +170,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114909791754392412
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_76.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_76.prefab
@@ -157,7 +157,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114764024703624026
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_95.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_95.prefab
@@ -188,7 +188,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!114 &114786537848864648
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_99.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Vending/vending_99.prefab
@@ -202,7 +202,7 @@ MonoBehaviour:
   stock: 5
   interactionMessage: bzzzz...
   deniedMessage: Vendor is refreshing stocking, please wait...
-  DispenseDirection: 2
+  EjectDirection: 2
 --- !u!212 &212474252750086624
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Scripts/Objects/VendorTrigger.cs
+++ b/UnityProject/Assets/Scripts/Objects/VendorTrigger.cs
@@ -54,7 +54,7 @@ public class VendorTrigger : InputTrigger
 
 		int randIndex = Random.Range(0, vendorcontent.Length);
 
-		var spawnedItem = PoolManager.PoolNetworkInstantiate(vendorcontent[randIndex], transform.position);
+		var spawnedItem = PoolManager.PoolNetworkInstantiate(vendorcontent[randIndex], transform.position, transform.parent);
 
 		//Dispensing in direction
 		if ( DispenseDirection != DispenseDirection.None ) {

--- a/UnityProject/Assets/Scripts/Objects/VendorTrigger.cs
+++ b/UnityProject/Assets/Scripts/Objects/VendorTrigger.cs
@@ -12,14 +12,17 @@ public class VendorTrigger : InputTrigger
 	public int stock = 5;
 	public string interactionMessage;
 	public string deniedMessage;
-	public DispenseDirection DispenseDirection = DispenseDirection.None;
+	public bool EjectObjects = false;
+	public EjectDirection EjectDirection = EjectDirection.None;
 
 	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
-		if(!CanUse(originator, hand, position, false)){
+		if (!CanUse(originator, hand, position, false))
+		{
 			return false;
 		}
-		if(!isServer){
+		if (!isServer)
+		{
 			//ask server to perform the interaction
 			InteractMessage.Send(gameObject, position, hand);
 			return true;
@@ -29,7 +32,7 @@ public class VendorTrigger : InputTrigger
 		{
 			UpdateChatMessage.Send(originator, ChatChannel.Examine, deniedMessage);
 		}
-		else if(allowSell)
+		else if (allowSell)
 		{
 			allowSell = false;
 			if (!GameData.Instance.testServer && !GameData.IsHeadlessServer)
@@ -46,7 +49,7 @@ public class VendorTrigger : InputTrigger
 	[Server]
 	private bool ServerVendorInteraction(Vector3 position)
 	{
-//		Debug.Log("status" + allowSell);
+		//		Debug.Log("status" + allowSell);
 		if (vendorcontent.Length == 0)
 		{
 			return false;
@@ -56,27 +59,30 @@ public class VendorTrigger : InputTrigger
 
 		var spawnedItem = PoolManager.PoolNetworkInstantiate(vendorcontent[randIndex], transform.position, transform.parent);
 
-		//Dispensing in direction
-		if ( DispenseDirection != DispenseDirection.None ) {
+		//Ejecting in direction
+		if (EjectObjects && EjectDirection != EjectDirection.None)
+		{
 			Vector3 offset = Vector3.zero;
-			switch ( DispenseDirection ) {
-				case DispenseDirection.Up:
-					offset = transform.rotation * Vector3.up / Random.Range(4,12);
+			switch (EjectDirection)
+			{
+				case EjectDirection.Up:
+					offset = transform.rotation * Vector3.up / Random.Range(4, 12);
 					break;
-				case DispenseDirection.Down:
-					offset = transform.rotation * Vector3.down / Random.Range(4,12);
+				case EjectDirection.Down:
+					offset = transform.rotation * Vector3.down / Random.Range(4, 12);
 					break;
-				case DispenseDirection.Random:
-					offset = new Vector3( Random.Range( -0.15f, 0.15f ), Random.Range( -0.15f, 0.15f ), 0 );
+				case EjectDirection.Random:
+					offset = new Vector3(Random.Range(-0.15f, 0.15f), Random.Range(-0.15f, 0.15f), 0);
 					break;
 			}
-			spawnedItem.GetComponent<CustomNetTransform>()?.Throw( new ThrowInfo {
+			spawnedItem.GetComponent<CustomNetTransform>()?.Throw(new ThrowInfo
+			{
 				ThrownBy = gameObject,
 				Aim = BodyPartType.Chest,
 				OriginPos = transform.position,
 				TargetPos = transform.position + offset,
-				SpinMode = DispenseDirection == DispenseDirection.Random ? SpinMode.Clockwise : SpinMode.None
-			} );
+				SpinMode = EjectDirection == EjectDirection.Random ? SpinMode.Clockwise : SpinMode.None
+			});
 		}
 		stock--;
 
@@ -86,7 +92,7 @@ public class VendorTrigger : InputTrigger
 	private IEnumerator VendorInputCoolDown()
 	{
 		yield return new WaitForSeconds(cooldownTimer);
-		if ( stock > 0 )
+		if (stock > 0)
 		{
 			allowSell = true;
 		}
@@ -94,4 +100,4 @@ public class VendorTrigger : InputTrigger
 
 }
 
-public enum DispenseDirection { None, Up, Down, Random }
+public enum EjectDirection { None, Up, Down, Random }

--- a/UnityProject/Assets/Scripts/Prefabs.meta
+++ b/UnityProject/Assets/Scripts/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b05b71ba763588d49ba947e7941a0515
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Prefabs.meta
+++ b/UnityProject/Assets/Scripts/Prefabs.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b05b71ba763588d49ba947e7941a0515
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
After an object from a vending machine was consumed and put into the object pool and then vended again it would pull from the pool but the parent would be set to null(default) as no parent is passed, making it so that the vended object is parented to root. This causes strange behaviour as the object would be pulled to a different tile by presumably the NetTransform as they mismatched. 

Made it so that it takes the parent of the vending machine as the parent of the vended object

Commit 2: Made it so the vending machine dispenses on top of itself instead of ejecting objects, added a boolean to allow for turning on of this functionality in cases like the machine being hacked. Also updated all the vending machine prefabs to eject downwards<br>
Fixes #1573 

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
This may possibly need to be done in either the PoolManager.cs or RegisterTile.cs scripts, but as i don't know how those scripts are intended to work this will fix the issue for now.
