### PR TITLE
Fixes NRE when respawning

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -62,7 +62,7 @@ public static class SpawnHandler
 		// If the player is inside a container, send a ClosetHandlerMessage.
 		// The ClosetHandlerMessage will attach the container to the transfered player.
 		var playerObjectBehavior = newBody.GetComponent<ObjectBehaviour>();
-		if (playerObjectBehavior.parentContainer)
+		if (playerObjectBehavior && playerObjectBehavior.parentContainer)
 		{
 			ClosetHandlerMessage.Send(newBody, playerObjectBehavior.parentContainer.gameObject);
 		}


### PR DESCRIPTION
When respawning a player's newBody does not have a playerObjectBehavior, so playerObjectBehavior.parentContainer causes an NRE.
This change adds a playerObjectBehavior check before the playerObjectBehavior.parentContainer check.

### Purpose
Fixes NRE when respawning.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:

