### PR TITLE
DNA scanner

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Cryogenic2/DNA_Scanner.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Cryogenic2/DNA_Scanner.prefab
@@ -1,21 +1,11 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1711816394935574}
-  m_IsPrefabAsset: 1
 --- !u!1 &1436691669501954
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4003879732099956}
@@ -27,32 +17,12 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1711816394935574
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4715117052207926}
-  - component: {fileID: 61404138305600890}
-  - component: {fileID: 61606735054646822}
-  - component: {fileID: 114818633338735330}
-  - component: {fileID: 114711834900947472}
-  - component: {fileID: 114165348889573076}
-  - component: {fileID: 114657711786529776}
-  m_Layer: 11
-  m_Name: DNA_Scanner
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!4 &4003879732099956
 Transform:
-  m_ObjectHideFlags: 1
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1436691669501954}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -61,144 +31,12 @@ Transform:
   m_Father: {fileID: 4715117052207926}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &4715117052207926
-Transform:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1711816394935574}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 64, y: 62, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 4003879732099956}
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &61404138305600890
-BoxCollider2D:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1711816394935574}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!61 &61606735054646822
-BoxCollider2D:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1711816394935574}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!114 &114165348889573076
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1711816394935574}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9a459a0316cc4d5b87d046f28dc136c8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ObjectType: 1
-  AtmosPassable: 1
-  Passable: 0
---- !u!114 &114657711786529776
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1711816394935574}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &114711834900947472
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1711816394935574}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 58b822814682f460baa30059c4fd7f42, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Message: Requires human bodies
---- !u!114 &114818633338735330
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1711816394935574}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 372142912, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SceneId:
-    m_Value: 0
-  m_AssetId:
-    i0: 75
-    i1: 80
-    i2: 112
-    i3: 117
-    i4: 115
-    i5: 67
-    i6: 132
-    i7: 134
-    i8: 123
-    i9: 19
-    i10: 1
-    i11: 189
-    i12: 190
-    i13: 209
-    i14: 14
-    i15: 129
-  m_ServerOnly: 0
-  m_LocalPlayerAuthority: 0
 --- !u!212 &212360857505739792
 SpriteRenderer:
-  m_ObjectHideFlags: 1
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1436691669501954}
   m_Enabled: 1
   m_CastShadows: 0
@@ -208,6 +46,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
   m_StaticBatchInfo:
@@ -240,3 +79,173 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &1711816394935574
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4715117052207926}
+  - component: {fileID: 61404138305600890}
+  - component: {fileID: 114818633338735330}
+  - component: {fileID: 9128197607768152992}
+  - component: {fileID: 2464575245303528366}
+  - component: {fileID: 114657711786529776}
+  - component: {fileID: 5293454678208234974}
+  m_Layer: 11
+  m_Name: DNA_Scanner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4715117052207926
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711816394935574}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4003879732099956}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &61404138305600890
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711816394935574}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &114818633338735330
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711816394935574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 372142912, guid: dc443db3e92b4983b9738c1131f555cb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SceneId:
+    m_Value: 0
+  m_AssetId:
+    i0: 0
+    i1: 0
+    i2: 0
+    i3: 0
+    i4: 0
+    i5: 0
+    i6: 0
+    i7: 0
+    i8: 0
+    i9: 0
+    i10: 0
+    i11: 0
+    i12: 0
+    i13: 0
+    i14: 0
+    i15: 0
+  m_ServerOnly: 0
+  m_LocalPlayerAuthority: 0
+--- !u!114 &9128197607768152992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711816394935574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 22bc22136d1c0934491149324f00dded, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DefaultContents: []
+  IsLocked: 0
+  lockLight: {fileID: 0}
+  playerLimit: 1
+  spriteSync: 0
+  doorOpened: {fileID: 21300012, guid: edb878353e4ae4062978273e8fca40e2, type: 3}
+  spriteRenderer: {fileID: 212360857505739792}
+  occupant: {fileID: 0}
+  closedWithOccupant: {fileID: 21300004, guid: edb878353e4ae4062978273e8fca40e2, type: 3}
+--- !u!114 &2464575245303528366
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711816394935574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc4af3ee3e2140f79050f19644af5e8d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnRotateEnd:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: OrientationEvent, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  OnRotateStart:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: OrientationEvent, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  ObjectType: 1
+  rotateWithMatrix: 0
+  AtmosPassable: 1
+  Passable: 0
+  closetType: 0
+--- !u!114 &114657711786529776
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711816394935574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5293454678208234974
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711816394935574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d54c3d183673c904882b6d1e8484ca73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nameOverride: 
+  backgroundColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  iconOverride: {fileID: 0}
+  backgroundSprite: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Closets/LockLightController.cs
+++ b/UnityProject/Assets/Scripts/Closets/LockLightController.cs
@@ -2,10 +2,8 @@
 
 public class LockLightController : MonoBehaviour
 {
-	private bool locked = true;
-
 	private Sprite spriteLocked;
-	private SpriteRenderer spriteRenderer;
+	public SpriteRenderer spriteRenderer;
 	public Sprite spriteUnlocked;
 
 	private void Start()
@@ -16,40 +14,21 @@ public class LockLightController : MonoBehaviour
 
 	public void Lock()
 	{
-		locked = true;
-		if (spriteRenderer != null)
-		{
-			spriteRenderer.sprite = spriteLocked;
-		}
+		spriteRenderer.sprite = spriteLocked;
 	}
 
 	public void Unlock()
 	{
-		locked = false;
-		if (spriteRenderer != null)
-		{
-			spriteRenderer.sprite = spriteUnlocked;
-		}
+		spriteRenderer.sprite = spriteUnlocked;
 	}
 
 	public void Show()
 	{
-		if (spriteRenderer != null)
-		{
-			spriteRenderer.enabled = true;
-		}
+		spriteRenderer.enabled = true;
 	}
 
 	public void Hide()
 	{
-		if (spriteRenderer != null)
-		{
-			spriteRenderer.enabled = false;
-		}
-	}
-
-	public bool IsLocked()
-	{
-		return locked;
+		spriteRenderer.enabled = false;
 	}
 }

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -347,6 +347,26 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour
 		return bodyPartDmg;
 	}
 
+	public float GetTotalBruteDamage()
+	{
+		float bruteDmg = 0;
+		for (int i = 0; i < BodyParts.Count; i++)
+		{
+			bruteDmg += BodyParts[i].BruteDamage;
+		}
+		return bruteDmg;
+	}
+
+	public float GetTotalBurnDamage()
+	{
+		float burnDmg = 0;
+		for (int i = 0; i < BodyParts.Count; i++)
+		{
+			burnDmg += BodyParts[i].BurnDamage;
+		}
+		return burnDmg;
+	}
+
 	/// Blood Loss and Toxin damage:
 	public int CalculateOverallBloodLossDamage()
 	{

--- a/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
+++ b/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
@@ -9,6 +9,7 @@ public class CloningConsole : NetworkTabTrigger
 	public static event ChangeEvent changeEvent;
 
 	public List<CloningRecord> CloningRecords = new List<CloningRecord>();
+	public DNAscanner scanner;
 
 	public override bool Interact(GameObject originator, Vector3 position, string hand)
 	{
@@ -29,11 +30,34 @@ public class CloningConsole : NetworkTabTrigger
 		return true;
 	}
 
-	public void Start()
+	public void ToggleLock()
 	{
-		//DEBUG
-		CreateRecord("Dana Ray", 50, 117, 0, 33, "630991235560514Eb1815");
-		CreateRecord("Trinity Ray", 50, 117, 0, 33, "630991235560514Eb1815");
+		if(scanner && scanner.IsClosed)
+		{
+			scanner.IsLocked = !scanner.IsLocked;
+		}
+	}
+
+	public void Scan()
+	{
+		if(scanner && scanner.occupant)
+		{
+			var mob = scanner.occupant;
+			var uniqueIdentifier = "35562Eb18150514630991";
+			for (int i = 0; i < CloningRecords.Count; i++)
+			{
+				if(uniqueIdentifier == CloningRecords[i].UniqueIdentifier)
+				{
+					return;
+				}
+			}
+			var name = mob.GetComponent<PlayerScript>().playerName;
+			var oxyDmg = mob.bloodSystem.oxygenDamage;
+			var burnDmg = mob.GetTotalBurnDamage();
+			var toxinDmg = 0;
+			var bruteDmg = mob.GetTotalBruteDamage();
+			CreateRecord(name, oxyDmg, burnDmg, toxinDmg, bruteDmg, uniqueIdentifier);
+		}
 	}
 
 	public void CreateRecord(string name, float oxyDmg, float burnDmg, float toxingDmg, float bruteDmg, string uniqueIdentifier)

--- a/UnityProject/Assets/Scripts/Medical/DNAscanner.cs
+++ b/UnityProject/Assets/Scripts/Medical/DNAscanner.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DNAscanner : ClosetControl
+{
+	public LivingHealthBehaviour occupant;
+	public Sprite closedWithOccupant;
+
+
+	public override void HandleItems()
+	{
+		base.HandleItems();
+		if(heldPlayers.Count > 0)
+		{
+			var mob = heldPlayers[0];
+			occupant = mob.GetComponent<LivingHealthBehaviour>();
+		}
+		else
+		{
+			occupant = null;
+		}
+	}
+
+	public override void SyncSprite(ClosetStatus value)
+	{
+		if (value == ClosetStatus.Closed)
+		{
+			spriteRenderer.sprite = doorClosed;
+		}
+		else if(value == ClosetStatus.ClosedWithOccupant)
+		{
+			spriteRenderer.sprite = closedWithOccupant;
+		}
+		else
+		{
+			spriteRenderer.sprite = doorOpened;
+		}
+	}
+
+}

--- a/UnityProject/Assets/Scripts/Medical/DNAscanner.cs.meta
+++ b/UnityProject/Assets/Scripts/Medical/DNAscanner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22bc22136d1c0934491149324f00dded
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/Cloning/GUI_Cloning.cs
+++ b/UnityProject/Assets/Scripts/UI/Cloning/GUI_Cloning.cs
@@ -50,13 +50,13 @@ public class GUI_Cloning : NetTab
 
 	public void StartScan()
 	{
-		Logger.Log("Scanning", Category.NetUI);
+		CloningConsole.Scan();
 		UpdateDisplay();
 	}
 
 	public void LockScanner()
 	{
-		Logger.Log("Toggling scanner lock", Category.NetUI);
+		CloningConsole.ToggleLock();
 		UpdateDisplay();
 	}
 


### PR DESCRIPTION
### Purpose
Adds the scanner functionality, they'll act like lockers.
Cloning consoles can now scan players inside the scanners and lock or unlock the scanner.
Cleaned LockLightController code slightly.
Added GetTotalBruteDamage and GetTotalBurnDamage functions for LivingHealthBehaviour.
Removes the debug records from cloning consoles.
Fixes lockers from taking one less mob than their limit.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
the scanner needs to be linked on the map to have the cloning console, just in case the map change will be in another PR to avoid conflicts
