### PR TITLE
Fixes VSCode opening the wrong project file in top level

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
+    "omnisharp.defaultLaunchSolution": "UnityProject.sln",
     "omnisharp.enableRoslynAnalyzers": true
 }


### PR DESCRIPTION
Ominsharp will pickup the wrong .sln file when opening the root of the repo normally. This should fix that.