### PR TITLE
Fixes player teleporting for a frame or more to 0,0 on spawn

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -33,7 +33,6 @@ public struct PlayerState
 			{
 				return TransformState.HiddenPos;
 			}
-
 			return MatrixManager.LocalToWorld(Position, MatrixManager.Get(MatrixId));
 		}
 		set
@@ -364,6 +363,7 @@ public partial class PlayerSync : NetworkBehaviour, IPushable
 
 	private void Start()
 	{
+		playerState.WorldPosition = transform.localPosition;
 		//Init pending actions queue for your local player
 		if (isLocalPlayer)
 		{


### PR DESCRIPTION
### Purpose
Fixes player teleporting for a frame or more to 0,0 on spawn

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)