### PR TITLE
Fixes scrubbers, vents and connectors being a pixel off when connecting to normal pipes

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/AirVent.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/AirVent.prefab
@@ -134,15 +134,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 49a3b980b33b4f6c945ab7c474875ab6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  nodes: []
-  anchored: 0
-  direction: 0
   registerTile: {fileID: 0}
+  objectBehaviour: {fileID: 0}
+  nodes: []
+  direction: 0
+  anchored: 0
+  volume: 70
   pipeSprites:
   - {fileID: 21300224, guid: b17c2d8fde0016741b3ddae80bb61948, type: 3}
   - {fileID: 21300162, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
+  - {fileID: 21300164, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
+  - {fileID: 21300166, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
+  - {fileID: 21300168, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
   spriteRenderer: {fileID: 8418407404781841632}
-  volume: 70
+  spriteSync: 0
   MinimumPressure: 101.325
 --- !u!114 &8354343867630940287
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/BentPipe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/BentPipe.prefab
@@ -116,10 +116,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4915420850159430}
-  - {fileID: 5674642621552903782}
-  - {fileID: 8104629571032404316}
-  - {fileID: 7043992998963375903}
-  - {fileID: 7997508652110997458}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -218,30 +214,32 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 022c38623e333ed43972834bba0f452b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  nodes: []
-  direction: 3
   registerTile: {fileID: 0}
   objectBehaviour: {fileID: 0}
-  pipeSprites:
-  - {fileID: 21300008, guid: b17c2d8fde0016741b3ddae80bb61948, type: 3}
-  - {fileID: 21300168, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
-  - {fileID: 21300174, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
-  - {fileID: 21300172, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
-  - {fileID: 21300170, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
-  spriteRenderer: {fileID: 212588640390319518}
-  spriteSync: 0
+  nodes: []
+  direction: 3
   anchored: 0
   volume: 70
-  conectionRenderer:
-  - {fileID: 3405745187045870037}
-  - {fileID: 671696593743680170}
-  - {fileID: 2369631279410760376}
-  - {fileID: 4656729331413939348}
-  connectionSprite:
-  - {fileID: 21300056, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
-  - {fileID: 21300058, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
-  - {fileID: 21300060, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
-  - {fileID: 21300062, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
+  pipeSprites:
+  - {fileID: 21300008, guid: b17c2d8fde0016741b3ddae80bb61948, type: 3}
+  - {fileID: 21300024, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300026, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300028, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300030, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300072, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300074, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300076, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300078, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300120, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300124, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300122, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300126, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300168, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300170, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300172, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300174, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  spriteRenderer: {fileID: 212588640390319518}
+  spriteSync: 0
 --- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -326,319 +324,3 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!1 &5219228456619383682
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5674642621552903782}
-  - component: {fileID: 3405745187045870037}
-  m_Layer: 10
-  m_Name: southConnection
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5674642621552903782
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5219228456619383682}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4199534395721968}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &3405745187045870037
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5219228456619383682}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -24161425
-  m_SortingLayer: 4
-  m_SortingOrder: 71
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &5249810998148279490
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8104629571032404316}
-  - component: {fileID: 671696593743680170}
-  m_Layer: 10
-  m_Name: northConnection
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8104629571032404316
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5249810998148279490}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4199534395721968}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &671696593743680170
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5249810998148279490}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -24161425
-  m_SortingLayer: 4
-  m_SortingOrder: 71
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &7680444928946771362
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7997508652110997458}
-  - component: {fileID: 4656729331413939348}
-  m_Layer: 10
-  m_Name: leftConnection
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7997508652110997458
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7680444928946771362}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4199534395721968}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &4656729331413939348
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7680444928946771362}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -24161425
-  m_SortingLayer: 4
-  m_SortingOrder: 71
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &8737505568656948416
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7043992998963375903}
-  - component: {fileID: 2369631279410760376}
-  m_Layer: 10
-  m_Name: rightConnection
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7043992998963375903
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8737505568656948416}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4199534395721968}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &2369631279410760376
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8737505568656948416}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -24161425
-  m_SortingLayer: 4
-  m_SortingOrder: 71
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Connector.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Connector.prefab
@@ -214,15 +214,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 53a1269dbab93b3419cff36c9ff3d531, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  nodes: []
-  anchored: 0
-  direction: 0
   registerTile: {fileID: 0}
+  objectBehaviour: {fileID: 0}
+  nodes: []
+  direction: 0
+  anchored: 0
+  volume: 70
   pipeSprites:
   - {fileID: 21300032, guid: b17c2d8fde0016741b3ddae80bb61948, type: 3}
   - {fileID: 21300072, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
+  - {fileID: 21300074, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
+  - {fileID: 21300076, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
+  - {fileID: 21300078, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
-  volume: 70
+  spriteSync: 0
 --- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/FourWayManifold.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/FourWayManifold.prefab
@@ -218,30 +218,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f6083c1f01853b44b287c22b0bb00c5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  nodes: []
-  direction: 3
   registerTile: {fileID: 0}
   objectBehaviour: {fileID: 0}
+  nodes: []
+  direction: 3
+  anchored: 0
+  volume: 70
   pipeSprites:
   - {fileID: 21300132, guid: b17c2d8fde0016741b3ddae80bb61948, type: 3}
   - {fileID: 21300038, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
-  - {fileID: 21300038, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
-  - {fileID: 21300038, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
-  - {fileID: 21300038, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
   spriteSync: 0
-  anchored: 0
-  volume: 70
-  conectionRenderer:
-  - {fileID: 3405745187045870037}
-  - {fileID: 671696593743680170}
-  - {fileID: 2369631279410760376}
-  - {fileID: 4656729331413939348}
   connectionSprite:
   - {fileID: 21300056, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   - {fileID: 21300058, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   - {fileID: 21300060, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   - {fileID: 21300062, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
+  conectionRenderer:
+  - {fileID: 3405745187045870037}
+  - {fileID: 671696593743680170}
+  - {fileID: 2369631279410760376}
+  - {fileID: 4656729331413939348}
 --- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Pipe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Pipe.prefab
@@ -1,84 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &1079633858563484
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4915420850159430}
-  - component: {fileID: 212588640390319518}
-  m_Layer: 10
-  m_Name: northConnection
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4915420850159430
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1079633858563484}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4199534395721968}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &212588640390319518
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1079633858563484}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -24161425
-  m_SortingLayer: 4
-  m_SortingOrder: 71
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!1 &1645856876941636
 GameObject:
   m_ObjectHideFlags: 0
@@ -116,10 +37,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 5498603995763496835}
-  - {fileID: 8455681318140071408}
-  - {fileID: 4915420850159430}
-  - {fileID: 6812343787306015170}
-  - {fileID: 5502854906346194372}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -218,30 +135,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: df059314980a56c419b3f924f346f192, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  nodes: []
-  direction: 0
   registerTile: {fileID: 0}
   objectBehaviour: {fileID: 0}
-  pipeSprites:
-  - {fileID: 21300000, guid: b17c2d8fde0016741b3ddae80bb61948, type: 3}
-  - {fileID: 21300160, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
-  - {fileID: 21300162, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
-  - {fileID: 21300164, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
-  - {fileID: 21300166, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
-  spriteRenderer: {fileID: 1047382295693061733}
-  spriteSync: 0
+  nodes: []
+  direction: 0
   anchored: 0
   volume: 70
-  conectionRenderer:
-  - {fileID: 3031157724356282768}
-  - {fileID: 212588640390319518}
-  - {fileID: 4733281306196067194}
-  - {fileID: 2496133828336841540}
-  connectionSprite:
-  - {fileID: 21300056, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
-  - {fileID: 21300058, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
-  - {fileID: 21300060, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
-  - {fileID: 21300062, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
+  pipeSprites:
+  - {fileID: 21300000, guid: b17c2d8fde0016741b3ddae80bb61948, type: 3}
+  - {fileID: 21300016, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300020, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300112, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300064, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300068, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300116, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300160, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  - {fileID: 21300164, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
+  spriteRenderer: {fileID: 1047382295693061733}
+  spriteSync: 0
 --- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -326,85 +237,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!1 &2392894565600687772
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6812343787306015170}
-  - component: {fileID: 4733281306196067194}
-  m_Layer: 10
-  m_Name: rightConnection
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6812343787306015170
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2392894565600687772}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4199534395721968}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &4733281306196067194
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2392894565600687772}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -24161425
-  m_SortingLayer: 4
-  m_SortingOrder: 71
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!1 &3573311523730322217
 GameObject:
   m_ObjectHideFlags: 0
@@ -482,163 +314,5 @@ SpriteRenderer:
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &3619459815982283439
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5502854906346194372}
-  - component: {fileID: 2496133828336841540}
-  m_Layer: 10
-  m_Name: leftConnection
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5502854906346194372
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3619459815982283439}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4199534395721968}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &2496133828336841540
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3619459815982283439}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -24161425
-  m_SortingLayer: 4
-  m_SortingOrder: 71
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &3659650163103410520
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8455681318140071408}
-  - component: {fileID: 3031157724356282768}
-  m_Layer: 10
-  m_Name: southConnection
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8455681318140071408
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3659650163103410520}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4199534395721968}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &3031157724356282768
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3659650163103410520}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -24161425
-  m_SortingLayer: 4
-  m_SortingOrder: 71
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Scrubber.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Scrubber.prefab
@@ -135,15 +135,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 284c55ecf95c48fe9eb8073c0d662d06, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  nodes: []
-  anchored: 0
-  direction: 0
   registerTile: {fileID: 0}
+  objectBehaviour: {fileID: 0}
+  nodes: []
+  direction: 0
+  anchored: 0
+  volume: 70
   pipeSprites:
   - {fileID: 21300216, guid: b17c2d8fde0016741b3ddae80bb61948, type: 3}
   - {fileID: 21300770, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
+  - {fileID: 21300772, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
+  - {fileID: 21300774, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
+  - {fileID: 21300776, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
   spriteRenderer: {fileID: 3335986396963275010}
-  volume: 70
+  spriteSync: 0
   MinimumPressure: 101.325
 --- !u!114 &4696558778661555457
 MonoBehaviour:

--- a/UnityProject/Assets/Scripts/Shuttles/ShuttleHeater.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/ShuttleHeater.cs
@@ -20,26 +20,24 @@ public class ShuttleHeater : AdvancedPipe
 		anchored = value;
 	}
 
-	public override void CalculateDirection()
+	public override void DirectionEast()		//shuttle sprites are upside down, turn direction
 	{
-		direction = 0;
-		var rotation = transform.rotation.eulerAngles.z;
-		if (rotation >= 45 && rotation <= 135)
-		{
-			direction = Direction.WEST;
-		}
-		else if (rotation > 135 && rotation < 225)
-		{
-			direction = Direction.SOUTH;
-		}
-		else if (rotation > 225 && rotation < 315)
-		{
-			direction = Direction.EAST;
-		}
-		else
-		{
-			direction = Direction.NORTH;
-		}
+		direction = Direction.WEST;
+	}
+
+	public override void DirectionNorth()
+	{
+		direction = Direction.SOUTH;
+	}
+
+	public override void DirectionWest()
+	{
+		direction = Direction.WEST;
+	}
+
+	public override void DirectionSouth()
+	{
+		direction = Direction.SOUTH;
 	}
 
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/AdvancedPipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/AdvancedPipe.cs
@@ -19,36 +19,4 @@ public class AdvancedPipe : Pipe
 
 	}
 
-	public override void CalculateSprite()
-	{
-		if (objectBehaviour.isNotPushable == false)
-		{
-			base.CalculateSprite();
-			return;
-		}
-		SetSprite(1);
-	}
-
-	public override void CalculateDirection()
-	{
-		direction = 0;
-		var rotation = transform.rotation.eulerAngles.z;
-		if (rotation >= 45 && rotation <= 135)
-		{
-			direction = Direction.EAST;
-		}
-		else if (rotation > 135 && rotation < 225)
-		{
-			direction = Direction.NORTH;
-		}
-		else if (rotation > 225 && rotation < 315)
-		{
-			direction = Direction.WEST;
-		}
-		else
-		{
-			direction = Direction.SOUTH;
-		}
-	}
-
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/BentPipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/BentPipe.cs
@@ -4,22 +4,137 @@ using UnityEngine;
 
 public class BentPipe : SimplePipe
 {
-	public override void DirectionEast()//3
+
+	public override void CalculateSprite()
+	{
+		if (anchored)
+		{
+			if (nodes.Count == 2)
+			{
+				if (HasDirection(direction, Direction.SOUTH))
+				{
+					if (HasDirection(direction, Direction.EAST))
+					{
+						SetSprite(1);
+					}
+					else
+					{
+						SetSprite(2);
+					}
+				}
+				else
+				{
+					if (HasDirection(direction, Direction.EAST))
+					{
+						SetSprite(3);
+					}
+					else
+					{
+						SetSprite(4);
+					}
+				}
+			}
+			else if (nodes.Count == 1)
+			{
+				for (int i = 0; i < nodes.Count; i++)
+				{
+					var pipe = nodes[i];
+					if (pipe.transform.position.y < transform.position.y)
+					{
+						if (HasDirection(direction, Direction.EAST))
+						{
+							SetSprite(5);
+						}
+						else
+						{
+							SetSprite(6);
+						}
+					}
+					else if (pipe.transform.position.y > transform.position.y)
+					{
+						if (HasDirection(direction, Direction.EAST))
+						{
+							SetSprite(7);
+						}
+						else
+						{
+							SetSprite(8);
+						}
+					}
+					else if (pipe.transform.position.x > transform.position.x)
+					{
+						if (HasDirection(direction, Direction.SOUTH))
+						{
+							SetSprite(9);
+						}
+						else
+						{
+							SetSprite(10);
+						}
+					}
+					else if (pipe.transform.position.x < transform.position.x)
+					{
+						if (HasDirection(direction, Direction.SOUTH))
+						{
+							SetSprite(11);
+						}
+						else
+						{
+							SetSprite(12);
+						}
+					}
+				}
+			}
+			else if (nodes.Count == 0)
+			{
+				if (HasDirection(direction, Direction.SOUTH))
+				{
+					if (HasDirection(direction, Direction.EAST))
+					{
+						SetSprite(13);
+					}
+					else
+					{
+						SetSprite(14);
+					}
+				}
+				else
+				{
+					if (HasDirection(direction, Direction.EAST))
+					{
+						SetSprite(15);
+					}
+					else
+					{
+						SetSprite(16);
+					}
+				}
+			}
+		}
+		else
+		{
+			SetSprite(0);
+		}
+	}
+
+
+
+	public override void DirectionEast()
 	{
 		direction = Direction.EAST | Direction.NORTH;
 	}
 
-	public override void DirectionNorth()// 2
+	public override void DirectionNorth()
 	{
 		direction = Direction.WEST | Direction.NORTH;
 	}
 
-	public override void DirectionWest()// 4
+	public override void DirectionWest()
 	{
 		direction = Direction.WEST | Direction.SOUTH;
 	}
 
-	public override void DirectionSouth() //1
+	public override void DirectionSouth()
 	{
 		direction = Direction.EAST | Direction.SOUTH;
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/FourWayManifold.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/FourWayManifold.cs
@@ -2,25 +2,29 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class FourWayManifold : SimplePipe
+public class FourWayManifold : Manifold
 {
 	public override void DirectionEast()
 	{
+		SetSprite(1);
 		direction = Direction.NORTH | Direction.SOUTH | Direction.WEST | Direction.EAST;
 	}
 
 	public override void DirectionNorth()
 	{
+		SetSprite(1);
 		direction = Direction.NORTH | Direction.SOUTH | Direction.WEST | Direction.EAST;
 	}
 
 	public override void DirectionWest()
 	{
+		SetSprite(1);
 		direction = Direction.NORTH | Direction.SOUTH | Direction.WEST | Direction.EAST;
 	}
 
 	public override void DirectionSouth()
 	{
+		SetSprite(1);
 		direction = Direction.NORTH | Direction.SOUTH | Direction.WEST | Direction.EAST;
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Manifold.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Manifold.cs
@@ -4,23 +4,66 @@ using UnityEngine;
 
 public class Manifold : SimplePipe
 {
-	public override void DirectionEast()//3
+
+	public Sprite[] connectionSprite;
+	public SpriteRenderer[] conectionRenderer;
+
+	public override void CalculateSprite()
 	{
+		for (int i = 0; i < conectionRenderer.Length; i++)
+		{
+			conectionRenderer[i].sprite = null;
+		}
+		if (anchored)
+		{
+			for (int i = 0; i < nodes.Count; i++)
+			{
+				var pipe = nodes[i];
+				if (pipe.transform.position.y < transform.position.y)
+				{
+					conectionRenderer[0].sprite = connectionSprite[0];
+				}
+				else if (pipe.transform.position.y > transform.position.y)
+				{
+					conectionRenderer[1].sprite = connectionSprite[1];
+				}
+				else if (pipe.transform.position.x > transform.position.x)
+				{
+					conectionRenderer[2].sprite = connectionSprite[2];
+				}
+				else if (pipe.transform.position.x < transform.position.x)
+				{
+					conectionRenderer[3].sprite = connectionSprite[3];
+				}
+			}
+		}
+		else
+		{
+			SetSprite(0);
+		}
+	}
+
+	public override void DirectionEast()
+	{
+		SetSprite(3);
 		direction = Direction.EAST | Direction.NORTH | Direction.SOUTH;
 	}
 
-	public override void DirectionNorth()// 2
+	public override void DirectionNorth()
 	{
+		SetSprite(2);
 		direction = Direction.WEST | Direction.NORTH | Direction.EAST;
 	}
 
-	public override void DirectionWest()// 4
+	public override void DirectionWest()
 	{
+		SetSprite(4);
 		direction = Direction.WEST | Direction.SOUTH | Direction.NORTH;
 	}
 
-	public override void DirectionSouth() //1
+	public override void DirectionSouth()
 	{
+		SetSprite(1);
 		direction = Direction.EAST | Direction.SOUTH | Direction.WEST;
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
@@ -239,7 +239,6 @@ public class Pipe : NetworkBehaviour
 		if(anchored == false)
 		{
 			SetSprite(0);	//not anchored, item sprite
-			return;
 		}
 	}
 
@@ -250,43 +249,43 @@ public class Pipe : NetworkBehaviour
 		transform.rotation = Quaternion.identity;
 		if ((rotation >= 45 && rotation < 135))
 		{
-			SetSprite(3);
 			DirectionEast();
 		}
 		else if (rotation >= 135 && rotation < 225)
 		{
-			SetSprite(2);
 			DirectionNorth();
 		}
 		else if (rotation >= 225 && rotation < 315)
 		{
-			SetSprite(4);
 			DirectionWest();
 		}
 		else
 		{
-			SetSprite(1);
 			DirectionSouth();
 		}
 	}
 
 	public virtual void DirectionEast()
 	{
+		SetSprite(3);
 		direction = Direction.EAST;
 	}
 
 	public virtual void DirectionNorth()
 	{
+		SetSprite(2);
 		direction = Direction.NORTH;
 	}
 
 	public virtual void DirectionWest()
 	{
+		SetSprite(4);
 		direction = Direction.WEST;
 	}
 
 	public virtual void DirectionSouth()
 	{
+		SetSprite(1);
 		direction = Direction.SOUTH;
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
@@ -8,17 +8,18 @@ using Tilemaps.Behaviours.Meta;
 
 public class Pipe : NetworkBehaviour
 {
-	public List<Pipe> nodes = new List<Pipe>();
-	public Direction direction = Direction.NORTH | Direction.SOUTH;
 	public RegisterTile registerTile;
 	public ObjectBehaviour objectBehaviour;
+
+	public List<Pipe> nodes = new List<Pipe>();
+	public Direction direction = Direction.NORTH | Direction.SOUTH;
+	public Pipenet pipenet;
+	public bool anchored;
+	public float volume = 70;
+
 	public Sprite[] pipeSprites;
 	public SpriteRenderer spriteRenderer;
 	[SyncVar(hook = nameof(SyncSprite))] public int spriteSync;
-	public bool anchored;
-
-	public Pipenet pipenet;
-	public float volume = 70;
 
 	[Flags]
 	public enum Direction
@@ -191,11 +192,6 @@ public class Pipe : NetworkBehaviour
 		}
 	}
 
-	public virtual void CalculateDirection()
-	{
-
-	}
-
 	Direction OppositeDirection(Direction dir)
 	{
 		if (dir == Direction.NORTH)
@@ -240,7 +236,58 @@ public class Pipe : NetworkBehaviour
 
 	public virtual void CalculateSprite()
 	{
-		SetSprite(0);
+		if(anchored == false)
+		{
+			SetSprite(0);	//not anchored, item sprite
+			return;
+		}
+	}
+
+	public virtual void CalculateDirection()
+	{
+		direction = 0;
+		var rotation = transform.rotation.eulerAngles.z;
+		transform.rotation = Quaternion.identity;
+		if ((rotation >= 45 && rotation < 135))
+		{
+			SetSprite(3);
+			DirectionEast();
+		}
+		else if (rotation >= 135 && rotation < 225)
+		{
+			SetSprite(2);
+			DirectionNorth();
+		}
+		else if (rotation >= 225 && rotation < 315)
+		{
+			SetSprite(4);
+			DirectionWest();
+		}
+		else
+		{
+			SetSprite(1);
+			DirectionSouth();
+		}
+	}
+
+	public virtual void DirectionEast()
+	{
+		direction = Direction.EAST;
+	}
+
+	public virtual void DirectionNorth()
+	{
+		direction = Direction.NORTH;
+	}
+
+	public virtual void DirectionWest()
+	{
+		direction = Direction.WEST;
+	}
+
+	public virtual void DirectionSouth()
+	{
+		direction = Direction.SOUTH;
 	}
 
 	public void SetSprite(int value)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/SimplePipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/SimplePipe.cs
@@ -5,8 +5,63 @@ using Atmospherics;
 
 public class SimplePipe : Pipe
 {
-	public Sprite[] connectionSprite;
-	public SpriteRenderer[] conectionRenderer;
+
+	public override void CalculateSprite()
+	{
+		if (anchored)
+		{
+			if(nodes.Count == 2)
+			{
+				if(HasDirection(direction, Direction.SOUTH))
+				{
+					SetSprite(1);
+				}
+				else
+				{
+					SetSprite(2);
+				}
+			}
+			else if(nodes.Count == 1)
+			{
+				for (int i = 0; i < nodes.Count; i++)
+				{
+					var pipe = nodes[i];
+					if (pipe.transform.position.y < transform.position.y)
+					{
+						SetSprite(3);
+					}
+					else if (pipe.transform.position.y > transform.position.y)
+					{
+						SetSprite(4);
+					}
+					else if (pipe.transform.position.x > transform.position.x)
+					{
+						SetSprite(5);
+					}
+					else if (pipe.transform.position.x < transform.position.x)
+					{
+						SetSprite(6);
+					}
+				}
+			}
+			else if(nodes.Count == 0)
+			{
+				if (HasDirection(direction, Direction.SOUTH))
+				{
+					SetSprite(7);
+				}
+				else
+				{
+					SetSprite(8);
+				}
+			}
+		}
+		else
+		{
+			SetSprite(0);
+		}
+	}
+
 
 	public override void DirectionEast()
 	{
@@ -26,38 +81,6 @@ public class SimplePipe : Pipe
 	public override void DirectionSouth()
 	{
 		direction = Direction.NORTH | Direction.SOUTH;
-	}
-
-	public override void CalculateSprite()
-	{
-		for (int i = 0; i < conectionRenderer.Length; i++)
-		{
-			conectionRenderer[i].sprite = null;
-		}
-		base.CalculateSprite();
-		if(anchored)
-		{
-			for (int i = 0; i < nodes.Count; i++)
-			{
-				var pipe = nodes[i];
-				if (pipe.transform.position.y < transform.position.y)
-				{
-					conectionRenderer[0].sprite = connectionSprite[0];
-				}
-				else if (pipe.transform.position.y > transform.position.y)
-				{
-					conectionRenderer[1].sprite = connectionSprite[1];
-				}
-				else if (pipe.transform.position.x > transform.position.x)
-				{
-					conectionRenderer[2].sprite = connectionSprite[2];
-				}
-				else if (pipe.transform.position.x < transform.position.x)
-				{
-					conectionRenderer[3].sprite = connectionSprite[3];
-				}
-			}
-		}
 	}
 
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/SimplePipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/SimplePipe.cs
@@ -5,8 +5,28 @@ using Atmospherics;
 
 public class SimplePipe : Pipe
 {
-	public SpriteRenderer[] conectionRenderer;
 	public Sprite[] connectionSprite;
+	public SpriteRenderer[] conectionRenderer;
+
+	public override void DirectionEast()
+	{
+		direction = Direction.EAST | Direction.WEST;
+	}
+
+	public override void DirectionNorth()
+	{
+		direction = Direction.NORTH | Direction.SOUTH;
+	}
+
+	public override void DirectionWest()
+	{
+		direction = Direction.EAST | Direction.WEST;
+	}
+
+	public override void DirectionSouth()
+	{
+		direction = Direction.NORTH | Direction.SOUTH;
+	}
 
 	public override void CalculateSprite()
 	{
@@ -14,79 +34,30 @@ public class SimplePipe : Pipe
 		{
 			conectionRenderer[i].sprite = null;
 		}
-		if(objectBehaviour.isNotPushable == false)
+		base.CalculateSprite();
+		if(anchored)
 		{
-			base.CalculateSprite();
-			return;
-		}
-		for (int i = 0; i < nodes.Count; i++)
-		{
-			var pipe = nodes[i];
-			if (pipe.transform.position.y < transform.position.y)
+			for (int i = 0; i < nodes.Count; i++)
 			{
-				conectionRenderer[0].sprite = connectionSprite[0];
+				var pipe = nodes[i];
+				if (pipe.transform.position.y < transform.position.y)
+				{
+					conectionRenderer[0].sprite = connectionSprite[0];
+				}
+				else if (pipe.transform.position.y > transform.position.y)
+				{
+					conectionRenderer[1].sprite = connectionSprite[1];
+				}
+				else if (pipe.transform.position.x > transform.position.x)
+				{
+					conectionRenderer[2].sprite = connectionSprite[2];
+				}
+				else if (pipe.transform.position.x < transform.position.x)
+				{
+					conectionRenderer[3].sprite = connectionSprite[3];
+				}
 			}
-			else if (pipe.transform.position.y > transform.position.y)
-			{
-				conectionRenderer[1].sprite = connectionSprite[1];
-			}
-			else if (pipe.transform.position.x > transform.position.x)
-			{
-				conectionRenderer[2].sprite = connectionSprite[2];
-			}
-			else if (pipe.transform.position.x < transform.position.x)
-			{
-				conectionRenderer[3].sprite = connectionSprite[3];
-			}
 		}
 	}
-
-	public override void CalculateDirection()
-	{
-		direction = 0;
-		var rotation = transform.rotation.eulerAngles.z;
-		transform.rotation = Quaternion.identity;
-		if ((rotation >= 45 && rotation < 135))
-		{
-			SetSprite(3);
-			DirectionEast();
-		}
-		else if (rotation >= 135 && rotation < 225)
-		{
-			SetSprite(2);
-			DirectionNorth();
-		}
-		else if (rotation >= 225 && rotation < 315)
-		{
-			SetSprite(4);
-			DirectionWest();
-		}
-		else
-		{
-			SetSprite(1);
-			DirectionSouth();
-		}
-	}
-
-	public virtual void DirectionEast()
-	{
-		direction = Direction.EAST | Direction.WEST;
-	}
-
-	public virtual void DirectionNorth()
-	{
-		direction = Direction.NORTH | Direction.SOUTH;
-	}
-
-	public virtual void DirectionWest()
-	{
-		direction = Direction.EAST | Direction.WEST;
-	}
-
-	public virtual void DirectionSouth()
-	{
-		direction = Direction.NORTH | Direction.SOUTH;
-	}
-
 
 }


### PR DESCRIPTION
### Purpose
Fixes scrubbers, vents and connectors being a pixel off when connecting to normal pipes

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- []  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
the purpose of all these changes on sprites is so the .png imported from tg never has to be edited
