### PR TITLE
Removes the reference of an old body to the client inside TransferPlayer()

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -64,6 +64,7 @@ public static class SpawnHandler
 		{
 			PlayerList.Instance.UpdatePlayer(conn, newBody);
 			NetworkServer.ReplacePlayerForConnection(conn, newBody, playerControllerId);
+			NetworkServer.ReplacePlayerForConnection(new NetworkConnection(), oldBody, 0);
 			TriggerEventMessage.Send(newBody, eventType);
 		}
 		var playerScript = newBody.GetComponent<PlayerScript>();


### PR DESCRIPTION
### Purpose
Removes the reference of an old body to the client inside TransferPlayer()

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
I do not believe this is the correct way of doing this, and it will bring up a warning on each body transfer. I don't know how to properly remove the reference.