### PR TITLE
Fix flying objects like glass shards getting stuck on player

### DIFF
--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.Move.cs
@@ -424,24 +424,16 @@ public partial class CustomNetTransform {
 		Vector3Int intGoal = Vector3Int.RoundToInt( goal );
 		var info = serverState.ActiveThrow;
 		List<LivingHealthBehaviour> hitDamageables;
-		if ( CanDriftTo( intOrigin, intGoal, isServer: true ) & !HittingSomething( intGoal, info.ThrownBy, out hitDamageables ) )
+
+        if(serverState.Speed > SpeedHitThreshold && HittingSomething( intGoal, info.ThrownBy, out hitDamageables ))
 		{
-			//if object is solid, check if player is nearby to make it stop
-			return registerTile && registerTile.IsPassable(true) || !IsPlayerNearby(serverState);
+			OnHit( intGoal, info, hitDamageables, MatrixManager.GetDamagetableTilemapsAt( intGoal ) );
 		}
 
-		if ( serverState.Speed > SpeedHitThreshold ) {
-			serverState.ActiveThrow = new ThrowInfo {
-				Aim = BodyPartType.Chest.Randomize(0),
-				OriginPos = origin,
-				TargetPos = goal,
-				SpinMode = SpinMode.None
-			};
-			info = serverState.ActiveThrow;
+		if (CanDriftTo( intOrigin, intGoal, isServer: true ))
+		{
+			return (registerTile && registerTile.IsPassable(true));
 		}
-
-		//Can't drift to goal for some reason:
-		OnHit( intGoal, info, hitDamageables, MatrixManager.GetDamagetableTilemapsAt( intGoal ) );
 
 		return false;
 	}
@@ -462,7 +454,7 @@ public partial class CustomNetTransform {
 		}
 
 		//Hurting objects
-		if ( objects != null && objects.Count > 0 && !Equals( info, ThrowInfo.NoThrow ) ) {
+		if ( objects != null && objects.Count > 0) {
 			for ( var i = 0; i < objects.Count; i++ ) {
 				//Remove cast to int when moving health values to float
 				var damage = (int)( ItemAttributes.throwDamage * 2 );


### PR DESCRIPTION
### Purpose
Floating objects over a speed threshold will now damage what is in their path, and continue floating. They are no longer stopped by the player, and do not spam damage until player is dead. This
fixes #1865.

There is room for more complexity in this system (perhaps changing momentum of flying objects), or 
handling heavy objects differently (knock down player?). This is not related to the bug.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
Changes that may have incurred side effects:
I removed the prerequisite for OnHit requiring object to have been thrown to do damage. Fast flying objects that were moved with space wind or other pushing forces should not need to be thrown to do damage. This should allow for emergent damage behavior instead of having to manually fake the throw data. This is only usage of OnHit, so shouldn't affect anything else at the moment.

I removed that !IsPlayerNearby check because I do not believe it makes sense. It seems this code intended to allow an object to drift into a solid object if no players are around. No idea what this is about.
