### PR TITLE
Nettab sprite loading change

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Net/Elements/NetSpriteAndColor.cs
+++ b/UnityProject/Assets/Scripts/UI/Net/Elements/NetSpriteAndColor.cs
@@ -36,7 +36,11 @@ public class NetSpriteAndColor : NetUIElement
 				else
 				{
 					GetComponent<Image>().enabled = true;
-					var spriteSheet = SpriteManager.PlayerSprites[spriteFile];
+					if (!Sprites.ContainsKey(spriteFile))
+					{
+						Sprites.Add(spriteFile, Resources.LoadAll<Sprite>(spriteFile));
+					}
+					var spriteSheet = Sprites[spriteFile];
 					GetComponent<Image>().sprite = spriteSheet[spriteOffset];
 					GetComponent<Graphic>().color = DebugTools.HexToColor(hexColor);
 				}

--- a/UnityProject/Assets/Scripts/UI/Net/Elements/NetSpriteImage.cs
+++ b/UnityProject/Assets/Scripts/UI/Net/Elements/NetSpriteImage.cs
@@ -35,7 +35,11 @@ public class NetSpriteImage : NetUIElement
 				else
 				{
 					GetComponent<Image>().enabled = true;
-					var spriteSheet = SpriteManager.PlayerSprites[spriteFile];
+					if (!Sprites.ContainsKey(spriteFile))
+					{
+						Sprites.Add(spriteFile, Resources.LoadAll<Sprite>(spriteFile));
+					}
+					var spriteSheet = Sprites[spriteFile];
 					GetComponent<Image>().sprite = spriteSheet[spriteOffset];
 				}
 			}

--- a/UnityProject/Assets/Scripts/UI/SecurityRecords/GUI_SecurityRecordsEntryPage.cs
+++ b/UnityProject/Assets/Scripts/UI/SecurityRecords/GUI_SecurityRecordsEntryPage.cs
@@ -96,25 +96,25 @@ public class GUI_SecurityRecordsEntryPage : NetPage
 
 		if(characterSettings != null)
 		{
-			torso.SetComplicatedValue("human_parts_greyscale", characterSettings.torsoSpriteIndex, characterSettings.skinTone);
-			head.SetComplicatedValue("human_parts_greyscale", characterSettings.headSpriteIndex, characterSettings.skinTone);
+			torso.SetComplicatedValue("icons/mob/human_parts_greyscale", characterSettings.torsoSpriteIndex, characterSettings.skinTone);
+			head.SetComplicatedValue("icons/mob/human_parts_greyscale", characterSettings.headSpriteIndex, characterSettings.skinTone);
 			rightLeg.SetValue = characterSettings.skinTone;
 			leftLeg.SetValue = characterSettings.skinTone;
 			rightArm.SetValue = characterSettings.skinTone;
 			leftArm.SetValue = characterSettings.skinTone;
 			eyes.SetValue = characterSettings.eyeColor;
-			beard.SetComplicatedValue("human_face", characterSettings.facialHairOffset, characterSettings.facialHairColor);
-			hair.SetComplicatedValue("human_face", characterSettings.hairStyleOffset, characterSettings.hairColor);
+			beard.SetComplicatedValue("icons/mob/human_face", characterSettings.facialHairOffset, characterSettings.facialHairColor);
+			hair.SetComplicatedValue("icons/mob/human_face", characterSettings.hairStyleOffset, characterSettings.hairColor);
 
-			exosuit.SetComplicatedValue("suit", GetSpriteOffset(record.jobOutfit.suit, ItemType.Suit));
-			jumpsuit.SetComplicatedValue("uniform", GetSpriteOffset(record.jobOutfit.uniform, ItemType.Uniform));
-			belt.SetComplicatedValue("belt", GetSpriteOffset(record.jobOutfit.belt, ItemType.Belt));
-			shoes.SetComplicatedValue("feet", GetSpriteOffset(record.jobOutfit.shoes, ItemType.Shoes));
-			back.SetComplicatedValue("back", GetSpriteOffset(record.jobOutfit.backpack, ItemType.Back));
-			//neck.SetComplicatedValue("neck", GetSpriteOffset(record.jobOutfit.neck, ItemType.Neck)); //JobOutfits dont have neck slots yet (will need for lawyer)
-			gloves.SetComplicatedValue("hands", GetSpriteOffset(record.jobOutfit.gloves, ItemType.Gloves));
-			underwear.SetComplicatedValue("underwear", characterSettings.underwearOffset);
-			socks.SetComplicatedValue("underwear", characterSettings.socksOffset);
+			exosuit.SetComplicatedValue("icons/mob/suit", GetSpriteOffset(record.jobOutfit.suit, ItemType.Suit));
+			jumpsuit.SetComplicatedValue("icons/mob/uniform", GetSpriteOffset(record.jobOutfit.uniform, ItemType.Uniform));
+			belt.SetComplicatedValue("icons/mob/belt", GetSpriteOffset(record.jobOutfit.belt, ItemType.Belt));
+			shoes.SetComplicatedValue("icons/mob/feet", GetSpriteOffset(record.jobOutfit.shoes, ItemType.Shoes));
+			back.SetComplicatedValue("icons/mob/back", GetSpriteOffset(record.jobOutfit.backpack, ItemType.Back));
+			//neck.SetComplicatedValue("icons/mob/neck", GetSpriteOffset(record.jobOutfit.neck, ItemType.Neck)); //JobOutfits dont have neck slots yet (will need for lawyer)
+			gloves.SetComplicatedValue("icons/mob/hands", GetSpriteOffset(record.jobOutfit.gloves, ItemType.Gloves));
+			underwear.SetComplicatedValue("icons/mob/underwear", characterSettings.underwearOffset);
+			socks.SetComplicatedValue("icons/mob/underwear", characterSettings.socksOffset);
 		}
 
 		securityRecordsTab.UpdateIdText(idNameText);


### PR DESCRIPTION


### Purpose
NetSpriteAndColor and NetSpriteImage will now load their sprites from a resource load rather than getting them from the PlayerSprites manager.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
Now vendor machines can use this instead of spawning an object and taking the snapshot for the sprite