### PR TITLE
Cloning console wrong charactersettings reference fix

### DIFF
--- a/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
+++ b/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
@@ -79,7 +79,7 @@ public class CloningRecord
 		var playerScript = mob.GetComponent<PlayerScript>();
 		mind = playerScript.mind;
 		name = playerScript.playerName;
-		characterSettings = playerScript.CharacterSettings;
+		characterSettings = playerScript.characterSettings;
 		oxyDmg = mob.bloodSystem.oxygenDamage;
 		burnDmg = mob.GetTotalBurnDamage();
 		toxinDmg = 0;


### PR DESCRIPTION
### Purpose
Fixes cloning console from referencing the incorrect characterSettings variable from PlayerScript.

### Open Questions and Pre-Merge TODOs

- [ ]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [ ]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)