### PR TITLE
Reduce Light2D GC

### DIFF
--- a/UnityProject/Assets/Scripts/Lighting System/Light2D/CustomSprite.cs
+++ b/UnityProject/Assets/Scripts/Lighting System/Light2D/CustomSprite.cs
@@ -65,7 +65,7 @@ namespace Light2D
             get { return _meshRenderer.isPartOfStaticBatch; }
         }
 
-        protected virtual void OnEnable()
+        protected virtual void Start()
         {
             _colors = new Color[4];
             _uv1 = new Vector2[4];
@@ -102,11 +102,6 @@ namespace Light2D
             RendererEnabled = _meshRenderer.enabled;
         }
 
-        protected virtual void Start()
-        {
-            UpdateMeshData(true);
-        }
-
         private void OnWillRenderObject()
         {
             UpdateMeshData();
@@ -114,14 +109,6 @@ namespace Light2D
             //{
             //    RendererEnabled = _meshRenderer.enabled;
             //    _meshRenderer.enabled = false; 
-            //}
-        }
-
-        private void OnRenderObject()
-        {
-            //if (Application.isPlaying && LightingSystem.Instance.EnableNormalMapping)
-            //{
-            //    _meshRenderer.enabled = RendererEnabled;
             //}
         }
 

--- a/UnityProject/Assets/Scripts/Lighting System/Light2D/LightSprite.cs
+++ b/UnityProject/Assets/Scripts/Lighting System/Light2D/LightSprite.cs
@@ -29,9 +29,8 @@ namespace Light2D
             get { return _meshRenderer; }
         }
 
-        protected override void OnEnable()
+        protected void OnEnable()
         {
-            base.OnEnable();
             AllLightSprites.Add(this);
         }
 


### PR DESCRIPTION
### Purpose
Reduces the amount of garbage created when 2D Light are turned on<br>

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [ ]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
`LightSprite.OnEnable`
Went from 70k garbage to almost 0.
This was done by doing the initialization on `Start` instead of `OnEnable`.
Can be tested by turning generator on Outpost Station on and off again.
Previously on turning the generator on again `LightSprite.OnEnable` created about 70k garbage cumulatively.