### PR TITLE
Make ignore more restrictive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,24 @@ ExportedObj/
 *.booproj
 *.svd
 
+# Binary windows
+*.dll
+*.lib
+*.exe
+*.bin
+*.zip
+
+# Binary linux
+*.so
+*.o
+*.a
+*.dylib
+
+# Generated Files and Folders
+[Bb]in/
+[Dd]ebug/
+[Rr]elease/
+
 # GIT specific
 .gitconfig
 


### PR DESCRIPTION
### Purpose
Prevent more binary files from getting committed and stop blowing up GitHub after building.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
None
