### PR TITLE
Fix for closet issues

### DIFF
--- a/UnityProject/Assets/Scripts/Closets/ClosetPlayerHandler.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetPlayerHandler.cs
@@ -69,11 +69,6 @@ public class ClosetPlayerHandler : MonoBehaviour
 					closetControl.Interact(HandApply.ByLocalPlayer(closetControl.gameObject));
 				}
 			}
-			//take the player with the closet so they can interact with it
-			if (closetControl.transform.position != transform.position)
-			{
-				transform.position = closetControl.transform.position;
-			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/ObjectBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Objects/ObjectBehaviour.cs
@@ -27,7 +27,9 @@ public class ObjectBehaviour : PushPull
         {
             lastNonHiddenPosition = parentContainer.AssumedWorldPosition();
         }
-		else if (registerTile.WorldPosition != TransformState.HiddenPos)
+		//Last condition checks if the player wasn't closed in a closet.
+		//While in a closet the player gets teleported out of the map, which causes the lastNonHiddenPosition to be assumed incorrectly.
+		else if (registerTile.WorldPosition != TransformState.HiddenPos && lastReliablePos != TransformState.HiddenPos)
 		{
 			lastNonHiddenPosition = registerTile.WorldPosition;
 		} else if ( lastNonHiddenPosition == TransformState.HiddenPos )

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -493,7 +493,7 @@ public class PushPull : VisibleBehaviour, IRightClickable {
 	private ApprovalState pushApproval = ApprovalState.None;
 	private bool CanPredictPush => pushPrediction == PushState.None && Pushable.CanPredictPush;
 	private Vector3Int predictivePushTarget = TransformState.HiddenPos;
-	private Vector3Int lastReliablePos = TransformState.HiddenPos;
+	protected Vector3Int lastReliablePos = TransformState.HiddenPos;
 
 	#endregion
 


### PR DESCRIPTION
### Purpose
Fixes #1970 for lockers and dna scanners
Fixes occasional bug, where player gets brute damage due to low pressure when exiting a locker

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients)

### Notes:
The removed if condition from ClosetPlayerHandler was causing the sprite flickering. It also has no purpose, I tested without it in multiplayer and players inside pulled lockers could still interact with them.
