### PR TITLE
Fixes sec records and ID names

### DIFF
--- a/UnityProject/Assets/Scripts/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Equipment/Equipment.cs
@@ -191,7 +191,7 @@ public class Equipment : NetworkBehaviour
 	private void SpawnID(JobOutfit outFit)
 	{
 
-		var realName = PlayerList.Instance.Get(gameObject).Name;
+		var realName = GetComponent<PlayerScript>().playerName;
 		GameObject idObj = PoolManager.PoolNetworkInstantiate(idPrefab, parent: transform.parent);
 		if (outFit.jobType == JobType.CAPTAIN)
 		{

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -34,8 +34,15 @@ public static class SpawnHandler
 		TransferPlayer(conn, playerControllerId, player, oldBody, EVENT.PlayerSpawned, characterSettings);
 		new Mind(player, jobType);
 		var equipment = player.GetComponent<Equipment>();
+
+		var playerScript = player.GetComponent<PlayerScript>();
+		var connectedPlayer = PlayerList.Instance.Get(conn);
+		connectedPlayer.Name = playerScript.playerName;
+		UpdateConnectedPlayersMessage.Send();
+		PlayerList.Instance.TryAddScores(playerScript.playerName);
+
 		equipment.SetPlayerLoadOuts();
-		SecurityRecordsManager.Instance.AddRecord(player.GetComponent<PlayerScript>());
+		SecurityRecordsManager.Instance.AddRecord(playerScript);
 	}
 
 	public static GameObject SpawnPlayerGhost(NetworkConnection conn, short playerControllerId, GameObject oldBody, CharacterSettings characterSettings)
@@ -91,6 +98,8 @@ public static class SpawnHandler
 		if(characterSettings != null)
 		{
 			playerScript.characterSettings = characterSettings;
+			playerScript.playerName = characterSettings.Name;
+			newBody.name = characterSettings.Name;
 			var playerSprites = newBody.GetComponent<PlayerSprites>();
 			if (playerSprites)
 			{

--- a/UnityProject/Assets/Scripts/Player/PlayerManager.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerManager.cs
@@ -18,8 +18,6 @@ public class PlayerManager : MonoBehaviour
 
 	public static bool HasSpawned { get; private set; }
 
-	public static string PlayerNameCache => CurrentCharacterSettings.Name;
-
 	public static CharacterSettings CurrentCharacterSettings { get; set; }
 
 	private int mobIDcount;


### PR DESCRIPTION
### Purpose
Moves the command in the initialization of PlayerScript to SpawnHandler, removing waitforload coroutines and cache variables.
Fixes security records and ID cards missing their respective names.
Fixes #2023

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

