### PR TITLE
Security records wont be created if the player is a syndie or an AI

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -42,7 +42,10 @@ public static class SpawnHandler
 		PlayerList.Instance.TryAddScores(playerScript.playerName);
 
 		equipment.SetPlayerLoadOuts();
-		SecurityRecordsManager.Instance.AddRecord(playerScript, jobType);
+		if(jobType != JobType.SYNDICATE && jobType != JobType.AI)
+		{
+			SecurityRecordsManager.Instance.AddRecord(playerScript, jobType);
+		}
 	}
 
 	public static GameObject SpawnPlayerGhost(NetworkConnection conn, short playerControllerId, GameObject oldBody, CharacterSettings characterSettings)


### PR DESCRIPTION
### Purpose
Security records wont be created if the player is a syndie or an AI

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
