### PR TITLE
Small fixes for movement and NetTab dynamic lists

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -165,9 +165,9 @@ public class GameData : MonoBehaviour
 		//Check if running in batchmode (headless server)
 		if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null || Instance.testServer)
 		{
-			float calcFrameRate = 1f / Time.fixedDeltaTime;
+			float calcFrameRate = 1f / Time.deltaTime;
 			Application.targetFrameRate = (int) calcFrameRate;
-			Logger.Log("Starting server in HEADLESS mode.", Category.Server);
+			Logger.Log($"Starting server in HEADLESS mode. Target framerate is {Application.targetFrameRate}", Category.Server);
 			IsHeadlessServer = true;
 			StartCoroutine(WaitToStartServer());
 

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -66,7 +66,10 @@ public partial class PlayerSync
 		get => predictedSpeedClient;
 		set
 		{
-			Logger.LogTraceFormat( "{0}: setting PREDICTED speed {1}->{2}", Category.Movement, gameObject.name, SpeedClient, value );
+			if ( Math.Abs( predictedSpeedClient - value ) > 0.01f )
+			{
+				Logger.LogTraceFormat( "{0}: setting PREDICTED speed {1}->{2}", Category.Movement, gameObject.name, SpeedClient, value );
+			}
 			predictedSpeedClient = value < 0 ? 0 : value;
 		}
 	}
@@ -113,7 +116,7 @@ public partial class PlayerSync
 		//arguably it shouldn't really be like that in the future
 		if (!blockClientMovement && (!isPseudoFloatingClient && !isFloatingClient || playerScript.IsGhost))
 		{
-			Logger.LogTraceFormat( "Requesting {0} ({1} in queue)\nclientState = {2}\npredictedState = {3}", Category.Movement, 
+			Logger.LogTraceFormat( "Requesting {0} ({1} in queue)\nclientState = {2}\npredictedState = {3}", Category.Movement,
 				action.Direction(), pendingActions.Count, ClientState, predictedState );
 
 			//experiment: not enqueueing or processing action if floating, unless we are stopped.
@@ -546,8 +549,9 @@ public partial class PlayerSync
 			}
 			else
 			{
-				transform.localPosition = Vector3.MoveTowards(transform.localPosition, targetPos,
-				predictedState.Speed * Time.deltaTime * transform.localPosition.SpeedTo(targetPos));
+				transform.localPosition =
+					Vector3.MoveTowards(transform.localPosition, targetPos,
+										predictedState.Speed * Time.deltaTime * transform.localPosition.SpeedTo(targetPos));
 			}
 
 			if (ClientPositionReady)

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -50,7 +50,10 @@ public partial class PlayerSync
 		get => masterSpeedServer;
 		set
 		{ // Future move speed (applied on the next step)
-			Logger.LogTraceFormat( "{0}: setting SERVER speed {1}->{2}", Category.Movement, gameObject.name, SpeedServer, value );
+			if ( Math.Abs( masterSpeedServer - value ) > 0.01f )
+			{
+				Logger.LogTraceFormat( "{0}: setting SERVER speed {1}->{2}", Category.Movement, gameObject.name, SpeedServer, value );
+			}
 			masterSpeedServer = value < 0 ? 0 : value;
 		}
 	}
@@ -327,13 +330,17 @@ public partial class PlayerSync
 		{
 			Logger.LogWarning("Server ignored queued move while player isn't supposed to move", Category.Movement);
 			serverPendingActions.Dequeue();
+
+			TryUpdateServerTarget();
 			return;
 		}
 
 		var curState = serverState;
 		PlayerState nextState = NextStateServer( curState, serverPendingActions.Dequeue() );
 
-		if ( Equals( curState, nextState ) ) {
+		if ( Equals( curState, nextState ) )
+		{
+			TryUpdateServerTarget();
 			return;
 		}
 
@@ -347,6 +354,8 @@ public partial class PlayerSync
 			CheckMovementServer();
 			OnStartMove().Invoke( oldPos.RoundToInt(), newPos.RoundToInt() );
 		}
+
+		TryUpdateServerTarget();
 		//Logger.Log($"Server Updated target {serverTargetState}. {serverPendingActions.Count} pending");
 	}
 

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -413,13 +413,6 @@ public partial class PlayerSync : NetworkBehaviour, IPushable
 
 		Synchronize();
 	}
-
-	private void RegisterObjects()
-	{
-		//Register playerpos in matrix
-
-	}
-
 	private void Synchronize()
 	{
 		if (isLocalPlayer && GameData.IsHeadlessServer)

--- a/UnityProject/Assets/Scripts/UI/Net/Elements/Dynamic/NetUIDynamicList.cs
+++ b/UnityProject/Assets/Scripts/UI/Net/Elements/Dynamic/NetUIDynamicList.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Tilemaps.Behaviours.Meta;
@@ -67,7 +67,7 @@ public class NetUIDynamicList : NetUIElement {
 			Logger.LogFormat( "{0} dynamic list: EntryPrefab not assigned, trying to find it as '{1}'", Category.NetUI, gameObject.name, elementType );
 			EntryPrefab = Resources.Load<GameObject>( elementType );
 		}
-		entryCount = 0;
+//		entryCount = 0;
 		foreach ( DynamicEntry value in Entries )
 		{
 			InitDynamicEntry( value );
@@ -165,7 +165,7 @@ public class NetUIDynamicList : NetUIElement {
 		else
 		{
 			//Reusing
-			dynamicEntry.transform.parent = transform;
+			dynamicEntry.transform.SetParent( transform, false );
 		}
 
 		return dynamicEntry;


### PR DESCRIPTION
### Purpose
Theoretically might fix #1898 – needs to be tested on headless
Fixes `ArgumentException` related to large amount of dynamic entries in one list and page switching
Fixes parenting warnings when adding dynamic entries

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
