### PR TITLE
Fixes pipes sprites on shuttle rotations

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/AirVent.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/AirVent.prefab
@@ -17,10 +17,10 @@ GameObject:
   - component: {fileID: 8354343867630940287}
   - component: {fileID: 966013011358701611}
   - component: {fileID: 6479037130962053368}
-  - component: {fileID: 114247328083268004}
   - component: {fileID: 114207068481858528}
   - component: {fileID: 3953549719403137607}
   - component: {fileID: 3771872541723634421}
+  - component: {fileID: 1554776711696640}
   m_Layer: 10
   m_Name: AirVent
   m_TagString: Untagged
@@ -152,6 +152,7 @@ MonoBehaviour:
   - {fileID: 21300168, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
   spriteRenderer: {fileID: 8418407404781841632}
   spriteSync: 0
+  ARANdirectionBool: 
   MinimumPressure: 101.325
 --- !u!114 &8354343867630940287
 MonoBehaviour:
@@ -217,19 +218,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &114247328083268004
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000010733523080}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spriteMatrixRotationBehavior: 1
 --- !u!114 &114207068481858528
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -282,6 +270,29 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+--- !u!114 &1554776711696640
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000010733523080}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  InitialDirection: 3
+  ChangeDirectionWithMatrix: 1
 --- !u!1 &8513106460640881890
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/BentPipe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/BentPipe.prefab
@@ -97,9 +97,9 @@ GameObject:
   - component: {fileID: 114007797438959630}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 114633532409969822}
   - component: {fileID: 114880245854591566}
   - component: {fileID: 114612731264727302}
+  - component: {fileID: 1739955761982081149}
   m_Layer: 10
   m_Name: BentPipe
   m_TagString: Untagged
@@ -243,6 +243,7 @@ MonoBehaviour:
   - {fileID: 21300174, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
   spriteSync: 0
+  ARANdirectionBool: 
 --- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -324,19 +325,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &114633532409969822
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spriteMatrixRotationBehavior: 1
 --- !u!114 &114880245854591566
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -372,3 +360,26 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+--- !u!114 &1739955761982081149
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  InitialDirection: 3
+  ChangeDirectionWithMatrix: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Connector.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Connector.prefab
@@ -97,9 +97,9 @@ GameObject:
   - component: {fileID: 114007797438959630}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 114110342887895142}
   - component: {fileID: 114079759797594526}
   - component: {fileID: 114643104810596728}
+  - component: {fileID: 7444202956614922778}
   m_Layer: 10
   m_Name: Connector
   m_TagString: Untagged
@@ -231,6 +231,7 @@ MonoBehaviour:
   - {fileID: 21300078, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
   spriteSync: 0
+  ARANdirectionBool: 
 --- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -312,19 +313,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &114110342887895142
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spriteMatrixRotationBehavior: 1
 --- !u!114 &114079759797594526
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -360,3 +348,26 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+--- !u!114 &7444202956614922778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  InitialDirection: 3
+  ChangeDirectionWithMatrix: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/FourWayManifold.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/FourWayManifold.prefab
@@ -97,9 +97,9 @@ GameObject:
   - component: {fileID: 114007797438959630}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 114854202956978172}
   - component: {fileID: 114670025683286498}
   - component: {fileID: 114665036458884384}
+  - component: {fileID: 8413143254154855439}
   m_Layer: 10
   m_Name: FourWayManifold
   m_TagString: Untagged
@@ -232,6 +232,7 @@ MonoBehaviour:
   - {fileID: 21300038, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
   spriteSync: 0
+  ARANdirectionBool: 
   connectionSprite:
   - {fileID: 21300056, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   - {fileID: 21300058, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
@@ -324,19 +325,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &114854202956978172
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spriteMatrixRotationBehavior: 1
 --- !u!114 &114670025683286498
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -372,6 +360,29 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+--- !u!114 &8413143254154855439
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  InitialDirection: 3
+  ChangeDirectionWithMatrix: 1
 --- !u!1 &5219228456619383682
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Manifold.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Manifold.prefab
@@ -97,9 +97,9 @@ GameObject:
   - component: {fileID: 114007797438959630}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 114052733633541110}
   - component: {fileID: 114450221674697092}
   - component: {fileID: 114481024304208226}
+  - component: {fileID: 5591104723912208015}
   m_Layer: 10
   m_Name: Manifold
   m_TagString: Untagged
@@ -235,6 +235,7 @@ MonoBehaviour:
   - {fileID: 21300034, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
   spriteSync: 0
+  ARANdirectionBool: 
   connectionSprite:
   - {fileID: 21300056, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   - {fileID: 21300058, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
@@ -327,19 +328,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &114052733633541110
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spriteMatrixRotationBehavior: 1
 --- !u!114 &114450221674697092
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -375,6 +363,29 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+--- !u!114 &5591104723912208015
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  InitialDirection: 3
+  ChangeDirectionWithMatrix: 1
 --- !u!1 &5219228456619383682
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Pipe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Pipe.prefab
@@ -18,9 +18,9 @@ GameObject:
   - component: {fileID: 114007797438959630}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 114928691138981868}
   - component: {fileID: 114271167785033994}
   - component: {fileID: 114405250905390060}
+  - component: {fileID: 7564706497059525126}
   m_Layer: 10
   m_Name: Pipe
   m_TagString: Untagged
@@ -156,6 +156,7 @@ MonoBehaviour:
   - {fileID: 21300164, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
   spriteRenderer: {fileID: 1047382295693061733}
   spriteSync: 0
+  ARANdirectionBool: 
 --- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -237,19 +238,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &114928691138981868
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spriteMatrixRotationBehavior: 1
 --- !u!114 &114271167785033994
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -285,6 +273,29 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+--- !u!114 &7564706497059525126
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  InitialDirection: 3
+  ChangeDirectionWithMatrix: 1
 --- !u!1 &3573311523730322217
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Scrubber.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Scrubber.prefab
@@ -18,9 +18,9 @@ GameObject:
   - component: {fileID: 493655120697083372}
   - component: {fileID: 3082018966209474044}
   - component: {fileID: 200003959481001672}
-  - component: {fileID: 114517870826636370}
   - component: {fileID: 114172504531317518}
   - component: {fileID: 114754654923298058}
+  - component: {fileID: 5447043449243603668}
   m_Layer: 10
   m_Name: Scrubber
   m_TagString: Untagged
@@ -152,6 +152,7 @@ MonoBehaviour:
   - {fileID: 21300776, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
   spriteRenderer: {fileID: 3335986396963275010}
   spriteSync: 0
+  ARANdirectionBool: 
   MinimumPressure: 101.325
 --- !u!114 &4696558778661555457
 MonoBehaviour:
@@ -234,19 +235,6 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &114517870826636370
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000011763452766}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spriteMatrixRotationBehavior: 1
 --- !u!114 &114172504531317518
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -282,6 +270,29 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+--- !u!114 &5447043449243603668
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011763452766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  InitialDirection: 3
+  ChangeDirectionWithMatrix: 1
 --- !u!1 &3223271260076572928
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Shuttle/ShuttleHeater.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Shuttle/ShuttleHeater.prefab
@@ -18,6 +18,7 @@ GameObject:
   - component: {fileID: 114215226708324816}
   - component: {fileID: 114388043038700156}
   - component: {fileID: 114632911715988304}
+  - component: {fileID: 3905972319176629353}
   m_Layer: 11
   m_Name: ShuttleHeater
   m_TagString: Untagged
@@ -223,6 +224,29 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+--- !u!114 &3905972319176629353
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1547459616489196}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  InitialDirection: 3
+  ChangeDirectionWithMatrix: 1
 --- !u!1 &1663957144760596
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
@@ -12,7 +12,6 @@ using Random = System.Random;
 [RequireComponent(typeof(ObjectBehaviour))]
 [RequireComponent(typeof(RegisterItem))]
 [RequireComponent(typeof(CustomNetTransform))]
-[RequireComponent(typeof(SpriteMatrixRotation))]
 public class ItemAttributes : NetworkBehaviour, IRightClickable
 {
 	private const string MaskInternalsFlag = "MASKINTERNALS";

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/BentPipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/BentPipe.cs
@@ -39,7 +39,7 @@ public class BentPipe : SimplePipe
 				for (int i = 0; i < nodes.Count; i++)
 				{
 					var pipe = nodes[i];
-					if (pipe.transform.position.y < transform.position.y)
+					if (pipe.registerTile.WorldPositionServer.y < registerTile.WorldPositionServer.y)
 					{
 						if (HasDirection(direction, Direction.EAST))
 						{
@@ -50,7 +50,7 @@ public class BentPipe : SimplePipe
 							SetSprite(6);
 						}
 					}
-					else if (pipe.transform.position.y > transform.position.y)
+					else if (pipe.registerTile.WorldPositionServer.y > registerTile.WorldPositionServer.y)
 					{
 						if (HasDirection(direction, Direction.EAST))
 						{
@@ -61,7 +61,7 @@ public class BentPipe : SimplePipe
 							SetSprite(8);
 						}
 					}
-					else if (pipe.transform.position.x > transform.position.x)
+					else if (pipe.registerTile.WorldPositionServer.x > registerTile.WorldPositionServer.x)
 					{
 						if (HasDirection(direction, Direction.SOUTH))
 						{
@@ -72,7 +72,7 @@ public class BentPipe : SimplePipe
 							SetSprite(10);
 						}
 					}
-					else if (pipe.transform.position.x < transform.position.x)
+					else if (pipe.registerTile.WorldPositionServer.x < registerTile.WorldPositionServer.x)
 					{
 						if (HasDirection(direction, Direction.SOUTH))
 						{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Manifold.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Manifold.cs
@@ -20,22 +20,22 @@ public class Manifold : SimplePipe
 			for (int i = 0; i < nodes.Count; i++)
 			{
 				var pipe = nodes[i];
-				if (pipe.transform.position.y < transform.position.y)
+				if (pipe.registerTile.WorldPositionServer.y < registerTile.WorldPositionServer.y)
 				{
 					syncValue |= Direction.SOUTH;
 					SetConnectionSprite(0);
 				}
-				else if (pipe.transform.position.y > transform.position.y)
+				else if (pipe.registerTile.WorldPositionServer.y > registerTile.WorldPositionServer.y)
 				{
 					syncValue |= Direction.NORTH;
 					SetConnectionSprite(1);
 				}
-				else if (pipe.transform.position.x > transform.position.x)
+				else if (pipe.registerTile.WorldPositionServer.x > registerTile.WorldPositionServer.x)
 				{
 					syncValue |= Direction.EAST;
 					SetConnectionSprite(2);
 				}
-				else if (pipe.transform.position.x < transform.position.x)
+				else if (pipe.registerTile.WorldPositionServer.x < registerTile.WorldPositionServer.x)
 				{
 					syncValue |= Direction.WEST;
 					SetConnectionSprite(3);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
@@ -13,6 +13,7 @@ public class Pipe : NetworkBehaviour
 
 	public List<Pipe> nodes = new List<Pipe>();
 	public Direction direction = Direction.NORTH | Direction.SOUTH;
+	private Directional directional;
 	public Pipenet pipenet;
 	public bool anchored;
 	public float volume = 70;
@@ -35,6 +36,8 @@ public class Pipe : NetworkBehaviour
 	public void Awake() {
 		registerTile = GetComponent<RegisterTile>();
 		objectBehaviour = GetComponent<ObjectBehaviour>();
+		directional = GetComponent<Directional>();
+		directional.OnDirectionChange.AddListener(OnDirectionChange);
 	}
 
 	public void Start(){
@@ -71,7 +74,7 @@ public class Pipe : NetworkBehaviour
 		}
 		CalculateAttachedNodes();
 
-		Pipenet foundPipenet = null;
+		Pipenet foundPipenet;
 		if(nodes.Count > 0)
 		{
 			foundPipenet = nodes[0].pipenet;
@@ -104,6 +107,7 @@ public class Pipe : NetworkBehaviour
 		}
 		else
 		{
+			transform.rotation = Quaternion.identity; //counter shuttle rotation
 			SetSpriteLayer(true);
 		}
 		SetSprite(value);
@@ -195,6 +199,51 @@ public class Pipe : NetworkBehaviour
 		}
 	}
 
+	private void CalculateDirection()
+	{
+		float rotation = transform.rotation.eulerAngles.z;
+		var orientation = Orientation.GetOrientation(rotation);
+		if(orientation == Orientation.Up)	//look over later
+		{
+			orientation = Orientation.Down;
+		}
+		else if (orientation == Orientation.Down)
+		{
+			orientation = Orientation.Up;
+		}
+		SetDirection(orientation);
+		directional.FaceDirection(orientation);
+	}
+
+	private void OnDirectionChange(Orientation direction)
+	{
+		if(anchored)
+		{
+			SetDirection(direction);
+			CalculateSprite();
+		}
+	}
+
+	private void SetDirection(Orientation direction)
+	{
+		if (direction == Orientation.Down)
+		{
+			DirectionSouth();
+		}
+		else if (direction == Orientation.Up)
+		{
+			DirectionNorth();
+		}
+		else if (direction == Orientation.Right)
+		{
+			DirectionEast();
+		}
+		else
+		{
+			DirectionWest();
+		}
+	}
+
 	Direction OppositeDirection(Direction dir)
 	{
 		if (dir == Direction.NORTH)
@@ -239,32 +288,9 @@ public class Pipe : NetworkBehaviour
 
 	public virtual void CalculateSprite()
 	{
-		if(anchored == false)
+		if (anchored == false)
 		{
-			SetSprite(0);	//not anchored, item sprite
-		}
-	}
-
-	public virtual void CalculateDirection()
-	{
-		direction = 0;
-		var rotation = transform.rotation.eulerAngles.z;
-		transform.rotation = Quaternion.identity;
-		if ((rotation >= 45 && rotation < 135))
-		{
-			DirectionEast();
-		}
-		else if (rotation >= 135 && rotation < 225)
-		{
-			DirectionNorth();
-		}
-		else if (rotation >= 225 && rotation < 315)
-		{
-			DirectionWest();
-		}
-		else
-		{
-			DirectionSouth();
+			SetSprite(0);   //not anchored, item sprite
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/SimplePipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/SimplePipe.cs
@@ -26,19 +26,19 @@ public class SimplePipe : Pipe
 				for (int i = 0; i < nodes.Count; i++)
 				{
 					var pipe = nodes[i];
-					if (pipe.transform.position.y < transform.position.y)
+					if (pipe.registerTile.WorldPositionServer.y < registerTile.WorldPositionServer.y)
 					{
 						SetSprite(3);
 					}
-					else if (pipe.transform.position.y > transform.position.y)
+					else if (pipe.registerTile.WorldPositionServer.y > registerTile.WorldPositionServer.y)
 					{
 						SetSprite(4);
 					}
-					else if (pipe.transform.position.x > transform.position.x)
+					else if (pipe.registerTile.WorldPositionServer.x > registerTile.WorldPositionServer.x)
 					{
 						SetSprite(5);
 					}
-					else if (pipe.transform.position.x < transform.position.x)
+					else if (pipe.registerTile.WorldPositionServer.x < registerTile.WorldPositionServer.x)
 					{
 						SetSprite(6);
 					}

--- a/UnityProject/Assets/Scripts/Transform/Orientation.cs
+++ b/UnityProject/Assets/Scripts/Transform/Orientation.cs
@@ -181,20 +181,27 @@ public struct Orientation
 	public static Orientation From( Vector2 direction )
 	{
 		float degree = AngleFromUp(direction);
-		var orientation = Down;
-		if ( degree > 315f && degree <= 360f || degree >= 0f && degree < 45f ) {
-			orientation = Up;
+		return GetOrientation(degree);
+	}
+
+	public static Orientation GetOrientation(float degree)
+	{
+		if (degree >= 135f && degree < 225f)
+		{
+			return Down;
 		}
-		if ( degree >= 45f && degree <= 135f ) {
-			orientation = Right;
+		else if (degree >= 45f && degree < 135f)
+		{
+			return Right;
 		}
-		if ( degree > 135f && degree < 225f ) {
-			orientation = Down;
+		else if (degree >= 225 && degree < 315f)
+		{
+			return Left;
 		}
-		if ( degree >= 225f && degree <= 315f ) {
-			orientation = Left;
+		else
+		{
+			return Up;
 		}
-		return orientation;
 	}
 
 	/// <summary>


### PR DESCRIPTION
### Purpose
Fixes pipes sprites on shuttle rotations
Pipes will now use their registerTile position to set their sprite.
Removes the SpriteMatrixRotation from pipes and the requirement of them in ItemAttributes.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
commit says server player but its both client/server, fixed it and forgot to change that
I'm thinking on renaming the bitflag later on so it isn't also called direction, but for another PR