### PR TITLE
Fixed #1922

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -154,7 +154,12 @@ namespace Atmospherics
 		{
 			GasMix removed = this * ratio;
 
-			this -= removed;
+			for (int i = 0; i < Gas.Count; i++)
+			{
+				Gases[i] -= removed.Gases[i];
+			}
+
+			Pressure -= removed.Pressure * removed.Volume / Volume;
 
 			return removed;
 		}


### PR DESCRIPTION
Gas wasn't removed correct by taking out a volume from a tile.

### Purpose
In #1922, it was shown that plasma wasn't removed from a correctly. Leading it to always exist, i.e. a fire wouldn't never go out and lead to huge temperatures.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
