### PR TITLE
DNA scanner APC/power interactions

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Cryogenic2/DNA_Scanner.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Cryogenic2/DNA_Scanner.prefab
@@ -98,6 +98,7 @@ GameObject:
   - component: {fileID: 114532654656294352}
   - component: {fileID: 114529692711081598}
   - component: {fileID: 114039584032850022}
+  - component: {fileID: 4585042576726451927}
   m_Layer: 11
   m_Name: DNA_Scanner
   m_TagString: Untagged
@@ -167,8 +168,12 @@ MonoBehaviour:
   doorOpened: {fileID: 21300012, guid: edb878353e4ae4062978273e8fca40e2, type: 3}
   spriteRenderer: {fileID: 212360857505739792}
   occupant: {fileID: 0}
-  closedWithOccupant: {fileID: 21300004, guid: edb878353e4ae4062978273e8fca40e2, type: 3}
   statusString: 
+  powered: 0
+  closedWithOccupant: {fileID: 21300004, guid: edb878353e4ae4062978273e8fca40e2, type: 3}
+  doorClosedPowerless: {fileID: 21300020, guid: edb878353e4ae4062978273e8fca40e2,
+    type: 3}
+  doorOpenPowerless: {fileID: 21300022, guid: edb878353e4ae4062978273e8fca40e2, type: 3}
 --- !u!114 &114818633338735330
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -313,3 +318,23 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+--- !u!114 &4585042576726451927
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711816394935574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MinimumWorkingVoltage: 190
+  MaximumWorkingVoltage: 300
+  IsEnvironmentalDevice: 0
+  Wattusage: 0.01
+  Resistance: 100000000
+  RelatedAPC: {fileID: 0}
+  AdvancedControlToScript: 0
+  State: 0

--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -159,6 +159,7 @@ public class ClosetControl : NBMouseDropHandApplyInteractable, IRightClickable
 
 	private void SyncStatus(ClosetStatus value)
 	{
+		statusSync = value;
 		if(value == ClosetStatus.Open)
 		{
 			registerTile.IsClosed = false;

--- a/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
+++ b/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
@@ -25,7 +25,7 @@ public class CloningConsole : MonoBehaviour
 
 	public void ToggleLock()
 	{
-		if(scanner && scanner.IsClosed)
+		if(scanner && scanner.IsClosed && scanner.powered)
 		{
 			scanner.IsLocked = !scanner.IsLocked;
 		}
@@ -33,7 +33,7 @@ public class CloningConsole : MonoBehaviour
 
 	public void Scan()
 	{
-		if (scanner && scanner.occupant)
+		if (scanner && scanner.occupant && scanner.powered)
 		{
 			var mob = scanner.occupant;
 			var mobID = scanner.occupant.mobID;

--- a/UnityProject/Assets/Scripts/Medical/DNAscanner.cs
+++ b/UnityProject/Assets/Scripts/Medical/DNAscanner.cs
@@ -1,16 +1,26 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Networking;
 
-public class DNAscanner : ClosetControl
+public class DNAscanner : ClosetControl, IAPCPowered
 {
 	public LivingHealthBehaviour occupant;
-	public Sprite closedWithOccupant;
 	public string statusString;
+	[SyncVar(hook = nameof(SyncPowered))] public bool powered;
+	public Sprite closedWithOccupant;
+	public Sprite doorClosedPowerless;
+	public Sprite doorOpenPowerless;
 
 	public override void OnStartServer()
 	{
 		statusString = "Ready to scan.";
+	}
+
+	public override void OnStartClient()
+	{
+		base.OnStartClient();
+		SyncPowered(powered);
 	}
 
 	public override void HandleItems()
@@ -55,7 +65,22 @@ public class DNAscanner : ClosetControl
 
 	public override void SyncSprite(ClosetStatus value)
 	{
-		if (value == ClosetStatus.Closed)
+		if (value == ClosetStatus.Open)
+		{
+			if (!powered)
+			{
+				spriteRenderer.sprite = doorOpenPowerless;
+			}
+			else
+			{
+				spriteRenderer.sprite = doorOpened;
+			}
+		}
+		else if (!powered)
+		{
+			spriteRenderer.sprite = doorClosedPowerless;
+		}
+		else if (value == ClosetStatus.Closed)
 		{
 			spriteRenderer.sprite = doorClosed;
 		}
@@ -63,9 +88,40 @@ public class DNAscanner : ClosetControl
 		{
 			spriteRenderer.sprite = closedWithOccupant;
 		}
+
+	}
+
+	public void SyncPowered(bool value)
+	{
+		powered = value;
+		SyncSprite(statusSync);
+	}
+
+	private void SetPowered(bool value)
+	{
+		powered = value;
+		if(!powered)
+		{
+			if(IsLocked)
+			{
+				IsLocked = false;
+			}
+		}
+	}
+
+	public void PowerNetworkUpdate(float Voltage)
+	{
+	}
+
+	public void StateUpdate(PowerStates State)
+	{
+		if (State == PowerStates.Off || State == PowerStates.LowVoltage)
+		{
+			SetPowered(false);
+		}
 		else
 		{
-			spriteRenderer.sprite = doorOpened;
+			SetPowered(true);
 		}
 	}
 


### PR DESCRIPTION
### Purpose
The DNA scanner will now interact with power, it will fail to work and the lock will disable, as well as a sprite change to reflect the lack of power.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
The map change is to link the scanner in genetics with the APC