### PR TITLE
Fixes Rejoining in locker bug and snaps the camera to the locker

### DIFF
--- a/UnityProject/Assets/Scripts/Closets/ClosetPlayerHandler.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetPlayerHandler.cs
@@ -40,6 +40,12 @@ public class ClosetPlayerHandler : MonoBehaviour
 		}
 	}
 
+	/// <summary>
+	/// Applies the camera dampening when the camera reaches the closet.
+	/// This makes the camera snap the to closet before making the camera "drag" as the closet moves.
+	/// Snapping the camera to the closet is needed for when a player inside the closet rejoins the game, otherwise the
+	/// camera will move/"drag" from coordinate 0,0 across the station to the closet's position.
+	/// </summary>
 	IEnumerator WaitForCameraToReachCloset()
 	{
 		yield return new WaitUntil(() =>

--- a/UnityProject/Assets/Scripts/Closets/ClosetPlayerHandler.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetPlayerHandler.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections;
+using UnityEngine;
 
 
 //TODO make into a more generic component to handle coffins, disposal bins etc. Will
@@ -23,7 +24,8 @@ public class ClosetPlayerHandler : MonoBehaviour
 		{
 			// TODO: Change this stuff to the proper settings once re-entering corpse becomes a feature.
 			Camera2DFollow.followControl.target = closetControl.transform;
-			Camera2DFollow.followControl.damping = 0.2f;
+			Camera2DFollow.followControl.damping = 0.0f;
+			StartCoroutine(WaitForCameraToReachCloset());
 		}
 
 		if (!closetControl)
@@ -36,6 +38,13 @@ public class ClosetPlayerHandler : MonoBehaviour
 		{
 			monitor = true;
 		}
+	}
+
+	IEnumerator WaitForCameraToReachCloset()
+	{
+		yield return new WaitUntil(() =>
+			Camera2DFollow.followControl.transform == Camera2DFollow.followControl.target);
+		Camera2DFollow.followControl.damping = 0.2f;
 	}
 
 	private void Update()

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -58,6 +58,13 @@ public static class SpawnHandler
 		{
 			playerScript.PlayerSync.NotifyPlayers(true);
 		}
+
+		var playerObjectBehavior = newBody.GetComponent<ObjectBehaviour>();
+		if (playerObjectBehavior.parentContainer)
+		{
+			ClosetHandlerMessage.Send(newBody, playerObjectBehavior.parentContainer.gameObject);
+		}
+
 		CustomNetworkManager.Instance.SyncPlayerData(newBody);
 	}
 

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -59,6 +59,8 @@ public static class SpawnHandler
 			playerScript.PlayerSync.NotifyPlayers(true);
 		}
 
+		// If the player is inside a container, send a ClosetHandlerMessage.
+		// The ClosetHandlerMessage will attach the container to the transfered player.
 		var playerObjectBehavior = newBody.GetComponent<ObjectBehaviour>();
 		if (playerObjectBehavior.parentContainer)
 		{


### PR DESCRIPTION
Fixes bug where the camera is at 0,0 when rejoining in a locker, and snaps the camera to the locker with 0 dampening, then goes to the normal 2f dampening when the camera hits the locker.

### Purpose
#Fixes #1765 

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

