### PR TITLE
Changes the default hit and throw damage from 2 to 0

### DIFF
--- a/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
@@ -80,11 +80,11 @@ public class ItemAttributes : NetworkBehaviour
 	/// throw-related fields
 	[Tooltip("Damage when we click someone with harm intent")]
 	[Range(0, 100)]
-	public float hitDamage = 2;
+	public float hitDamage = 0;
 
 	[Tooltip("How painful it is when someone throws it at you")]
 	[Range(0, 100)]
-	public float throwDamage = 2;
+	public float throwDamage = 0;
 
 	[Tooltip("How many tiles to move per 0.1s when being thrown")]
 	public float throwSpeed = 2;
@@ -132,7 +132,7 @@ public class ItemAttributes : NetworkBehaviour
 
 	public List<string> TryParseList(string attr)
 	{
-		return 
+		return
 			TryGetAttr(attr)
 			.Trim()
 			.Replace("list(", "")
@@ -321,7 +321,7 @@ public class ItemAttributes : NetworkBehaviour
 			DmiState state = dmi.searchStateInIcon(states[i], icons, 4, false);
 
 			if (state == null) continue;
-			
+
 			return state.offset;
 		}
 


### PR DESCRIPTION
### Purpose
Changes the default hit and throw damage from 2 to 0

### Open Questions and Pre-Merge TODOs

- [ ]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [ ]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
it doesnt change any value from existing prefabs, its so when you make a new one its set to 0 from the getgo
