### PR TITLE
Fixes death UI interaction not going off if the health number is below -100.

### DIFF
--- a/UnityProject/Assets/Scripts/UI/UI_HeartMonitor.cs
+++ b/UnityProject/Assets/Scripts/UI/UI_HeartMonitor.cs
@@ -140,7 +140,7 @@ public class UI_HeartMonitor : MonoBehaviour
 			overlayCrits.SetState(OverlayState.crit);
 		}
 
-		if (overallHealthCache == -100 &&
+		if (overallHealthCache <= -100 &&
 			spriteStart != deathStart)
 		{
 			SoundManager.Stop("Critstate");


### PR DESCRIPTION
### Purpose
Fixes death UI interaction not going off if the health number is below -100.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

