### PR TITLE
Fixes HealthScanner text being always sent to the server player instead of the player using it

### DIFF
--- a/UnityProject/Assets/Scripts/Medical/HealthScanner.cs
+++ b/UnityProject/Assets/Scripts/Medical/HealthScanner.cs
@@ -7,10 +7,10 @@ public class HealthScanner : PickUpTrigger
 	public override void Attack(GameObject target, GameObject originator, BodyPartType bodyPart)
 	{
 		var playerHealth = target.GetComponent<PlayerHealth>();
-		PlayerFound(playerHealth);
+		PlayerFound(playerHealth, originator);
 	}
 
-	public void PlayerFound(PlayerHealth Playerhealth) {
+	public void PlayerFound(PlayerHealth Playerhealth, GameObject originator) {
 		string ToShow = (Playerhealth.name + " is " + Playerhealth.ConsciousState.ToString() + "\n"
 			+ "OverallHealth = " + Playerhealth.OverallHealth.ToString() + " Blood level = " + Playerhealth.bloodSystem.BloodLevel.ToString() + "\n"
 						 + "Blood levels = " + Playerhealth.CalculateOverallBloodLossDamage() + "\n");
@@ -27,6 +27,6 @@ public class HealthScanner : PickUpTrigger
 			StringBuffer += "\n";
 		}
 		ToShow = ToShow + "Overall, Brute " + TotalBruteDamage.ToString() + " Burn " + TotalBurnDamage.ToString() + " OxyLoss " + Playerhealth.bloodSystem.OxygenDamage.ToString() + "\n" + "Body Part, Brute, Burn \n" + StringBuffer;
-		ChatRelay.Instance.AddToChatLogClient(ToShow, ChatChannel.Examine);
+		UpdateChatMessage.Send(originator, ChatChannel.Examine, ToShow);
 	}
 }


### PR DESCRIPTION
### Purpose
Fixes HealthScanner text being always sent to the server player instead of the player using it

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [ ]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
