### PR TITLE
Removes two leftlover .meta files

### DIFF
--- a/UnityProject/Assets/Plugins/Editor.meta
+++ b/UnityProject/Assets/Plugins/Editor.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 711387686670be74b9127b6f10480d30
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Items/Weapons/Explosive.meta
+++ b/UnityProject/Assets/Prefabs/Items/Weapons/Explosive.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a94ad81163917e24697515eba544626a
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Removes two leftlover .meta files

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
deja-vu
