### PR TITLE
Spray mechanic and effects

### DIFF
--- a/UnityProject/Assets/Prefabs/GUI/Resources/GUI_ChemistryDispenser.cs
+++ b/UnityProject/Assets/Prefabs/GUI/Resources/GUI_ChemistryDispenser.cs
@@ -38,6 +38,7 @@ public class GUI_ChemistryDispenser : NetTab {
 		"sulfur",
 		"water",
 		"welding_fuel",
+		"space_cleaner"
 	};
 
 	private List<string> DispenseAmounts = new List<string>(){ //Some security bizz

--- a/UnityProject/Assets/Prefabs/Items/Tools/Resources/Extinguisher.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Resources/Extinguisher.prefab
@@ -248,7 +248,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   clothingReference: -1
-  hierarchy: /obj/item/weapon/extinguisher
+  hierarchy: 
   inHandReferenceLeft: 88
   inHandReferenceRight: 96
   itemName: Extinguisher

--- a/UnityProject/Assets/Prefabs/Items/Tools/Resources/SpaceCleaner.prefab
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Resources/SpaceCleaner.prefab
@@ -68,7 +68,7 @@ SpriteRenderer:
   m_SortingLayerID: -1463207863
   m_SortingLayer: 11
   m_SortingOrder: 640
-  m_Sprite: {fileID: 21300182, guid: 0bccb8bbbef5f45b798662f9614b955c, type: 3}
+  m_Sprite: {fileID: 21300002, guid: ea189f77b4a3246baa4a2e08c3e3cbb1, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -90,7 +90,7 @@ GameObject:
   - component: {fileID: 4827893193398430}
   - component: {fileID: 61818042941755762}
   - component: {fileID: 114022233371835864}
-  - component: {fileID: 1769529668165702070}
+  - component: {fileID: 7075596509325728911}
   - component: {fileID: 4953889069794681373}
   - component: {fileID: 114875290499615288}
   - component: {fileID: 114567485071167784}
@@ -103,7 +103,7 @@ GameObject:
   - component: {fileID: 114229085023085202}
   - component: {fileID: 2076902986949784288}
   m_Layer: 10
-  m_Name: Extinguisher
+  m_Name: SpaceCleaner
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -121,7 +121,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4264625479318156}
-  - {fileID: 8528023420532377585}
+  - {fileID: 8345797578854887532}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -184,7 +184,7 @@ MonoBehaviour:
     i15: 0
   m_ServerOnly: 0
   m_LocalPlayerAuthority: 0
---- !u!114 &1769529668165702070
+--- !u!114 &7075596509325728911
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -193,17 +193,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 1907679543779350}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: df14585efc20d2f4c9f0b66982db3b8d, type: 3}
+  m_Script: {fileID: 11500000, guid: 96edd14bb3cb38c4fac108e8865c1afd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   reagentContainer: {fileID: 4953889069794681373}
   registerItem: {fileID: 114690376875817604}
-  spriteRenderer: {fileID: 212125191403727516}
-  spriteSync: 0
-  spriteList:
-  - {fileID: 21300182, guid: 0bccb8bbbef5f45b798662f9614b955c, type: 3}
-  - {fileID: 21300184, guid: 0bccb8bbbef5f45b798662f9614b955c, type: 3}
-  particleSystem: {fileID: 2917038433635740771}
+  particleSystem: {fileID: 5403326954991061525}
   particleSync: 0
 --- !u!114 &4953889069794681373
 MonoBehaviour:
@@ -218,11 +213,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Temperature: 20
-  MaxCapacity: 50
+  MaxCapacity: 100
   Reagents:
-  - water
+  - space_cleaner
   Amounts:
-  - 50
+  - 100
 --- !u!114 &114875290499615288
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -248,19 +243,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   clothingReference: -1
-  hierarchy: /obj/item/weapon/extinguisher
-  inHandReferenceLeft: 88
-  inHandReferenceRight: 96
-  itemName: Extinguisher
-  itemDescription: A heavy fire extinguisher
+  hierarchy: 
+  inHandReferenceLeft: 308
+  inHandReferenceRight: 320
+  itemName: Space Cleaner
+  itemDescription: BLAM!-brand non-foaming space cleaner!
   itemType: 0
   size: 2
   spriteType: 0
   CanConnectToTank: 0
-  hitDamage: 10
+  hitDamage: 0
   damageType: 0
-  throwDamage: 10
-  throwSpeed: 2
+  throwDamage: 0
+  throwSpeed: 3
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
@@ -402,7 +397,7 @@ MonoBehaviour:
   backgroundColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   iconOverride: {fileID: 0}
   backgroundSprite: {fileID: 0}
---- !u!1 &1645206611696558437
+--- !u!1 &7396984611411425534
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -410,9 +405,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8528023420532377585}
-  - component: {fileID: 2917038433635740771}
-  - component: {fileID: 3091482609919773039}
+  - component: {fileID: 8345797578854887532}
+  - component: {fileID: 5403326954991061525}
+  - component: {fileID: 3453238643628682561}
   m_Layer: 10
   m_Name: ParticleEffect
   m_TagString: Untagged
@@ -420,27 +415,27 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8528023420532377585
+--- !u!4 &8345797578854887532
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645206611696558437}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 7396984611411425534}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4827893193398430}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!198 &2917038433635740771
+--- !u!198 &5403326954991061525
 ParticleSystem:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645206611696558437}
+  m_GameObject: {fileID: 7396984611411425534}
   serializedVersion: 6
   lengthInSec: 1
   simulationSpeed: 1
@@ -622,9 +617,9 @@ ParticleSystem:
         m_RotationOrder: 4
     startColor:
       serializedVersion: 2
-      minMaxState: 2
-      minColor: {r: 1, g: 1, b: 1, a: 1}
-      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      minMaxState: 0
+      minColor: {r: 0, g: 0.97092485, b: 1, a: 1}
+      maxColor: {r: 0, g: 1, b: 0.9806142, a: 1}
       maxGradient:
         serializedVersion: 2
         key0: {r: 1, g: 1, b: 1, a: 1}
@@ -1002,7 +997,7 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     randomizeRotationDirection: 0
-    maxNumParticles: 15
+    maxNumParticles: 1
     size3D: 0
     rotation3D: 0
     gravityModifier:
@@ -1068,7 +1063,7 @@ ParticleSystem:
     radiusThickness: 1
     donutRadius: 0.2
     m_Position: {x: 0, y: 0, z: 0}
-    m_Rotation: {x: 0, y: 0, z: -12}
+    m_Rotation: {x: 0, y: 0, z: 0}
     m_Scale: {x: 1, y: 1, z: 1}
     placementMode: 0
     m_MeshMaterialIndex: 0
@@ -1205,7 +1200,7 @@ ParticleSystem:
           m_PostInfinity: 2
           m_RotationOrder: 4
     arc:
-      value: 24
+      value: 0
       mode: 0
       spread: 0
       speed:
@@ -1939,10 +1934,18 @@ ParticleSystem:
     uvChannelMask: -1
     randomRow: 1
     sprites:
-    - sprite: {fileID: 21300222, guid: 166411a427a249d692cc1274cc54ce19, type: 3}
-    - sprite: {fileID: 21300206, guid: 166411a427a249d692cc1274cc54ce19, type: 3}
-    - sprite: {fileID: 21300190, guid: 166411a427a249d692cc1274cc54ce19, type: 3}
-    - sprite: {fileID: 21300174, guid: 166411a427a249d692cc1274cc54ce19, type: 3}
+    - sprite: {fileID: 21300038, guid: 1abcb01a2a80f4d2d9bbd96c2adfd7b8, type: 3}
+    - sprite: {fileID: 21300038, guid: 1abcb01a2a80f4d2d9bbd96c2adfd7b8, type: 3}
+    - sprite: {fileID: 21300038, guid: 1abcb01a2a80f4d2d9bbd96c2adfd7b8, type: 3}
+    - sprite: {fileID: 21300038, guid: 1abcb01a2a80f4d2d9bbd96c2adfd7b8, type: 3}
+    - sprite: {fileID: 21300038, guid: 1abcb01a2a80f4d2d9bbd96c2adfd7b8, type: 3}
+    - sprite: {fileID: 21300038, guid: 1abcb01a2a80f4d2d9bbd96c2adfd7b8, type: 3}
+    - sprite: {fileID: 21300038, guid: 1abcb01a2a80f4d2d9bbd96c2adfd7b8, type: 3}
+    - sprite: {fileID: 21300038, guid: 1abcb01a2a80f4d2d9bbd96c2adfd7b8, type: 3}
+    - sprite: {fileID: 21300030, guid: 1abcb01a2a80f4d2d9bbd96c2adfd7b8, type: 3}
+    - sprite: {fileID: 21300022, guid: 1abcb01a2a80f4d2d9bbd96c2adfd7b8, type: 3}
+    - sprite: {fileID: 21300014, guid: 1abcb01a2a80f4d2d9bbd96c2adfd7b8, type: 3}
+    - sprite: {fileID: 21300006, guid: 1abcb01a2a80f4d2d9bbd96c2adfd7b8, type: 3}
     flipU: 0
     flipV: 0
   VelocityModule:
@@ -5099,14 +5102,14 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     vectorLabel1_3: W
---- !u!199 &3091482609919773039
+--- !u!199 &3453238643628682561
 ParticleSystemRenderer:
   serializedVersion: 6
   m_ObjectHideFlags: 2
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645206611696558437}
+  m_GameObject: {fileID: 7396984611411425534}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0

--- a/UnityProject/Assets/Prefabs/Items/Tools/Resources/SpaceCleaner.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Items/Tools/Resources/SpaceCleaner.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 95adc0cf36af55d46baf1b7d4ef71eef
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/SoundManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/SoundManager.prefab
@@ -465,6 +465,161 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
+--- !u!1 &2799621680949093512
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5799916562896938898}
+  - component: {fileID: 1064629769158042070}
+  m_Layer: 0
+  m_Name: Spray2
+  m_TagString: SoundFX
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5799916562896938898
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2799621680949093512}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5630492256413423177}
+  m_RootOrder: 56
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!82 &1064629769158042070
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2799621680949093512}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 24300001, guid: 94208a0928046438d9b8a00796e7a5a7,
+    type: 2}
+  m_audioClip: {fileID: 8300000, guid: dcbbe42ff8d3e40419bda7142285b361, type: 3}
+  m_PlayOnAwake: 0
+  m_Volume: 0.36
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 37
+  Pan2D: 0
+  rolloffMode: 2
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0.07018814
+      value: 1
+      inSlope: -10.0039835
+      outSlope: -10.0039835
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.1729004
+      value: 0.46014404
+      inSlope: -2.5009959
+      outSlope: -2.5009959
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.3593506
+      value: 0.17427063
+      inSlope: -0.62524897
+      outSlope: -0.62524897
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.7241333
+      value: 0.045288086
+      inSlope: -0.15631224
+      outSlope: -0.15631224
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: -0.10003988
+      outSlope: -0.10003988
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
 --- !u!1 &4329565692742045440
 GameObject:
   m_ObjectHideFlags: 0
@@ -7199,6 +7354,8 @@ Transform:
   - {fileID: 7360215890881518888}
   - {fileID: 6730530166740706150}
   - {fileID: 6644422323327552616}
+  - {fileID: 5799916562896938898}
+  - {fileID: 5477680893511631477}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -9235,6 +9392,161 @@ AudioSource:
   m_audioClip: {fileID: 8300000, guid: 411b25ffb8d7a40508af33734214c95f, type: 3}
   m_PlayOnAwake: 0
   m_Volume: 0.323
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 37
+  Pan2D: 0
+  rolloffMode: 2
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0.07018814
+      value: 1
+      inSlope: -10.0039835
+      outSlope: -10.0039835
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.1729004
+      value: 0.46014404
+      inSlope: -2.5009959
+      outSlope: -2.5009959
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.3593506
+      value: 0.17427063
+      inSlope: -0.62524897
+      outSlope: -0.62524897
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.7241333
+      value: 0.045288086
+      inSlope: -0.15631224
+      outSlope: -0.15631224
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: -0.10003988
+      outSlope: -0.10003988
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+--- !u!1 &5793051300131986238
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5477680893511631477}
+  - component: {fileID: 5927358234457777973}
+  m_Layer: 0
+  m_Name: Extinguish
+  m_TagString: SoundFX
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5477680893511631477
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5793051300131986238}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5630492256413423177}
+  m_RootOrder: 57
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!82 &5927358234457777973
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5793051300131986238}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 24300001, guid: 94208a0928046438d9b8a00796e7a5a7,
+    type: 2}
+  m_audioClip: {fileID: 8300000, guid: d8ae707d14b9946459523053d6a39412, type: 3}
+  m_PlayOnAwake: 0
+  m_Volume: 0.36
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBAimApplyHandActivateInteractable.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBAimApplyHandActivateInteractable.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+/// <summary>
+/// Version of Interactable which uses AimApply and HandActivate
+/// </summary>
+public abstract class NBAimApplyHandActivateInteractable
+	: NetworkBehaviour, IInteractable<AimApply>, IInteractionProcessor<AimApply>, IInteractable<HandActivate>, IInteractionProcessor<HandActivate>
+{
+	//we delegate our interaction logic to this.
+	private InteractionCoordinator<AimApply> coordinatorAimApply;
+	private InteractionCoordinator<HandActivate> coordinatorHandActivate;
+
+	protected void Start()
+	{
+		EnsureCoordinatorInit();
+	}
+
+	private void EnsureCoordinatorInit()
+	{
+		if (coordinatorAimApply == null)
+		{
+			coordinatorAimApply = new InteractionCoordinator<AimApply>(this, WillInteract, ServerPerformInteraction);
+		}
+		if (coordinatorHandActivate == null)
+		{
+			coordinatorHandActivate = new InteractionCoordinator<HandActivate>(this, WillInteract, ServerPerformInteraction);
+		}
+	}
+
+
+	/// <summary>
+	/// Decides if interaction logic should proceed. On client side, the interaction
+	/// request will only be sent to the server if this returns true. On server side,
+	/// the interaction will only be performed if this returns true.
+	///
+	/// Each interaction has a default implementation of this which should apply for most cases.
+	/// By overriding this and adding more specific logic, you can reduce the amount of messages
+	/// sent by the client to the server, decreasing overall network load.
+	/// </summary>
+	/// <param name="interaction">interaction to validate</param>
+	/// <param name="side">which side of the network this is being invoked on</param>
+	/// <returns>True/False based on whether the interaction logic should proceed as described above.</returns>
+	protected virtual bool WillInteract(AimApply interaction, NetworkSide side)
+	{
+		return DefaultWillInteract.Default(interaction, side);
+	}
+
+	/// <summary>
+	/// Server-side. Called after validation succeeds on server side.
+	/// Server should perform the interaction and inform clients as needed.
+	/// </summary>
+	/// <param name="interaction"></param>
+	protected abstract void ServerPerformInteraction(AimApply interaction);
+
+	/// <summary>
+	/// Client-side prediction. Called after validation succeeds on client side.
+	/// Client can perform client side prediction. NOT invoked for server player, since there is no need
+	/// for prediction.
+	/// </summary>
+	/// <param name="interaction"></param>
+	protected virtual void ClientPredictInteraction(AimApply interaction) { }
+
+	public bool Interact(AimApply info)
+	{
+		EnsureCoordinatorInit();
+		return InteractionComponentUtils.CoordinatedInteract(info, coordinatorAimApply, ClientPredictInteraction);
+	}
+
+	public bool ServerProcessInteraction(AimApply info)
+	{
+		EnsureCoordinatorInit();
+		return InteractionComponentUtils.ServerProcessCoordinatedInteraction(info, coordinatorAimApply);
+	}
+
+
+	/// <summary>
+	/// Decides if interaction logic should proceed. On client side, the interaction
+	/// request will only be sent to the server if this returns true. On server side,
+	/// the interaction will only be performed if this returns true.
+	///
+	/// Each interaction has a default implementation of this which should apply for most cases.
+	/// By overriding this and adding more specific logic, you can reduce the amount of messages
+	/// sent by the client to the server, decreasing overall network load.
+	/// </summary>
+	/// <param name="interaction">interaction to validate</param>
+	/// <param name="side">which side of the network this is being invoked on</param>
+	/// <returns>True/False based on whether the interaction logic should proceed as described above.</returns>
+	protected virtual bool WillInteract(HandActivate interaction, NetworkSide side)
+	{
+		return DefaultWillInteract.Default(interaction, side);
+	}
+
+	/// <summary>
+	/// Server-side. Called after validation succeeds on server side.
+	/// Server should perform the interaction and inform clients as needed.
+	/// </summary>
+	/// <param name="interaction"></param>
+	protected abstract void ServerPerformInteraction(HandActivate interaction);
+
+	/// <summary>
+	/// Client-side prediction. Called after validation succeeds on client side.
+	/// Client can perform client side prediction. NOT invoked for server player, since there is no need
+	/// for prediction.
+	/// </summary>
+	/// <param name="interaction"></param>
+	protected virtual void ClientPredictInteraction(HandActivate interaction) { }
+
+	public bool Interact(HandActivate info)
+	{
+		EnsureCoordinatorInit();
+		return InteractionComponentUtils.CoordinatedInteract(info, coordinatorHandActivate, ClientPredictInteraction);
+	}
+
+	public bool ServerProcessInteraction(HandActivate info)
+	{
+		EnsureCoordinatorInit();
+		return InteractionComponentUtils.ServerProcessCoordinatedInteraction(info, coordinatorHandActivate);
+	}
+}

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBAimApplyHandActivateInteractable.cs.meta
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBAimApplyHandActivateInteractable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16e7eaba211582240835888bd7b544c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Others/FireExtinguisher.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/FireExtinguisher.cs
@@ -18,7 +18,7 @@ public class FireExtinguisher : NBAimApplyHandActivateInteractable
 	public ParticleSystem particleSystem;
 	[SyncVar(hook = nameof(SyncParticles))] public float particleSync;
 
-	private void OnStartClient()
+	public override void OnStartClient()
 	{
 		SyncSprite(spriteSync);
 		base.OnStartClient();
@@ -66,6 +66,7 @@ public class FireExtinguisher : NBAimApplyHandActivateInteractable
 
 			var angle = Mathf.Atan2(targetPos.y - startPos.y, targetPos.x - startPos.x) * 180 / Mathf.PI;
 			particleSync = angle;
+			SoundManager.PlayNetworkedAtPos("Extinguish", startPos, 1);
 			reagentContainer.MoveReagentsTo(5);
 		}
 	}
@@ -116,7 +117,7 @@ public class FireExtinguisher : NBAimApplyHandActivateInteractable
 		spriteSync = value;
 		spriteRenderer.sprite = spriteList[spriteSync];
 
-		if (UIManager.Hands.CurrentSlot.Item == gameObject)
+		if (UIManager.Hands.CurrentSlot && UIManager.Hands.CurrentSlot.Item == gameObject)
 		{
 			UIManager.Hands.CurrentSlot.UpdateImage(gameObject);
 		}

--- a/UnityProject/Assets/Scripts/Items/Others/FireExtinguisher.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/FireExtinguisher.cs
@@ -1,8 +1,133 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Networking;
 
-public class FireExtinguisher : Pickupable
+[RequireComponent(typeof(Pickupable))]
+public class FireExtinguisher : NBAimApplyHandActivateInteractable
 {
+	bool safety = true;
+	int travelDistance = 6;
+	public ReagentContainer reagentContainer;
+	public RegisterItem registerItem;
 
+	public SpriteRenderer spriteRenderer;
+	[SyncVar(hook = nameof(SyncSprite))] public int spriteSync;
+	public Sprite[] spriteList;
+
+	public ParticleSystem particleSystem;
+	[SyncVar(hook = nameof(SyncParticles))] public float particleSync;
+
+	private void OnStartClient()
+	{
+		SyncSprite(spriteSync);
+		base.OnStartClient();
+	}
+
+	protected override void ServerPerformInteraction(HandActivate interaction)
+	{
+		if (safety)
+		{
+			safety = false;
+			spriteSync = 1;
+		}
+		else
+		{
+			safety = true;
+			spriteSync = 0;
+		}
+	}
+
+	protected override bool WillInteract(AimApply interaction, NetworkSide side)
+	{
+		if (interaction.MouseButtonState == MouseButtonState.PRESS)
+		{
+			return true;
+		}
+		return false;
+	}
+
+	protected override void ServerPerformInteraction(AimApply interaction)
+	{
+		if(reagentContainer.CurrentCapacity >= 5 && !safety)
+		{
+			Vector2 startPos = interaction.Performer.transform.position; //TODO: use registeritem position once picked up items get fixed
+			Vector2 targetPos = new Vector2(Mathf.RoundToInt(interaction.WorldPositionTarget.x), Mathf.RoundToInt(interaction.WorldPositionTarget.y));
+			List<Vector3Int> positionList = MatrixManager.GetTiles(startPos, targetPos, travelDistance);
+			StartCoroutine(Fire(positionList));
+
+			var points = GetParallelPoints(startPos, targetPos, true);
+			positionList = MatrixManager.GetTiles(points[0], points[1], travelDistance);
+			StartCoroutine(Fire(positionList));
+
+			points = GetParallelPoints(startPos, targetPos, false);
+			positionList = MatrixManager.GetTiles(points[0], points[1], travelDistance);
+			StartCoroutine(Fire(positionList));
+
+			var angle = Mathf.Atan2(targetPos.y - startPos.y, targetPos.x - startPos.x) * 180 / Mathf.PI;
+			particleSync = angle;
+			reagentContainer.MoveReagentsTo(5);
+		}
+	}
+
+	/// <summary>
+	/// Returns the vectors that form a line parallel to the arguments
+	/// </summary>
+	private Vector2[] GetParallelPoints(Vector2 startPos, Vector2 targetPos, bool rightSide)
+	{
+		Vector2 difference = targetPos - startPos;
+		Vector2 rotated = Vector2.Perpendicular(difference).normalized;
+		Vector2 paralelStart;
+		Vector2 paralelTarget;
+		if(rightSide)
+		{
+			paralelStart = startPos - rotated;
+			paralelTarget = startPos - rotated + difference;
+		}
+		else
+		{
+			paralelStart = startPos + rotated;
+			paralelTarget = startPos + rotated + difference;
+		}
+		paralelStart = new Vector2(Mathf.RoundToInt(paralelStart.x), Mathf.RoundToInt(paralelStart.y));
+		paralelTarget = new Vector2(Mathf.RoundToInt(paralelTarget.x), Mathf.RoundToInt(paralelTarget.y));
+		var points = new Vector2[]{paralelStart, paralelTarget };
+		return points;
+	}
+
+	private IEnumerator Fire(List<Vector3Int> positionList)
+	{
+		for (int i = 0; i < positionList.Count; i++)
+		{
+			ExtinguishTile(positionList[i]);
+			yield return WaitFor.Seconds(0.1f);
+		}
+	}
+
+	void ExtinguishTile(Vector3Int worldPos)
+	{
+		var matrix = MatrixManager.AtPoint(worldPos, true);
+		var localPosInt = MatrixManager.WorldToLocalInt(worldPos, matrix);
+		matrix.MetaDataLayer.ReagentReact(reagentContainer.Contents, worldPos, localPosInt);
+	}
+
+	public void SyncSprite(int value)
+	{
+		spriteSync = value;
+		spriteRenderer.sprite = spriteList[spriteSync];
+
+		if (UIManager.Hands.CurrentSlot.Item == gameObject)
+		{
+			UIManager.Hands.CurrentSlot.UpdateImage(gameObject);
+		}
+	}
+
+	public void SyncParticles(float value)
+	{
+		particleSystem.transform.position = registerItem.WorldPositionClient;
+		particleSystem.transform.rotation = Quaternion.Euler(0, 0, value);
+		var renderer = particleSystem.GetComponent<ParticleSystemRenderer>();
+		renderer.enabled = true;
+		particleSystem.Play();
+	}
 }

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager.cs
@@ -675,6 +675,42 @@ public class MatrixManager : MonoBehaviour
 		return WorldToLocal(worldPos, Get(matrix));
 	}
 
+	/// <summary>
+	/// Returns a list of turfs that are inbetween two points
+	/// </summary>
+	public static List<Vector3Int> GetTiles(Vector3 startPos, Vector2 targetPos, int travelDistance)
+	{
+		List<Vector3Int> positionList = new List<Vector3Int>();
+		for (int i = 0; i < travelDistance; i++)
+		{
+			startPos = Vector2.MoveTowards(startPos, targetPos, 1);
+			positionList.Add((startPos).CutToInt());
+		}
+		return positionList;
+	}
+
+	public void CleanTile(Vector3 worldPos, bool makeSlippery)
+	{
+		var worldPosInt = worldPos.CutToInt();
+		var matrix = AtPoint(worldPosInt, true);
+		var localPosInt = WorldToLocalInt(worldPosInt, matrix);
+		var floorDecals = GetAt<FloorDecal>(worldPosInt, isServer: true);
+
+	    for (var i = 0; i<floorDecals.Count; i++ )
+	    {
+		    floorDecals[i].TryClean();
+		}
+
+	    if (!IsSpaceAt(worldPosInt, true) && makeSlippery)
+	    {
+		    // Create a WaterSplat Decal (visible slippery tile)
+		    EffectsFactory.Instance.WaterSplat(worldPosInt);
+
+		    // Sets a tile to slippery
+		    matrix.MetaDataLayer.MakeSlipperyAt(localPosInt);
+	    }
+	}
+
 }
 
 /// Struct that helps identify matrices

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Hotspot.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Hotspot.cs
@@ -22,7 +22,7 @@ namespace Atmospherics
 		/// <summary>
 		/// Node this hotspot lives on.
 		/// </summary>
-		private MetaDataNode node;
+		public MetaDataNode node;
 
 		public Hotspot(MetaDataNode node, float temperature, float volume)
 		{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -112,9 +112,7 @@ public class ReactionManager : MonoBehaviour
 				}
 				else
 				{
-					node.Hotspot = null;
-					hotspots.Remove(node.Position);
-					tileChangeManager.RemoveTile(node.Position, LayerType.Effects);
+					RemoveHotspot(node);
 				}
 			}
 		}
@@ -126,6 +124,21 @@ public class ReactionManager : MonoBehaviour
 	public void ExposeHotspotWorldPosition(Vector2Int tileWorldPosition, float temperature, float volume)
 	{
 		ExposeHotspot(MatrixManager.WorldToLocalInt(tileWorldPosition.To3Int(), MatrixManager.Get(matrix)), temperature, volume);
+	}
+
+	void RemoveHotspot(MetaDataNode node)
+	{
+		node.Hotspot = null;
+		hotspots.Remove(node.Position);
+		tileChangeManager.RemoveTile(node.Position, LayerType.Effects);
+	}
+
+	public void ExtinguishHotspot(Vector3Int localPosition)
+	{
+		if (hotspots.ContainsKey(localPosition) && hotspots[localPosition].Hotspot != null)
+		{
+			RemoveHotspot(hotspots[localPosition].Hotspot.node);
+		}
 	}
 
 	public void ExposeHotspot(Vector3Int localPosition, float temperature, float volume)

--- a/UnityProject/Assets/Scripts/Tool Construction Deconstruction/Mop.cs
+++ b/UnityProject/Assets/Scripts/Tool Construction Deconstruction/Mop.cs
@@ -33,6 +33,7 @@ public class Mop : Interactable<PositionalHandApply>
 					else if (reason == FinishProgressAction.FinishReason.COMPLETED)
 					{
 						CleanTile(interaction.WorldPositionTarget);
+						isCleaning = false;
 					}
 				}
 			);
@@ -44,29 +45,14 @@ public class Mop : Interactable<PositionalHandApply>
 		}
 	}
 
-	private void CleanTile (Vector3 worldPos)
-    {
-	    var worldPosInt = worldPos.CutToInt();
-	    var matrix = MatrixManager.AtPoint( worldPosInt, true );
-	    var localPosInt = MatrixManager.WorldToLocalInt( worldPosInt, matrix );
-	    var floorDecals = MatrixManager.GetAt<FloorDecal>(worldPosInt, isServer: true);
+	public void CleanTile(Vector3 worldPos)
+	{
+		var worldPosInt = worldPos.CutToInt();
+		var matrix = MatrixManager.AtPoint(worldPosInt, true);
+		var localPosInt = MatrixManager.WorldToLocalInt(worldPosInt, matrix);
+		matrix.MetaDataLayer.Clean(worldPosInt, localPosInt, true);
+	}
 
-	    for ( var i = 0; i < floorDecals.Count; i++ )
-	    {
-		    floorDecals[i].TryClean();
-	    }
-
-	    if (!MatrixManager.IsSpaceAt(worldPosInt, true))
-	    {
-		    // Create a WaterSplat Decal (visible slippery tile)
-		    EffectsFactory.Instance.WaterSplat(worldPosInt);
-
-		    // Sets a tile to slippery
-		    matrix.MetaDataLayer.MakeSlipperyAt(localPosInt);
-	    }
-
-	    isCleaning = false;
-    }
 
 	private void CancelCleanTile()
 	{

--- a/UnityProject/Assets/Scripts/Tool Construction Deconstruction/SpaceCleaner.cs
+++ b/UnityProject/Assets/Scripts/Tool Construction Deconstruction/SpaceCleaner.cs
@@ -35,6 +35,7 @@ public class SpaceCleaner : NBAimApplyInteractable
 			particleSync = angle;
 
 			reagentContainer.MoveReagentsTo(5);
+			SoundManager.PlayNetworkedAtPos("Spray2", startPos, 1);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tool Construction Deconstruction/SpaceCleaner.cs
+++ b/UnityProject/Assets/Scripts/Tool Construction Deconstruction/SpaceCleaner.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+[RequireComponent(typeof(Pickupable))]
+public class SpaceCleaner : NBAimApplyInteractable
+{
+	int travelDistance = 6;
+	public ReagentContainer reagentContainer;
+	public RegisterItem registerItem;
+
+	public ParticleSystem particleSystem;
+	[SyncVar(hook = nameof(SyncParticles))] public float particleSync;
+
+	protected override bool WillInteract(AimApply interaction, NetworkSide side)
+	{
+		if (interaction.MouseButtonState == MouseButtonState.PRESS)
+		{
+			return true;
+		}
+		return false;
+	}
+
+	protected override void ServerPerformInteraction(AimApply interaction)
+	{
+		if (reagentContainer.CurrentCapacity >= 5)
+		{
+			Vector2 startPos = interaction.Performer.transform.position;
+			Vector2 targetPos = new Vector2(Mathf.RoundToInt(interaction.WorldPositionTarget.x), Mathf.RoundToInt(interaction.WorldPositionTarget.y));
+			List<Vector3Int> positionList = MatrixManager.GetTiles(startPos, targetPos, travelDistance);
+			StartCoroutine(Fire(positionList));
+
+			var angle = Mathf.Atan2(targetPos.y - startPos.y, targetPos.x - startPos.x) * 180 / Mathf.PI;
+			particleSync = angle;
+
+			reagentContainer.MoveReagentsTo(5);
+		}
+	}
+
+	private IEnumerator Fire(List<Vector3Int> positionList)
+	{
+		for (int i = 0; i < positionList.Count; i++)
+		{
+			SprayTile(positionList[i]);
+			yield return WaitFor.Seconds(0.1f);
+		}
+	}
+
+	void SprayTile(Vector3Int worldPos)
+	{
+		var matrix = MatrixManager.AtPoint(worldPos, true);
+		var localPosInt = MatrixManager.WorldToLocalInt(worldPos, matrix);
+		matrix.MetaDataLayer.ReagentReact(reagentContainer.Contents, worldPos, localPosInt);
+	}
+
+	public void SyncParticles(float value)
+	{
+		particleSystem.transform.position = registerItem.WorldPositionClient;
+		particleSystem.transform.rotation = Quaternion.Euler(0, 0, value);
+		var renderer = particleSystem.GetComponent<ParticleSystemRenderer>();
+		renderer.enabled = true;
+		particleSystem.Play();
+	}
+
+}

--- a/UnityProject/Assets/Scripts/Tool Construction Deconstruction/SpaceCleaner.cs.meta
+++ b/UnityProject/Assets/Scripts/Tool Construction Deconstruction/SpaceCleaner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96edd14bb3cb38c4fac108e8865c1afd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
The fire extinguisher will now contain reagents, water by default.
Adds a security toggle mechanic for the fire extinguisher, it'll change its sprite.
Fire extinguishers will now remove hotspots if used in the general direction of the fire.

Adds a space cleaner sprayer.
Adds space_cleaner to the chemical reagents list, it'll clean floors.
Adds a particle effect for the extinguisher and space cleaner spray.

Adds NBAimApplyHandActivateInteractable for both of the extinguisher interactions.


### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
Particle effects are locked in 0,0 due to a bug where registeritem is not saving the position when picked up