### PR TITLE
Canister connected sprite will now appear to clients

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Canister.cs
+++ b/UnityProject/Assets/Scripts/Objects/Canister.cs
@@ -1,11 +1,13 @@
 using Objects;
 using UnityEngine;
+using UnityEngine.Networking;
 
 public class Canister : InputTrigger
 {
 	public ObjectBehaviour objectBehaviour;
 	public GasContainer container;
-	private Connector connector;
+	public Connector connector;
+	[SyncVar(hook = nameof(SyncConnected))] public bool isConnected;
 	private RegisterTile registerTile;
 	public SpriteRenderer connectorRenderer;
 	public Sprite connectorSprite;
@@ -32,7 +34,16 @@ public class Canister : InputTrigger
 		GameObject handObj = pna.Inventory[hand].Item;
 		if (handObj && handObj.GetComponent<WrenchTrigger>())
 		{
-			if(connector == null)
+			if(isConnected)
+			{
+				connector.DisconnectCanister();
+				isConnected = false;
+				connectorRenderer.sprite = null;
+				SetConnectedSprite(null);
+				objectBehaviour.isNotPushable = false;
+				return true;
+			}
+			else
 			{
 				var foundConnectors = MatrixManager.GetAt<Connector>(registerTile.WorldPositionServer, true);
 				for (int n = 0; n < foundConnectors.Count; n++)
@@ -41,20 +52,13 @@ public class Canister : InputTrigger
 					if (conn.objectBehaviour.isNotPushable)
 					{
 						connector = conn;
+						isConnected = true;
 						connector.ConnectCanister(this);
-						connectorRenderer.sprite = connectorSprite;
+						SetConnectedSprite(connectorSprite);
 						objectBehaviour.isNotPushable = true;
 						return true;
 					}
 				}
-			}
-			else
-			{
-				connector.DisconnectCanister();
-				connectorRenderer.sprite = null;
-				connector = null;
-				objectBehaviour.isNotPushable = false;
-				return true;
 			}
 		}
 
@@ -64,5 +68,28 @@ public class Canister : InputTrigger
 		UpdateChatMessage.Send(originator, ChatChannel.Examine, msg);
 
 		return true;
+	}
+
+	public override void OnStartClient()
+	{
+		base.OnStartClient();
+		SyncConnected(isConnected);
+	}
+
+	void SetConnectedSprite(Sprite value)
+	{
+		connectorRenderer.sprite = value;
+	}
+
+	void SyncConnected(bool value)
+	{
+		if(value)
+		{
+			SetConnectedSprite(connectorSprite);
+		}
+		else
+		{
+			SetConnectedSprite(null);
+		}
 	}
 }


### PR DESCRIPTION
### Purpose
Canister connected sprite will now appear to clients

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)