### PR TITLE
Fixes pipe sprite not being set

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Pipe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Pipe.prefab
@@ -68,7 +68,7 @@ SpriteRenderer:
   m_SortingLayerID: -1463207863
   m_SortingLayer: 11
   m_SortingOrder: 70
-  m_Sprite: {fileID: 21300000, guid: cbb5ae82494a04dc38f6754e5800761e, type: 3}
+  m_Sprite: {fileID: 21300000, guid: b17c2d8fde0016741b3ddae80bb61948, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -204,6 +204,7 @@ MonoBehaviour:
   nodes: []
   anchored: 0
   direction: 0
+  registerTile: {fileID: 0}
   pipeSprites:
   - {fileID: 21300000, guid: b17c2d8fde0016741b3ddae80bb61948, type: 3}
   - {fileID: 21300016, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
@@ -212,9 +213,6 @@ MonoBehaviour:
   - {fileID: 21300160, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
   volume: 70
-  ARANpipenetmembers: 0
-  ARANpipenetName: 
-  ARANpipenetVolume: 0
 --- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Purpose
Fixes pipe sprite not being set, the prefab sprite doesnt have anything for some reason

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
