### PR TITLE
DNA scanner drag and drop

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V3(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V3(uNet).prefab
@@ -785,6 +785,10 @@ MonoBehaviour:
     socksCollectionIndex: 3
     headSpriteIndex: 20
     torsoSpriteIndex: 28
+    rightLegSpriteIndex: 12
+    leftLegSpriteIndex: 16
+    rightArmSpriteIndex: 4
+    leftArmSpriteIndex: 8
   playerName: ' '
 --- !u!114 &114285118255153820
 MonoBehaviour:
@@ -910,8 +914,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 91ec24547a834ed59569affa30e7249b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mobID: 0
   maxHealth: 100
+  cloningDamage: 0
   bloodSystem: {fileID: 0}
   brainSystem: {fileID: 0}
   respiratorySystem: {fileID: 0}
@@ -1075,7 +1079,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dropLayers:
     serializedVersion: 2
-    m_Bits: 553666560
+    m_Bits: 553667584
   shadow: {fileID: 21300750, guid: edb6a9bb8c0d64b80953e48ba732f4e9, type: 3}
   draggerMustBeAdjacent: 1
   allowDragWhileSoftCrit: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Cryogenic2/DNA_Scanner.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Cryogenic2/DNA_Scanner.prefab
@@ -157,7 +157,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   DefaultContents: []
-  IsClosed: 0
+  IsClosed: 1
   IsLocked: 0
   lockLight: {fileID: 0}
   playerLimit: 1
@@ -166,6 +166,7 @@ MonoBehaviour:
   spriteRenderer: {fileID: 212360857505739792}
   occupant: {fileID: 0}
   closedWithOccupant: {fileID: 21300004, guid: edb878353e4ae4062978273e8fca40e2, type: 3}
+  statusString: 
 --- !u!114 &114818633338735330
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -9,7 +9,7 @@ using UnityEngine.Networking;
 /// Allows closet to be opened / closed / locked
 /// </summary>
 [RequireComponent(typeof(RightClickAppearance))]
-public class ClosetControl : NBHandApplyInteractable, IRightClickable
+public class ClosetControl : NBMouseDropHandApplyInteractable, IRightClickable
 {
 	[Header("Contents that will spawn inside every locker of type")]
 	public List<GameObject> DefaultContents;
@@ -121,7 +121,7 @@ public class ClosetControl : NBHandApplyInteractable, IRightClickable
 		}
 	}
 
-	private void ChangeSprite()
+	public void ChangeSprite()
 	{
 		if(IsClosed)
 		{
@@ -208,6 +208,11 @@ public class ClosetControl : NBHandApplyInteractable, IRightClickable
 		if (interaction.TargetObject != gameObject) return false;
 
 		return true;
+	}
+
+	protected override void ServerPerformInteraction(MouseDrop interaction)
+	{
+
 	}
 
 	protected override void ServerPerformInteraction(HandApply interaction)
@@ -305,19 +310,24 @@ public class ClosetControl : NBHandApplyInteractable, IRightClickable
 				return;
 			}
 			mobsIndex++;
-			heldPlayers.Add(player);
-			var playerScript = player.GetComponent<PlayerScript>();
-			var playerSync = playerScript.PlayerSync;
+			StorePlayer(player);
+		}
+	}
 
-			player.visibleState = false;
-			player.parentContainer = objectBehaviour;
-			playerSync.DisappearFromWorldServer();
-			//Make sure a ClosetPlayerHandler is created on the client to monitor
-			//the players input inside the storage. The handler also controls the camera follow targets:
-			if (!playerScript.IsGhost)
-			{
-				ClosetHandlerMessage.Send(player.gameObject, gameObject);
-			}
+	public void StorePlayer(ObjectBehaviour player)
+	{
+		heldPlayers.Add(player);
+		var playerScript = player.GetComponent<PlayerScript>();
+		var playerSync = playerScript.PlayerSync;
+
+		player.visibleState = false;
+		player.parentContainer = objectBehaviour;
+		playerSync.DisappearFromWorldServer();
+		//Make sure a ClosetPlayerHandler is created on the client to monitor
+		//the players input inside the storage. The handler also controls the camera follow targets:
+		if (!playerScript.IsGhost)
+		{
+			ClosetHandlerMessage.Send(player.gameObject, gameObject);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBMouseDropHandApplyInteractable.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBMouseDropHandApplyInteractable.cs
@@ -1,0 +1,122 @@
+
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+/// <summary>
+/// Version of Interactable which supports MouseDrop and extends NetworkBehavior rather than MonoBehavior
+/// </summary>
+public abstract class NBMouseDropHandApplyInteractable
+	: NetworkBehaviour, IInteractable<MouseDrop>, IInteractionProcessor<MouseDrop>, IInteractable<HandApply>, IInteractionProcessor<HandApply>
+{
+	//we delegate our interaction logic to this.
+	private InteractionCoordinator<MouseDrop> coordinatorMouseDrop;
+	private InteractionCoordinator<HandApply> coordinatorHandApply;
+
+	protected void Start()
+	{
+		EnsureCoordinatorInit();
+	}
+
+	private void EnsureCoordinatorInit()
+	{
+		if (coordinatorMouseDrop == null)
+		{
+			coordinatorMouseDrop = new InteractionCoordinator<MouseDrop>(this,  WillInteract, ServerPerformInteraction);
+		}
+		if (coordinatorHandApply == null)
+		{
+			coordinatorHandApply = new InteractionCoordinator<HandApply>(this, WillInteract, ServerPerformInteraction);
+		}
+	}
+
+
+	/// <summary>
+	/// Decides if interaction logic should proceed. On client side, the interaction
+	/// request will only be sent to the server if this returns true. On server side,
+	/// the interaction will only be performed if this returns true.
+	///
+	/// Each interaction has a default implementation of this which should apply for most cases.
+	/// By overriding this and adding more specific logic, you can reduce the amount of messages
+	/// sent by the client to the server, decreasing overall network load.
+	/// </summary>
+	/// <param name="interaction">interaction to validate</param>
+	/// <param name="side">which side of the network this is being invoked on</param>
+	/// <returns>True/False based on whether the interaction logic should proceed as described above.</returns>
+	protected virtual bool WillInteract(MouseDrop interaction, NetworkSide side)
+	{
+		return DefaultWillInteract.Default(interaction, side);
+	}
+
+	/// <summary>
+	/// Server-side. Called after validation succeeds on server side.
+	/// Server should perform the interaction and inform clients as needed.
+	/// </summary>
+	/// <param name="interaction"></param>
+	protected abstract void ServerPerformInteraction(MouseDrop interaction);
+
+	/// <summary>
+	/// Client-side prediction. Called after validation succeeds on client side.
+	/// Client can perform client side prediction. NOT invoked for server player, since there is no need
+	/// for prediction.
+	/// </summary>
+	/// <param name="interaction"></param>
+	protected virtual void ClientPredictInteraction(MouseDrop interaction) { }
+
+	public bool Interact(MouseDrop info)
+	{
+		EnsureCoordinatorInit();
+		return InteractionComponentUtils.CoordinatedInteract(info, coordinatorMouseDrop, ClientPredictInteraction);
+	}
+
+	public bool ServerProcessInteraction(MouseDrop info)
+	{
+		EnsureCoordinatorInit();
+		UnityEngine.Debug.Log("ServerProcessInteraction");
+		return InteractionComponentUtils.ServerProcessCoordinatedInteraction(info, coordinatorMouseDrop);
+	}
+
+	/// <summary>
+	/// Decides if interaction logic should proceed. On client side, the interaction
+	/// request will only be sent to the server if this returns true. On server side,
+	/// the interaction will only be performed if this returns true.
+	///
+	/// Each interaction has a default implementation of this which should apply for most cases.
+	/// By overriding this and adding more specific logic, you can reduce the amount of messages
+	/// sent by the client to the server, decreasing overall network load.
+	/// </summary>
+	/// <param name="interaction">interaction to validate</param>
+	/// <param name="side">which side of the network this is being invoked on</param>
+	/// <returns>True/False based on whether the interaction logic should proceed as described above.</returns>
+	protected virtual bool WillInteract(HandApply interaction, NetworkSide side)
+	{
+		return DefaultWillInteract.Default(interaction, side);
+	}
+
+	/// <summary>
+	/// Server-side. Called after validation succeeds on server side.
+	/// Server should perform the interaction and inform clients as needed.
+	/// </summary>
+	/// <param name="interaction"></param>
+	protected abstract void ServerPerformInteraction(HandApply interaction);
+
+	/// <summary>
+	/// Client-side prediction. Called after validation succeeds on client side.
+	/// Client can perform client side prediction. NOT invoked for server player, since there is no need
+	/// for prediction.
+	/// </summary>
+	/// <param name="interaction"></param>
+	protected virtual void ClientPredictInteraction(HandApply interaction) { }
+
+	public bool Interact(HandApply info)
+	{
+		EnsureCoordinatorInit();
+		return InteractionComponentUtils.CoordinatedInteract(info, coordinatorHandApply, ClientPredictInteraction);
+	}
+
+	public bool ServerProcessInteraction(HandApply info)
+	{
+		EnsureCoordinatorInit();
+		return InteractionComponentUtils.ServerProcessCoordinatedInteraction(info, coordinatorHandApply);
+	}
+}

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBMouseDropHandApplyInteractable.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBMouseDropHandApplyInteractable.cs
@@ -72,7 +72,6 @@ public abstract class NBMouseDropHandApplyInteractable
 	public bool ServerProcessInteraction(MouseDrop info)
 	{
 		EnsureCoordinatorInit();
-		UnityEngine.Debug.Log("ServerProcessInteraction");
 		return InteractionComponentUtils.ServerProcessCoordinatedInteraction(info, coordinatorMouseDrop);
 	}
 

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBMouseDropHandApplyInteractable.cs.meta
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBMouseDropHandApplyInteractable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5620aa0ed521d1b479d3ca8212440b1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/Validations.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/Validations.cs
@@ -49,7 +49,17 @@ public static class Validations
 		return obj1.TileWorldPosition() == obj2.TileWorldPosition();
 	}
 
-
+	public static bool IsAdjacent(GameObject obj1, GameObject obj2)
+	{
+		var dir1 = obj1.TileWorldPosition();
+		var dir2 = obj2.TileWorldPosition();
+		if(Mathf.Abs(dir1.x - dir2.x) <= 1 && Mathf.Abs(dir1.y - dir2.y) <= 1)
+		{
+			return true;
+		}
+		//TODO: check if there's a one sided window or something alike blocking
+		return false;
+	}
 
 	/// <summary>
 	/// Checks if a player is allowed to interact with things (based on this player's status, such

--- a/UnityProject/Assets/Scripts/Medical/DNAscanner.cs
+++ b/UnityProject/Assets/Scripts/Medical/DNAscanner.cs
@@ -27,6 +27,26 @@ public class DNAscanner : ClosetControl
 		}
 	}
 
+	protected override bool WillInteract(MouseDrop interaction, NetworkSide side)
+	{
+		return true;
+	}
+
+	protected override void ServerPerformInteraction(MouseDrop drop)
+	{
+		if(IsClosed)
+		{
+			return;
+		}
+		var objectBehaviour = drop.DroppedObject.GetComponent<ObjectBehaviour>();
+		if(objectBehaviour)
+		{
+			IsClosed = true;
+			StorePlayer(objectBehaviour);
+			ChangeSprite();
+		}
+	}
+
 	public override void SyncSprite(ClosetStatus value)
 	{
 		if (value == ClosetStatus.Closed)

--- a/UnityProject/Assets/Scripts/Medical/DNAscanner.cs
+++ b/UnityProject/Assets/Scripts/Medical/DNAscanner.cs
@@ -29,15 +29,21 @@ public class DNAscanner : ClosetControl
 
 	protected override bool WillInteract(MouseDrop interaction, NetworkSide side)
 	{
+		if (side == NetworkSide.Server && IsClosed)
+			return false;
+		if (!Validations.CanInteract(interaction.Performer, side))
+			return false;
+		if (!Validations.IsAdjacent(interaction.Performer, interaction.DroppedObject))
+			return false;
+		if (!Validations.IsAdjacent(interaction.Performer, gameObject))
+			return false;
+		if (interaction.Performer == interaction.DroppedObject)
+			return false;
 		return true;
 	}
 
 	protected override void ServerPerformInteraction(MouseDrop drop)
 	{
-		if(IsClosed)
-		{
-			return;
-		}
 		var objectBehaviour = drop.DroppedObject.GetComponent<ObjectBehaviour>();
 		if(objectBehaviour)
 		{


### PR DESCRIPTION
### Purpose
Adds the layer Items to the MouseDraggable layer of the player prefab.
Sets the DNA scanner IsClosed on by default.
Adds drag and drop interaction for the DNA scanner, now players can place other mobs inside it this way.
Adds all the validations that the DNAscanner should check for its drag and drop.
Adds an IsAdjacent() to Validations.cs

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)


