### PR TITLE
DMI to Unity fix

### DIFF
--- a/Tools/DMI_splitter_and_meta_maker/DMI_To_Unity_Sprite.py
+++ b/Tools/DMI_splitter_and_meta_maker/DMI_To_Unity_Sprite.py
@@ -104,7 +104,7 @@ for root, dirs, files in os.walk(path):
                 addString = addString + image.info['Description'][(FoundLocation+offset+Count)]
                 Count = Count + 1
             if addString == ' DMI':
-                break
+                continue
             Width = int(addString)
             Count = 0
             offset = 8
@@ -160,7 +160,7 @@ for root, dirs, files in os.walk(path):
                             NumberOfFrames = int(StringToEndOfline(Description,IndexOfFrames, 9 ))
                         except:
                             Spriteindex = Spriteindex + 1
-                            break
+                            continue
 
                         IndexOfdirs = find_nth(Description,'dirs = ',  Spriteindex)
                         number_of_variants = int(StringToEndOfline(Description,IndexOfdirs, 7 ))


### PR DESCRIPTION
### Purpose
I use the wrong statement for skipping the Element in the loop, it broke out of the loop instead of skipping an element, resulting if it failed on a file it would skip the rest in the folder , Instead of that individual file

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
