### PR TITLE
Debugging steam builds, no access without steamid

### DIFF
--- a/UnityProject/Assets/Scripts/Editor/BuildServer.cs
+++ b/UnityProject/Assets/Scripts/Editor/BuildServer.cs
@@ -20,6 +20,7 @@ public class BuildScript
 		buildPlayerOptions.locationPathName = "../Tools/ContentBuilder/content/Windows/Unitystation.exe";
 		buildPlayerOptions.target = BuildTarget.StandaloneWindows64;
 		buildPlayerOptions.options = BuildOptions.Development;
+		buildPlayerOptions.options = BuildOptions.AllowDebugging;
 		buildPlayerOptions.options = BuildOptions.CompressWithLz4HC;
 		BuildPreferences.SetRelease(true);
 		BuildPipeline.BuildPlayer(buildPlayerOptions);
@@ -31,6 +32,7 @@ public class BuildScript
 		buildPlayerOptions.locationPathName = "../Tools/ContentBuilder/content/OSX/Unitystation.app";
 		buildPlayerOptions.target = BuildTarget.StandaloneOSX;
 		buildPlayerOptions.options = BuildOptions.Development;
+		buildPlayerOptions.options = BuildOptions.AllowDebugging;
 		buildPlayerOptions.options = BuildOptions.CompressWithLz4HC;
 		BuildPreferences.SetRelease(true);
 		BuildPipeline.BuildPlayer(buildPlayerOptions);
@@ -42,6 +44,7 @@ public class BuildScript
 		buildPlayerOptions.locationPathName = "../Tools/ContentBuilder/content/Linux/Unitystation";
 		buildPlayerOptions.target = BuildTarget.StandaloneLinux64;
 		buildPlayerOptions.options = BuildOptions.Development;
+		buildPlayerOptions.options = BuildOptions.AllowDebugging;
 		buildPlayerOptions.options = BuildOptions.CompressWithLz4HC;
 		BuildPreferences.SetRelease(true);
 		BuildPipeline.BuildPlayer(buildPlayerOptions);
@@ -52,6 +55,7 @@ public class BuildScript
 		buildPlayerOptions.scenes = new[] {"Assets/scenes/Lobby.unity", "Assets/scenes/OutpostStation.unity"};
 		buildPlayerOptions.locationPathName = "../Builds/OSX/Unitystation.app";
 		buildPlayerOptions.options = BuildOptions.Development;
+		buildPlayerOptions.options = BuildOptions.AllowDebugging;
 		buildPlayerOptions.target = BuildTarget.StandaloneOSX;
 		BuildPipeline.BuildPlayer(buildPlayerOptions);
 	}
@@ -61,6 +65,7 @@ public class BuildScript
 		buildPlayerOptions.scenes = new[] {"Assets/scenes/Lobby.unity", "Assets/scenes/OutpostStation.unity"};
 		buildPlayerOptions.locationPathName = "../Builds/Linux/Unitystation";
 		buildPlayerOptions.options = BuildOptions.Development;
+		buildPlayerOptions.options = BuildOptions.AllowDebugging;
 		buildPlayerOptions.target = BuildTarget.StandaloneLinux64;
 		BuildPipeline.BuildPlayer(buildPlayerOptions);
 	}
@@ -70,6 +75,7 @@ public class BuildScript
 		buildPlayerOptions.scenes = new[] {"Assets/scenes/Lobby.unity", "Assets/scenes/OutpostStation.unity"};
 		buildPlayerOptions.locationPathName = "../Builds/Windows/Unitystation.exe";
 		buildPlayerOptions.options = BuildOptions.Development;
+		buildPlayerOptions.options = BuildOptions.AllowDebugging;
 		buildPlayerOptions.target = BuildTarget.StandaloneWindows64;
 		BuildPipeline.BuildPlayer(buildPlayerOptions);
 	}

--- a/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
+++ b/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
@@ -79,17 +79,10 @@ public class ConnectedPlayer
         get { return steamId; }
         set
         {
-
             if ( value != 0 )
             {
                 steamId = value;
 				Logger.Log( $"Updated steamID! {this}" , Category.Steam);
-            }
-            else
-            {
-	            //todo: temporary allowing non-steam players
-	            steamId = ulong.MaxValue;
-				Logger.Log( $"Player supposedly without steamID! {this}" , Category.Steam);
             }
         }
     }


### PR DESCRIPTION
### Purpose
Allowed debugging steam clients; steamid kicks are back in place

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

