### PR TITLE
Removes a leftlover .meta file

### DIFF
--- a/UnityProject/Assets/Prefabs/Electricity/High voltage cable.meta
+++ b/UnityProject/Assets/Prefabs/Electricity/High voltage cable.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: e86c8001c7262e049a523f994284ac65
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Removes a leftlover .meta file

### Open Questions and Pre-Merge TODOs

- [ ]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [ ]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
