### PR TITLE
Fix Deconstruct Request using incorrect reach distance test.

### DIFF
--- a/UnityProject/Assets/Scripts/Construction/Managers/Deconstruction.cs
+++ b/UnityProject/Assets/Scripts/Construction/Managers/Deconstruction.cs
@@ -24,11 +24,12 @@ public class Deconstruction : MonoBehaviour
 	public void ProcessDeconstructRequest(GameObject player, GameObject matrixRoot, TileType tileType,
 		Vector3 cellPos, Vector3 worldCellPos)
 	{
-		if (Vector3.Distance(player.transform.position, worldCellPos) > 1.5f)
+		if (PlayerScript.IsInReach(player.transform.position, worldCellPos) == false)
 		{
 			//Not in range on the server, do not process any further:
 			return;
 		}
+
 		//Process Wall deconstruct request:
 		if (tileType == TileType.Wall)
 		{

--- a/UnityProject/Assets/Scripts/Construction/Managers/Deconstruction.cs
+++ b/UnityProject/Assets/Scripts/Construction/Managers/Deconstruction.cs
@@ -24,7 +24,7 @@ public class Deconstruction : MonoBehaviour
 	public void ProcessDeconstructRequest(GameObject player, GameObject matrixRoot, TileType tileType,
 		Vector3 cellPos, Vector3 worldCellPos)
 	{
-		if (PlayerScript.IsInReach(player.transform.position, worldCellPos) == false)
+		if (player.Player().Script.IsInReach(worldCellPos, true) == false)
 		{
 			//Not in range on the server, do not process any further:
 			return;


### PR DESCRIPTION
### Purpose
Deconstruct request used an incorrect distance check to verify if tile could be deconstructed. Fixed to use PlayerScript.IsInReach.  #1799

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
