### PR TITLE
Tweaked atmos to make gas freeze in closed airlocks/shutters

### DIFF
--- a/UnityProject/Assets/Scripts/Editor/Matrix/Views/MetaDataView.cs
+++ b/UnityProject/Assets/Scripts/Editor/Matrix/Views/MetaDataView.cs
@@ -26,6 +26,8 @@ public class MetaDataView : BasicView
 		localChecks.Add(new OxygenCheck());
 		localChecks.Add(new CarbonDioxideCheck());
 		localChecks.Add(new RoomNumberCheck());
+		localChecks.Add(new AirlockCheck());
+		localChecks.Add(new SlipperyCheck());
 	}
 
 	public override void DrawContent()
@@ -209,6 +211,32 @@ public class MetaDataView : BasicView
 				GizmoUtils.DrawText($"{node.WindForce:0.#}", LocalToWorld(source, position) + (Vector3)Vector2.down/4, false);
 
 				GizmoUtils.DrawArrow( position, (Vector2)node.WindDirection/2 );
+			}
+		}
+	}
+	private class AirlockCheck : Check<MetaDataLayer>
+	{
+		public override string Label { get; } = "Closed Airlock";
+
+		public override void DrawGizmo(MetaDataLayer source, Vector3Int position)
+		{
+			MetaDataNode node = source.Get(position, false);
+			if (node.IsClosedAirlock)
+			{
+				GizmoUtils.DrawCube( position, Color.blue, true );
+			}
+		}
+	}
+	private class SlipperyCheck : Check<MetaDataLayer>
+	{
+		public override string Label { get; } = "Slippery";
+
+		public override void DrawGizmo(MetaDataLayer source, Vector3Int position)
+		{
+			MetaDataNode node = source.Get(position, false);
+			if (node.IsSlippery)
+			{
+				GizmoUtils.DrawCube( position, Color.cyan, true );
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -11,8 +11,11 @@ using UnityEngine;
 public class Matrix : MonoBehaviour
 {
 	private MetaTileMap metaTileMap;
+	private MetaTileMap MetaTileMap => metaTileMap ? metaTileMap : metaTileMap = GetComponent<MetaTileMap>();
 	private TileList serverObjects;
+	private TileList ServerObjects => serverObjects ?? (serverObjects = ((ObjectLayer) MetaTileMap.Layers[LayerType.Objects] ).ServerObjects);
 	private TileList clientObjects;
+	private TileList ClientObjects => clientObjects ?? (clientObjects = ((ObjectLayer) MetaTileMap.Layers[LayerType.Objects]).ClientObjects);
 	private Vector3Int initialOffset;
 	public Vector3Int InitialOffset => initialOffset;
 	public int Id { get; set; } = 0;
@@ -20,20 +23,6 @@ public class Matrix : MonoBehaviour
 	private void Awake()
 	{
 		initialOffset = Vector3Int.CeilToInt(gameObject.transform.position);
-		metaTileMap = GetComponent<MetaTileMap>();
-	}
-
-	private void Start()
-	{
-		try
-		{
-			serverObjects = ((ObjectLayer) metaTileMap.Layers[LayerType.Objects]).ServerObjects;
-			clientObjects = ((ObjectLayer) metaTileMap.Layers[LayerType.Objects]).ClientObjects;
-		}
-		catch
-		{
-			Logger.LogError("CAST ERROR: Make sure everything is in its proper layer type.", Category.Matrix);
-		}
 	}
 
 	public bool IsPassableAt(Vector3Int position, bool isServer)
@@ -58,22 +47,22 @@ public class Matrix : MonoBehaviour
 	/// <returns></returns>
 	public bool IsPassableAt(Vector3Int origin, Vector3Int position, bool isServer, CollisionType collisionType = CollisionType.Player, bool includingPlayers = true, GameObject context = null)
 	{
-		return metaTileMap.IsPassableAt(origin, position, isServer, collisionType: collisionType, inclPlayers: includingPlayers, context: context);
+		return MetaTileMap.IsPassableAt(origin, position, isServer, collisionType: collisionType, inclPlayers: includingPlayers, context: context);
 	}
 
 	public bool IsAtmosPassableAt(Vector3Int origin, Vector3Int position, bool isServer)
 	{
-		return metaTileMap.IsAtmosPassableAt(origin, position, isServer);
+		return MetaTileMap.IsAtmosPassableAt(origin, position, isServer);
 	}
 
 	public bool IsSpaceAt(Vector3Int position, bool isServer)
 	{
-		return metaTileMap.IsSpaceAt(position, isServer);
+		return MetaTileMap.IsSpaceAt(position, isServer);
 	}
 
 	public bool IsEmptyAt(Vector3Int position, bool isServer)
 	{
-		return metaTileMap.IsEmptyAt(position, isServer);
+		return MetaTileMap.IsEmptyAt(position, isServer);
 	}
 
 	/// Is this position and surrounding area completely clear of solid objects?
@@ -81,7 +70,7 @@ public class Matrix : MonoBehaviour
 	{
 		foreach (Vector3Int pos in position.BoundsAround().allPositionsWithin)
 		{
-			if (!metaTileMap.IsEmptyAt(pos, isServer))
+			if (!MetaTileMap.IsEmptyAt(pos, isServer))
 			{
 				return false;
 			}
@@ -93,7 +82,7 @@ public class Matrix : MonoBehaviour
 	/// Is current position NOT a station tile? (Objects not taken into consideration)
 	public bool IsNoGravityAt( Vector3Int position, bool isServer )
 	{
-		return metaTileMap.IsNoGravityAt(position, isServer);
+		return MetaTileMap.IsNoGravityAt(position, isServer);
 	}
 
 	/// Should player NOT stick to the station at this position?
@@ -101,7 +90,7 @@ public class Matrix : MonoBehaviour
 	{
 		foreach (Vector3Int pos in position.BoundsAround().allPositionsWithin)
 		{
-			if (!metaTileMap.IsNoGravityAt(pos, isServer))
+			if (!MetaTileMap.IsNoGravityAt(pos, isServer))
 			{
 				return false;
 			}
@@ -115,7 +104,7 @@ public class Matrix : MonoBehaviour
 	{
 		foreach (Vector3Int pos in position.BoundsAround().allPositionsWithin)
 		{
-			if (!metaTileMap.IsEmptyAt(context, pos, isServer))
+			if (!MetaTileMap.IsEmptyAt(context, pos, isServer))
 			{
 				return false;
 			}
@@ -126,13 +115,13 @@ public class Matrix : MonoBehaviour
 
 	public IEnumerable<T> Get<T>(Vector3Int position, bool isServer) where T : MonoBehaviour
 	{
-		if ( (isServer ? serverObjects : clientObjects) == null || !(isServer ? serverObjects : clientObjects).HasObjects( position ) )
+		if ( !(isServer ? ServerObjects : ClientObjects).HasObjects( position ) )
 		{
 			return Enumerable.Empty<T>(); //?
 		}
 
 		var filtered = new List<T>();
-		foreach ( RegisterTile t in (isServer ? serverObjects : clientObjects).Get(position) )
+		foreach ( RegisterTile t in (isServer ? ServerObjects : ClientObjects).Get(position) )
 		{
 			T x = t.GetComponent<T>();
 			if (x != null)
@@ -147,7 +136,7 @@ public class Matrix : MonoBehaviour
 	public T GetFirst<T>(Vector3Int position, bool isServer) where T : MonoBehaviour
 	{
 		//This has been checked in the profiler. 0% CPU and 0kb garbage, so should be fine
-		foreach ( RegisterTile t in (isServer ? serverObjects : clientObjects).Get(position) )
+		foreach ( RegisterTile t in (isServer ? ServerObjects : ClientObjects).Get(position) )
 		{
 			T c = t.GetComponent<T>();
 			if (c != null)
@@ -157,19 +146,17 @@ public class Matrix : MonoBehaviour
 		}
 
 		return null;
-		//Old way that only checked the first RegisterTile on a cell pos:
-		//return objects.GetFirst(position)?.GetComponent<T>();
 	}
 
 	public IEnumerable<T> Get<T>(Vector3Int position, ObjectType type, bool isServer) where T : MonoBehaviour
 	{
-		if ( !(isServer ? serverObjects : clientObjects).HasObjects( position ) )
+		if ( !(isServer ? ServerObjects : ClientObjects).HasObjects( position ) )
 		{
 			return Enumerable.Empty<T>();
 		}
 
 		var filtered = new List<T>();
-		foreach ( RegisterTile t in (isServer ? serverObjects : clientObjects).Get(position, type) )
+		foreach ( RegisterTile t in (isServer ? ServerObjects : ClientObjects).Get(position, type) )
 		{
 			T x = t.GetComponent<T>();
 			if (x != null)
@@ -183,14 +170,14 @@ public class Matrix : MonoBehaviour
 
 	public bool HasTile( Vector3Int position, bool isServer )
 	{
-		return metaTileMap.HasTile( position, isServer );
+		return MetaTileMap.HasTile( position, isServer );
 	}
 
 	public IEnumerable<ElectricalOIinheritance> GetElectricalConnections(Vector3Int position)
 	{
-		if (serverObjects != null)
+		if (ServerObjects != null)
 		{
-			return serverObjects.Get(position).Select(x => x.GetComponent<ElectricalOIinheritance>()).Where(x => x != null);
+			return ServerObjects.Get(position).Select(x => x.GetComponent<ElectricalOIinheritance>()).Where(x => x != null);
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
@@ -70,7 +70,11 @@ namespace Atmospherics
 		private void Update(MetaDataNode node)
 		{
 			nodes.Clear();
-			nodes.Add(node);
+
+			if ( !node.IsClosedAirlock )
+			{ //Gases are frozen within closed airlocks
+				nodes.Add(node);
+			}
 
 			node.AddNeighborsToList(ref nodes);
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
@@ -12,7 +12,7 @@ public class AtmosSystem : SubsystemBehaviour
 		{
 			MetaDataNode node = metaDataLayer.Get(position, false);
 
-			node.GasMix = new GasMix(node.IsRoom ? GasMixes.Air : GasMixes.Space);
+			node.GasMix = new GasMix( (node.IsRoom||node.IsClosedAirlock) ? GasMixes.Air : GasMixes.Space );
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
@@ -104,6 +104,12 @@ public class MetaDataNode: IGasMixContainer
 	public bool IsRoom => Type == NodeType.Room;
 
 	/// <summary>
+	/// Does this tile contain a closed airlock/shutters?
+	/// (used for gas freezing)
+	/// </summary>
+	public bool IsClosedAirlock { get; set; }
+
+	/// <summary>
 	/// Is this tile occupied by something impassable (airtight!)
 	/// </summary>
 	public bool IsOccupied => Type == NodeType.Occupied;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -76,10 +76,15 @@ public class MetaDataSystem : SubsystemBehaviour
 			node.Type = metaTileMap.IsSpaceAt(position, true) ? NodeType.Space : NodeType.Room;
 			SetupNeighbors(node);
 			MetaUtils.AddToNeighbors(node);
+			node.IsClosedAirlock = false;
 		}
 		else
 		{
 			node.Type = NodeType.Occupied;
+			if ( matrix.GetFirst<RegisterDoor>(position, true) )
+			{
+				node.IsClosedAirlock = true;
+			}
 		}
 	}
 
@@ -99,6 +104,11 @@ public class MetaDataSystem : SubsystemBehaviour
 		{
 			MetaDataNode node = metaDataLayer.Get(position);
 			node.Type = NodeType.Occupied;
+
+			if ( matrix.GetFirst<RegisterDoor>(position, true) )
+			{
+				node.IsClosedAirlock = true;
+			}
 
 			SetupNeighbors(node);
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
@@ -5,13 +5,9 @@
 	public class RegisterDoor : RegisterTile
 	{
 		private SubsystemManager subsystemManager;
+		private SubsystemManager SubsystemManager => subsystemManager ? subsystemManager : subsystemManager = GetComponentInParent<SubsystemManager>();
 
 		public bool OneDirectionRestricted;
-
-		private void Awake()
-		{
-			subsystemManager = GetComponentInParent<SubsystemManager>();
-		}
 
 		[SerializeField]
 		private bool isClosed = true;
@@ -24,7 +20,7 @@
 				if (isClosed != value)
 				{
 					isClosed = value;
-					subsystemManager.UpdateAt(PositionServer);
+					SubsystemManager.UpdateAt(PositionServer);
 				}
 			}
 		}


### PR DESCRIPTION
No longer get pressure damage under normal conditions
Fixes #1826 
Fixes #1689

### Purpose
Closed airlock/shutters are now initialized with air.
Pressure inside airlocks no longer drops to zero, gas mixes get frozen instead.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
