### PR TITLE
Fix ClosetControl not clearing held items upon opening container.

### DIFF
--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -279,6 +280,12 @@ public class ClosetControl : InputTrigger
 			}
 
 			item.visibleState = isOpen;
+		}
+
+		if(isOpen)
+		{
+			// If open, no items are held anymore.
+			heldItems = Enumerable.Empty<ObjectBehaviour>();
 		}
 	}
 


### PR DESCRIPTION
### Purpose
ClosetControl removes items from crate upon opening, but did not clear record of items held. This caused the held items to be transferred to the possession of the shuttle's matrix when the crate is moved onto it, although the crate's contents were left on the station. Fixes #1825

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
