### PR TITLE
Cloning pod behaviour and player cloning acceptance

### DIFF
--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/GhostHud.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/UIManager/GhostHud.prefab
@@ -1,5 +1,134 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &87750028717620605
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3158313293057501380}
+  - component: {fileID: 6710286554198401370}
+  - component: {fileID: 820000214959157369}
+  - component: {fileID: 8686764556263563692}
+  m_Layer: 5
+  m_Name: Allow Clone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3158313293057501380
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 87750028717620605}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.30781, y: 1.30781, z: 1.30781}
+  m_Children:
+  - {fileID: 4190382443672369672}
+  m_Father: {fileID: 8098718680817705657}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 400, y: 60}
+  m_SizeDelta: {x: 67.86426, y: 62.724213}
+  m_Pivot: {x: 1, y: 0}
+--- !u!222 &6710286554198401370
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 87750028717620605}
+  m_CullTransparentMesh: 0
+--- !u!114 &820000214959157369
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 87750028717620605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300026, guid: 21eafc120e3d4ad794ffdb4f179af841, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!114 &8686764556263563692
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 87750028717620605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 820000214959157369}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8355319641317481474}
+        m_MethodName: ToggleAllowCloning
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
 --- !u!1 &819786889913424350
 GameObject:
   m_ObjectHideFlags: 0
@@ -384,6 +513,88 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
+--- !u!1 &7324651201055438336
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4190382443672369672}
+  - component: {fileID: 5977574357361724509}
+  - component: {fileID: 2231058000972495106}
+  m_Layer: 5
+  m_Name: text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4190382443672369672
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7324651201055438336}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3158313293057501380}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 28.4, y: -27.8}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5977574357361724509
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7324651201055438336}
+  m_CullTransparentMesh: 0
+--- !u!114 &2231058000972495106
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7324651201055438336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'ALLOW
+
+
+    CLONE'
 --- !u!1 &7798651070204786658
 GameObject:
   m_ObjectHideFlags: 0
@@ -653,7 +864,7 @@ GameObject:
   - component: {fileID: 8101706763436526557}
   - component: {fileID: 8355319641317481474}
   m_Layer: 5
-  m_Name: Hud_Bottom_Ghost
+  m_Name: GhostHud
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -676,6 +887,7 @@ RectTransform:
   - {fileID: 253946668298316641}
   - {fileID: 3246135552328137059}
   - {fileID: 2922954088206612692}
+  - {fileID: 3158313293057501380}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Cryogenic2/DNA_Scanner.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Cryogenic2/DNA_Scanner.prefab
@@ -89,10 +89,11 @@ GameObject:
   m_Component:
   - component: {fileID: 4715117052207926}
   - component: {fileID: 61404138305600890}
-  - component: {fileID: 114818633338735330}
   - component: {fileID: 9128197607768152992}
-  - component: {fileID: 2464575245303528366}
+  - component: {fileID: 114818633338735330}
   - component: {fileID: 114657711786529776}
+  - component: {fileID: 5322609074420117545}
+  - component: {fileID: 2464575245303528366}
   - component: {fileID: 5293454678208234974}
   - component: {fileID: 114532654656294352}
   m_Layer: 11
@@ -143,6 +144,28 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &9128197607768152992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711816394935574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 22bc22136d1c0934491149324f00dded, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DefaultContents: []
+  IsClosed: 0
+  IsLocked: 0
+  lockLight: {fileID: 0}
+  playerLimit: 1
+  statusSync: 0
+  doorOpened: {fileID: 21300012, guid: edb878353e4ae4062978273e8fca40e2, type: 3}
+  spriteRenderer: {fileID: 212360857505739792}
+  occupant: {fileID: 0}
+  closedWithOccupant: {fileID: 21300004, guid: edb878353e4ae4062978273e8fca40e2, type: 3}
 --- !u!114 &114818633338735330
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -176,44 +199,6 @@ MonoBehaviour:
     i15: 0
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &9128197607768152992
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1711816394935574}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 22bc22136d1c0934491149324f00dded, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  DefaultContents: []
-  IsClosed: 0
-  IsLocked: 0
-  lockLight: {fileID: 0}
-  playerLimit: 1
-  statusSync: 0
-  doorOpened: {fileID: 21300012, guid: edb878353e4ae4062978273e8fca40e2, type: 3}
-  spriteRenderer: {fileID: 212360857505739792}
-  occupant: {fileID: 0}
-  closedWithOccupant: {fileID: 21300004, guid: edb878353e4ae4062978273e8fca40e2, type: 3}
---- !u!114 &2464575245303528366
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1711816394935574}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc4af3ee3e2140f79050f19644af5e8d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ObjectType: 1
-  AtmosPassable: 1
-  Passable: 0
-  closetType: 0
 --- !u!114 &114657711786529776
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -226,6 +211,41 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &5322609074420117545
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711816394935574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ignoredSpriteRenderers: []
+  registerTile: {fileID: 0}
+  visibleState: 1
+  isNotPushable: 1
+  closetHandlerCache: {fileID: 0}
+  parentContainer: {fileID: 0}
+--- !u!114 &2464575245303528366
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711816394935574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc4af3ee3e2140f79050f19644af5e8d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  layer: {fileID: 0}
+  ObjectType: 1
+  AtmosPassable: 1
+  Passable: 0
+  closetType: 0
 --- !u!114 &5293454678208234974
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/cloning_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/cloning_0.prefab
@@ -89,12 +89,13 @@ GameObject:
   m_Component:
   - component: {fileID: 4083625178683586}
   - component: {fileID: 61870206456321914}
-  - component: {fileID: 61140193105072512}
+  - component: {fileID: 8210323885322932869}
   - component: {fileID: 114702847724008018}
-  - component: {fileID: 114854167501777618}
+  - component: {fileID: 3673450989709832100}
   - component: {fileID: 114793930797753706}
   - component: {fileID: 114465014309967340}
   - component: {fileID: 114272959470978344}
+  - component: {fileID: 934759992999344732}
   m_Layer: 11
   m_Name: cloning_0
   m_TagString: Untagged
@@ -143,32 +144,22 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!61 &61140193105072512
-BoxCollider2D:
+--- !u!114 &8210323885322932869
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1671969700958660}
   m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9111f55ba241daa4eb1492b439c76197, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  statusSync: 0
+  spriteRenderer: {fileID: 212392876378255176}
+  cloningSprite: {fileID: 21300002, guid: 81e026231754b4cef89ed568b7af049e, type: 3}
+  emptySprite: {fileID: 21300000, guid: 81e026231754b4cef89ed568b7af049e, type: 3}
 --- !u!114 &114702847724008018
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -202,7 +193,7 @@ MonoBehaviour:
     i15: 0
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114854167501777618
+--- !u!114 &3673450989709832100
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -211,10 +202,15 @@ MonoBehaviour:
   m_GameObject: {fileID: 1671969700958660}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 58b822814682f460baa30059c4fd7f42, type: 3}
+  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Message: Tube not connected correctly...
+  ignoredSpriteRenderers: []
+  registerTile: {fileID: 0}
+  visibleState: 1
+  isNotPushable: 1
+  closetHandlerCache: {fileID: 0}
+  parentContainer: {fileID: 0}
 --- !u!114 &114793930797753706
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -227,6 +223,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9a459a0316cc4d5b87d046f28dc136c8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  layer: {fileID: 0}
   ObjectType: 1
   AtmosPassable: 1
   Passable: 0
@@ -255,3 +252,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+--- !u!114 &934759992999344732
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1671969700958660}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d54c3d183673c904882b6d1e8484ca73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nameOverride: 
+  backgroundColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  iconOverride: {fileID: 0}
+  backgroundSprite: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -23,16 +23,16 @@ public static class SpawnHandler
 	{
 		GameObject player = CreateMob(spawnSpot, CustomNetworkManager.Instance.humanPlayerPrefab);
 		TransferPlayer(conn, playerControllerId, player, oldBody, EVENT.PlayerSpawned, characterSettings);
+		var playerScript = player.GetComponent<PlayerScript>();
+		var oldPlayerScript = oldBody.GetComponent<PlayerScript>();
+		oldPlayerScript.mind.SetNewBody(playerScript);
 	}
 
 	public static void RespawnPlayer(NetworkConnection conn, short playerControllerId, JobType jobType, CharacterSettings characterSettings, GameObject oldBody)
 	{
 		GameObject player = CreatePlayer(jobType);
 		TransferPlayer(conn, playerControllerId, player, oldBody, EVENT.PlayerSpawned, characterSettings);
-		var playerScript = player.GetComponent<PlayerScript>();
-		playerScript.mind = new Mind();
-		playerScript.mind.body = playerScript;
-		playerScript.mind.jobType = jobType;
+		new Mind(player, jobType);
 		var equipment = player.GetComponent<Equipment>();
 		equipment.SetPlayerLoadOuts();
 	}

--- a/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
+++ b/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
@@ -12,6 +12,7 @@ public class CloningConsole : MonoBehaviour
 
 	public List<CloningRecord> CloningRecords = new List<CloningRecord>();
 	public DNAscanner scanner;
+	public CloningPod cloningPod;
 
 	public void ToggleLock()
 	{
@@ -40,9 +41,16 @@ public class CloningConsole : MonoBehaviour
 		}
 	}
 
-	public void Clone(CloningRecord record)
+	public void TryClone(CloningRecord record)
 	{
-		record.mind.ClonePlayer(gameObject, record.characterSettings);
+		if (cloningPod && cloningPod.CanClone())
+		{
+			if(record.mind.ConfirmClone())
+			{
+				cloningPod.StartCloning(record);
+				CloningRecords.Remove(record);
+			}
+		}
 	}
 
 	private void CreateRecord(LivingHealthBehaviour mob)

--- a/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
+++ b/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
@@ -28,16 +28,21 @@ public class CloningConsole : MonoBehaviour
 		{
 			var mob = scanner.occupant;
 			var mobID = scanner.occupant.mobID;
+			var playerScript = mob.GetComponent<PlayerScript>();
+			if(playerScript.mind.bodyMobID != mobID)
+			{
+				return;
+			}
 			for (int i = 0; i < CloningRecords.Count; i++)
 			{
 				var record = CloningRecords[i];
 				if (mobID == record.mobID)
 				{
-					record.UpdateRecord(mob);
+					record.UpdateRecord(mob, playerScript);
 					return;
 				}
 			}
-			CreateRecord(mob);
+			CreateRecord(mob, playerScript);
 		}
 	}
 
@@ -45,7 +50,7 @@ public class CloningConsole : MonoBehaviour
 	{
 		if (cloningPod && cloningPod.CanClone())
 		{
-			if(record.mind.ConfirmClone())
+			if(record.mind.ConfirmClone(record.mobID))
 			{
 				cloningPod.StartCloning(record);
 				CloningRecords.Remove(record);
@@ -53,11 +58,10 @@ public class CloningConsole : MonoBehaviour
 		}
 	}
 
-	private void CreateRecord(LivingHealthBehaviour mob)
+	private void CreateRecord(LivingHealthBehaviour mob, PlayerScript playerScript)
 	{
-
 		var record = new CloningRecord();
-		record.UpdateRecord(mob);
+		record.UpdateRecord(mob, playerScript);
 		CloningRecords.Add(record);
 	}
 
@@ -81,10 +85,9 @@ public class CloningRecord
 		scanID = Random.Range(0, 9999).ToString();
 	}
 
-	public void UpdateRecord(LivingHealthBehaviour mob)
+	public void UpdateRecord(LivingHealthBehaviour mob, PlayerScript playerScript)
 	{
 		mobID = mob.mobID;
-		var playerScript = mob.GetComponent<PlayerScript>();
 		mind = playerScript.mind;
 		name = playerScript.playerName;
 		characterSettings = playerScript.characterSettings;

--- a/UnityProject/Assets/Scripts/Medical/CloningPod.cs
+++ b/UnityProject/Assets/Scripts/Medical/CloningPod.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+
+public class CloningPod : NetworkBehaviour
+{
+	[SyncVar(hook = nameof(SyncSprite))] public CloningPodStatus statusSync;
+	public SpriteRenderer spriteRenderer;
+	public Sprite cloningSprite;
+	public Sprite emptySprite;
+
+	public enum CloningPodStatus
+	{
+		Empty,
+		Cloning
+	}
+
+	public override void OnStartClient()
+	{
+		SyncSprite(statusSync);
+	}
+
+	public void StartCloning(CloningRecord record)
+	{
+		statusSync = CloningPodStatus.Cloning;
+		StartCoroutine(ProcessCloning(record));
+	}
+
+	private IEnumerator ProcessCloning(CloningRecord record)
+	{
+		yield return WaitFor.Seconds(10f);
+		if(record.mind.IsOnline(record.mind.GetCurrentMob()))
+		{
+			record.mind.ClonePlayer(gameObject, record.characterSettings);
+		}
+		statusSync = CloningPodStatus.Empty;
+	}
+
+	public bool CanClone()
+	{
+		if(statusSync == CloningPodStatus.Cloning)
+		{
+			return false;
+		}
+		else
+		{
+			return true;
+		}
+
+	}
+
+	public void SyncSprite(CloningPodStatus value)
+	{
+		statusSync = value;
+		if (value == CloningPodStatus.Empty)
+		{
+			spriteRenderer.sprite = emptySprite;
+		}
+		else
+		{
+			spriteRenderer.sprite = cloningSprite;
+		}
+	}
+
+}

--- a/UnityProject/Assets/Scripts/Medical/CloningPod.cs.meta
+++ b/UnityProject/Assets/Scripts/Medical/CloningPod.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9111f55ba241daa4eb1492b439c76197
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -13,13 +13,28 @@ public class Mind
 	public PlayerScript body;
 	public bool IsGhosting;
 	public bool DenyCloning;
+	public int bodyMobID;
+
+	public Mind(GameObject player, JobType newJobType)
+	{
+		jobType = newJobType;
+		var playerScript = player.GetComponent<PlayerScript>();
+		SetNewBody(playerScript);
+	}
+
+	public void SetNewBody(PlayerScript playerScript){
+		playerScript.mind = this;
+		body = playerScript;
+		bodyMobID = playerScript.GetComponent<LivingHealthBehaviour>().mobID;
+		StopGhosting();
+	}
 
 	public void ClonePlayer(GameObject spawnPoint, CharacterSettings characterSettings)
 	{
 		GameObject oldBody = GetCurrentMob();
 		var connection = oldBody.GetComponent<NetworkIdentity>().connectionToClient;
 		var playerID = oldBody.GetComponent<NetworkBehaviour>().playerControllerId;
-		//SpawnHandler.ClonePlayer(connection, playerID, jobType, characterSettings, oldBody, spawnPoint);
+		SpawnHandler.ClonePlayer(connection, playerID, jobType, characterSettings, oldBody, spawnPoint);
 	}
 
 	public GameObject GetCurrentMob()
@@ -42,13 +57,16 @@ public class Mind
 		ghost = PS;
 	}
 
-	public void ReturnToBody()
+	public void StopGhosting()
 	{
 		IsGhosting = false;
 	}
 
-	public bool ConfirmClone()
+	public bool ConfirmClone(int recordMobID)
 	{
+		if(bodyMobID != recordMobID){  //an old record might still exist even after several body swaps
+			return false;
+		}
 		if(DenyCloning)
 		{
 			return false;

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -12,21 +12,26 @@ public class Mind
 	public PlayerScript ghost;
 	public PlayerScript body;
 	public bool IsGhosting;
+	public bool DenyCloning;
 
 	public void ClonePlayer(GameObject spawnPoint, CharacterSettings characterSettings)
 	{
-		GameObject oldBody;
-		if(IsGhosting)
-		{
-			oldBody = ghost.gameObject;
-		}
-		else
-		{
-			oldBody = body.gameObject;
-		}
+		GameObject oldBody = GetCurrentMob();
 		var connection = oldBody.GetComponent<NetworkIdentity>().connectionToClient;
 		var playerID = oldBody.GetComponent<NetworkBehaviour>().playerControllerId;
 		//SpawnHandler.ClonePlayer(connection, playerID, jobType, characterSettings, oldBody, spawnPoint);
+	}
+
+	public GameObject GetCurrentMob()
+	{
+		if (IsGhosting)
+		{
+			return ghost.gameObject;
+		}
+		else
+		{
+			return body.gameObject;
+		}
 	}
 
 	public void Ghosting(GameObject newGhost)
@@ -40,5 +45,38 @@ public class Mind
 	public void ReturnToBody()
 	{
 		IsGhosting = false;
+	}
+
+	public bool ConfirmClone()
+	{
+		if(DenyCloning)
+		{
+			return false;
+		}
+		var currentMob = GetCurrentMob();
+		if(!IsGhosting)
+		{
+			var livingHealthBehaviour = currentMob.GetComponent<LivingHealthBehaviour>();
+			if(!livingHealthBehaviour.IsDead)
+			{
+				return false;
+			}
+		}
+		if(!IsOnline(currentMob))
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	public bool IsOnline(GameObject currentMob)
+	{
+		NetworkConnection connection = currentMob.GetComponent<NetworkIdentity>().connectionToClient;
+		if (PlayerList.Instance.ContainsConnection(connection) == false)
+		{
+			return false;
+		}
+		return true;
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -742,7 +742,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	[Command]
 	public void CmdEnterBody()
 	{
-		playerScript.mind.ReturnToBody();
+		playerScript.mind.StopGhosting();
 		var body = playerScript.mind.body.gameObject;
 		SpawnHandler.TransferPlayer(connectionToClient, playerControllerId, body, gameObject, EVENT.PlayerSpawned, null);
 		body.GetComponent<PlayerScript>().playerNetworkActions.ReenterBodyUpdates(body);

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -714,6 +714,12 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		}
 	}
 
+	[Command]
+	public void CmdToggleAllowCloning()
+	{
+		playerScript.mind.DenyCloning = !playerScript.mind.DenyCloning;
+	}
+
 	/// <summary>
 	/// Spawn the ghost for this player and tell the client to switch input / camera to it
 	/// </summary>

--- a/UnityProject/Assets/Scripts/UI/Cloning/GUI_Cloning.cs
+++ b/UnityProject/Assets/Scripts/UI/Cloning/GUI_Cloning.cs
@@ -75,8 +75,7 @@ public class GUI_Cloning : NetTab
 
 	public void Clone()
 	{
-		Logger.Log($"Cloning {specificRecord.name}", Category.NetUI);
-		RemoveRecord();
+		CloningConsole.TryClone(specificRecord);
 		UpdateDisplay();
 		netPageSwitcher.SetActivePage(PageAllRecords);
 	}

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_GhostOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_GhostOptions.cs
@@ -29,4 +29,9 @@ public class UI_GhostOptions : MonoBehaviour
 	{
 		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRespawnPlayer();
 	}
+
+	public void ToggleAllowCloning()
+	{
+		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdToggleAllowCloning();
+	}
 }


### PR DESCRIPTION
### Purpose
Adds an objectBehaviour component to the cloning pod and DNA scanner.
Adds a button to ghost UI to toggle the acceptance of being cloned.
Cloning will now check if the player is dead, online and if they accept the cloning.
Adds a reference to the cloning pod for the cloning console.
Adds the CloningPod class, it'll be used to determined the spawn location of the cloned mobs and it changes its sprite depending on the status of the cloning process.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)