### PR TITLE
Moves the closet handler deletion from ghosting to all body transfers.

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -54,6 +54,12 @@ public static class SpawnHandler
 	/// <param name="eventType">Event type for the player sync.</param>
 	public static void TransferPlayer(NetworkConnection conn, short playerControllerId, GameObject newBody, GameObject oldBody, EVENT eventType, CharacterSettings characterSettings)
 	{
+		var oldPlayerNetworkActions = oldBody.GetComponent<PlayerNetworkActions>();
+		if(oldPlayerNetworkActions)
+		{
+			oldPlayerNetworkActions.RpcBeforeBodyTransfer();
+		}
+
 		var connectedPlayer = PlayerList.Instance.Get(conn);
 		if (connectedPlayer == ConnectedPlayer.Invalid) //this isn't an online player
 		{

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -8,8 +8,6 @@ using Random = UnityEngine.Random;
 
 public partial class PlayerNetworkActions : NetworkBehaviour
 {
-	// time that player will spend as a ghost until they respawn
-	private const int RESPAWN_TIME_SECONDS = 10;
 	private readonly string[] slotNames = {
 		"suit",
 		"belt",
@@ -730,7 +728,6 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	{
 		if(GetComponent<LivingHealthBehaviour>().IsDead)
 		{
-			RpcBeforeGhost();
 			var newGhost = SpawnHandler.SpawnPlayerGhost(connectionToClient, playerControllerId, gameObject, playerScript.characterSettings);
 			playerScript.mind.Ghosting(newGhost);
 		}
@@ -752,15 +749,12 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	}
 
 	/// <summary>
-	/// Invoked before the ghost is going to be created and input will be shifted to ghost. Allows this body object
-	/// to perform needed cleanup. Note this will be invoked on all clients.
+	/// Disables input before a body transfer.
+	/// Note this will be invoked on all clients.
 	/// </summary>
-	/// <param name="bodyObject">object which was turned into a ghost</param>
 	[ClientRpc]
-	public void RpcBeforeGhost()
+	public void RpcBeforeBodyTransfer()
 	{
-		//only need to clean up client side if we are controlling the body who is becoming a ghost
-		//no more closet handler, they are dead
 		ClosetPlayerHandler cph = GetComponent<ClosetPlayerHandler>();
 		if (cph != null)
 		{
@@ -1012,7 +1006,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 			});
 		}
 	}
-  
+
 	//admin only commands
 	#region Admin
 


### PR DESCRIPTION
### Purpose
Moves the closet handler deletion from ghosting to all body transfers.
Deletes the unused RESPAWN_TIME_SECONDS in PlayerNetworkActions.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
This will fix strange behaviours when a player is cloned without ghosting out
