### PR TITLE
Pipes attached at roundstart

### DIFF
--- a/UnityProject/Assets/Scripts/Shuttles/ShuttleHeater.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/ShuttleHeater.cs
@@ -9,4 +9,14 @@ public class ShuttleHeater : AdvancedPipe
 	{
 		return;
 	}
+
+	public override void SetSpriteLayer()
+	{
+		return;
+	}
+
+	public override void SetAnchored(bool value)
+	{
+		anchored = value;
+	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosManager.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 public class AtmosManager : MonoBehaviour
@@ -10,6 +12,22 @@ public class AtmosManager : MonoBehaviour
 	public AtmosMode Mode = AtmosMode.Threaded;
 
 	public bool Running { get; private set; }
+
+	public bool roundStartedServer = false;
+	public List<Pipe> roundStartPipes = new List<Pipe>();
+
+	private static AtmosManager atmosManager;
+	public static AtmosManager Instance
+	{
+		get
+		{
+			if (atmosManager == null)
+			{
+				atmosManager = FindObjectOfType<AtmosManager>();
+			}
+			return atmosManager;
+		}
+	}
 
 	private void OnValidate()
 	{
@@ -41,6 +59,39 @@ public class AtmosManager : MonoBehaviour
 			}
 		}
 	}
+
+	void OnEnable()
+	{
+		EventManager.AddHandler(EVENT.RoundStarted, OnRoundStart);
+		EventManager.AddHandler(EVENT.RoundEnded, OnRoundEnd);
+	}
+
+	void OnDisable()
+	{
+		EventManager.RemoveHandler(EVENT.RoundStarted, OnRoundStart);
+		EventManager.RemoveHandler(EVENT.RoundEnded, OnRoundEnd);
+	}
+
+	void OnRoundStart()
+	{
+		roundStartedServer = true;
+		StartCoroutine(SetPipes());
+	}
+
+	private IEnumerator SetPipes() /// TODO: FIX ALL MANAGERS LOADING ORDER AND REMOVE ANY WAITFORSECONDS
+	{
+		yield return new WaitForSeconds(2);
+		for (int i = 0; i < roundStartPipes.Count; i++)
+		{
+			roundStartPipes[i].Attach();
+		}
+	}
+
+	void OnRoundEnd()
+	{
+		roundStartedServer = false;
+	}
+
 
 	private void OnApplicationQuit()
 	{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/AdvancedPipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/AdvancedPipe.cs
@@ -5,6 +5,19 @@ using UnityEngine;
 //scrubbers, vents, pumps, etc
 public class AdvancedPipe : Pipe
 {
+	private void Start()
+	{
+		var registerTile = GetComponent<RegisterTile>();
+		if (registerTile.isServer)
+		{
+			UpdateManager.Instance.Add(UpdateMe);
+		}
+	}
+
+	public virtual void UpdateMe()
+	{
+
+	}
 
 	public override void SpriteChange()
 	{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/AirVent.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/AirVent.cs
@@ -9,15 +9,6 @@ public class AirVent : AdvancedPipe
 	private MetaDataNode metaNode;
 	private MetaDataLayer metaDataLayer;
 
-	private void Start()
-	{
-		if(objectBehaviour.isNotPushable)
-		{
-			LoadTurf();
-		}
-		UpdateManager.Instance.Add(UpdateMe);
-	}
-
 	public override void Attach()
 	{
 		base.Attach();
@@ -30,9 +21,9 @@ public class AirVent : AdvancedPipe
 		metaNode = metaDataLayer.Get(registerTile.WorldPositionServer, false);
 	}
 
-	void UpdateMe()
+	public override void UpdateMe()
 	{
-		if (objectBehaviour.isNotPushable)
+		if (anchored)
 		{
 			CheckAtmos();
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Connector.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Connector.cs
@@ -7,10 +7,6 @@ public class Connector : AdvancedPipe
 {
 	private Canister canister;
 
-	private void Start() {
-		UpdateManager.Instance.Add(UpdateMe);
-	}
-
 	public void ConnectCanister(Canister newCanister)
 	{
 		canister = newCanister;
@@ -21,9 +17,9 @@ public class Connector : AdvancedPipe
 		canister = null;
 	}
 
-	void UpdateMe()
+	public override void UpdateMe()
 	{
-		if (objectBehaviour.isNotPushable && canister != null)
+		if ( anchored && canister != null)
 		{
 			MergeAir();
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
@@ -9,15 +9,6 @@ public class Scrubber : AdvancedPipe
 	private MetaDataNode metaNode;
 	private MetaDataLayer metaDataLayer;
 
-	private void Start()
-	{
-		if (objectBehaviour.isNotPushable)
-		{
-			LoadTurf();
-		}
-		UpdateManager.Instance.Add(UpdateMe);
-	}
-
 	public override void Attach()
 	{
 		base.Attach();
@@ -30,9 +21,9 @@ public class Scrubber : AdvancedPipe
 		metaNode = metaDataLayer.Get(registerTile.WorldPositionServer, false);
 	}
 
-	void UpdateMe()
+	public override void UpdateMe()
 	{
-		if (objectBehaviour.isNotPushable)
+		if (anchored)
 		{
 			CheckAtmos();
 		}


### PR DESCRIPTION
### Purpose
Fixes clients throwing errors by trying to perform pipenet server only interactions.
Adds roundstart attachment for pipes, they'll spawn anchored down.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [ ]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

