### PR TITLE
Cloning record changes and mobID

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -14,7 +14,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour
 	/// <summary>
 	/// Server side, each mob has a different one and never it never changes
 	/// </summary>
-	public int mobID;
+	public int mobID { get; private set; }
 
 	public float maxHealth = 100;
 	public float OverallHealth { get; private set; } = 100;

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -10,8 +10,13 @@ using UnityEngine.Networking;
 [RequireComponent(typeof(HealthStateMonitor))]
 public abstract class LivingHealthBehaviour : NetworkBehaviour
 {
-	public float maxHealth = 100;
 
+	/// <summary>
+	/// Server side, each mob has a different one and never it never changes
+	/// </summary>
+	public int mobID;
+
+	public float maxHealth = 100;
 	public float OverallHealth { get; private set; } = 100;
 	public float cloningDamage;
 
@@ -128,6 +133,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour
 
 	public override void OnStartServer()
 	{
+		mobID = PlayerManager.Instance.GetMobID();
 		ResetBodyParts();
 		if (maxHealth <= 0)
 		{

--- a/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
+++ b/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
@@ -27,25 +27,16 @@ public class CloningConsole : MonoBehaviour
 		{
 			var mob = scanner.occupant;
 			var mobID = scanner.occupant.mobID;
-			var playerScript = mob.GetComponent<PlayerScript>();
-			var mind = playerScript.mind;
-			var name = playerScript.playerName;
-			var characterSettings = playerScript.CharacterSettings;
-			var oxyDmg = mob.bloodSystem.oxygenDamage;
-			var burnDmg = mob.GetTotalBurnDamage();
-			var toxinDmg = 0;
-			var bruteDmg = mob.GetTotalBruteDamage();
-			var uniqueIdentifier = "35562Eb18150514630991";
 			for (int i = 0; i < CloningRecords.Count; i++)
 			{
 				var record = CloningRecords[i];
 				if (mobID == record.mobID)
 				{
-					record.UpdateRecord(name, oxyDmg, burnDmg, toxinDmg, bruteDmg, uniqueIdentifier, characterSettings, mobID, mind);
+					record.UpdateRecord(mob);
 					return;
 				}
 			}
-			CreateRecord(name, oxyDmg, burnDmg, toxinDmg, bruteDmg, uniqueIdentifier, characterSettings, mobID, mind);
+			CreateRecord(mob);
 		}
 	}
 
@@ -54,11 +45,11 @@ public class CloningConsole : MonoBehaviour
 		record.mind.ClonePlayer(gameObject, record.characterSettings);
 	}
 
-	private void CreateRecord(string name, float oxyDmg, float burnDmg, float toxinDmg, float bruteDmg, string uniqueIdentifier, CharacterSettings characterSettings, int mobID, Mind mind)
+	private void CreateRecord(LivingHealthBehaviour mob)
 	{
 
 		var record = new CloningRecord();
-		record.UpdateRecord(name, oxyDmg, burnDmg, toxinDmg, bruteDmg, uniqueIdentifier, characterSettings, mobID, mind);
+		record.UpdateRecord(mob);
 		CloningRecords.Add(record);
 	}
 
@@ -66,33 +57,33 @@ public class CloningConsole : MonoBehaviour
 
 public class CloningRecord
 {
-	public string Name;
-	public string ScanID;
-	public float OxyDmg;
-	public float BurnDmg;
-	public float ToxinDmg;
-	public float BruteDmg;
-	public string UniqueIdentifier;
+	public string name;
+	public string scanID;
+	public float oxyDmg;
+	public float burnDmg;
+	public float toxinDmg;
+	public float bruteDmg;
+	public string uniqueIdentifier;
 	public CharacterSettings characterSettings;
 	public int mobID;
 	public Mind mind;
 
 	public CloningRecord()
 	{
-		int scanID = Random.Range(0, 1000);
-		ScanID = scanID.ToString();
+		scanID = Random.Range(0, 9999).ToString();
 	}
 
-	public void UpdateRecord(string name, float oxyDmg, float burnDmg, float toxinDmg, float bruteDmg, string uniqueIdentifier, CharacterSettings charSettings, int newID, Mind newMind)
+	public void UpdateRecord(LivingHealthBehaviour mob)
 	{
-		Name = name;
-		OxyDmg = oxyDmg;
-		BurnDmg = burnDmg;
-		ToxinDmg = toxinDmg;
-		BruteDmg = bruteDmg;
-		UniqueIdentifier = uniqueIdentifier;
-		characterSettings = charSettings;
-		mobID = newID;
-		mind = newMind;
+		mobID = mob.mobID;
+		var playerScript = mob.GetComponent<PlayerScript>();
+		mind = playerScript.mind;
+		name = playerScript.playerName;
+		characterSettings = playerScript.CharacterSettings;
+		oxyDmg = mob.bloodSystem.oxygenDamage;
+		burnDmg = mob.GetTotalBurnDamage();
+		toxinDmg = 0;
+		bruteDmg = mob.GetTotalBruteDamage();
+		uniqueIdentifier = "35562Eb18150514630991";
 	}
 }

--- a/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
+++ b/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Networking;
 
 /// <summary>
 /// Main component for cloning console
@@ -24,32 +23,45 @@ public class CloningConsole : MonoBehaviour
 
 	public void Scan()
 	{
-		if(scanner && scanner.occupant)
+		if (scanner && scanner.occupant)
 		{
 			var mob = scanner.occupant;
-			var uniqueIdentifier = "35562Eb18150514630991";
-			for (int i = 0; i < CloningRecords.Count; i++)
-			{
-				if(uniqueIdentifier == CloningRecords[i].UniqueIdentifier)
-				{
-					return;
-				}
-			}
-			var name = mob.GetComponent<PlayerScript>().playerName;
+			var mobID = scanner.occupant.mobID;
+			var playerScript = mob.GetComponent<PlayerScript>();
+			var mind = playerScript.mind;
+			var name = playerScript.playerName;
+			var characterSettings = playerScript.CharacterSettings;
 			var oxyDmg = mob.bloodSystem.oxygenDamage;
 			var burnDmg = mob.GetTotalBurnDamage();
 			var toxinDmg = 0;
 			var bruteDmg = mob.GetTotalBruteDamage();
-			CreateRecord(name, oxyDmg, burnDmg, toxinDmg, bruteDmg, uniqueIdentifier);
+			var uniqueIdentifier = "35562Eb18150514630991";
+			for (int i = 0; i < CloningRecords.Count; i++)
+			{
+				var record = CloningRecords[i];
+				if (mobID == record.mobID)
+				{
+					record.UpdateRecord(name, oxyDmg, burnDmg, toxinDmg, bruteDmg, uniqueIdentifier, characterSettings, mobID, mind);
+					return;
+				}
+			}
+			CreateRecord(name, oxyDmg, burnDmg, toxinDmg, bruteDmg, uniqueIdentifier, characterSettings, mobID, mind);
 		}
 	}
 
-	public void CreateRecord(string name, float oxyDmg, float burnDmg, float toxingDmg, float bruteDmg, string uniqueIdentifier)
+	public void Clone(CloningRecord record)
 	{
-		int scanID = Random.Range(0, 1000);
-		var CRone = new CloningRecord(name, scanID, oxyDmg, burnDmg, toxingDmg, bruteDmg, uniqueIdentifier);
-		CloningRecords.Add(CRone);
+		record.mind.ClonePlayer(gameObject, record.characterSettings);
 	}
+
+	private void CreateRecord(string name, float oxyDmg, float burnDmg, float toxinDmg, float bruteDmg, string uniqueIdentifier, CharacterSettings characterSettings, int mobID, Mind mind)
+	{
+
+		var record = new CloningRecord();
+		record.UpdateRecord(name, oxyDmg, burnDmg, toxinDmg, bruteDmg, uniqueIdentifier, characterSettings, mobID, mind);
+		CloningRecords.Add(record);
+	}
+
 }
 
 public class CloningRecord
@@ -58,18 +70,29 @@ public class CloningRecord
 	public string ScanID;
 	public float OxyDmg;
 	public float BurnDmg;
-	public float ToxingDmg;
+	public float ToxinDmg;
 	public float BruteDmg;
 	public string UniqueIdentifier;
+	public CharacterSettings characterSettings;
+	public int mobID;
+	public Mind mind;
 
-	public CloningRecord(string name, int scanID, float oxyDmg, float burnDmg, float toxingDmg, float bruteDmg, string uniqueIdentifier)
+	public CloningRecord()
+	{
+		int scanID = Random.Range(0, 1000);
+		ScanID = scanID.ToString();
+	}
+
+	public void UpdateRecord(string name, float oxyDmg, float burnDmg, float toxinDmg, float bruteDmg, string uniqueIdentifier, CharacterSettings charSettings, int newID, Mind newMind)
 	{
 		Name = name;
-		ScanID = scanID.ToString();
 		OxyDmg = oxyDmg;
 		BurnDmg = burnDmg;
-		ToxingDmg = toxingDmg;
+		ToxinDmg = toxinDmg;
 		BruteDmg = bruteDmg;
 		UniqueIdentifier = uniqueIdentifier;
+		characterSettings = charSettings;
+		mobID = newID;
+		mind = newMind;
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerManager.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerManager.cs
@@ -22,6 +22,8 @@ public class PlayerManager : MonoBehaviour
 
 	public static CharacterSettings CurrentCharacterSettings { get; set; }
 
+	private int mobIDcount;
+
 	public static PlayerManager Instance
 	{
 		get
@@ -96,5 +98,11 @@ public class PlayerManager : MonoBehaviour
 	private void OnPlayerDeath()
 	{
 		EventManager.Broadcast(EVENT.DisableInternals);
+	}
+
+	public int GetMobID()
+	{
+		mobIDcount++;
+		return mobIDcount;
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Cloning/GUI_Cloning.cs
+++ b/UnityProject/Assets/Scripts/UI/Cloning/GUI_Cloning.cs
@@ -102,7 +102,7 @@ public class GUI_Cloning : NetTab
 			recordScanID.SetValue = "Scan ID " + specificRecord.ScanID;
 			recordOxy.SetValue = specificRecord.OxyDmg + "\tOxygen Damage";
 			recordBurn.SetValue = specificRecord.BurnDmg + "\tBurn Damage";
-			recordToxin.SetValue = specificRecord.ToxingDmg + "\tToxin Damage";
+			recordToxin.SetValue = specificRecord.ToxinDmg + "\tToxin Damage";
 			recordBrute.SetValue = specificRecord.BruteDmg + "\tBrute Damage";
 			recordUniqueID.SetValue = specificRecord.UniqueIdentifier;
 		}

--- a/UnityProject/Assets/Scripts/UI/Cloning/GUI_Cloning.cs
+++ b/UnityProject/Assets/Scripts/UI/Cloning/GUI_Cloning.cs
@@ -75,7 +75,7 @@ public class GUI_Cloning : NetTab
 
 	public void Clone()
 	{
-		Logger.Log($"Cloning {specificRecord.Name}", Category.NetUI);
+		Logger.Log($"Cloning {specificRecord.name}", Category.NetUI);
 		RemoveRecord();
 		UpdateDisplay();
 		netPageSwitcher.SetActivePage(PageAllRecords);
@@ -98,13 +98,13 @@ public class GUI_Cloning : NetTab
 	{
 		if(specificRecord != null)
 		{
-			recordName.SetValue = specificRecord.Name;
-			recordScanID.SetValue = "Scan ID " + specificRecord.ScanID;
-			recordOxy.SetValue = specificRecord.OxyDmg + "\tOxygen Damage";
-			recordBurn.SetValue = specificRecord.BurnDmg + "\tBurn Damage";
-			recordToxin.SetValue = specificRecord.ToxinDmg + "\tToxin Damage";
-			recordBrute.SetValue = specificRecord.BruteDmg + "\tBrute Damage";
-			recordUniqueID.SetValue = specificRecord.UniqueIdentifier;
+			recordName.SetValue = specificRecord.name;
+			recordScanID.SetValue = "Scan ID " + specificRecord.scanID;
+			recordOxy.SetValue = specificRecord.oxyDmg + "\tOxygen Damage";
+			recordBurn.SetValue = specificRecord.burnDmg + "\tBurn Damage";
+			recordToxin.SetValue = specificRecord.toxinDmg + "\tToxin Damage";
+			recordBrute.SetValue = specificRecord.bruteDmg + "\tBrute Damage";
+			recordUniqueID.SetValue = specificRecord.uniqueIdentifier;
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/UI/Cloning/GUI_CloningRecordItem.cs
+++ b/UnityProject/Assets/Scripts/UI/Cloning/GUI_CloningRecordItem.cs
@@ -13,8 +13,8 @@ public class GUI_CloningRecordItem : DynamicEntry
 
 	public void SetValues()
 	{
-		recordName.SetValue = cloningRecord.Name;
-		recrodScanID.SetValue = "Scan ID " + cloningRecord.ScanID;
+		recordName.SetValue = cloningRecord.name;
+		recrodScanID.SetValue = "Scan ID " + cloningRecord.scanID;
 	}
 
 	public void ViewRecord()


### PR DESCRIPTION
### Purpose
Adds a serverside mobID.
The cloning console will now create or update the records based on that ID.
Cloning records will now save the player's name, mind and characterSettings.
Renames the variable from cloning records ToxingDmg to ToxinDmg.


### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

