### PR TITLE
fixed references for emergency lights 

### DIFF
--- a/UnityProject/Assets/Scripts/Electricity/PoweredDevices/APC.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PoweredDevices/APC.cs
@@ -284,7 +284,7 @@ public class APC  : InputTrigger, INodeControl
 				break;
 			case APCState.Critical:
 				loadedScreenSprites = criticalSprites;
-				EmergencyState = false;
+				EmergencyState = true;
 				if (!RefreshDisplay) StartRefresh();
 				break;
 			case APCState.Dead:

--- a/UnityProject/Assets/Scripts/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/Lighting/LightSource.cs
@@ -22,7 +22,7 @@ internal enum LightState
 
 	TypeCount,
 }
-
+[ExecuteInEditMode]
 public class LightSource : ObjectTrigger
 {
 	private const LightState InitialState = LightState.Off;
@@ -219,6 +219,23 @@ public class LightSource : ObjectTrigger
 		State = InitialState;
 
 		ExtractLightSprites();
+	}
+
+	void Update() { 
+#if UNITY_EDITOR
+		if (!Application.isPlaying)
+		{
+			if (gameObject.tag == "EmergencyLight")
+			{
+				if (RelatedAPC == null)
+				{
+					Logger.LogError("EmergencyLight is missing APC reference, at " + transform.position, Category.Electrical); 
+					RelatedAPC.Current = 1;
+				}
+			}
+			return;
+		}
+#endif
 	}
 
 	void Start()

--- a/UnityProject/Assets/Scripts/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/Lighting/LightSource.cs
@@ -230,7 +230,7 @@ public class LightSource : ObjectTrigger
 				if (RelatedAPC == null)
 				{
 					Logger.LogError("EmergencyLight is missing APC reference, at " + transform.position, Category.Electrical); 
-					RelatedAPC.Current = 1;
+					RelatedAPC.Current = 1; //so It will bring up an error, you can go to click on to go to the actual object with the missing reference 
 				}
 			}
 			return;

--- a/UnityProject/Assets/Scripts/Lighting/LightSwitchTrigger.cs
+++ b/UnityProject/Assets/Scripts/Lighting/LightSwitchTrigger.cs
@@ -52,7 +52,7 @@ public class LightSwitchTrigger : InputTrigger
 			if (!SelfPowered && RelatedAPC == null)
 			{
 				Logger.LogError("Lightswitch is missing APC reference, at " + transform.position, Category.Electrical);
-				RelatedAPC.Current = 1;
+				RelatedAPC.Current = 1; //so It will bring up an error, you can go to click on to go to the actual object with the missing reference 
 			}
 			return;
 		}

--- a/UnityProject/Assets/Scripts/Lighting/LightSwitchTrigger.cs
+++ b/UnityProject/Assets/Scripts/Lighting/LightSwitchTrigger.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.Networking;
 using System;
 
+[ExecuteInEditMode]
 public class LightSwitchTrigger : InputTrigger
 {
 
@@ -43,10 +44,25 @@ public class LightSwitchTrigger : InputTrigger
 		clickSFX = GetComponent<AudioSource>();
 	}
 
+	void Update()
+	{
+#if UNITY_EDITOR
+		if (!Application.isPlaying)
+		{
+			if (!SelfPowered && RelatedAPC == null)
+			{
+				Logger.LogError("Lightswitch is missing APC reference, at " + transform.position, Category.Electrical);
+				RelatedAPC.Current = 1;
+			}
+			return;
+		}
+#endif
+	}
+
 	private void Start()
 	{
-		//This is needed because you can no longer apply lightSwitch prefabs (it will move all of the child sprite positions)
-		gameObject.layer = LayerMask.NameToLayer("WallMounts");
+	   //This is needed because you can no longer apply lightSwitch prefabs (it will move all of the child sprite positions)
+	   gameObject.layer = LayerMask.NameToLayer("WallMounts");
 		//and the rest of the mask caches:
 		lightingMask = LayerMask.GetMask("Lighting");
 		obstacleMask = LayerMask.GetMask("Walls", "Door Open", "Door Closed");


### PR DESCRIPTION
and made light switches and emergency lights complain if missing references to APCs

### Purpose
fixed emergency lights not turning on
make light switches and emergency lights complaine about missing APC reference to  prevent the references accidentally being lost

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
