### PR TITLE
Fixes DNA scanner draggeable interaction

### DIFF
--- a/UnityProject/Assets/Prefabs/Player/Resources/Player_V3(uNet).prefab
+++ b/UnityProject/Assets/Prefabs/Player/Resources/Player_V3(uNet).prefab
@@ -1082,7 +1082,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dropLayers:
     serializedVersion: 2
-    m_Bits: 562055168
+    m_Bits: 562056192
   shadow: {fileID: 21300750, guid: edb6a9bb8c0d64b80953e48ba732f4e9, type: 3}
   draggerMustBeAdjacent: 1
   allowDragWhileSoftCrit: 1


### PR DESCRIPTION
### Purpose
Toggles the item layer in the human player prefab for the draggeable interaction

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
