### PR TITLE
Healthscanner fix

### DIFF
--- a/UnityProject/Assets/Scripts/Medical/HealthScanner.cs
+++ b/UnityProject/Assets/Scripts/Medical/HealthScanner.cs
@@ -4,11 +4,11 @@ using UnityEngine;
 
 public class HealthScanner : PickUpTrigger
 {
-    public override void Attack(GameObject target, GameObject originator, BodyPartType bodyPart)
-    {
+	public override void Attack(GameObject target, GameObject originator, BodyPartType bodyPart)
+	{
 		var playerHealth = target.GetComponent<PlayerHealth>();
-        PlayerFound(playerHealth);
-    }
+		PlayerFound(playerHealth);
+	}
 
 	public void PlayerFound(PlayerHealth Playerhealth) {
 		string ToShow = (Playerhealth.name + " is " + Playerhealth.ConsciousState.ToString() + "\n"

--- a/UnityProject/Assets/Scripts/Medical/HealthScanner.cs
+++ b/UnityProject/Assets/Scripts/Medical/HealthScanner.cs
@@ -4,6 +4,12 @@ using UnityEngine;
 
 public class HealthScanner : PickUpTrigger
 {
+    public override void Attack(GameObject target, GameObject originator, BodyPartType bodyPart)
+    {
+		var playerHealth = target.GetComponent<PlayerHealth>();
+        PlayerFound(playerHealth);
+    }
+
 	public void PlayerFound(PlayerHealth Playerhealth) {
 		string ToShow = (Playerhealth.name + " is " + Playerhealth.ConsciousState.ToString() + "\n"
 			+ "OverallHealth = " + Playerhealth.OverallHealth.ToString() + " Blood level = " + Playerhealth.bloodSystem.BloodLevel.ToString() + "\n"
@@ -22,23 +28,5 @@ public class HealthScanner : PickUpTrigger
 		}
 		ToShow = ToShow + "Overall, Brute " + TotalBruteDamage.ToString() + " Burn " + TotalBurnDamage.ToString() + " OxyLoss " + Playerhealth.bloodSystem.OxygenDamage.ToString() + "\n" + "Body Part, Brute, Burn \n" + StringBuffer;
 		ChatRelay.Instance.AddToChatLogClient(ToShow, ChatChannel.Examine);
-		//PostToChatMessage.Send(ToShow,ChatChannel.System);
-		//Logger.Log(ToShow);
-	}
-	public override bool Interact(GameObject originator, Vector3 position, string hand)
-	{
-		if (gameObject == UIManager.Hands.CurrentSlot.Item)
-		{
-			Vector3 tposition = Camera.main.ScreenToWorldPoint(UnityEngine.Input.mousePosition);
-			tposition.z = 0f;
-			foreach (PlayerHealth theObject in MatrixManager.GetAt<PlayerHealth>(tposition.RoundToInt(), false)) {
-				PlayerFound(theObject);
-			}
-			return base.Interact(originator, position, hand);;
-		}
-		else
-		{
-			return base.Interact(originator, position, hand);
-		}
 	}
 }


### PR DESCRIPTION
### Purpose
Makes the healthscanner use Attack() instead of Interact()
In some cases the healthscanner wasn't working due to the strange interact logic

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)


