### PR TITLE
Ensure crit overlay disappears when returning to lobby, fix health monitor state after logging out.

### DIFF
--- a/UnityProject/Assets/Scripts/UI/OverlayCrits.cs
+++ b/UnityProject/Assets/Scripts/UI/OverlayCrits.cs
@@ -64,14 +64,23 @@ using UnityEngine.UI;
 			await Task.Delay(TimeSpan.FromSeconds(0.1f));
 			if (!pref.shroudActive)
 			{
-				shroudImg.enabled = false;
+				if (shroudImg != null)
+				{
+					shroudImg.enabled = false;
+				}
+
 				return;
 			}
+
 			DoAdjust();
-			shroudImg.enabled = true;
 			holeMat.SetColor("_Color", pref.shroudColor);
 			holeMat.SetFloat("_Radius", pref.holeRadius);
 			holeMat.SetFloat("_Shape", pref.holeShape);
+
+			if(shroudImg != null)
+			{
+				shroudImg.enabled = true;
+			}
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/UI/UI_HeartMonitor.cs
+++ b/UnityProject/Assets/Scripts/UI/UI_HeartMonitor.cs
@@ -24,19 +24,13 @@ public class UI_HeartMonitor : MonoBehaviour
 	private Sprite[] sprites;
 
 	private int spriteStart;
-	private bool startMonitoring;
 	private float timeWait;
 	private float overallHealthCache = 100;
 
 	private void Start()
 	{
+		spriteStart = fullHealthStart;
 		sprites = SpriteManager.ScreenUISprites["gen"];
-		if (SceneManager.GetActiveScene().name != "Lobby")
-		{
-			//Game has been started without the lobby scene
-			//so start the heart monitor manually
-			TryStartMonitor();
-		}
 	}
 
 	private void OnEnable()
@@ -56,29 +50,14 @@ public class UI_HeartMonitor : MonoBehaviour
 
 	private void OnSceneChange(Scene prev, Scene next)
 	{
-		if (next.name != "Lobby")
-		{
-			TryStartMonitor();
-		}
-		else
-		{
-			startMonitoring = false;
-		}
-	}
-
-	private void TryStartMonitor()
-	{
-		if (!startMonitoring)
-		{
-			spriteStart = fullHealthStart;
-			startMonitoring = true;
-		}
+		// Ensure crit overlay is reset to normal.
+		overlayCrits.SetState(OverlayState.normal);
 	}
 
 	//Managed by UpdateManager
 	void UpdateMe()
 	{
-		if (startMonitoring && PlayerManager.LocalPlayer != null && !PlayerManager.LocalPlayerScript.IsGhost)
+		if (PlayerManager.LocalPlayer != null && !PlayerManager.LocalPlayerScript.IsGhost)
 		{
 			CheckHealth();
 			timeWait += Time.deltaTime;


### PR DESCRIPTION
### Purpose
Fixes crit overlay not going away when logging out. Also fixes health monitor not updating from previous state after logging out. (Was broken when starting a second game). #1771 

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
