### PR TITLE
Adds RequireComponents to ItemAttributes.cs

### DIFF
--- a/UnityProject/Assets/Prefabs/Items/Other/Resources/Emergency Oxygen Tank.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/Resources/Emergency Oxygen Tank.prefab
@@ -90,13 +90,13 @@ GameObject:
   - component: {fileID: 4370604793044084}
   - component: {fileID: 61625481682341612}
   - component: {fileID: 114277704357941144}
-  - component: {fileID: 114651414057651298}
   - component: {fileID: 114342755618585978}
   - component: {fileID: 114288380597099474}
   - component: {fileID: 114267664904661214}
   - component: {fileID: 114330809230976920}
   - component: {fileID: 3305593915559126072}
   - component: {fileID: 114896479765772544}
+  - component: {fileID: 114892250899287116}
   m_Layer: 10
   m_Name: Emergency Oxygen Tank
   m_TagString: Untagged
@@ -178,21 +178,6 @@ MonoBehaviour:
     i15: 0
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114651414057651298
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1277678737481138}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9a459a0316cc4d5b87d046f28dc136c8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ObjectType: 0
-  AtmosPassable: 1
-  Passable: 1
 --- !u!114 &114342755618585978
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -303,3 +288,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+--- !u!114 &114892250899287116
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1277678737481138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  layer: {fileID: 0}
+  ObjectType: 0
+  crossed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

--- a/UnityProject/Assets/Prefabs/Items/Other/Resources/Oxygen Tank.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/Resources/Oxygen Tank.prefab
@@ -90,13 +90,13 @@ GameObject:
   - component: {fileID: 4370604793044084}
   - component: {fileID: 61625481682341612}
   - component: {fileID: 114277704357941144}
-  - component: {fileID: 114651414057651298}
   - component: {fileID: 114342755618585978}
   - component: {fileID: 114288380597099474}
   - component: {fileID: 114267664904661214}
   - component: {fileID: 114330809230976920}
   - component: {fileID: 3305593915559126072}
   - component: {fileID: 114892679667736192}
+  - component: {fileID: 114550202335981176}
   m_Layer: 10
   m_Name: Oxygen Tank
   m_TagString: Untagged
@@ -178,21 +178,6 @@ MonoBehaviour:
     i15: 0
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114651414057651298
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1277678737481138}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9a459a0316cc4d5b87d046f28dc136c8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ObjectType: 0
-  AtmosPassable: 1
-  Passable: 1
 --- !u!114 &114342755618585978
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -302,3 +287,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+--- !u!114 &114550202335981176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1277678737481138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  layer: {fileID: 0}
+  ObjectType: 0
+  crossed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

--- a/UnityProject/Assets/Prefabs/Items/Other/Resources/Paper.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/Resources/Paper.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 4222321654889152}
   - component: {fileID: 61178295307230726}
   - component: {fileID: 114280203122771016}
-  - component: {fileID: 114812256408381122}
   - component: {fileID: 114680268422892540}
   - component: {fileID: 114646101893439272}
   - component: {fileID: 114741019056190926}
@@ -19,6 +18,7 @@ GameObject:
   - component: {fileID: 114559639511531318}
   - component: {fileID: 114930140412175382}
   - component: {fileID: 114414318728299190}
+  - component: {fileID: 114455083295167806}
   m_Layer: 10
   m_Name: Paper
   m_TagString: Untagged
@@ -100,21 +100,6 @@ MonoBehaviour:
     i15: 0
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114812256408381122
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1320386684021000}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9a459a0316cc4d5b87d046f28dc136c8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ObjectType: 0
-  AtmosPassable: 1
-  Passable: 1
 --- !u!114 &114680268422892540
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -234,6 +219,24 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+--- !u!114 &114455083295167806
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1320386684021000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  layer: {fileID: 0}
+  ObjectType: 0
+  crossed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 --- !u!1 &1731708282254700
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Prefabs/Items/Other/Resources/Pen.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Other/Resources/Pen.prefab
@@ -90,13 +90,13 @@ GameObject:
   - component: {fileID: 4370604793044084}
   - component: {fileID: 61625481682341612}
   - component: {fileID: 114277704357941144}
-  - component: {fileID: 114651414057651298}
   - component: {fileID: 114342755618585978}
   - component: {fileID: 114288380597099474}
   - component: {fileID: 114267664904661214}
   - component: {fileID: 114330809230976920}
   - component: {fileID: 114779724774409168}
   - component: {fileID: 114694305165720408}
+  - component: {fileID: 114561525083604656}
   m_Layer: 10
   m_Name: Pen
   m_TagString: Untagged
@@ -178,21 +178,6 @@ MonoBehaviour:
     i15: 0
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &114651414057651298
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1277678737481138}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9a459a0316cc4d5b87d046f28dc136c8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ObjectType: 0
-  AtmosPassable: 1
-  Passable: 1
 --- !u!114 &114342755618585978
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -293,3 +278,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+--- !u!114 &114561525083604656
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1277678737481138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  layer: {fileID: 0}
+  ObjectType: 0
+  crossed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/AirVent.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/AirVent.prefab
@@ -18,6 +18,7 @@ GameObject:
   - component: {fileID: 966013011358701611}
   - component: {fileID: 6479037130962053368}
   - component: {fileID: 114247328083268004}
+  - component: {fileID: 114207068481858528}
   m_Layer: 10
   m_Name: AirVent
   m_TagString: Untagged
@@ -208,6 +209,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  layer: {fileID: 0}
   ObjectType: 0
   crossed:
     m_PersistentCalls:
@@ -226,6 +228,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+--- !u!114 &114207068481858528
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000010733523080}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnDropServer:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
 --- !u!1 &8513106460640881890
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
@@ -8,7 +8,6 @@ using UnityEngine.Networking;
 using UnityEngine.Serialization;
 using Random = System.Random;
 
-[RequireComponent(typeof(NetworkIdentity))]
 [RequireComponent(typeof(Pickupable))]
 [RequireComponent(typeof(ObjectBehaviour))]
 [RequireComponent(typeof(RegisterItem))]

--- a/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
@@ -8,7 +8,12 @@ using UnityEngine.Networking;
 using UnityEngine.Serialization;
 using Random = System.Random;
 
+[RequireComponent(typeof(NetworkIdentity))]
+[RequireComponent(typeof(Pickupable))]
 [RequireComponent(typeof(ObjectBehaviour))]
+[RequireComponent(typeof(RegisterItem))]
+[RequireComponent(typeof(CustomNetTransform))]
+[RequireComponent(typeof(SpriteMatrixRotation))]
 public class ItemAttributes : NetworkBehaviour, IRightClickable
 {
 	private const string MaskInternalsFlag = "MASKINTERNALS";


### PR DESCRIPTION
### Purpose
Added these:
```cs
[RequireComponent(typeof(NetworkIdentity))]
[RequireComponent(typeof(Pickupable))]
[RequireComponent(typeof(ObjectBehaviour))]
[RequireComponent(typeof(RegisterItem))]
[RequireComponent(typeof(CustomNetTransform))]
[RequireComponent(typeof(SpriteMatrixRotation))]
```

Updated some prefabs that were missing RegisterItem and made sure to remove RegisterObject from them too:

![](https://media.discordapp.net/attachments/443317202179981322/593939609734610944/unknown.png)


### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
