### PR TITLE
Issue 1824 Girder deconstruction doesn't make tile passable on serverside

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/ConstructionMaterials/Resources/Metal.prefab
+++ b/UnityProject/Assets/Prefabs/Items/ConstructionMaterials/Resources/Metal.prefab
@@ -201,7 +201,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bdeba87d80ded9942845c952e8aa1902, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  griderPrefab: {fileID: 7376449702682419346, guid: 384a51cf5ff9a794e8aa15449d16f05c,
+  girderPrefab: {fileID: 7376449702682419346, guid: 384a51cf5ff9a794e8aa15449d16f05c,
     type: 3}
 --- !u!114 &114836435796936700
 MonoBehaviour:

--- a/UnityProject/Assets/Scripts/Items/MetalTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/MetalTrigger.cs
@@ -9,7 +9,7 @@ using UnityEngine.Networking;
 public class MetalTrigger : PickUpTrigger
 {
 	private bool isBuilding;
-	public GameObject griderPrefab;
+	public GameObject girderPrefab;
 
 
 	public override void UI_Interact(GameObject originator, string hand)
@@ -53,7 +53,7 @@ public class MetalTrigger : PickUpTrigger
 	[Server]
 	private void BuildGirder(Vector3 position)
 	{
-		PoolManager.PoolNetworkInstantiate(griderPrefab, position);
+		PoolManager.PoolNetworkInstantiate(girderPrefab, position);
 		isBuilding = false;
 		DisappearObject();
 	}

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
@@ -442,6 +442,11 @@ public partial class CustomNetTransform : ManagedNetworkBehaviour, IPushable //s
 		OnPullInterrupt().Invoke();
 		serverState.Position = TransformState.HiddenPos;
 		serverLerpState.Position = TransformState.HiddenPos;
+
+		RegisterObject registerObject = GetComponent<RegisterObject>();
+		if (registerObject)
+			registerObject.Passable = true;
+
 		if (CheckFloatingServer() && stopInertia )
 		{
 			Stop();

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
@@ -443,10 +443,6 @@ public partial class CustomNetTransform : ManagedNetworkBehaviour, IPushable //s
 		serverState.Position = TransformState.HiddenPos;
 		serverLerpState.Position = TransformState.HiddenPos;
 
-		RegisterObject registerObject = GetComponent<RegisterObject>();
-		if (registerObject)
-			registerObject.Passable = true;
-
 		if (CheckFloatingServer() && stopInertia )
 		{
 			Stop();
@@ -512,7 +508,7 @@ public partial class CustomNetTransform : ManagedNetworkBehaviour, IPushable //s
 	/// Registers if unhidden, unregisters if hidden
 	private void UpdateActiveStatusServer()
 	{
-		if (predictedState.Active)
+		if (serverState.Active)
 		{
 			registerTile.UpdatePositionServer();
 		}


### PR DESCRIPTION
### Purpose
Fixes #1824 

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code (Not much to comment)
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
Turns out to be a pretty simple fix: The girder doesn't actually get destroyed (because pooling) so we need to make it passable when it disappears.

I also fixed a typo in a related file