### PR TITLE
Pipes connection based on rotation

### DIFF
--- a/UnityProject/Assets/Scripts/Shuttles/ShuttleHeater.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/ShuttleHeater.cs
@@ -19,4 +19,32 @@ public class ShuttleHeater : AdvancedPipe
 	{
 		anchored = value;
 	}
+
+	public override void CalculateDirection()
+	{
+		direction = 0;
+		var rotation = transform.rotation.eulerAngles.z;
+		if (rotation >= 45 && rotation <= 135)
+		{
+			direction = Direction.WEST;
+		}
+		else
+		{
+			if (rotation > 135 && rotation < 225)
+			{
+				direction = Direction.SOUTH;
+			}
+			else
+			{
+				if (rotation > 225 && rotation < 315)
+				{
+					direction = Direction.EAST;
+				}
+				else
+				{
+					direction = Direction.NORTH;
+				}
+			}
+		}
+	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/AdvancedPipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/AdvancedPipe.cs
@@ -31,4 +31,32 @@ public class AdvancedPipe : Pipe
 			spriteRenderer.sprite = pipeSprites[1];
 		}
 	}
+
+	public override void CalculateDirection()
+	{
+		direction = 0;
+		var rotation = transform.rotation.eulerAngles.z;
+		if (rotation >= 45 && rotation <= 135)
+		{
+			direction = Direction.EAST;
+		}
+		else
+		{
+			if (rotation > 135 && rotation < 225)
+			{
+				direction = Direction.NORTH;
+			}
+			else
+			{
+				if (rotation > 225 && rotation < 315)
+				{
+					direction = Direction.WEST;
+				}
+				else
+				{
+					direction = Direction.SOUTH;
+				}
+			}
+		}
+	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Atmospherics;
@@ -7,7 +8,7 @@ using Tilemaps.Behaviours.Meta;
 public class Pipe : MonoBehaviour
 {
 	public List<Pipe> nodes = new List<Pipe>();
-	public Direction direction = Direction.NORTH;
+	public Direction direction = Direction.NORTH | Direction.SOUTH;
 	public RegisterTile registerTile;
 	public ObjectBehaviour objectBehaviour;
 	public Sprite[] pipeSprites;
@@ -17,13 +18,16 @@ public class Pipe : MonoBehaviour
 	public Pipenet pipenet;
 	public float volume = 70;
 
+	[Flags]
 	public enum Direction
 	{
-		NORTH,
-		SOUTH,
-		WEST,
-		EAST
+		NONE = 0,
+		NORTH = 1,
+		SOUTH = 2,
+		WEST = 4,
+		EAST = 8
 	}
+	public static readonly Direction[] allDirections = { Direction.NORTH, Direction.SOUTH, Direction.WEST, Direction.EAST, };
 
 	public void Awake() {
 		registerTile = GetComponent<RegisterTile>();
@@ -39,24 +43,28 @@ public class Pipe : MonoBehaviour
 		if (anchored)
 		{
 			Detach();
+			SpriteChange();
 		}
 		else
 		{
-			if (GetAnchoredPipe(registerTile.WorldPositionServer) != null)
+			if(Attach() == false)
 			{
+				// show message to the player 'theres something attached in this direction already'
 				return;
 			}
-			Attach();
-			transform.rotation = new Quaternion();
-			transform.position = registerTile.WorldPositionServer;
 		}
-		SpriteChange();
 		SoundManager.PlayAtPosition("Wrench", registerTile.WorldPositionServer);
 	}
 
-	public virtual void Attach()
+	public virtual bool Attach()
 	{
+		CalculateDirection();
+		if (GetAnchoredPipe(registerTile.WorldPositionServer, direction) != null)
+		{
+			return false;
+		}
 		CalculateAttachedNodes();
+
 		Pipenet foundPipenet = null;
 		if(nodes.Count > 0)
 		{
@@ -69,6 +77,11 @@ public class Pipe : MonoBehaviour
 		foundPipenet.AddPipe(this);
 		SetAnchored(true);
 		SetSpriteLayer();
+
+		transform.position = registerTile.WorldPositionServer;
+		SpriteChange();
+
+		return true;
 	}
 
 	public virtual void SetAnchored(bool value)
@@ -111,41 +124,27 @@ public class Pipe : MonoBehaviour
 	}
 
 
-	public bool IsCorrectDirection(Direction oppositeDir)
+	public bool HasDirection(Direction a, Direction b)
 	{
-		if(oppositeDir == Direction.NORTH || oppositeDir == Direction.SOUTH)
-		{
-			if(direction == Direction.NORTH || direction == Direction.SOUTH)
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		}
-		else
-		{
-			if (direction == Direction.EAST || direction == Direction.WEST)
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		}
+		return (a & b) == b;
 	}
 
-	public Pipe GetAnchoredPipe(Vector3Int position)
+	public Pipe GetAnchoredPipe(Vector3Int position, Direction dir)
 	{
 		var foundPipes = MatrixManager.GetAt<Pipe>(position, true);
-		for (int n = 0; n < foundPipes.Count; n++)
+		for (int i = 0; i < allDirections.Length; i++)
 		{
-			var pipe = foundPipes[n];
-			if (pipe.anchored && pipe.IsCorrectDirection(direction))
+			var specificDir = allDirections[i];
+			if (HasDirection(dir, specificDir))
 			{
-				return pipe;
+				for (int n = 0; n < foundPipes.Count; n++)
+				{
+					var pipe = foundPipes[n];
+					if (pipe.anchored && HasDirection(pipe.direction, specificDir))
+					{
+						return pipe;
+					}
+				}
 			}
 		}
 		return null;
@@ -153,26 +152,84 @@ public class Pipe : MonoBehaviour
 
 	public void CalculateAttachedNodes()
 	{
-		Vector3Int[] dir;
-		if (direction == Direction.NORTH || direction == Direction.SOUTH)
+		for (int i = 0; i < allDirections.Length; i++)
 		{
-			dir = new Vector3Int[] { Vector3Int.up, Vector3Int.down };
+			var dir = allDirections[i];
+			if(HasDirection(direction, dir))
+			{
+				var adjacentTurf = MetaUtils.GetNeighbors(registerTile.WorldPositionServer, DirectionToVector3IntList(dir));
+				var pipe = GetAnchoredPipe(adjacentTurf[0], OppositeDirection(dir));
+				if (pipe)
+				{
+					nodes.Add(pipe);
+					pipe.nodes.Add(this);
+					pipe.SpriteChange();
+				}
+			}
+		}
+	}
+
+	/* cheatsheet:
+	0-45 = south
+	45-135 = east
+	135-225 = north
+	225-315 = west
+	315-360 = south
+	*/
+	public virtual void CalculateDirection()
+	{
+		direction = 0;
+		var rotation = transform.rotation.eulerAngles.z;
+		if ((rotation >= 45 && rotation <= 135) || (rotation >= 225 && rotation <= 315))
+		{
+			direction = Direction.EAST | Direction.WEST;
 		}
 		else
 		{
-			dir = new Vector3Int[] { Vector3Int.left, Vector3Int.right };
+			direction = Direction.NORTH | Direction.SOUTH;
 		}
-		var adjacentTurfs = MetaUtils.GetNeighbors(registerTile.WorldPositionServer, dir);
-		for (int i = 0; i < adjacentTurfs.Length; i++)
+	}
+
+	Direction OppositeDirection(Direction dir)
+	{
+		if (dir == Direction.NORTH)
 		{
-			var pipe = GetAnchoredPipe(adjacentTurfs[i]);
-			if (pipe)
-			{
-				nodes.Add(pipe);
-				pipe.nodes.Add(this);
-				pipe.SpriteChange();
-			}
+			return Direction.SOUTH;
 		}
+		if (dir == Direction.SOUTH)
+		{
+			return Direction.NORTH;
+		}
+		if (dir == Direction.WEST)
+		{
+			return Direction.EAST;
+		}
+		if (dir == Direction.EAST)
+		{
+			return Direction.WEST;
+		}
+		return Direction.NONE;
+	}
+
+	Vector3Int[] DirectionToVector3IntList(Direction dir)
+	{
+		if (dir == Direction.NORTH)
+		{
+			return new Vector3Int[] { Vector3Int.up };
+		}
+		if (dir == Direction.SOUTH)
+		{
+			return new Vector3Int[] { Vector3Int.down };
+		}
+		if (dir == Direction.WEST)
+		{
+			return new Vector3Int[] { Vector3Int.left };
+		}
+		if (dir == Direction.EAST)
+		{
+			return new Vector3Int[] { Vector3Int.right };
+		}
+		return null;
 	}
 
 	public virtual void SpriteChange()

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/SimplePipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/SimplePipe.cs
@@ -20,13 +20,27 @@ public class SimplePipe : Pipe
 
 			case 1:
 				var pipe = nodes[0];
-				if(pipe.transform.position.y > transform.position.y)
+				if (HasDirection(direction, Direction.NORTH))
 				{
-					spriteRenderer.sprite = pipeSprites[2];
+					if(pipe.transform.position.y > transform.position.y)
+					{
+						spriteRenderer.sprite = pipeSprites[2];
+					}
+					else
+					{
+						spriteRenderer.sprite = pipeSprites[3];
+					}
 				}
 				else
 				{
-					spriteRenderer.sprite = pipeSprites[3];
+					if (pipe.transform.position.x < transform.position.x)
+					{
+						spriteRenderer.sprite = pipeSprites[2];
+					}
+					else
+					{
+						spriteRenderer.sprite = pipeSprites[3];
+					}
 				}
 				break;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/AirVent.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/AirVent.cs
@@ -9,10 +9,14 @@ public class AirVent : AdvancedPipe
 	private MetaDataNode metaNode;
 	private MetaDataLayer metaDataLayer;
 
-	public override void Attach()
+	public override bool Attach()
 	{
-		base.Attach();
+		if (base.Attach() == false)
+		{
+			return false;
+		}
 		LoadTurf();
+		return true;
 	}
 
 	private void LoadTurf()

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
@@ -9,10 +9,14 @@ public class Scrubber : AdvancedPipe
 	private MetaDataNode metaNode;
 	private MetaDataLayer metaDataLayer;
 
-	public override void Attach()
+	public override bool Attach()
 	{
-		base.Attach();
+		if(base.Attach() == false)
+		{
+			return false;
+		}
 		LoadTurf();
+		return true;
 	}
 
 	private void LoadTurf()


### PR DESCRIPTION
### Purpose
Vents, scrubbers, connectors and shuttleheaters will only connect from one side.
Pipes will now connect eachother based on their direction instead of always north/south.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- []  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
later on all the direction code (including cables) should be merged into one
