### PR TITLE
Pipe push/pull when anchored fix

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Canister.cs
+++ b/UnityProject/Assets/Scripts/Objects/Canister.cs
@@ -38,7 +38,7 @@ public class Canister : InputTrigger
 				for (int n = 0; n < foundConnectors.Count; n++)
 				{
 					var conn = foundConnectors[n];
-					if (conn.anchored)
+					if (conn.objectBehaviour.isNotPushable)
 					{
 						connector = conn;
 						connector.ConnectCanister(this);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/AdvancedPipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/AdvancedPipe.cs
@@ -8,7 +8,7 @@ public class AdvancedPipe : Pipe
 
 	public override void SpriteChange()
 	{
-		if (anchored == false)
+		if (objectBehaviour.isNotPushable == false)
 		{
 			base.SpriteChange();
 			return;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
@@ -7,9 +7,9 @@ using Tilemaps.Behaviours.Meta;
 public class Pipe : MonoBehaviour
 {
 	public List<Pipe> nodes = new List<Pipe>();
-	public bool anchored = false;
 	public Direction direction = Direction.NORTH;
 	public RegisterTile registerTile;
+	public ObjectBehaviour objectBehaviour;
 	public Sprite[] pipeSprites;
 	public SpriteRenderer spriteRenderer;
 
@@ -26,13 +26,14 @@ public class Pipe : MonoBehaviour
 
 	public void Awake() {
 		registerTile = GetComponent<RegisterTile>();
+		objectBehaviour = GetComponent<ObjectBehaviour>();
 	}
 
 	public void WrenchAct()
 	{
-		if (anchored)
+		if (objectBehaviour.isNotPushable)
 		{
-			anchored = false;
+			objectBehaviour.isNotPushable = false;
 			spriteRenderer.sortingLayerID = SortingLayer.NameToID("Items");
 			Detach();
 		}
@@ -44,7 +45,7 @@ public class Pipe : MonoBehaviour
 			}
 			CalculateAttachedNodes();
 			Attach();
-			anchored = true;
+			objectBehaviour.isNotPushable = true;
 			spriteRenderer.sortingLayerID = SortingLayer.NameToID("Objects");
 		}
 		SpriteChange();
@@ -135,7 +136,7 @@ public class Pipe : MonoBehaviour
 		for (int n = 0; n < foundPipes.Count; n++)
 		{
 			var pipe = foundPipes[n];
-			if (pipe.anchored && pipe.IsCorrectDirection(direction))
+			if (pipe.objectBehaviour.isNotPushable && pipe.IsCorrectDirection(direction))
 			{
 				return pipe;
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/PipeTrigger.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/PipeTrigger.cs
@@ -29,7 +29,7 @@ public class PipeTrigger : PickUpTrigger
 
 		if (handObj == null)
 		{
-			if (!pipe.anchored)
+			if (!pipe.objectBehaviour.isNotPushable)
 			{
 				return base.Interact(originator, position, hand);
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/SimplePipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/SimplePipe.cs
@@ -7,7 +7,7 @@ public class SimplePipe : Pipe
 {
 	public override void SpriteChange()
 	{
-		if(anchored == false)
+		if(objectBehaviour.isNotPushable == false)
 		{
 			base.SpriteChange();
 			return;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/AirVent.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/AirVent.cs
@@ -11,7 +11,7 @@ public class AirVent : AdvancedPipe
 
 	private void Start()
 	{
-		if(anchored)
+		if(objectBehaviour.isNotPushable)
 		{
 			LoadTurf();
 		}
@@ -32,7 +32,7 @@ public class AirVent : AdvancedPipe
 
 	void UpdateMe()
 	{
-		if (anchored)
+		if (objectBehaviour.isNotPushable)
 		{
 			CheckAtmos();
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Connector.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Connector.cs
@@ -23,7 +23,7 @@ public class Connector : AdvancedPipe
 
 	void UpdateMe()
 	{
-		if (anchored && canister != null)
+		if (objectBehaviour.isNotPushable && canister != null)
 		{
 			MergeAir();
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
@@ -11,7 +11,7 @@ public class Scrubber : AdvancedPipe
 
 	private void Start()
 	{
-		if (anchored)
+		if (objectBehaviour.isNotPushable)
 		{
 			LoadTurf();
 		}
@@ -32,7 +32,7 @@ public class Scrubber : AdvancedPipe
 
 	void UpdateMe()
 	{
-		if (anchored)
+		if (objectBehaviour.isNotPushable)
 		{
 			CheckAtmos();
 		}


### PR DESCRIPTION
### Purpose
Removes 'anchored' from pipe code and makes it use 'objectBehaviour.isNotPushable'
Pipes cannot be pulled or pushed now when wrenched down

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [ ]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)