### PR TITLE
Girders and pipes will now play sounds to clients on wrench usage

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/GirderTrigger.cs
+++ b/UnityProject/Assets/Scripts/Objects/GirderTrigger.cs
@@ -48,7 +48,7 @@ public class GirderTrigger : InputTrigger
 		}
 
 		if (handObj.GetComponent<WrenchTrigger>()){
-			SoundManager.PlayAtPosition("Wrench", transform.localPosition);
+			SoundManager.PlayNetworkedAtPos("Wrench", transform.localPosition, 1f);
 			var progressFinishAction = new FinishProgressAction(
 				reason =>
 				{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
@@ -56,7 +56,7 @@ public class Pipe : NetworkBehaviour
 				return;
 			}
 		}
-		SoundManager.PlayAtPosition("Wrench", registerTile.WorldPositionServer);
+		SoundManager.PlayNetworkedAtPos("Wrench", registerTile.WorldPositionServer, 1f);
 	}
 
 	public virtual bool Attach()


### PR DESCRIPTION
### Purpose
Girders and pipes will now play sounds to clients on wrench usage

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
