### PR TITLE
Changes all syncvars to use nameof() for their hook

### DIFF
--- a/UnityProject/Assets/Scripts/Construction/Glass/GlassShard.cs
+++ b/UnityProject/Assets/Scripts/Construction/Glass/GlassShard.cs
@@ -9,7 +9,7 @@ public class GlassShard : NetworkBehaviour
 {
 	public Sprite[] glassSprites;
 
-	[SyncVar(hook = "SpriteChange")]
+	[SyncVar(hook = nameof(SpriteChange))]
 	public int spriteIndex;
 
 	private SpriteRenderer spriteRenderer;

--- a/UnityProject/Assets/Scripts/Electricity/PowerSupplies/DepartmentBattery.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PowerSupplies/DepartmentBattery.cs
@@ -22,7 +22,7 @@ public class DepartmentBattery : NetworkBehaviour, IInteractable<HandApply>, IIn
 
 	public Sprite BatteryCharged;
 	public Sprite PartialCharge;
-	[SyncVar(hook = "UpdateBattery")]
+	[SyncVar(hook = nameof(UpdateBattery))]
 	public BatteryStateSprite CurrentState;
 
 	public Sprite LightOn;
@@ -40,7 +40,7 @@ public class DepartmentBattery : NetworkBehaviour, IInteractable<HandApply>, IIn
 	public ElectricalNodeControl ElectricalNodeControl;
 	public BatterySupplyingModule BatterySupplyingModule;
 
-	[SyncVar(hook = "UpdateState")]
+	[SyncVar(hook = nameof(UpdateState))]
 	public bool isOn = false;
 
 

--- a/UnityProject/Assets/Scripts/Electricity/PowerSupplies/PowerGenerator.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PowerSupplies/PowerGenerator.cs
@@ -5,7 +5,7 @@ using UnityEngine.Networking;
 public class PowerGenerator : NBHandApplyInteractable, INodeControl
 {
 	public ObjectBehaviour objectBehaviour;
-	[SyncVar(hook = "UpdateSecured")]
+	[SyncVar(hook = nameof(UpdateSecured))]
 	public bool isSecured; //To ground
 	private RegisterTile registerTile;
 	public bool startSecured;
@@ -20,7 +20,7 @@ public class PowerGenerator : NBHandApplyInteractable, INodeControl
 	//Server only
 	public List<SolidPlasma> plasmaFuel = new List<SolidPlasma>();
 
-	[SyncVar(hook = "UpdateState")]
+	[SyncVar(hook = nameof(UpdateState))]
 	public bool isOn = false;
 
 	public ElectricalNodeControl ElectricalNodeControl;

--- a/UnityProject/Assets/Scripts/Electricity/PowerSupplies/ToggleableElectricalNode.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PowerSupplies/ToggleableElectricalNode.cs
@@ -8,7 +8,7 @@ using UnityEngine.Networking;
 /// </summary>
 public class ToggleableElectricalNode : NBHandApplyInteractable, INodeControl
 {
-  	[SyncVar(hook = "UpdateState")]
+  	[SyncVar(hook = nameof(UpdateState))]
 	public bool isOn = false;
 	public ElectricalNodeControl ElectricalNodeControl;
 

--- a/UnityProject/Assets/Scripts/Electricity/PoweredDevices/APCPoweredDevice.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PoweredDevices/APCPoweredDevice.cs
@@ -14,7 +14,7 @@ public class APCPoweredDevice : NetworkBehaviour
 	public IAPCPowered Powered;
 	public bool AdvancedControlToScript;
 
-	[SyncVar(hook = "UpdateSynchronisedState")]
+	[SyncVar(hook = nameof(UpdateSynchronisedState))]
 	public PowerStates State;
 
 	void Start()
@@ -70,7 +70,7 @@ public class APCPoweredDevice : NetworkBehaviour
 				{
 					State = PowerStates.LowVoltage;
 				}
-				else { 
+				else {
 					State = PowerStates.On;
 				}
 				Powered.StateUpdate(State);
@@ -98,9 +98,10 @@ public class APCPoweredDevice : NetworkBehaviour
 			}
 		}
 	}
-	public void UpdateSynchronisedState(PowerStates _State) {		State = _State;
+	public void UpdateSynchronisedState(PowerStates _State) {
+		State = _State;
 		if (Powered != null)
-		{ 
+		{
 			Powered.StateUpdate(State);
 		}
 	}
@@ -111,5 +112,5 @@ public enum PowerStates{
 	Off,
 	LowVoltage,
 	On,
-	OverVoltage, 
+	OverVoltage,
 }

--- a/UnityProject/Assets/Scripts/Electricity/PoweredDevices/FieldGenerator.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PoweredDevices/FieldGenerator.cs
@@ -19,7 +19,7 @@ public class FieldGenerator : NBHandApplyInteractable, INodeControl
 
 	public ResistanceSourceModule ResistanceSourceModule;
 
-	[SyncVar(hook = "UpdateSprites")]
+	[SyncVar(hook = nameof(UpdateSprites))]
 	public bool isOn = false;
 
 	public override void OnStartClient()

--- a/UnityProject/Assets/Scripts/Electricity/Wire/MachineConnectorSpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Electricity/Wire/MachineConnectorSpriteHandler.cs
@@ -15,7 +15,7 @@ public class MachineConnectorSpriteHandler : NetworkBehaviour
 	public SpriteRenderer SRWest;
 	public SpriteRenderer SREast;
 
-	[SyncVar(hook = "UpdateSprites")]
+	[SyncVar(hook = nameof(UpdateSprites))]
 	public string Syncstring;
 
 

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -70,7 +70,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IFireExposable
 	}
 
 	// JSON string for blood types and DNA.
-	[SyncVar(hook = "DNASync")] //May remove this in the future and only provide DNA info on request
+	[SyncVar(hook = nameof(DNASync))] //May remove this in the future and only provide DNA info on request
 	private string DNABloodTypeJSON;
 
 	//how on fire we are, sames as tg fire_stacks. 0 = not on fire.

--- a/UnityProject/Assets/Scripts/Health/Living/SimpleAnimal/SimpleAnimal.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/SimpleAnimal/SimpleAnimal.cs
@@ -5,11 +5,11 @@ using UnityEngine.Networking;
 public class SimpleAnimal : LivingHealthBehaviour
 {
 	public Sprite aliveSprite;
-	
+
 	public Sprite deadSprite;
 
 	//Syncvar hook so that new players can sync state on start
-	[SyncVar(hook = "SetAliveState")] public bool deadState;
+	[SyncVar(hook = nameof(SetAliveState))] public bool deadState;
 
 	public SpriteRenderer spriteRend;
 

--- a/UnityProject/Assets/Scripts/Items/IDCard.cs
+++ b/UnityProject/Assets/Scripts/Items/IDCard.cs
@@ -15,11 +15,11 @@ public class IDCard : NetworkBehaviour
 	public Sprite commandSprite;
 
 	//What type of card? (standard, command, captain, emag etc)
-	[SyncVar(hook = "SyncIDCardType")] public int idCardTypeInt;
+	[SyncVar(hook = nameof(SyncIDCardType))] public int idCardTypeInt;
 
 	private bool isInit;
 
-	[SyncVar(hook = "SyncJobType")] public int jobTypeInt;
+	[SyncVar(hook = nameof(SyncJobType))] public int jobTypeInt;
 
 	[Tooltip("This is used to place ID cards via map editor and then setting their initial access type")]
 	public List<Access> ManuallyAddedAccess = new List<Access>();
@@ -29,7 +29,7 @@ public class IDCard : NetworkBehaviour
 
 	public int MiningPoints; //For redeeming at mining equipment vendors
 
-	[SyncVar(hook = "SyncName")] public string RegisteredName;
+	[SyncVar(hook = nameof(SyncName))] public string RegisteredName;
 
 	//To switch the card sprites when the type changes
 	public SpriteRenderer spriteRenderer;

--- a/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
@@ -51,7 +51,7 @@ public class ItemAttributes : NetworkBehaviour, IRightClickable
 	private Dictionary<string, string> dmDic;
 	private string hier;
 
-	[SyncVar(hook = "ConstructItem")] public string hierarchy;
+	[SyncVar(hook = nameof(ConstructItem))] public string hierarchy;
 	/// <summary>
 	/// Custom inventory(?) icon, if present
 	/// </summary>

--- a/UnityProject/Assets/Scripts/Items/Others/Paper.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Paper.cs
@@ -7,7 +7,7 @@ public class Paper : NetworkBehaviour
 {
 	public Sprite[] spriteStates; //0 = No text, 1 = text
 
-	[SyncVar(hook = "UpdateState")][Range(0, 1)]
+	[SyncVar(hook = nameof(UpdateState))][Range(0, 1)]
 	public int spriteState;
 
 	public string ServerString { get; private set; }

--- a/UnityProject/Assets/Scripts/Lighting/LightSwitch.cs
+++ b/UnityProject/Assets/Scripts/Lighting/LightSwitch.cs
@@ -22,7 +22,7 @@ public class LightSwitch : NetworkBehaviour, IInteractable<HandApply>
 	private readonly Collider2D[] lightSpriteColliders = new Collider2D[MAX_TARGETS];
 	private AudioSource clickSFX;
 
-	[SyncVar(hook = "SyncLightSwitch")]
+	[SyncVar(hook = nameof(SyncLightSwitch))]
 	public States isOn = States.On;
 
 	public float AtShutOffVoltage = 50;

--- a/UnityProject/Assets/Scripts/Player/LightEmissionPlayer.cs
+++ b/UnityProject/Assets/Scripts/Player/LightEmissionPlayer.cs
@@ -22,7 +22,7 @@ public class LightEmissionPlayer : NetworkBehaviour
 
 	public GameObject mLightRendererObject;
 
-	[SyncVar(hook = "UpdateHook")]
+	[SyncVar(hook = nameof(UpdateHook))]
 	public string stringPlayerLightData;
 
 

--- a/UnityProject/Assets/Scripts/Switches/ShutterSwitch.cs
+++ b/UnityProject/Assets/Scripts/Switches/ShutterSwitch.cs
@@ -10,7 +10,7 @@ public class ShutterSwitch : NetworkBehaviour, IInteractable<HandApply>
 {
 	private Animator animator;
 
-	[SyncVar(hook = "SyncShutters")] public bool IsClosed;
+	[SyncVar(hook = nameof(SyncShutters))] public bool IsClosed;
 
 	[Tooltip("Shutters this switch controls.")]
 	public ObjectTrigger[] TriggeringObjects;


### PR DESCRIPTION
### Purpose
Changes all syncvars to use nameof() for their hook
I believe its way more friendly for devs on things like rightclick->find references

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

