### PR TITLE
Replaced Color collection with NativeArray in TextureDataRequest.cs

### DIFF
--- a/UnityProject/Assets/Scripts/Lighting System/LightingSystem.cs
+++ b/UnityProject/Assets/Scripts/Lighting System/LightingSystem.cs
@@ -222,7 +222,7 @@ public class LightingSystem : MonoBehaviour
 		{
 
 			if (mTextureDataRequest.TryGetPixelNormalized(_normalizedMaskPoint.x, _normalizedMaskPoint.y,
-				out _sampledColor))
+					out _sampledColor))
 			{
 				bool _sampledVisibleWall = _sampledColor.r > 0;
 				bool _sampledVisibleFloor = _sampledColor.g > 0;
@@ -244,7 +244,7 @@ public class LightingSystem : MonoBehaviour
 	{
 		if (iMainCamera.backgroundColor.a > 0)
 		{
-			Logger.Log("FovSystem Camera Validation: Camera backgroundColor.a must be 0."+
+			Logger.Log("FovSystem Camera Validation: Camera backgroundColor.a must be 0." +
 				" This is required to create background mask. Adjusted...", Category.Lighting);
 
 			iMainCamera.backgroundColor = new Color(iMainCamera.backgroundColor.r, iMainCamera.backgroundColor.g, iMainCamera.backgroundColor.b, 0);
@@ -252,13 +252,13 @@ public class LightingSystem : MonoBehaviour
 
 		if (((LayerMask)iMainCamera.cullingMask).HasAny(iRenderSettings.lightSourceLayers))
 		{
-			Logger.Log("FovSystem Camera Validation: Camera does not cull one of Light Source Layers!"+
+			Logger.Log("FovSystem Camera Validation: Camera does not cull one of Light Source Layers!" +
 				" Light System may not work currently.", Category.Lighting);
 		}
 
 		if (((LayerMask)iMainCamera.cullingMask).HasAny(iRenderSettings.backgroundLayers))
 		{
-			Logger.Log("FovSystem Camera Validation: Camera does not cull one of Background Layers!"+
+			Logger.Log("FovSystem Camera Validation: Camera does not cull one of Background Layers!" +
 				"Light System wound be able to mask background and would not work correctly.", Category.Lighting);
 		}
 	}
@@ -275,7 +275,7 @@ public class LightingSystem : MonoBehaviour
 		if (!SystemInfo.supportsAsyncGPUReadback)
 		{
 			Logger.LogWarning("LightingSystem: Async GPU Readback not supported on this machine, slower synchronous readback will" +
-										 " be used instead.", Category.Lighting);
+				" be used instead.", Category.Lighting);
 		}
 		HandlePPPositionRequest += ProviderPPPosition;
 
@@ -337,6 +337,11 @@ public class LightingSystem : MonoBehaviour
 		operationParameters = default(OperationParameters);
 
 		HandlePPPositionRequest -= ProviderPPPosition;
+
+		if (mTextureDataRequest != null)
+		{
+			mTextureDataRequest.DeallocateOnClose();
+		}
 	}
 
 	private void Update()
@@ -401,7 +406,7 @@ public class LightingSystem : MonoBehaviour
 			return;
 		}
 
-		using (new DisposableProfiler("1. Occlusion Mask Render (No Gfx Time)"))
+		using(new DisposableProfiler("1. Occlusion Mask Render (No Gfx Time)"))
 		{
 			mOcclusionPPRT = mOcclusionRenderer.Render(mMainCamera, operationParameters.occlusionPPRTParameter, matrixRotationMode);
 
@@ -411,7 +416,7 @@ public class LightingSystem : MonoBehaviour
 			}
 		}
 
-		using (new DisposableProfiler("2. Generate FoV"))
+		using(new DisposableProfiler("2. Generate FoV"))
 		{
 			if (wallFloorOcclusionMask == null)
 			{
@@ -447,7 +452,7 @@ public class LightingSystem : MonoBehaviour
 			}
 		}
 
-		using (new DisposableProfiler("3. Object Occlusion Mask"))
+		using(new DisposableProfiler("3. Object Occlusion Mask"))
 		{
 			// These step calculates the objectOcclusionMask using the wallFloorOcclusionMask, so that objects / wallmounts will be hidden
 			// if they are not in view
@@ -458,7 +463,7 @@ public class LightingSystem : MonoBehaviour
 			Shader.SetGlobalVector("_ObjectFovMaskTransformation", objectOcclusionMask.GetTransformation(mMainCamera));
 		}
 
-		using (new DisposableProfiler("4. Blur Object Occlusion Mask"))
+		using(new DisposableProfiler("4. Blur Object Occlusion Mask"))
 		{
 			// Note: This blur is used only with shaders during scene render, so 1 pass should be enough.
 			mPostProcessingStack.BlurOcclusionMask(objectOcclusionMask.renderTexture, renderSettings, operationParameters.cameraOrthographicSize);
@@ -521,7 +526,7 @@ public class LightingSystem : MonoBehaviour
 			return;
 		}
 
-		using (new DisposableProfiler("5. Light Mask Render (No Gfx Time)"))
+		using(new DisposableProfiler("5. Light Mask Render (No Gfx Time)"))
 		{
 			mlightPPRT = mLightMaskRenderer.Render(
 				mMainCamera,
@@ -531,7 +536,7 @@ public class LightingSystem : MonoBehaviour
 				matrixRotationMode);
 		}
 
-		using (new DisposableProfiler("6. Generate Obstacle Light Mask"))
+		using(new DisposableProfiler("6. Generate Obstacle Light Mask"))
 		{
 			mPostProcessingStack.CreateWallLightMask(
 				mlightPPRT,
@@ -578,14 +583,14 @@ public class LightingSystem : MonoBehaviour
 			return;
 		}
 
-		using (new DisposableProfiler("7. Light Mask Blur"))
+		using(new DisposableProfiler("7. Light Mask Blur"))
 		{
 			mPostProcessingStack.BlurLightMask(mlightPPRT.renderTexture, renderSettings, operationParameters.cameraOrthographicSize, mMatrixRotationModeBlend);
 		}
 
 		RenderTexture _backgroundMask = null;
 
-		using (new DisposableProfiler("8. Render Background"))
+		using(new DisposableProfiler("8. Render Background"))
 		{
 			_backgroundMask = mBackgroundRenderer.Render(renderSettings);
 		}
@@ -604,7 +609,7 @@ public class LightingSystem : MonoBehaviour
 			return;
 		}
 
-		using (new DisposableProfiler("9. Blit Scene with Mixed Lights"))
+		using(new DisposableProfiler("9. Blit Scene with Mixed Lights"))
 		{
 			mlightPPRT.renderTexture.filterMode = FilterMode.Bilinear;
 			obstacleLightMask.renderTexture.filterMode = FilterMode.Bilinear;


### PR DESCRIPTION
### Purpose
Reduces the high CPU usage of converting the NativeArray to a List. Had to import Jobs and Entities to use the updated NativeArray collections.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
You will get errors about not disposing of the native array if you make changes to the class and recompile it. This is fine. The array is disposed of properly at runtime.
