### PR TITLE
Fix chat window not closing

### DIFF
--- a/UnityProject/Assets/Scripts/UI/ControlChat.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlChat.cs
@@ -129,14 +129,11 @@ public class ControlChat : MonoBehaviour
 
 		if (UIManager.IsInputFocus && KeyboardInputManager.IsEnterPressed())
 		{
-			if (KeyboardInputManager.IsEnterPressed())
+			if (!string.IsNullOrEmpty(InputFieldChat.text.Trim()))
 			{
-				if (!string.IsNullOrEmpty(InputFieldChat.text.Trim()))
-				{
-					PlayerSendChat();
-				}
-				CloseChatWindow();
+				PlayerSendChat();
 			}
+			CloseChatWindow();
 		}
 
 		if (!chatInputWindow.activeInHierarchy) return;

--- a/UnityProject/Assets/Scripts/UI/ControlChat.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlChat.cs
@@ -127,7 +127,7 @@ public class ControlChat : MonoBehaviour
 			RefreshChannelPanel();
 		}
 
-		if (UIManager.IsInputFocus)
+		if (UIManager.IsInputFocus && KeyboardInputManager.IsEnterPressed())
 		{
 			if (KeyboardInputManager.IsEnterPressed())
 			{

--- a/UnityProject/Assets/Scripts/UI/ControlChat.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlChat.cs
@@ -73,7 +73,6 @@ public class ControlChat : MonoBehaviour
 	/// Are the channel toggles on show?
 	/// </summary>
 	private bool showChannels = false;
-	private bool debounceCloseChat = false;
 
 	private void Awake()
 	{
@@ -118,8 +117,6 @@ public class ControlChat : MonoBehaviour
 
 	private void Update()
 	{
-		debounceCloseChat = false;
-
 		// TODO add events to inventory slot changes to trigger channel refresh
 		if (chatInputWindow.activeInHierarchy && !isChannelListUpToDate())
 		{
@@ -225,11 +222,6 @@ public class ControlChat : MonoBehaviour
 	/// <param name="selectedChannel">The chat channels to select when opening it</param>
 	public void OpenChatWindow (ChatChannel selectedChannel = ChatChannel.None)
 	{
-		// Prevent the chat opening on the same frame as it was closed
-		if (debounceCloseChat) {
-			return;
-		}
-
 		// Can't open chat window while main menu open
 		if (GUI_IngameMenu.Instance.mainIngameMenu.activeInHierarchy)
 		{
@@ -268,7 +260,6 @@ public class ControlChat : MonoBehaviour
 		chatInputWindow.SetActive(false);
 		EventManager.Broadcast(EVENT.ChatUnfocused);
 		background.SetActive(false);
-		debounceCloseChat = true;
 	}
 
 	/// <summary>


### PR DESCRIPTION
### Purpose
The chat window would never close when I pressed enter or submitted a message, because the event that opens it because enter was pressed occurred later. I didn't find an issue about it, though.
Also, this change makes pressing enter without a message close the chat.


### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
