### PR TITLE
Revert "Merges Outfits and OccupationRosters prefabs"

### DIFF
--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Assistant.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Assistant.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1907548023066798}
+  m_IsPrefabParent: 1
 --- !u!1 &1907548023066798
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4378771042932918}
   - component: {fileID: 114770154129646446}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4378771042932918
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1907548023066798}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,16 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114770154129646446
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1907548023066798}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  limit: -1
-  jobsTaken: 0
+  Type: 2
+  limit: 99
   priority: 99
-  jobType: 2
-  accessory: 
-  allowedAccess: 310000001a00000022000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset
-  mask: 
-  neck: 
-  exosuit: 
-  suitStorage: 
-  uniform: /obj/item/clothing/under/color/grey
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/black
-  backpack: /obj/item/weapon/storage/backpack
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents: []
+  outfit: {fileID: 1111331989989182, guid: 7ea972a2309ab5a47b6203a07139f247, type: 2}

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/AtmosphericTechnician.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/AtmosphericTechnician.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1866127696583700}
+  m_IsPrefabParent: 1
 --- !u!1 &1866127696583700
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4507014599290814}
   - component: {fileID: 114903656805233692}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4507014599290814
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1866127696583700}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,39 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114903656805233692
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1866127696583700}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 2
   limit: 3
-  jobsTaken: 0
+  outfit: {fileID: 1791234296732672, guid: 8d15c89c00802874489ff3c7770daf65, type: 2}
   priority: 99
-  jobType: 3
-  accessory: 
-  allowedAccess: 0400000020000000220000001a00000031000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_eng
-  mask: 
-  neck: 
-  exosuit: 
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/atmospheric_technician
-  leftPocket: /obj/item/device/pda/atmos
-  rightPocket: /obj/item/device/analyzer
-  belt: /obj/item/weapon/storage/belt/utility/atmostech
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/black
-  backpack: /obj/item/weapon/storage/backpack/industrial
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/engineering
-  satchel: /obj/item/weapon/storage/backpack/satchel/eng
-  box: /obj/item/weapon/storage/box/engineer
-  backpack_contents:
-  - /obj/item/device/modular_computer/tablet/preset/advanced
+  Type: 3

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Bartender.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Bartender.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1565708968720630}
+  m_IsPrefabParent: 1
 --- !u!1 &1565708968720630
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4449676447197518}
   - component: {fileID: 114808229622716488}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4449676447197518
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1565708968720630}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114808229622716488
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1565708968720630}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 5
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1362172151900346, guid: 03167bfe9f318d04cbe4c719b932c9e4, type: 2}
   priority: 99
-  jobType: 4
-  accessory: 
-  allowedAccess: 050000001a0000002200000031000000
-  head: 
-  glasses: /obj/item/clothing/glasses/sunglasses/reagent
-  ears: /obj/item/device/radio/headset/headset_srv
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/armor/vest
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/bartender
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/bar
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/laceup
-  backpack: /obj/item/weapon/storage/backpack
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/beanbag
-  backpack_contents: []
+  Type: 4

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Botanist.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Botanist.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1095216131823204}
+  m_IsPrefabParent: 1
 --- !u!1 &1095216131823204
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4255797483069276}
   - component: {fileID: 114685359379298424}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4255797483069276
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1095216131823204}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114685359379298424
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1095216131823204}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 5
   limit: 3
-  jobsTaken: 0
+  outfit: {fileID: 1022723665480262, guid: 49fc383b5a0ff1a4eb70b2e52e9cf366, type: 2}
   priority: 99
-  jobType: 5
-  accessory: 
-  allowedAccess: 220000002a00000031000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_srv
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/apron
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/hydroponics
-  leftPocket: 
-  rightPocket: /obj/item/device/plant_analyzer
-  belt: /obj/item/device/pda/botanist
-  gloves: /obj/item/clothing/gloves/botanic_leather
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/black
-  backpack: /obj/item/weapon/storage/backpack/botany
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel/hyd
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents: []
+  Type: 5

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Captain.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Captain.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1387094316131694}
+  m_IsPrefabParent: 1
 --- !u!1 &1387094316131694
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4383656569659340}
   - component: {fileID: 114539947820853932}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4383656569659340
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1387094316131694}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,40 +42,16 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114539947820853932
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1387094316131694}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Type: 6
   limit: 1
-  jobsTaken: 0
   priority: 0
-  jobType: 6
-  accessory: /obj/item/clothing/accessory/medal/gold/captain
-  allowedAccess: 01000000030000000400000005000000060000000700000008000000090000000a00000015000000160000001700000018000000190000001a0000001b0000001d0000001e0000001f000000200000002100000022000000230000002400000025000000260000002700000028000000290000002a0000002b0000002c0000002d0000002e0000002f00000030000000310000003200000033000000340000003500000036000000370000003a0000003b0000003c0000003d0000003e0000003f0000004000000042000000430000004500000046000000490000004a0000004b0000004c0000004d0000004e0000004f00000050000000
-  head: /obj/item/clothing/head/caphat
-  glasses: /obj/item/clothing/glasses/sunglasses
-  ears: /obj/item/device/radio/headset/heads/captain
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/armor/vest/capcarapace
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/captain
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/captain
-  gloves: /obj/item/clothing/gloves/color/captain
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/brown
-  backpack: /obj/item/weapon/storage/backpack/captain
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel/cap
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents:
-  - /obj/item/weapon/melee/classic_baton/telescopic
-  - /obj/item/weapon/station_charter
+  outfit: {fileID: 1494963329605038, guid: 94a73cbc162a81e4b8f544aa635edc55, type: 2}

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/CargoTechnician.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/CargoTechnician.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1542514950764114}
+  m_IsPrefabParent: 1
 --- !u!1 &1542514950764114
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4638105304072714}
   - component: {fileID: 114710987489201792}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4638105304072714
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1542514950764114}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114710987489201792
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1542514950764114}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 5
   limit: 3
-  jobsTaken: 0
+  outfit: {fileID: 1136714444673464, guid: d582bc4338c6704428f4815708fc8523, type: 2}
   priority: 99
-  jobType: 7
-  accessory: 
-  allowedAccess: 08000000090000001a00000022000000310000003000000035000000360000003700000045000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_cargo
-  mask: 
-  neck: 
-  exosuit: 
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/cargotech
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/cargo
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/black
-  backpack: /obj/item/weapon/storage/backpack
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents: []
+  Type: 7

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Chaplain.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Chaplain.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1977045321645812}
+  m_IsPrefabParent: 1
 --- !u!1 &1977045321645812
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4224673167520248}
   - component: {fileID: 114759171035914890}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4224673167520248
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1977045321645812}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,39 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114759171035914890
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1977045321645812}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 5
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1476561106451396, guid: ce5893c0e3788504aaa0dfb89f244fe5, type: 2}
   priority: 99
-  jobType: 8
-  accessory: 
-  allowedAccess: 160000001a0000002200000031000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset
-  mask: 
-  neck: 
-  exosuit: 
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/chaplainv
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda
-  gloves: 
-  leftHand: /obj/item/device/pda/chaplain
-  shoes: /obj/item/clothing/shoes/sneakers/black
-  backpack: /obj/item/weapon/storage/backpack/cultpack
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents:
-  - /obj/item/device/camera/spooky
+  Type: 8

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Chemist.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Chemist.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1233643564516408}
+  m_IsPrefabParent: 1
 --- !u!1 &1233643564516408
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4266577026266170}
   - component: {fileID: 114744413334003856}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4266577026266170
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1233643564516408}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114744413334003856
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1233643564516408}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 1
   limit: 2
-  jobsTaken: 0
+  outfit: {fileID: 1214411874072222, guid: 5ace8ed887faa2945a2dda8083f809cd, type: 2}
   priority: 99
-  jobType: 9
-  accessory: 
-  allowedAccess: 170000001a000000220000003100000033000000
-  head: 
-  glasses: /obj/item/clothing/glasses/science
-  ears: /obj/item/device/radio/headset/headset_med
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/toggle/labcoat/chemist
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/chemist
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/chemist
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/white
-  backpack: /obj/item/weapon/storage/backpack/chemistry
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/med
-  satchel: /obj/item/weapon/storage/backpack/satchel/chem
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents: []
+  Type: 9

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/ChiefEngineer.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/ChiefEngineer.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1389842405221104}
+  m_IsPrefabParent: 1
 --- !u!1 &1389842405221104
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4840744162022116}
   - component: {fileID: 114338157040407634}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4840744162022116
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1389842405221104}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,40 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114338157040407634
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1389842405221104}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 2
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1080733297063956, guid: 8bff47b0f7025e446987788c8006fc00, type: 2}
   priority: 2
-  jobType: 10
-  accessory: 
-  allowedAccess: 040000000a0000001a0000001e0000001f000000200000002100000022000000260000002c0000003100000032000000490000004a000000
-  head: /obj/item/clothing/head/hardhat/white
-  glasses: 
-  ears: /obj/item/device/radio/headset/heads/ce
-  mask: 
-  neck: 
-  exosuit: 
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/chief_engineer
-  leftPocket: /obj/item/device/pda/heads/ce
-  rightPocket: 
-  belt: /obj/item/weapon/storage/belt/utility/chief/full
-  gloves: /obj/item/clothing/gloves/color/black/ce
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/brown
-  backpack: /obj/item/weapon/storage/backpack/industrial
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/engineering
-  satchel: /obj/item/weapon/storage/backpack/satchel/eng
-  box: /obj/item/weapon/storage/box/engineer
-  backpack_contents:
-  - /obj/item/weapon/melee/classic_baton/telescopic
-  - /obj/item/device/modular_computer/tablet/preset/advanced
+  Type: 10

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/ChiefMedicalOfficer.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/ChiefMedicalOfficer.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1456289663796778}
+  m_IsPrefabParent: 1
 --- !u!1 &1456289663796778
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4879828886494634}
   - component: {fileID: 114724883360912620}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4879828886494634
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1456289663796778}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,39 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114724883360912620
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1456289663796778}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 1
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1000022580185544, guid: 5639c0b75afbd264b9abcfd4850b3775, type: 2}
   priority: 2
-  jobType: 13
-  accessory: 
-  allowedAccess: 190000001a000000220000001700000025000000260000002c00000031000000330000003a0000003b000000460000004e000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset/heads/cmo
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/toggle/labcoat/cmo
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/chief_medical_officer
-  leftPocket: /obj/item/device/flashlight/pen
-  rightPocket: 
-  belt: /obj/item/device/pda/heads/cmo
-  gloves: 
-  leftHand: /obj/item/weapon/storage/firstaid/regular
-  shoes: /obj/item/clothing/shoes/sneakers/brown
-  backpack: /obj/item/weapon/storage/backpack/medic
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/med
-  satchel: /obj/item/weapon/storage/backpack/satchel/med
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents:
-  - /obj/item/weapon/melee/classic_baton/telescopic
+  Type: 13

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Clown.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Clown.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1558448658196052}
+  m_IsPrefabParent: 1
 --- !u!1 &1558448658196052
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4253833468299200}
   - component: {fileID: 114925571666636192}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4253833468299200
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1558448658196052}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,42 +42,16 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114925571666636192
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1558448658196052}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Type: 12
   limit: 1
-  jobsTaken: 0
   priority: 99
-  jobType: 12
-  accessory: 
-  allowedAccess: 310000002200000018000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset
-  mask: /obj/item/clothing/mask/gas/clown_hat
-  neck: 
-  exosuit: 
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/clown
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/clown
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/clown_shoes
-  backpack: /obj/item/weapon/storage/backpack/clown
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/clown
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/hug/survival
-  backpack_contents:
-  - /obj/item/weapon/stamp/clown
-  - /obj/item/weapon/reagent_containers/spray/waterflower
-  - /obj/item/weapon/reagent_containers/food/snacks/grown/banana
-  - /obj/item/weapon/bikehorn
+  outfit: {fileID: 1274075780459964, guid: f333100d3e93aec419cecb2f797912ee, type: 2}

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Cook.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Cook.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1077496234113506}
+  m_IsPrefabParent: 1
 --- !u!1 &1077496234113506
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4406184209974022}
   - component: {fileID: 114991219850476776}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4406184209974022
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1077496234113506}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,39 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114991219850476776
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1077496234113506}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 5
   limit: 2
-  jobsTaken: 0
+  outfit: {fileID: 1316978556928262, guid: 8cadc733b028e694eaff2e60c0bac4a9, type: 2}
   priority: 99
-  jobType: 14
-  accessory: 
-  allowedAccess: 2d000000310000001a00000022000000
-  head: /obj/item/clothing/head/chefhat
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_srv
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/toggle/chef
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/chef
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/cook
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/black
-  backpack: /obj/item/weapon/storage/backpack
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents:
-  - /obj/item/weapon/sharpener
+  Type: 14

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Curator.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Curator.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1927430407107944}
+  m_IsPrefabParent: 1
 --- !u!1 &1927430407107944
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4386942234670212}
   - component: {fileID: 114548354090148952}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4386942234670212
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1927430407107944}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,41 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114548354090148952
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1927430407107944}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 5
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1285918740150374, guid: a55d1875d8e327e4e9dabfcb1a4a4eea, type: 2}
   priority: 99
-  jobType: 15
-  accessory: 
-  allowedAccess: 1a00000031000000220000002f000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset
-  mask: 
-  neck: 
-  exosuit: 
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/curator
-  leftPocket: /obj/item/device/laser_pointer
-  rightPocket: /obj/item/key/displaycase
-  belt: /obj/item/device/pda
-  gloves: 
-  leftHand: /obj/item/weapon/storage/bag/books
-  shoes: /obj/item/clothing/shoes/sneakers/black
-  backpack: /obj/item/weapon/storage/backpack
-  duffelbag: /obj/item/weapon/storage/bag/books
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents:
-  - /obj/item/weapon/melee/curator_whip
-  - /obj/item/soapstone
-  - /obj/item/weapon/barcodescanner
+  Type: 15

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Detective.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Detective.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1564130566163522}
+  m_IsPrefabParent: 1
 --- !u!1 &1564130566163522
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4236446839796988}
   - component: {fileID: 114921496756850354}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4236446839796988
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1564130566163522}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,41 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114921496756850354
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1564130566163522}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 3
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1961709938469034, guid: 22105c049e63a8e4c8c97568e3526174, type: 2}
   priority: 99
-  jobType: 17
-  accessory: 
-  allowedAccess: 060000001b0000002200000023000000430000004400000031000000
-  head: /obj/item/clothing/head/fedora/det_hat
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_sec/alt
-  mask: /obj/item/clothing/mask/cigarette
-  neck: 
-  exosuit: /obj/item/clothing/suit/det_suit
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/det
-  leftPocket: /obj/item/toy/crayon/white
-  rightPocket: /obj/item/weapon/lighter
-  belt: /obj/item/device/pda/detective
-  gloves: /obj/item/clothing/gloves/color/black
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/brown
-  backpack: /obj/item/weapon/storage/backpack
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents:
-  - /obj/item/weapon/storage/box/evidence
-  - /obj/item/device/detective_scanner
-  - /obj/item/weapon/melee/classic_baton
+  Type: 17

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Engineer.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Engineer.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1639774341900186}
+  m_IsPrefabParent: 1
 --- !u!1 &1639774341900186
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4834524201596000}
   - component: {fileID: 114183438210680130}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4834524201596000
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1639774341900186}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,39 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114183438210680130
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1639774341900186}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 2
   limit: 5
-  jobsTaken: 0
+  outfit: {fileID: 1401796472915240, guid: 00cfe327b26d9b142a697f1c82146828, type: 2}
   priority: 88
-  jobType: 20
-  accessory: 
-  allowedAccess: 1a0000001e0000001f00000020000000220000003100000032000000
-  head: /obj/item/clothing/head/hardhat
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_eng
-  mask: 
-  neck: 
-  exosuit: 
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/engineer
-  leftPocket: /obj/item/device/pda/engineering
-  rightPocket: /obj/item/device/t_scanner
-  belt: /obj/item/weapon/storage/belt/utility/full
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/workboots
-  backpack: /obj/item/weapon/storage/backpack/industrial
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/engineering
-  satchel: /obj/item/weapon/storage/backpack/satchel/eng
-  box: /obj/item/weapon/storage/box/engineer
-  backpack_contents:
-  - /obj/item/device/modular_computer/tablet/preset/advanced
+  Type: 20

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Geneticist.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Geneticist.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1361754647138198}
+  m_IsPrefabParent: 1
 --- !u!1 &1361754647138198
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4753758464966248}
   - component: {fileID: 114479936876315980}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4753758464966248
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1361754647138198}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114479936876315980
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1361754647138198}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 1
   limit: 2
-  jobsTaken: 0
+  outfit: {fileID: 1316251908361052, guid: 5f0f1d65018f51a4e94149cffae22311, type: 2}
   priority: 99
-  jobType: 21
-  accessory: 
-  allowedAccess: 1a00000025000000330000003100000022000000420000003f00000050000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_medsci
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/toggle/labcoat/genetics
-  suitStorage: /obj/item/device/flashlight/pen
-  uniform: /obj/item/clothing/under/rank/geneticist
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/geneticist
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/white
-  backpack: /obj/item/weapon/storage/backpack/genetics
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/med
-  satchel: /obj/item/weapon/storage/backpack/satchel/gen
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents: []
+  Type: 21

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/HeadOfPersonnel.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/HeadOfPersonnel.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1217795466810960}
+  m_IsPrefabParent: 1
 --- !u!1 &1217795466810960
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4281619383891628}
   - component: {fileID: 114151551211946104}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4281619383891628
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1217795466810960}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,41 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114151551211946104
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1217795466810960}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 5
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1624884259146988, guid: 47a11f75b419c0d43bb0e68e05c2a59b, type: 2}
   priority: 1
-  jobType: 22
-  accessory: 
-  allowedAccess: 06000000080000001a0000001b0000001e000000200000001f0000002200000026000000280000002b0000002c0000002f00000030000000310000003300000034000000180000004200000044000000430000001500000035000000
-  head: /obj/item/clothing/head/hopcap
-  glasses: 
-  ears: /obj/item/device/radio/headset/heads/hop
-  mask: 
-  neck: 
-  exosuit: 
-  suitStorage: 
-  uniform: '/obj/item/clothing/under/rank/head_of_personnel '
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/heads/hop
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/brown
-  backpack: /obj/item/weapon/storage/backpack
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents:
-  - /obj/item/weapon/storage/box/ids
-  - /obj/item/weapon/melee/classic_baton/telescopic
-  - /obj/item/device/modular_computer/tablet/preset/advanced
+  Type: 22

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/HeadofSecurity.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/HeadofSecurity.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1493080786879964}
+  m_IsPrefabParent: 1
 --- !u!1 &1493080786879964
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4172572422631500}
   - component: {fileID: 114644283964880676}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4172572422631500
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1493080786879964}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,39 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114644283964880676
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1493080786879964}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 3
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1643359509851492, guid: 9745b35ba5c3ecd45805fe511e35fb46, type: 2}
   priority: 2
-  jobType: 23
-  accessory: 
-  allowedAccess: 03000000060000001a0000001b00000022000000230000002600000027000000290000002c0000002e000000310000003a00000043000000440000004f000000
-  head: /obj/item/clothing/head/HoS/beret
-  glasses: /obj/item/clothing/glasses/hud/security/sunglasses
-  ears: /obj/item/device/radio/headset/heads/hos
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/armor/hos/trenchcoat
-  suitStorage: /obj/item/weapon/gun/energy/e_gun
-  uniform: /obj/item/clothing/under/rank/head_of_security
-  leftPocket: /obj/item/device/assembly/flash/handheld
-  rightPocket: /obj/item/weapon/restraints/handcuffs
-  belt: /obj/item/device/pda/heads/hos
-  gloves: /obj/item/clothing/gloves/color/black/hos
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/jackboots
-  backpack: /obj/item/weapon/storage/backpack/security
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/sec
-  satchel: /obj/item/weapon/storage/backpack/satchel/sec
-  box: /obj/item/weapon/storage/box/security
-  backpack_contents:
-  - /obj/item/weapon/melee/baton/loaded
+  Type: 23

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Janitor.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Janitor.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1594083957048648}
+  m_IsPrefabParent: 1
 --- !u!1 &1594083957048648
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4178523939619928}
   - component: {fileID: 114864864129673492}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4178523939619928
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1594083957048648}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,39 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114864864129673492
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1594083957048648}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 5
   limit: 2
-  jobsTaken: 0
+  outfit: {fileID: 1058409517316502, guid: 8b4a5b3c12d5ce548826cc7d5755483a, type: 2}
   priority: 99
-  jobType: 24
-  accessory: 
-  allowedAccess: 1a000000220000002b00000031000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_srv
-  mask: 
-  neck: 
-  exosuit: 
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/janitor
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/janitor
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/black
-  backpack: /obj/item/weapon/storage/backpack
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents:
-  - /obj/item/device/modular_computer/tablet/preset/advanced
+  Type: 24

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Lawyer.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Lawyer.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1703511763521866}
+  m_IsPrefabParent: 1
 --- !u!1 &1703511763521866
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4338233971019504}
   - component: {fileID: 114890647799891260}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4338233971019504
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1703511763521866}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114890647799891260
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1703511763521866}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 3
   limit: 2
-  jobsTaken: 0
+  outfit: {fileID: 1803395098687542, guid: ececfd37070c61c4db48b7a0fea096d5, type: 2}
   priority: 99
-  jobType: 25
-  accessory: /obj/item/clothing/accessory/lawyers_badge
-  allowedAccess: 060000001a000000220000002e0000004400000043000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_sec
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/toggle/lawyer
-  suitStorage: 
-  uniform: /obj/item/clothing/under/lawyer/bluesuit
-  leftPocket: /obj/item/device/laser_pointer
-  rightPocket: 
-  belt: /obj/item/device/pda/lawyer
-  gloves: 
-  leftHand: /obj/item/weapon/storage/briefcase/lawyer
-  shoes: /obj/item/clothing/shoes/laceup
-  backpack: /obj/item/weapon/storage/backpack
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents: []
+  Type: 25

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/MedicalDoctor.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/MedicalDoctor.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1795478352249764}
+  m_IsPrefabParent: 1
 --- !u!1 &1795478352249764
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4830018230053568}
   - component: {fileID: 114627780839628786}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4830018230053568
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1795478352249764}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114627780839628786
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1795478352249764}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 1
   limit: 5
-  jobsTaken: 0
+  outfit: {fileID: 1567982637835890, guid: c9d1c6b5df5fbef4f87cdc57df02efb8, type: 2}
   priority: 99
-  jobType: 18
-  accessory: 
-  allowedAccess: 1a00000022000000330000003a0000004600000031000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_med
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/toggle/labcoat
-  suitStorage: /obj/item/device/flashlight/pen
-  uniform: /obj/item/clothing/under/rank/medical
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/medical
-  gloves: 
-  leftHand: /obj/item/weapon/storage/firstaid/regular
-  shoes: /obj/item/clothing/shoes/sneakers/white
-  backpack: /obj/item/weapon/storage/backpack/medic
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/med
-  satchel: /obj/item/weapon/storage/backpack/satchel/med
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents: []
+  Type: 18

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Mime.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Mime.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1791784211476486}
+  m_IsPrefabParent: 1
 --- !u!1 &1791784211476486
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4499983253024822}
   - component: {fileID: 114209644629902292}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4499983253024822
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1791784211476486}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,39 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114209644629902292
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1791784211476486}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 5
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1011004731350688, guid: 1f411e4452a081a47b9808341fe52b6f, type: 2}
   priority: 99
-  jobType: 27
-  accessory: 
-  allowedAccess: 220000001a0000003100000034000000
-  head: /obj/item/clothing/head/beret
-  glasses: 
-  ears: /obj/item/device/radio/headset
-  mask: /obj/item/clothing/mask/gas/mime
-  neck: 
-  exosuit: /obj/item/clothing/suit/suspenders
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/mime
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/mime
-  gloves: /obj/item/clothing/gloves/color/white
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/black
-  backpack: /obj/item/weapon/storage/backpack/mime
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents:
-  - '/obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing '
+  Type: 27

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/QuarterMaster.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/QuarterMaster.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1155409023102902}
+  m_IsPrefabParent: 1
 --- !u!1 &1155409023102902
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4614504402957612}
   - component: {fileID: 114882286145020194}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4614504402957612
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1155409023102902}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114882286145020194
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1155409023102902}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 5
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1436717421391230, guid: 9c69eb65325cb284e9b49b33f752d380, type: 2}
   priority: 2
-  jobType: 29
-  accessory: 
-  allowedAccess: 08000000090000001a0000001e00000022000000260000002c0000003000000031000000320000003500000036000000370000003c00000045000000
-  head: 
-  glasses: /obj/item/clothing/glasses/sunglasses
-  ears: /obj/item/device/radio/headset/headset_cargo
-  mask: 
-  neck: 
-  exosuit: 
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/cargo
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/quartermaster
-  gloves: 
-  leftHand: /obj/item/weapon/clipboard
-  shoes: /obj/item/clothing/shoes/sneakers/brown
-  backpack: /obj/item/weapon/storage/backpack
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents: []
+  Type: 29

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/ResearchDirector.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/ResearchDirector.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1558353132545772}
+  m_IsPrefabParent: 1
 --- !u!1 &1558353132545772
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4827493799059534}
   - component: {fileID: 114492915465789058}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4827493799059534
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1558353132545772}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,40 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114492915465789058
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1558353132545772}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 4
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1768072235564342, guid: 57b4ed3ccdfda674582b3b5305a82bcf, type: 2}
   priority: 2
-  jobType: 30
-  accessory: 
-  allowedAccess: 1a0000002200000025000000310000003e0000003f00000042000000400000004a000000500000004d000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset/heads/rd
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/toggle/labcoat
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/research_director
-  leftPocket: /obj/item/device/laser_pointer
-  rightPocket: 
-  belt: /obj/item/device/pda/heads/rd
-  gloves: 
-  leftHand: /obj/item/weapon/clipboard
-  shoes: /obj/item/clothing/shoes/sneakers/brown
-  backpack: /obj/item/weapon/storage/backpack/science
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel/tox
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents:
-  - /obj/item/weapon/melee/classic_baton/telescopic
-  - /obj/item/device/modular_computer/tablet/preset/advanced
+  Type: 30

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Roboticist.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Roboticist.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1334888342882360}
+  m_IsPrefabParent: 1
 --- !u!1 &1334888342882360
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4760040315967178}
   - component: {fileID: 114453458061749320}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4760040315967178
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1334888342882360}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114453458061749320
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1334888342882360}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 2
   limit: 2
-  jobsTaken: 0
+  outfit: {fileID: 1899692014714044, guid: 84e1416f33ce3514f97eac8bdc1d0f94, type: 2}
   priority: 99
-  jobType: 31
-  accessory: 
-  allowedAccess: 1a0000002200000031000000320000003f00000040000000420000004d0000002000000032000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_sci
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/toggle/labcoat
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/roboticist
-  leftPocket: /obj/item/device/pda/roboticist
-  rightPocket: 
-  belt: /obj/item/weapon/storage/belt/utility/full
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/black
-  backpack: /obj/item/weapon/storage/backpack
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents: []
+  Type: 31

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Scientist.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Scientist.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1048553205546368}
+  m_IsPrefabParent: 1
 --- !u!1 &1048553205546368
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4763657062367032}
   - component: {fileID: 114948910528933562}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4763657062367032
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1048553205546368}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114948910528933562
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1048553205546368}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 4
   limit: 5
-  jobsTaken: 0
+  outfit: {fileID: 1369951651615546, guid: d25decb62df497247b5c637034063478, type: 2}
   priority: 99
-  jobType: 32
-  accessory: 
-  allowedAccess: 22000000310000003f000000420000004d00000050000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_sci
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/toggle/labcoat/science
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/scientist
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/toxins
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/white
-  backpack: /obj/item/weapon/storage/backpack/science
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel/tox
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents: []
+  Type: 32

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/SecurityOfficer.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/SecurityOfficer.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1710672413038410}
+  m_IsPrefabParent: 1
 --- !u!1 &1710672413038410
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4217394237791866}
   - component: {fileID: 114768286689842576}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4217394237791866
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1710672413038410}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,39 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114768286689842576
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1710672413038410}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 3
   limit: 5
-  jobsTaken: 0
+  outfit: {fileID: 1212771459599398, guid: e9221d12cb336f448b0661c33662df7c, type: 2}
   priority: 99
-  jobType: 33
-  accessory: 
-  allowedAccess: 060000001a0000001b0000003100000043000000440000002300000022000000
-  head: /obj/item/clothing/head/helmet/sec
-  glasses: /obj/item/clothing/glasses/hud/security/sunglasses
-  ears: /obj/item/device/radio/headset/headset_sec
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/armor/vest/alt
-  suitStorage: /obj/item/weapon/gun/energy/e_gun/advtaser
-  uniform: /obj/item/clothing/under/rank/security
-  leftPocket: /obj/item/weapon/restraints/handcuffs
-  rightPocket: /obj/item/device/assembly/flash/handheld
-  belt: /obj/item/device/pda/security
-  gloves: /obj/item/clothing/gloves/color/black
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/jackboots
-  backpack: /obj/item/weapon/storage/backpack/security
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/sec
-  satchel: /obj/item/weapon/storage/backpack/satchel/sec
-  box: /obj/item/weapon/storage/box/security
-  backpack_contents:
-  - /obj/item/weapon/melee/baton/loaded
+  Type: 33

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/ShaftMiner.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/ShaftMiner.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1038932695181158}
+  m_IsPrefabParent: 1
 --- !u!1 &1038932695181158
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4247235449452472}
   - component: {fileID: 114274993402726546}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4247235449452472
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1038932695181158}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114274993402726546
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1038932695181158}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 5
   limit: 3
-  jobsTaken: 0
+  outfit: {fileID: 1965380579708374, guid: 8413a5234b2271748a9e685a417d662b, type: 2}
   priority: 99
-  jobType: 28
-  accessory: 
-  allowedAccess: 080000001a0000002200000031000000350000003600000037000000
-  head: /obj/item/clothing/head/helmet/space/hardsuit/
-  glasses: 
-  ears: /obj/item/device/radio/headset
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/space/hardsuit/mining
-  suitStorage: 
-  uniform: /obj/item/clothing/under/rank/miner
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/workboots
-  backpack: /obj/item/weapon/storage/backpack
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
-  satchel: /obj/item/weapon/storage/backpack/satchel
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents: []
+  Type: 28

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/SyndicateOperative.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/SyndicateOperative.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1160015512762250}
+  m_IsPrefabParent: 1
 --- !u!1 &1160015512762250
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4275407361977316}
   - component: {fileID: 114329545210965172}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4275407361977316
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1160015512762250}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,10 +42,9 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114329545210965172
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1160015512762250}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -44,28 +52,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   limit: 10
-  jobsTaken: 0
+  outfit: {fileID: 1307009445476176, guid: 3d6b6ec632a9c44bf8db14801f4be36c, type: 2}
   priority: 99
-  jobType: 36
-  accessory: 
-  allowedAccess: 22000000230000003100000047000000
-  head: /obj/item/clothing/head/helmet/space/hardsuit/syndi
-  glasses: /obj/item/clothing/glasses/hud/security/sunglasses
-  ears: /obj/item/device/radio/headset/syndicate/alt
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/space/hardsuit/syndi
-  suitStorage: /obj/item/weapon/gun/energy/e_gun/advtaser
-  uniform: /obj/item/clothing/under/syndicate/tacticool
-  leftPocket: /obj/item/weapon/restraints/handcuffs
-  rightPocket: 
-  belt: /obj/item/device/pda/warden
-  gloves: /obj/item/clothing/gloves/color/black
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/jackboots
-  backpack: /obj/item/weapon/storage/backpack/security
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/sec
-  satchel: /obj/item/weapon/storage/backpack/satchel/sec
-  box: /obj/item/weapon/storage/box/security
-  backpack_contents:
-  - /obj/item/weapon/melee/baton/loaded
+  Type: 36

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Virologist.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Virologist.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1767374215272712}
+  m_IsPrefabParent: 1
 --- !u!1 &1767374215272712
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4034371299463806}
   - component: {fileID: 114786801744095452}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4034371299463806
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1767374215272712}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,38 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114786801744095452
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1767374215272712}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 1
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1860008544557904, guid: 9dd6a0e161b36714db4f88ee203fd346, type: 2}
   priority: 99
-  jobType: 34
-  accessory: 
-  allowedAccess: 2200000031000000330000004e000000
-  head: 
-  glasses: 
-  ears: /obj/item/device/radio/headset/headset_med
-  mask: /obj/item/clothing/mask/surgical
-  neck: 
-  exosuit: /obj/item/clothing/suit/toggle/labcoat/virologist
-  suitStorage: /obj/item/device/flashlight/pen
-  uniform: /obj/item/clothing/under/rank/virologist
-  leftPocket: 
-  rightPocket: 
-  belt: /obj/item/device/pda/viro
-  gloves: 
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/sneakers/white
-  backpack: /obj/item/weapon/storage/backpack/virology
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/med
-  satchel: /obj/item/weapon/storage/backpack/satchel/vir
-  box: /obj/item/weapon/storage/box/survival
-  backpack_contents: []
+  Type: 34

--- a/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Warden.prefab
+++ b/UnityProject/Assets/Prefabs/OccupationRosters/Resources/Warden.prefab
@@ -1,12 +1,22 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1160015512762250}
+  m_IsPrefabParent: 1
 --- !u!1 &1160015512762250
 GameObject:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
   m_Component:
   - component: {fileID: 4275407361977316}
   - component: {fileID: 114329545210965172}
@@ -19,10 +29,9 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4275407361977316
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1160015512762250}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,39 +42,17 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &114329545210965172
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1160015512762250}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1758e66ff4476fd44a105877728bea23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  department: 3
   limit: 1
-  jobsTaken: 0
+  outfit: {fileID: 1307009445476176, guid: 934b722f97bab1e4d9ad74065ba20f6d, type: 2}
   priority: 99
-  jobType: 35
-  accessory: 
-  allowedAccess: 22000000230000003100000043000000440000004f00000003000000
-  head: /obj/item/clothing/head/warden
-  glasses: /obj/item/clothing/glasses/hud/security/sunglasses
-  ears: /obj/item/device/radio/headset/headset_sec
-  mask: 
-  neck: 
-  exosuit: /obj/item/clothing/suit/armor/vest/warden/alt
-  suitStorage: /obj/item/weapon/gun/energy/e_gun/advtaser
-  uniform: /obj/item/clothing/under/rank/warden
-  leftPocket: /obj/item/weapon/restraints/handcuffs
-  rightPocket: /obj/item/device/assembly/flash/handheld
-  belt: /obj/item/device/pda/warden
-  gloves: /obj/item/clothing/gloves/color/black
-  leftHand: 
-  shoes: /obj/item/clothing/shoes/jackboots
-  backpack: /obj/item/weapon/storage/backpack/security
-  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/sec
-  satchel: /obj/item/weapon/storage/backpack/satchel/sec
-  box: /obj/item/weapon/storage/box/security
-  backpack_contents:
-  - /obj/item/weapon/melee/baton/loaded
+  Type: 35

--- a/UnityProject/Assets/Prefabs/Outfits.meta
+++ b/UnityProject/Assets/Prefabs/Outfits.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a3b89c05f7f83904cbb3cf0d9a2dab25
+folderAsset: yes
+timeCreated: 1498593085
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: bdcd090a9b7f3a64884940d2e6e83368
+folderAsset: yes
+timeCreated: 1498593095
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Assistant.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Assistant.prefab
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1111331989989182}
+  m_IsPrefabParent: 1
+--- !u!1 &1111331989989182
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4080449884896346}
+  - component: {fileID: 114707459436319684}
+  m_Layer: 0
+  m_Name: Assistant
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4080449884896346
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1111331989989182}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114707459436319684
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1111331989989182}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/color/grey
+  jobType: 2
+  allowedAccess: 310000001a00000022000000
+  ears: /obj/item/device/radio/headset
+  belt: 
+  back: 
+  shoes: 
+  glasses: 
+  gloves: 
+  suit: 
+  head: 
+  accessory: 
+  mask: 
+  backpack: 
+  satchel: 
+  duffelbag: 
+  box: 
+  l_hand: 
+  l_pocket: 
+  r_pocket: 
+  suit_store: 
+  backpack_contents: []

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Assistant.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Assistant.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 7ea972a2309ab5a47b6203a07139f247
+timeCreated: 1498593485
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Atmospheric Technician.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Atmospheric Technician.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1791234296732672}
+  m_IsPrefabParent: 1
+--- !u!1 &1791234296732672
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4868494107598260}
+  - component: {fileID: 114832646600250942}
+  m_Layer: 0
+  m_Name: Atmospheric Technician
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4868494107598260
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1791234296732672}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114832646600250942
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1791234296732672}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/atmospheric_technician
+  jobType: 3
+  allowedAccess: 0400000020000000220000001a00000031000000
+  ears: /obj/item/device/radio/headset/headset_eng
+  belt: /obj/item/weapon/storage/belt/utility/atmostech
+  back: 
+  shoes: 
+  glasses: 
+  gloves: 
+  suit: 
+  head: 
+  accessory: /obj/item/clothing/accessory/pocketprotector/full
+  mask: 
+  backpack: /obj/item/weapon/storage/backpack/industrial
+  satchel: /obj/item/weapon/storage/backpack/satchel/eng
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/engineering
+  box: /obj/item/weapon/storage/box/engineer
+  l_hand: 
+  l_pocket: /obj/item/device/pda/atmos
+  r_pocket: /obj/item/device/analyzer
+  suit_store: 
+  backpack_contents:
+  - /obj/item/device/modular_computer/tablet/preset/advanced

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Atmospheric Technician.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Atmospheric Technician.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8d15c89c00802874489ff3c7770daf65
+timeCreated: 1498596819
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Bartender.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Bartender.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1362172151900346}
+  m_IsPrefabParent: 1
+--- !u!1 &1362172151900346
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4147121270029476}
+  - component: {fileID: 114669502392733078}
+  m_Layer: 0
+  m_Name: Bartender
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4147121270029476
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1362172151900346}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114669502392733078
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1362172151900346}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/bartender
+  jobType: 4
+  allowedAccess: 050000001a0000002200000031000000
+  ears: /obj/item/device/radio/headset/headset_srv
+  belt: /obj/item/device/pda/bar
+  back: 
+  shoes: /obj/item/clothing/shoes/laceup
+  glasses: /obj/item/clothing/glasses/sunglasses/reagent
+  gloves: 
+  suit: /obj/item/clothing/suit/armor/vest
+  head: 
+  accessory: 
+  mask: 
+  backpack: 
+  satchel: 
+  duffelbag: 
+  box: 
+  l_hand: 
+  l_pocket: 
+  r_pocket: 
+  suit_store: 
+  backpack_contents:
+  - /obj/item/weapon/storage/box/beanbag

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Bartender.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Bartender.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 03167bfe9f318d04cbe4c719b932c9e4
+timeCreated: 1498596588
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Botanist.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Botanist.prefab
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1022723665480262}
+  m_IsPrefabParent: 1
+--- !u!1 &1022723665480262
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4981173802191486}
+  - component: {fileID: 114182341205565478}
+  m_Layer: 0
+  m_Name: Botanist
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4981173802191486
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1022723665480262}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114182341205565478
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1022723665480262}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/hydroponics
+  jobType: 5
+  allowedAccess: 220000002a00000031000000
+  ears: /obj/item/device/radio/headset/headset_srv
+  belt: /obj/item/device/pda/botanist
+  back: 
+  shoes: 
+  glasses: 
+  gloves: /obj/item/clothing/gloves/botanic_leather
+  suit: /obj/item/clothing/suit/apron
+  head: 
+  accessory: 
+  mask: 
+  backpack: /obj/item/weapon/storage/backpack/botany
+  satchel: /obj/item/weapon/storage/backpack/satchel/hyd
+  duffelbag: 
+  box: 
+  l_hand: 
+  l_pocket: 
+  r_pocket: 
+  suit_store: /obj/item/device/plant_analyzer
+  backpack_contents: []

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Botanist.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Botanist.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 49fc383b5a0ff1a4eb70b2e52e9cf366
+timeCreated: 1498596661
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Captain.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Captain.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1494963329605038}
+  m_IsPrefabParent: 1
+--- !u!1 &1494963329605038
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4808317555433196}
+  - component: {fileID: 114735874007604360}
+  m_Layer: 0
+  m_Name: Captain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4808317555433196
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1494963329605038}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114735874007604360
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1494963329605038}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/captain
+  jobType: 6
+  allowedAccess: 01000000030000000400000005000000060000000700000008000000090000000a00000015000000160000001700000018000000190000001a0000001b0000001e0000001f000000200000002100000022000000230000002400000025000000260000002700000028000000290000002a0000002b0000002c0000002d0000002e0000002f00000030000000310000003200000033000000340000003500000036000000370000003a0000003b0000003c0000003d0000003e0000003f00000040000000420000004300000044000000450000004600000047000000490000004a0000004b0000004c0000004d0000004e0000004f00000050000000
+  ears: /obj/item/device/radio/headset/heads/captain
+  belt: /obj/item/device/pda/captain
+  back: 
+  shoes: /obj/item/clothing/shoes/sneakers/brown
+  glasses: /obj/item/clothing/glasses/sunglasses
+  gloves: /obj/item/clothing/gloves/color/captain
+  suit: /obj/item/clothing/suit/armor/vest/capcarapace
+  head: /obj/item/clothing/head/caphat
+  accessory: /obj/item/clothing/accessory/medal/gold/captain
+  mask: 
+  backpack: /obj/item/weapon/storage/backpack/captain
+  satchel: /obj/item/weapon/storage/backpack/satchel/cap
+  duffelbag: 
+  box: 
+  l_hand: 
+  l_pocket: 
+  r_pocket: 
+  suit_store: 
+  backpack_contents:
+  - /obj/item/weapon/melee/classic_baton/telescopic
+  - /obj/item/weapon/station_charter

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Captain.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Captain.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 94a73cbc162a81e4b8f544aa635edc55
+timeCreated: 1498593737
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Cargo Technician.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Cargo Technician.prefab
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1136714444673464}
+  m_IsPrefabParent: 1
+--- !u!1 &1136714444673464
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4648298864692282}
+  - component: {fileID: 114990701537150922}
+  m_Layer: 0
+  m_Name: Cargo Technician
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4648298864692282
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1136714444673464}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114990701537150922
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1136714444673464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/cargotech
+  jobType: 7
+  allowedAccess: 08000000090000001a00000022000000310000003000000035000000360000003700000045000000
+  ears: /obj/item/device/radio/headset/headset_cargo
+  belt: /obj/item/device/pda/cargo
+  back: 
+  shoes: 
+  glasses: 
+  gloves: 
+  suit: 
+  head: 
+  accessory: 
+  mask: 
+  backpack: 
+  satchel: 
+  duffelbag: 
+  box: 
+  l_hand: 
+  l_pocket: 
+  r_pocket: 
+  suit_store: 
+  backpack_contents: []

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Cargo Technician.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Cargo Technician.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d582bc4338c6704428f4815708fc8523
+timeCreated: 1498594550
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Chaplain.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Chaplain.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1476561106451396}
+  m_IsPrefabParent: 1
+--- !u!1 &1476561106451396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4997483820150072}
+  - component: {fileID: 114516408134387702}
+  m_Layer: 0
+  m_Name: Chaplain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4997483820150072
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1476561106451396}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114516408134387702
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1476561106451396}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/chaplain
+  jobType: 8
+  allowedAccess: 160000001a0000002200000031000000
+  ears: /obj/item/device/radio/headset
+  belt: /obj/item/device/pda/chaplain
+  back: 
+  shoes: 
+  glasses: 
+  gloves: 
+  suit: 
+  head: 
+  accessory: /obj/item/clothing/accessory/pocketprotector/cosmetology
+  mask: 
+  backpack: /obj/item/weapon/storage/backpack/cultpack
+  satchel: /obj/item/weapon/storage/backpack/cultpack
+  duffelbag: 
+  box: 
+  l_hand: 
+  l_pocket: 
+  r_pocket: 
+  suit_store: 
+  backpack_contents:
+  - /obj/item/device/camera/spooky

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Chaplain.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Chaplain.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ce5893c0e3788504aaa0dfb89f244fe5
+timeCreated: 1498596931
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Chemist.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Chemist.prefab
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1214411874072222}
+  m_IsPrefabParent: 1
+--- !u!1 &1214411874072222
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4404476972468370}
+  - component: {fileID: 114549109945797754}
+  m_Layer: 0
+  m_Name: Chemist
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4404476972468370
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1214411874072222}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114549109945797754
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1214411874072222}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/chemist
+  jobType: 9
+  allowedAccess: 170000001a000000220000003100000033000000
+  ears: /obj/item/device/radio/headset/headset_med
+  belt: /obj/item/device/pda/chemist
+  back: 
+  shoes: /obj/item/clothing/shoes/sneakers/white
+  glasses: /obj/item/clothing/glasses/science
+  gloves: 
+  suit: /obj/item/clothing/suit/toggle/labcoat/chemist
+  head: 
+  accessory: /obj/item/clothing/accessory/pocketprotector/full
+  mask: 
+  backpack: /obj/item/weapon/storage/backpack/chemistry
+  satchel: /obj/item/weapon/storage/backpack/satchel/chem
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/med
+  box: 
+  l_hand: 
+  l_pocket: 
+  r_pocket: 
+  suit_store: 
+  backpack_contents: []

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Chemist.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Chemist.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5ace8ed887faa2945a2dda8083f809cd
+timeCreated: 1498595546
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Chief Engineer.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Chief Engineer.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1080733297063956}
+  m_IsPrefabParent: 1
+--- !u!1 &1080733297063956
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4012161329755658}
+  - component: {fileID: 114135205603922694}
+  m_Layer: 0
+  m_Name: Chief Engineer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4012161329755658
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1080733297063956}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114135205603922694
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1080733297063956}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/chief_engineer
+  jobType: 10
+  allowedAccess: 040000000a0000001a0000001e0000001f000000200000002100000022000000260000002c0000003100000032000000490000004a000000
+  ears: /obj/item/device/radio/headset/heads/ce
+  belt: /obj/item/weapon/storage/belt/utility/chief/full
+  back: 
+  shoes: /obj/item/clothing/shoes/sneakers/brown
+  glasses: 
+  gloves: /obj/item/clothing/gloves/color/black/ce
+  suit: 
+  head: /obj/item/clothing/head/hardhat/white
+  accessory: /obj/item/clothing/accessory/pocketprotector/full
+  mask: 
+  backpack: /obj/item/weapon/storage/backpack/industrial
+  satchel: /obj/item/weapon/storage/backpack/satchel/eng
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/engineering
+  box: /obj/item/weapon/storage/box/engineer
+  l_hand: 
+  l_pocket: /obj/item/device/pda/heads/ce
+  r_pocket: 
+  suit_store: 
+  backpack_contents:
+  - /obj/item/weapon/melee/classic_baton/telescopic
+  - /obj/item/device/modular_computer/tablet/preset/advanced

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Chief Engineer.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Chief Engineer.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8bff47b0f7025e446987788c8006fc00
+timeCreated: 1498595162
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Chief Medical Officer.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Chief Medical Officer.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1000022580185544}
+  m_IsPrefabParent: 1
+--- !u!1 &1000022580185544
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4209368524515870}
+  - component: {fileID: 114520892188753644}
+  m_Layer: 0
+  m_Name: Chief Medical Officer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4209368524515870
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000022580185544}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114520892188753644
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000022580185544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/chief_medical_officer
+  jobType: 13
+  allowedAccess: 190000001a000000220000001700000025000000260000002c00000031000000330000003a0000003b000000460000004e000000
+  ears: /obj/item/device/radio/headset/heads/cmo
+  belt: /obj/item/device/pda/heads/cmo
+  back: 
+  shoes: /obj/item/clothing/shoes/sneakers/brown
+  glasses: 
+  gloves: 
+  suit: /obj/item/clothing/suit/toggle/labcoat/cmo
+  head: 
+  accessory: 
+  mask: 
+  backpack: /obj/item/weapon/storage/backpack/medic
+  satchel: /obj/item/weapon/storage/backpack/satchel/med
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/med
+  box: 
+  l_hand: /obj/item/weapon/storage/firstaid/regular
+  l_pocket: 
+  r_pocket: 
+  suit_store: /obj/item/device/flashlight/pen
+  backpack_contents:
+  - /obj/item/weapon/melee/classic_baton/telescopic

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Chief Medical Officer.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Chief Medical Officer.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5639c0b75afbd264b9abcfd4850b3775
+timeCreated: 1498595377
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Clown.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Clown.prefab
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1274075780459964}
+  m_IsPrefabParent: 1
+--- !u!1 &1274075780459964
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4506439321681736}
+  - component: {fileID: 114444770487309922}
+  m_Layer: 0
+  m_Name: Clown
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4506439321681736
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1274075780459964}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114444770487309922
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1274075780459964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/clown
+  jobType: 12
+  allowedAccess: 180000003100000022000000
+  ears: /obj/item/device/radio/headset
+  belt: /obj/item/device/pda/clown
+  back: 
+  shoes: /obj/item/clothing/shoes/clown_shoes
+  glasses: 
+  gloves: 
+  suit: 
+  head: 
+  accessory: 
+  mask: /obj/item/clothing/mask/gas/clown_hat
+  backpack: /obj/item/weapon/storage/backpack/clown
+  satchel: /obj/item/weapon/storage/backpack/clown
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/clown
+  box: /obj/item/weapon/storage/box/hug/survival
+  l_hand: 
+  l_pocket: /obj/item/weapon/bikehorn
+  r_pocket: 
+  suit_store: 
+  backpack_contents:
+  - /obj/item/weapon/stamp/clown
+  - /obj/item/weapon/reagent_containers/spray/waterflower
+  - /obj/item/weapon/reagent_containers/food/snacks/grown/banana

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Clown.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Clown.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f333100d3e93aec419cecb2f797912ee
+timeCreated: 1498594715
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Cook.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Cook.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1316978556928262}
+  m_IsPrefabParent: 1
+--- !u!1 &1316978556928262
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4355388960733504}
+  - component: {fileID: 114136623110866566}
+  m_Layer: 0
+  m_Name: Cook
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4355388960733504
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1316978556928262}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114136623110866566
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1316978556928262}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/chef
+  jobType: 14
+  allowedAccess: 2d000000310000001a00000022000000
+  ears: /obj/item/device/radio/headset/headset_srv
+  belt: /obj/item/device/pda/cook
+  back: 
+  shoes: 
+  glasses: 
+  gloves: 
+  suit: /obj/item/clothing/suit/toggle/chef
+  head: /obj/item/clothing/head/chefhat
+  accessory: 
+  mask: 
+  backpack: 
+  satchel: 
+  duffelbag: 
+  box: 
+  l_hand: 
+  l_pocket: 
+  r_pocket: 
+  suit_store: 
+  backpack_contents:
+  - /obj/item/weapon/sharpener

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Cook.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Cook.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8cadc733b028e694eaff2e60c0bac4a9
+timeCreated: 1498596531
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Curator.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Curator.prefab
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1285918740150374}
+  m_IsPrefabParent: 1
+--- !u!1 &1285918740150374
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4026457327316812}
+  - component: {fileID: 114925413886211518}
+  m_Layer: 0
+  m_Name: Curator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4026457327316812
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1285918740150374}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114925413886211518
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1285918740150374}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/curator
+  jobType: 15
+  allowedAccess: 1a00000031000000220000002f000000
+  ears: /obj/item/device/radio/headset
+  belt: /obj/item/device/pda/curator
+  back: 
+  shoes: 
+  glasses: 
+  gloves: 
+  suit: 
+  head: 
+  accessory: /obj/item/clothing/accessory/pocketprotector/full
+  mask: 
+  backpack: 
+  satchel: 
+  duffelbag: 
+  box: 
+  l_hand: /obj/item/weapon/storage/bag/books
+  l_pocket: /obj/item/device/laser_pointer
+  r_pocket: /obj/item/key/displaycase
+  suit_store: 
+  backpack_contents:
+  - /obj/item/weapon/melee/curator_whip
+  - /obj/item/soapstone
+  - /obj/item/weapon/barcodescanner

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Curator.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Curator.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a55d1875d8e327e4e9dabfcb1a4a4eea
+timeCreated: 1498594890
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Detective.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Detective.prefab
@@ -1,0 +1,69 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1961709938469034
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4371063069824940}
+  - component: {fileID: 114271083428414816}
+  m_Layer: 0
+  m_Name: Detective
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4371063069824940
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961709938469034}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114271083428414816
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961709938469034}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  accessory: 
+  allowedAccess: 060000001b0000002200000023000000430000004400000031000000
+  backpack: 
+  backpack_contents:
+  - /obj/item/weapon/storage/box/evidence
+  - /obj/item/device/detective_scanner
+  - /obj/item/weapon/melee/classic_baton
+  belt: /obj/item/device/pda/detective
+  box: 
+  duffelbag: 
+  ears: /obj/item/device/radio/headset/headset_sec/alt
+  glasses: 
+  gloves: /obj/item/clothing/gloves/color/black
+  head: /obj/item/clothing/head/fedora/det_hat
+  jobType: 17
+  l_hand: 
+  l_pocket: /obj/item/toy/crayon/white
+  mask: /obj/item/clothing/mask/cigarette
+  r_pocket: /obj/item/weapon/lighter
+  satchel: 
+  shoes: /obj/item/clothing/shoes/sneakers/brown
+  suit: /obj/item/clothing/suit/det_suit
+  suit_store: 
+  uniform: /obj/item/clothing/under/rank/det

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Detective.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Detective.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 22105c049e63a8e4c8c97568e3526174
+timeCreated: 1498596283
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Engineer.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Engineer.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1401796472915240}
+  m_IsPrefabParent: 1
+--- !u!1 &1401796472915240
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4248451115683536}
+  - component: {fileID: 114660657461198928}
+  m_Layer: 0
+  m_Name: Engineer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4248451115683536
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1401796472915240}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114660657461198928
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1401796472915240}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/engineer
+  jobType: 20
+  allowedAccess: 1a0000001e0000001f00000020000000220000003100000032000000
+  ears: /obj/item/device/radio/headset/headset_eng
+  belt: /obj/item/weapon/storage/belt/utility/full
+  back: 
+  shoes: /obj/item/clothing/shoes/workboots
+  glasses: 
+  gloves: 
+  suit: 
+  head: /obj/item/clothing/head/hardhat
+  accessory: /obj/item/clothing/accessory/pocketprotector/full
+  mask: 
+  backpack: /obj/item/weapon/storage/backpack/industrial
+  satchel: /obj/item/weapon/storage/backpack/satchel/eng
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/engineering
+  box: /obj/item/weapon/storage/box/engineer
+  l_hand: 
+  l_pocket: /obj/item/device/pda/engineering
+  r_pocket: /obj/item/device/t_scanner
+  suit_store: 
+  backpack_contents:
+  - /obj/item/device/modular_computer/tablet/preset/advanced

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Engineer.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Engineer.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 00cfe327b26d9b142a697f1c82146828
+timeCreated: 1498595255
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Geneticist.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Geneticist.prefab
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1316251908361052}
+  m_IsPrefabParent: 1
+--- !u!1 &1316251908361052
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4220107430346350}
+  - component: {fileID: 114244525475922640}
+  m_Layer: 0
+  m_Name: Geneticist
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4220107430346350
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1316251908361052}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114244525475922640
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1316251908361052}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  accessory: 
+  allowedAccess: 1a00000025000000330000003100000022000000420000003f00000050000000
+  back: 
+  backpack: /obj/item/weapon/storage/backpack/genetics
+  backpack_contents: []
+  belt: /obj/item/device/pda/geneticist
+  box: 
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/med
+  ears: /obj/item/device/radio/headset/headset_medsci
+  glasses: 
+  gloves: 
+  head: 
+  jobType: 21
+  l_hand: 
+  l_pocket: 
+  mask: 
+  r_pocket: 
+  satchel: /obj/item/weapon/storage/backpack/satchel/gen
+  shoes: /obj/item/clothing/shoes/sneakers/white
+  suit: /obj/item/clothing/suit/toggle/labcoat/genetics
+  suit_store: /obj/item/device/flashlight/pen
+  uniform: /obj/item/clothing/under/rank/geneticist

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Geneticist.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Geneticist.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5f0f1d65018f51a4e94149cffae22311
+timeCreated: 1498595603
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Head of Personnel.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Head of Personnel.prefab
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1624884259146988}
+  m_IsPrefabAsset: 1
+--- !u!1 &1624884259146988
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4821836103487530}
+  - component: {fileID: 114418886390058330}
+  m_Layer: 0
+  m_Name: Head of Personnel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4821836103487530
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1624884259146988}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114418886390058330
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1624884259146988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  accessory: 
+  allowedAccess: 06000000080000001a0000001b0000001e000000200000001f0000002200000026000000280000002b0000002c0000002f00000030000000310000003300000034000000180000004200000044000000430000001500000035000000
+  back: 
+  backpack: 
+  backpack_contents:
+  - /obj/item/weapon/storage/box/ids
+  - /obj/item/weapon/melee/classic_baton/telescopic
+  - /obj/item/device/modular_computer/tablet/preset/advanced
+  belt: /obj/item/device/pda/heads/hop
+  box: 
+  duffelbag: 
+  ears: /obj/item/device/radio/headset/heads/hop
+  glasses: 
+  gloves: 
+  head: /obj/item/clothing/head/hopcap
+  jobType: 22
+  l_hand: 
+  l_pocket: 
+  mask: 
+  r_pocket: 
+  satchel: 
+  shoes: /obj/item/clothing/shoes/sneakers/brown
+  suit: 
+  suit_store: 
+  uniform: /obj/item/clothing/under/rank/head_of_personnel

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Head of Personnel.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Head of Personnel.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 47a11f75b419c0d43bb0e68e05c2a59b
+timeCreated: 1498594276
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Head of Security.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Head of Security.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1643359509851492}
+  m_IsPrefabParent: 1
+--- !u!1 &1643359509851492
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4864939860013544}
+  - component: {fileID: 114988381238879854}
+  m_Layer: 0
+  m_Name: Head of Security
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4864939860013544
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1643359509851492}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114988381238879854
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1643359509851492}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/head_of_security
+  jobType: 23
+  allowedAccess: 03000000060000001a0000001b00000022000000230000002600000027000000290000002c0000002e000000310000003a00000043000000440000004f000000
+  ears: /obj/item/device/radio/headset/heads/hos
+  belt: /obj/item/device/pda/heads/hos
+  back: 
+  shoes: /obj/item/clothing/shoes/jackboots
+  glasses: /obj/item/clothing/glasses/hud/security/sunglasses
+  gloves: /obj/item/clothing/gloves/color/black/hos
+  suit: /obj/item/clothing/suit/armor/hos/trenchcoat
+  head: /obj/item/clothing/head/HoS/beret
+  accessory: 
+  mask: 
+  backpack: /obj/item/weapon/storage/backpack/security
+  satchel: /obj/item/weapon/storage/backpack/satchel/sec
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/sec
+  box: /obj/item/weapon/storage/box/security
+  l_hand: 
+  l_pocket: /obj/item/weapon/restraints/handcuffs
+  r_pocket: /obj/item/device/assembly/flash/handheld
+  suit_store: /obj/item/weapon/gun/energy/e_gun
+  backpack_contents:
+  - /obj/item/weapon/melee/baton/loaded

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Head of Security.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Head of Security.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9745b35ba5c3ecd45805fe511e35fb46
+timeCreated: 1498596060
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Janitor.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Janitor.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1058409517316502}
+  m_IsPrefabParent: 1
+--- !u!1 &1058409517316502
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4947722521964176}
+  - component: {fileID: 114485698327620128}
+  m_Layer: 0
+  m_Name: Janitor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4947722521964176
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1058409517316502}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114485698327620128
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1058409517316502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/janitor
+  jobType: 24
+  allowedAccess: 1a000000220000002b00000031000000
+  ears: /obj/item/device/radio/headset/headset_srv
+  belt: /obj/item/device/pda/janitor
+  back: 
+  shoes: 
+  glasses: 
+  gloves: 
+  suit: 
+  head: 
+  accessory: 
+  mask: 
+  backpack: 
+  satchel: 
+  duffelbag: 
+  box: 
+  l_hand: 
+  l_pocket: 
+  r_pocket: 
+  suit_store: 
+  backpack_contents:
+  - /obj/item/device/modular_computer/tablet/preset/advanced

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Janitor.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Janitor.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8b4a5b3c12d5ce548826cc7d5755483a
+timeCreated: 1498596709
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Lawyer.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Lawyer.prefab
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1803395098687542}
+  m_IsPrefabParent: 1
+--- !u!1 &1803395098687542
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4190727639927858}
+  - component: {fileID: 114424121736988246}
+  m_Layer: 0
+  m_Name: Lawyer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4190727639927858
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1803395098687542}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114424121736988246
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1803395098687542}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/lawyer/bluesuit
+  jobType: 25
+  allowedAccess: 060000001a000000220000002e0000004400000043000000
+  ears: /obj/item/device/radio/headset/headset_sec
+  belt: /obj/item/device/pda/lawyer
+  back: 
+  shoes: /obj/item/clothing/shoes/laceup
+  glasses: 
+  gloves: 
+  suit: /obj/item/clothing/suit/toggle/lawyer
+  head: 
+  accessory: 
+  mask: 
+  backpack: 
+  satchel: 
+  duffelbag: 
+  box: 
+  l_hand: /obj/item/weapon/storage/briefcase/lawyer
+  l_pocket: /obj/item/device/laser_pointer
+  r_pocket: /obj/item/clothing/accessory/lawyers_badge
+  suit_store: 
+  backpack_contents: []

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Lawyer.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Lawyer.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ececfd37070c61c4db48b7a0fea096d5
+timeCreated: 1498595055
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Medical Doctor.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Medical Doctor.prefab
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1567982637835890}
+  m_IsPrefabAsset: 1
+--- !u!1 &1567982637835890
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4415884133303432}
+  - component: {fileID: 114739750320285804}
+  m_Layer: 0
+  m_Name: Medical Doctor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4415884133303432
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1567982637835890}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114739750320285804
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1567982637835890}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  accessory: 
+  allowedAccess: 1a00000022000000330000003a0000004600000031000000
+  back: 
+  backpack: /obj/item/weapon/storage/backpack/medic
+  backpack_contents: []
+  belt: /obj/item/device/pda/medical
+  box: 
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/med
+  ears: /obj/item/device/radio/headset/headset_med
+  glasses: 
+  gloves: 
+  head: 
+  jobType: 18
+  l_hand: /obj/item/weapon/storage/firstaid/regular
+  l_pocket: 
+  mask: 
+  r_pocket: 
+  satchel: /obj/item/weapon/storage/backpack/satchel/med
+  shoes: /obj/item/clothing/shoes/sneakers/white
+  suit: /obj/item/clothing/suit/toggle/labcoat
+  suit_store: /obj/item/device/flashlight/pen
+  uniform: /obj/item/clothing/under/rank/medical

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Medical Doctor.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Medical Doctor.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c9d1c6b5df5fbef4f87cdc57df02efb8
+timeCreated: 1498595458
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Mime.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Mime.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1011004731350688}
+  m_IsPrefabParent: 1
+--- !u!1 &1011004731350688
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4350242904132210}
+  - component: {fileID: 114921848515463808}
+  m_Layer: 0
+  m_Name: Mime
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4350242904132210
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1011004731350688}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114921848515463808
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1011004731350688}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/mime
+  jobType: 27
+  allowedAccess: 220000001a0000003100000034000000
+  ears: /obj/item/device/radio/headset
+  belt: /obj/item/device/pda/mime
+  back: 
+  shoes: 
+  glasses: 
+  gloves: /obj/item/clothing/gloves/color/white
+  suit: /obj/item/clothing/suit/suspenders
+  head: /obj/item/clothing/head/beret
+  accessory: /obj/item/clothing/accessory/pocketprotector/cosmetology
+  mask: /obj/item/clothing/mask/gas/mime
+  backpack: /obj/item/weapon/storage/backpack/mime
+  satchel: /obj/item/weapon/storage/backpack/mime
+  duffelbag: 
+  box: 
+  l_hand: 
+  l_pocket: 
+  r_pocket: 
+  suit_store: 
+  backpack_contents:
+  - /obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Mime.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Mime.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1f411e4452a081a47b9808341fe52b6f
+timeCreated: 1498594789
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Quartermaster.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Quartermaster.prefab
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1436717421391230}
+  m_IsPrefabParent: 1
+--- !u!1 &1436717421391230
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4881961151361478}
+  - component: {fileID: 114152506943473860}
+  m_Layer: 0
+  m_Name: Quartermaster
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4881961151361478
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1436717421391230}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114152506943473860
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1436717421391230}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/cargo
+  jobType: 29
+  allowedAccess: 08000000090000001a0000001e00000022000000260000002c0000003000000031000000320000003500000036000000370000003c00000045000000
+  ears: /obj/item/device/radio/headset/headset_cargo
+  belt: /obj/item/device/pda/quartermaster
+  back: 
+  shoes: /obj/item/clothing/shoes/sneakers/brown
+  glasses: /obj/item/clothing/glasses/sunglasses
+  gloves: 
+  suit: 
+  head: 
+  accessory: 
+  mask: 
+  backpack: 
+  satchel: 
+  duffelbag: 
+  box: 
+  l_hand: /obj/item/weapon/clipboard
+  l_pocket: 
+  r_pocket: 
+  suit_store: 
+  backpack_contents: []

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Quartermaster.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Quartermaster.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9c69eb65325cb284e9b49b33f752d380
+timeCreated: 1498594491
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Research Director.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Research Director.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1768072235564342}
+  m_IsPrefabParent: 1
+--- !u!1 &1768072235564342
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4775023256924256}
+  - component: {fileID: 114057224822473346}
+  m_Layer: 0
+  m_Name: Research Director
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4775023256924256
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1768072235564342}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114057224822473346
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1768072235564342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/research_director
+  jobType: 30
+  allowedAccess: 1a0000002200000025000000310000003e0000003f00000042000000400000004a000000500000004d000000
+  ears: /obj/item/device/radio/headset/heads/rd
+  belt: /obj/item/device/pda/heads/rd
+  back: 
+  shoes: /obj/item/clothing/shoes/sneakers/brown
+  glasses: 
+  gloves: 
+  suit: /obj/item/clothing/suit/toggle/labcoat
+  head: 
+  accessory: /obj/item/clothing/accessory/pocketprotector/full
+  mask: 
+  backpack: /obj/item/weapon/storage/backpack/science
+  satchel: /obj/item/weapon/storage/backpack/satchel/tox
+  duffelbag: 
+  box: 
+  l_hand: /obj/item/weapon/clipboard
+  l_pocket: /obj/item/device/laser_pointer
+  r_pocket: 
+  suit_store: 
+  backpack_contents:
+  - /obj/item/weapon/melee/classic_baton/telescopic
+  - /obj/item/device/modular_computer/tablet/preset/advanced

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Research Director.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Research Director.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 57b4ed3ccdfda674582b3b5305a82bcf
+timeCreated: 1498595852
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Roboticist.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Roboticist.prefab
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1899692014714044}
+  m_IsPrefabParent: 1
+--- !u!1 &1899692014714044
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4804719088928274}
+  - component: {fileID: 114856171827697158}
+  m_Layer: 0
+  m_Name: Roboticist
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4804719088928274
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1899692014714044}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114856171827697158
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1899692014714044}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  accessory: 
+  allowedAccess: 1a0000002200000031000000320000003f00000040000000420000004d0000002000000032000000
+  back: 
+  backpack: /obj/item/weapon/storage/backpack/science
+  backpack_contents: []
+  belt: /obj/item/weapon/storage/belt/utility/full
+  box: 
+  duffelbag: 
+  ears: /obj/item/device/radio/headset/headset_sci
+  glasses: 
+  gloves: 
+  head: 
+  jobType: 31
+  l_hand: 
+  l_pocket: /obj/item/device/pda/roboticist
+  mask: 
+  r_pocket: 
+  satchel: /obj/item/weapon/storage/backpack/satchel/tox
+  shoes: 
+  suit: /obj/item/clothing/suit/toggle/labcoat
+  suit_store: 
+  uniform: /obj/item/clothing/under/rank/roboticist

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Roboticist.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Roboticist.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 84e1416f33ce3514f97eac8bdc1d0f94
+timeCreated: 1498595957
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Scientist.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Scientist.prefab
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1369951651615546}
+  m_IsPrefabParent: 1
+--- !u!1 &1369951651615546
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4430631878100118}
+  - component: {fileID: 114061764803648696}
+  m_Layer: 0
+  m_Name: Scientist
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4430631878100118
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1369951651615546}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114061764803648696
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1369951651615546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/scientist
+  jobType: 32
+  allowedAccess: 22000000310000003f000000420000004d00000050000000
+  ears: /obj/item/device/radio/headset/headset_sci
+  belt: /obj/item/device/pda/toxins
+  back: 
+  shoes: /obj/item/clothing/shoes/sneakers/white
+  glasses: 
+  gloves: 
+  suit: /obj/item/clothing/suit/toggle/labcoat/science
+  head: 
+  accessory: /obj/item/clothing/accessory/pocketprotector/full
+  mask: 
+  backpack: /obj/item/weapon/storage/backpack/science
+  satchel: /obj/item/weapon/storage/backpack/satchel/tox
+  duffelbag: 
+  box: 
+  l_hand: 
+  l_pocket: 
+  r_pocket: 
+  suit_store: 
+  backpack_contents: []

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Scientist.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Scientist.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d25decb62df497247b5c637034063478
+timeCreated: 1498595902
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Security Officer.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Security Officer.prefab
@@ -1,0 +1,67 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1212771459599398
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4059602406184756}
+  - component: {fileID: 114072119395226880}
+  m_Layer: 0
+  m_Name: Security Officer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4059602406184756
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1212771459599398}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114072119395226880
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1212771459599398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  accessory: 
+  allowedAccess: 060000001a0000001b0000003100000043000000440000002300000022000000
+  backpack: /obj/item/weapon/storage/backpack/security
+  backpack_contents:
+  - /obj/item/weapon/melee/baton/loaded
+  belt: /obj/item/device/pda/security
+  box: /obj/item/weapon/storage/box/security
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/sec
+  ears: /obj/item/device/radio/headset/headset_sec
+  glasses: 
+  gloves: /obj/item/clothing/gloves/color/black
+  head: /obj/item/clothing/head/helmet/sec
+  jobType: 33
+  l_hand: 
+  l_pocket: /obj/item/weapon/restraints/handcuffs
+  mask: 
+  r_pocket: /obj/item/device/assembly/flash/handheld
+  satchel: /obj/item/weapon/storage/backpack/satchel/sec
+  shoes: /obj/item/clothing/shoes/jackboots
+  suit: /obj/item/clothing/suit/armor/vest/alt
+  suit_store: /obj/item/weapon/gun/energy/e_gun/advtaser
+  uniform: /obj/item/clothing/under/rank/security

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Security Officer.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Security Officer.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: e9221d12cb336f448b0661c33662df7c
+timeCreated: 1498596392
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Shaft Miner.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Shaft Miner.prefab
@@ -1,0 +1,66 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1965380579708374
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4245055658697674}
+  - component: {fileID: 114605407999850278}
+  m_Layer: 0
+  m_Name: Shaft Miner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4245055658697674
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1965380579708374}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114605407999850278
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1965380579708374}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  accessory: 
+  allowedAccess: 080000001a0000002200000031000000350000003600000037000000
+  backpack: 
+  backpack_contents: []
+  belt: 
+  box: 
+  duffelbag: 
+  ears: /obj/item/device/radio/headset
+  glasses: 
+  gloves: 
+  head: /obj/item/clothing/head/helmet/space/hardsuit/
+  jobType: 28
+  l_hand: 
+  l_pocket: 
+  mask: 
+  r_pocket: 
+  satchel: 
+  shoes: /obj/item/clothing/shoes/workboots
+  suit: /obj/item/clothing/suit/space/hardsuit/mining
+  suit_store: 
+  uniform: /obj/item/clothing/under/rank/miner

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Shaft Miner.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Shaft Miner.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8413a5234b2271748a9e685a417d662b
+timeCreated: 1498596480
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Standard Gear.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Standard Gear.prefab
@@ -1,0 +1,64 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1422542566252154}
+  m_IsPrefabParent: 1
+--- !u!1 &1422542566252154
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4858855116394646}
+  - component: {fileID: 114195016563368306}
+  m_Layer: 0
+  m_Name: Standard Gear
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4858855116394646
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1422542566252154}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114195016563368306
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1422542566252154}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  outfitname: Standard Gear
+  uniform: /obj/item/clothing/under/color/grey
+  id: /obj/item/weapon/card/id
+  ears: /obj/item/device/radio/headset
+  belt: /obj/item/device/pda
+  back: /obj/item/weapon/storage/backpack
+  shoes: /obj/item/clothing/shoes/sneakers/black
+  backpack: /obj/item/weapon/storage/backpack
+  satchel: /obj/item/weapon/storage/backpack/satchel
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag
+  box: /obj/item/weapon/storage/box/survival

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Standard Gear.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Standard Gear.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 20382c4d00a98944f99ee2ddc86c0fe9
+timeCreated: 1498593273
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/SyndicateOperative.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/SyndicateOperative.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1307009445476176}
+  m_IsPrefabParent: 1
+--- !u!1 &1307009445476176
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4879325915106406}
+  - component: {fileID: 114995929624158314}
+  m_Layer: 0
+  m_Name: SyndicateOperative
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4879325915106406
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1307009445476176}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114995929624158314
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1307009445476176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  accessory: 
+  allowedAccess: 220000002300000031000000
+  back: 
+  backpack: /obj/item/weapon/storage/backpack/security
+  backpack_contents:
+  - /obj/item/weapon/melee/baton/loaded
+  belt: /obj/item/device/pda/warden
+  box: /obj/item/weapon/storage/box/security
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/sec
+  ears: /obj/item/device/radio/headset/syndicate/alt
+  glasses: /obj/item/clothing/glasses/hud/security/sunglasses
+  gloves: /obj/item/clothing/gloves/color/black
+  head: /obj/item/clothing/head/helmet/space/hardsuit/syndi
+  jobType: 36
+  l_hand: 
+  l_pocket: /obj/item/weapon/restraints/handcuffs
+  mask: 
+  r_pocket: /obj/item/device/assembly/flash/handheld
+  satchel: /obj/item/weapon/storage/backpack/satchel/sec
+  shoes: /obj/item/clothing/shoes/jackboots
+  suit: /obj/item/clothing/suit/space/hardsuit/syndi
+  suit_store: /obj/item/weapon/gun/energy/e_gun/advtaser
+  uniform: /obj/item/clothing/under/syndicate/tacticool

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/SyndicateOperative.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/SyndicateOperative.prefab.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 3d6b6ec632a9c44bf8db14801f4be36c
+timeCreated: 1518336372
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Virologist.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Virologist.prefab
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1860008544557904}
+  m_IsPrefabParent: 1
+--- !u!1 &1860008544557904
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4545090818377940}
+  - component: {fileID: 114170456118253346}
+  m_Layer: 0
+  m_Name: Virologist
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4545090818377940
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1860008544557904}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114170456118253346
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1860008544557904}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/virologist
+  jobType: 34
+  allowedAccess: 2200000031000000330000004e000000
+  ears: /obj/item/device/radio/headset/headset_med
+  belt: /obj/item/device/pda/viro
+  back: 
+  shoes: /obj/item/clothing/shoes/sneakers/white
+  glasses: 
+  gloves: 
+  suit: /obj/item/clothing/suit/toggle/labcoat/virologist
+  head: 
+  accessory: 
+  mask: /obj/item/clothing/mask/surgical
+  backpack: /obj/item/weapon/storage/backpack/virology
+  satchel: /obj/item/weapon/storage/backpack/satchel/vir
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/med
+  box: 
+  l_hand: 
+  l_pocket: 
+  r_pocket: 
+  suit_store: /obj/item/device/flashlight/pen
+  backpack_contents: []

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Virologist.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Virologist.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9dd6a0e161b36714db4f88ee203fd346
+timeCreated: 1498595681
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Warden.prefab
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Warden.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1307009445476176}
+  m_IsPrefabParent: 1
+--- !u!1 &1307009445476176
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4879325915106406}
+  - component: {fileID: 114995929624158314}
+  m_Layer: 0
+  m_Name: Warden
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4879325915106406
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1307009445476176}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114995929624158314
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1307009445476176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ef832313bc8da84b8fa31c209efe06e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniform: /obj/item/clothing/under/rank/warden
+  jobType: 35
+  allowedAccess: 22000000230000003100000043000000440000004f00000003000000
+  ears: /obj/item/device/radio/headset/headset_sec
+  belt: /obj/item/device/pda/warden
+  back: 
+  shoes: /obj/item/clothing/shoes/jackboots
+  glasses: /obj/item/clothing/glasses/hud/security/sunglasses
+  gloves: /obj/item/clothing/gloves/color/black
+  suit: /obj/item/clothing/suit/armor/vest/warden/alt
+  head: /obj/item/clothing/head/warden
+  accessory: 
+  mask: 
+  backpack: /obj/item/weapon/storage/backpack/security
+  satchel: /obj/item/weapon/storage/backpack/satchel/sec
+  duffelbag: /obj/item/weapon/storage/backpack/duffelbag/sec
+  box: /obj/item/weapon/storage/box/security
+  l_hand: 
+  l_pocket: /obj/item/weapon/restraints/handcuffs
+  r_pocket: /obj/item/device/assembly/flash/handheld
+  suit_store: /obj/item/weapon/gun/energy/e_gun/advtaser
+  backpack_contents:
+  - /obj/item/weapon/melee/baton/loaded

--- a/UnityProject/Assets/Prefabs/Outfits/Resources/Warden.prefab.meta
+++ b/UnityProject/Assets/Prefabs/Outfits/Resources/Warden.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 934b722f97bab1e4d9ad74065ba20f6d
+timeCreated: 1498596171
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab
+++ b/UnityProject/Assets/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab
@@ -45,43 +45,45 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameMode: 1
+  RoundTime: 600
   counting: 0
   Occupations:
-  - {fileID: 114770154129646446, guid: 21b1766adb51e3349890b2d2f9db3227, type: 3}
-  - {fileID: 114903656805233692, guid: 4ad72e00f3116964dba8efeaad0882d9, type: 3}
-  - {fileID: 114808229622716488, guid: c006a7ffbdddb904295cb509d53f609f, type: 3}
-  - {fileID: 114685359379298424, guid: fc6594ec54edd1b4a8b4f0c37614e1bd, type: 3}
-  - {fileID: 114539947820853932, guid: 1931ef679fdf9d140b5598d6284c902e, type: 3}
-  - {fileID: 114710987489201792, guid: 74b0f21957a9fac46abd326a8727b3bb, type: 3}
-  - {fileID: 114759171035914890, guid: c06c397454295e04d9ef175ea1b804d6, type: 3}
-  - {fileID: 114744413334003856, guid: c6b2b41cf82f3ef4c833e4f604bcc0fa, type: 3}
-  - {fileID: 114338157040407634, guid: de040a3e1948bdc4fb1b96e398ab3546, type: 3}
-  - {fileID: 114724883360912620, guid: c566621f9bf83ef43a0c4134e59e0e15, type: 3}
-  - {fileID: 114925571666636192, guid: 8eb826f1e18a51d45907f8e59b2df073, type: 3}
-  - {fileID: 114991219850476776, guid: 29edbb963514e864f8a9efe57cba71ad, type: 3}
-  - {fileID: 114548354090148952, guid: 6b55745ab58047d44a055e7e1524deec, type: 3}
-  - {fileID: 114921496756850354, guid: 363d5a9966200e745bbf44c6355a5ac7, type: 3}
-  - {fileID: 114183438210680130, guid: 2e9facb6298c467428bd6de4f511be15, type: 3}
-  - {fileID: 114479936876315980, guid: 340c2cfdf2ef5974b86e23bc54395d3b, type: 3}
-  - {fileID: 114151551211946104, guid: eb96e24ea81195a4aa320741597ed5da, type: 3}
-  - {fileID: 114644283964880676, guid: d046171d9de251b448307b00350af9b0, type: 3}
-  - {fileID: 114864864129673492, guid: 60d742d968b30144e8c8e34c99706a95, type: 3}
-  - {fileID: 114890647799891260, guid: 32b8e3be23877aa49bed3511613a669d, type: 3}
-  - {fileID: 114627780839628786, guid: 18449c976bad9694eaa68de8bb423288, type: 3}
-  - {fileID: 114209644629902292, guid: bf4c5d3dc83aa484b9a3f2dc8aff0f5c, type: 3}
-  - {fileID: 114882286145020194, guid: 6bf9ff28fdf62fe4e8bbce25601881da, type: 3}
-  - {fileID: 114492915465789058, guid: 236f5194e03cc694f9e753d8ac52e4c8, type: 3}
-  - {fileID: 114453458061749320, guid: dd34494fb334795478f8ad48bb7c9a46, type: 3}
-  - {fileID: 114948910528933562, guid: 6887a6540f33238488ee370b8dbfcaf8, type: 3}
-  - {fileID: 114768286689842576, guid: 45429c638a622df40a27fc4af7d1a37a, type: 3}
-  - {fileID: 114274993402726546, guid: 8e24a8fa58e3fb44abf98bd9ce692107, type: 3}
-  - {fileID: 114329545210965172, guid: 8ecf387cd4531408b94a7814e0ab8be4, type: 3}
-  - {fileID: 114786801744095452, guid: b2f4f1d6bba6d274badb1a08a8f83b25, type: 3}
-  - {fileID: 114329545210965172, guid: 547f5d5a3b17a4044ba6f350892fd192, type: 3}
-  StandardOutfit: {fileID: 0}
+  - {fileID: 1907548023066798, guid: 21b1766adb51e3349890b2d2f9db3227, type: 3}
+  - {fileID: 1866127696583700, guid: 4ad72e00f3116964dba8efeaad0882d9, type: 3}
+  - {fileID: 1565708968720630, guid: c006a7ffbdddb904295cb509d53f609f, type: 3}
+  - {fileID: 1095216131823204, guid: fc6594ec54edd1b4a8b4f0c37614e1bd, type: 3}
+  - {fileID: 1387094316131694, guid: 1931ef679fdf9d140b5598d6284c902e, type: 3}
+  - {fileID: 1542514950764114, guid: 74b0f21957a9fac46abd326a8727b3bb, type: 3}
+  - {fileID: 1977045321645812, guid: c06c397454295e04d9ef175ea1b804d6, type: 3}
+  - {fileID: 1233643564516408, guid: c6b2b41cf82f3ef4c833e4f604bcc0fa, type: 3}
+  - {fileID: 1389842405221104, guid: de040a3e1948bdc4fb1b96e398ab3546, type: 3}
+  - {fileID: 1456289663796778, guid: c566621f9bf83ef43a0c4134e59e0e15, type: 3}
+  - {fileID: 1558448658196052, guid: 8eb826f1e18a51d45907f8e59b2df073, type: 3}
+  - {fileID: 1077496234113506, guid: 29edbb963514e864f8a9efe57cba71ad, type: 3}
+  - {fileID: 1927430407107944, guid: 6b55745ab58047d44a055e7e1524deec, type: 3}
+  - {fileID: 1564130566163522, guid: 363d5a9966200e745bbf44c6355a5ac7, type: 3}
+  - {fileID: 1639774341900186, guid: 2e9facb6298c467428bd6de4f511be15, type: 3}
+  - {fileID: 1361754647138198, guid: 340c2cfdf2ef5974b86e23bc54395d3b, type: 3}
+  - {fileID: 1217795466810960, guid: eb96e24ea81195a4aa320741597ed5da, type: 3}
+  - {fileID: 1493080786879964, guid: d046171d9de251b448307b00350af9b0, type: 3}
+  - {fileID: 1594083957048648, guid: 60d742d968b30144e8c8e34c99706a95, type: 3}
+  - {fileID: 1703511763521866, guid: 32b8e3be23877aa49bed3511613a669d, type: 3}
+  - {fileID: 1795478352249764, guid: 18449c976bad9694eaa68de8bb423288, type: 3}
+  - {fileID: 1791784211476486, guid: bf4c5d3dc83aa484b9a3f2dc8aff0f5c, type: 3}
+  - {fileID: 1155409023102902, guid: 6bf9ff28fdf62fe4e8bbce25601881da, type: 3}
+  - {fileID: 1558353132545772, guid: 236f5194e03cc694f9e753d8ac52e4c8, type: 3}
+  - {fileID: 1334888342882360, guid: dd34494fb334795478f8ad48bb7c9a46, type: 3}
+  - {fileID: 1048553205546368, guid: 6887a6540f33238488ee370b8dbfcaf8, type: 3}
+  - {fileID: 1710672413038410, guid: 45429c638a622df40a27fc4af7d1a37a, type: 3}
+  - {fileID: 1038932695181158, guid: 8e24a8fa58e3fb44abf98bd9ce692107, type: 3}
+  - {fileID: 1767374215272712, guid: b2f4f1d6bba6d274badb1a08a8f83b25, type: 3}
+  - {fileID: 1160015512762250, guid: 547f5d5a3b17a4044ba6f350892fd192, type: 3}
+  - {fileID: 1160015512762250, guid: 8ecf387cd4531408b94a7814e0ab8be4, type: 3}
   restartTime: 10
   RespawnAllowed: 1
   roundTimer: {fileID: 0}
+  StandardOutfit: {fileID: 1422542566252154, guid: 20382c4d00a98944f99ee2ddc86c0fe9,
+    type: 3}
   waitForRestart: 0
   RoundsPerMap: 10
   Maps:

--- a/UnityProject/Assets/Scripts/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Equipment/Equipment.cs
@@ -68,69 +68,91 @@ public class Equipment : NetworkBehaviour
 
 	public void SetPlayerLoadOuts()
 	{
-		OccupationRoster occupation = GameManager.Instance.GetOccupationRoster(playerScript.mind.jobType);
+		JobOutfit standardOutfit = GameManager.Instance.StandardOutfit.GetComponent<JobOutfit>();
+		JobOutfit jobOutfit = GameManager.Instance.GetOccupationOutfit(playerScript.mind.jobType);
 
 		Dictionary<string, string> gear = new Dictionary<string, string>();
 
-		if (!string.IsNullOrEmpty(occupation.uniform))
+		gear.Add("uniform", standardOutfit.uniform);
+		gear.Add("ears", standardOutfit.ears);
+		gear.Add("belt", standardOutfit.belt);
+		gear.Add("back", standardOutfit.backpack);
+		gear.Add("shoes", standardOutfit.shoes);
+		gear.Add("glasses", standardOutfit.glasses);
+		gear.Add("gloves", standardOutfit.gloves);
+		gear.Add("suit", standardOutfit.suit);
+		gear.Add("head", standardOutfit.head);
+		//gear.Add("accessory", standardOutfit.accessory);
+		gear.Add("mask", standardOutfit.mask);
+		//gear.Add("backpack", standardOutfit.backpack);
+		//gear.Add("satchel", standardOutfit.satchel);
+		//gear.Add("duffelbag", standardOutfit.duffelbag);
+		//gear.Add("box", standardOutfit.box);
+		//gear.Add("l_hand", standardOutfit.l_hand);
+		//gear.Add("l_pocket", standardOutfit.l_pocket);
+		//gear.Add("r_pocket", standardOutfit.r_pocket);
+		//gear.Add("suit_store", standardOutfit.suit_store);
+
+		if (!string.IsNullOrEmpty(jobOutfit.uniform))
 		{
-			gear.Add("uniform", occupation.uniform);
+			gear["uniform"] = jobOutfit.uniform;
 		}
-		/*if (!String.IsNullOrEmpty(occupation.id))
-			gear.Add("id", occupation.id);*/
-		if (!string.IsNullOrEmpty(occupation.ears))
+		/*if (!String.IsNullOrEmpty(jobOutfit.id))
+			gear["id"] = jobOutfit.id;*/
+		if (!string.IsNullOrEmpty(jobOutfit.ears))
 		{
-			gear.Add("ears", occupation.ears);
+			gear["ears"] = jobOutfit.ears;
 		}
-		if (!string.IsNullOrEmpty(occupation.belt))
+		if (!string.IsNullOrEmpty(jobOutfit.belt))
 		{
-			gear.Add("belt", occupation.belt);
+			gear["belt"] = jobOutfit.belt;
 		}
-		if (!string.IsNullOrEmpty(occupation.backpack))
+		if (!string.IsNullOrEmpty(jobOutfit.backpack))
 		{
-			gear.Add("back", occupation.backpack);
+			gear["back"] = jobOutfit.backpack;
 		}
-		if (!string.IsNullOrEmpty(occupation.shoes))
+		if (!string.IsNullOrEmpty(jobOutfit.shoes))
 		{
-			gear.Add("shoes", occupation.shoes);
+			gear["shoes"] = jobOutfit.shoes;
 		}
-		if (!string.IsNullOrEmpty(occupation.glasses))
+		if (!string.IsNullOrEmpty(jobOutfit.glasses))
 		{
-			gear.Add("glasses", occupation.glasses);
+			gear["glasses"] = jobOutfit.glasses;
 		}
-		if (!string.IsNullOrEmpty(occupation.gloves))
+		if (!string.IsNullOrEmpty(jobOutfit.gloves))
 		{
-			gear.Add("gloves", occupation.gloves);
+			gear["gloves"] = jobOutfit.gloves;
 		}
-		if (!string.IsNullOrEmpty(occupation.exosuit))
+		if (!string.IsNullOrEmpty(jobOutfit.suit))
 		{
-			gear.Add("suit", occupation.exosuit);
+			gear["suit"] = jobOutfit.suit;
 		}
-		if (!string.IsNullOrEmpty(occupation.head))
+		if (!string.IsNullOrEmpty(jobOutfit.head))
 		{
-			gear.Add("head", occupation.head);
+			gear["head"] = jobOutfit.head;
 		}
-		/*if (!String.IsNullOrEmpty(occupation.accessory))
-			gear.Add("accessory", occupation.accessory);*/
-		if (!string.IsNullOrEmpty(occupation.mask))
+		/*if (!String.IsNullOrEmpty(jobOutfit.accessory))
+			gear["accessory"] = jobOutfit.accessory;*/
+		if (!string.IsNullOrEmpty(jobOutfit.mask))
 		{
-			gear.Add("mask", occupation.mask);
+			gear["mask"] = jobOutfit.mask;
 		}
-		/*
-		if (!String.IsNullOrEmpty(occupation.satchel))
-			gear.Add("satchel", occupation.satchel);
-		if (!String.IsNullOrEmpty(occupation.duffelbag))
-			gear.Add("duffelbag", occupation.duffelbag);
-		if (!String.IsNullOrEmpty(occupation.box))
-			gear.Add("box", occupation.box);
-		if (!String.IsNullOrEmpty(occupation.l_hand))
-			gear.Add("l_hand", occupation.l_hand);
-		if (!String.IsNullOrEmpty(occupation.l_pocket))
-			gear.Add("l_pocket", occupation.l_pocket);
-		if (!String.IsNullOrEmpty(occupation.r_pocket))
-			gear.Add("r_pocket", occupation.r_pocket);
-		if (!String.IsNullOrEmpty(occupation.suit_store))
-			gear.Add("suit_store", occupation.suit_store);*/
+		/*if (!String.IsNullOrEmpty(jobOutfit.backpack))
+			gear["backpack"] = jobOutfit.backpack;
+		if (!String.IsNullOrEmpty(jobOutfit.satchel))
+			gear["satchel"] = jobOutfit.satchel;
+		if (!String.IsNullOrEmpty(jobOutfit.duffelbag))
+			gear["duffelbag"] = jobOutfit.duffelbag;
+		if (!String.IsNullOrEmpty(jobOutfit.box))
+			gear["box"] = jobOutfit.box;
+		if (!String.IsNullOrEmpty(jobOutfit.l_hand))
+			gear["l_hand"] = jobOutfit.l_hand;
+		if (!String.IsNullOrEmpty(jobOutfit.l_pocket))
+			gear["l_pocket"] = jobOutfit.l_pocket;
+		if (!String.IsNullOrEmpty(jobOutfit.r_pocket))
+			gear["r_pocket"] = jobOutfit.r_pocket;
+		if (!String.IsNullOrEmpty(jobOutfit.suit_store))
+			gear["suit_store"] = jobOutfit.suit_store;*/
 
 		foreach (KeyValuePair<string, string> gearItem in gear)
 		{
@@ -152,7 +174,7 @@ public class Equipment : NetworkBehaviour
 				//					Logger.Log(gearItem.Value + " creation not implemented yet.");
 			}
 		}
-		SpawnID(occupation);
+		SpawnID(jobOutfit);
 
 		if (playerScript.mind.jobType == JobType.SYNDICATE)
 		{
@@ -166,23 +188,23 @@ public class Equipment : NetworkBehaviour
 		}
 	}
 
-	private void SpawnID(OccupationRoster occupation)
+	private void SpawnID(JobOutfit outFit)
 	{
 
 		var realName = GetComponent<PlayerScript>().playerName;
 		GameObject idObj = PoolManager.PoolNetworkInstantiate(idPrefab, parent: transform.parent);
-		if (occupation.jobType == JobType.CAPTAIN)
+		if (outFit.jobType == JobType.CAPTAIN)
 		{
-			idObj.GetComponent<IDCard>().Initialize(IDCardType.captain, occupation.jobType, occupation.allowedAccess, realName);
+			idObj.GetComponent<IDCard>().Initialize(IDCardType.captain, outFit.jobType, outFit.allowedAccess, realName);
 		}
-		else if (occupation.jobType == JobType.HOP || occupation.jobType == JobType.HOS || occupation.jobType == JobType.CMO || occupation.jobType == JobType.RD ||
-				 occupation.jobType == JobType.CHIEF_ENGINEER)
+		else if (outFit.jobType == JobType.HOP || outFit.jobType == JobType.HOS || outFit.jobType == JobType.CMO || outFit.jobType == JobType.RD ||
+				 outFit.jobType == JobType.CHIEF_ENGINEER)
 		{
-			idObj.GetComponent<IDCard>().Initialize(IDCardType.command, occupation.jobType, occupation.allowedAccess, realName);
+			idObj.GetComponent<IDCard>().Initialize(IDCardType.command, outFit.jobType, outFit.allowedAccess, realName);
 		}
 		else
 		{
-			idObj.GetComponent<IDCard>().Initialize(IDCardType.standard, occupation.jobType, occupation.allowedAccess, realName);
+			idObj.GetComponent<IDCard>().Initialize(IDCardType.standard, outFit.jobType, outFit.allowedAccess, realName);
 		}
 
 		SetItem("id", idObj);

--- a/UnityProject/Assets/Scripts/Jobs/OccupationRoster.cs
+++ b/UnityProject/Assets/Scripts/Jobs/OccupationRoster.cs
@@ -1,34 +1,19 @@
 ﻿using UnityEngine;
-using System.Collections.Generic;
 
 public class OccupationRoster : MonoBehaviour
 {
 	public int limit;
-	public int jobsTaken;
+	public GameObject outfit;
 	public int priority = 99;
-	public JobType jobType;
+	public JobType Type;
 
-	public string accessory;
-	public List<Access> allowedAccess;
+	// Use this for initialization
+	private void Start()
+	{
+	}
 
-	public string head;
-	public string glasses;
-	public string ears;
-	public string mask;
-	public string neck;
-	public string exosuit;
-	public string suitStorage;
-	public string uniform;
-	public string leftPocket;
-	public string rightPocket;
-	public string belt;
-	public string gloves;
-	public string leftHand;
-	public string shoes;
-
-	public string backpack;
-	public string duffelbag;
-	public string satchel;
-	public string box;
-	public List<string> backpack_contents = new List<string>();
+	// Update is called once per frame
+	private void Update()
+	{
+	}
 }

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -40,7 +40,6 @@ public static class SpawnHandler
 		connectedPlayer.Name = playerScript.playerName;
 		UpdateConnectedPlayersMessage.Send();
 		PlayerList.Instance.TryAddScores(playerScript.playerName);
-		GameManager.Instance.GetOccupationRoster(jobType).jobsTaken ++;
 
 		equipment.SetPlayerLoadOuts();
 		if(jobType != JobType.SYNDICATE && jobType != JobType.AI)

--- a/UnityProject/Assets/Scripts/Outfits.meta
+++ b/UnityProject/Assets/Scripts/Outfits.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 0c3469cc02b6c514f95746b40b0c2b73
+folderAsset: yes
+timeCreated: 1498592599
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Outfits/JobOutfit.cs
+++ b/UnityProject/Assets/Scripts/Outfits/JobOutfit.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+public class JobOutfit : MonoBehaviour
+{
+	public string accessory;
+	public List<Access> allowedAccess;
+
+	public string backpack;
+
+	public List<string> backpack_contents = new List<string>();
+	public string belt;
+	public string box;
+	public string duffelbag;
+	public string ears;
+
+	public string glasses;
+	public string gloves;
+	public string head;
+	public JobType jobType;
+
+	public string l_hand;
+
+	public string l_pocket;
+	public string mask;
+	public string r_pocket;
+	public string satchel;
+	public string shoes;
+	public string suit;
+
+	public string suit_store;
+	public string uniform;
+}

--- a/UnityProject/Assets/Scripts/Outfits/JobOutfit.cs.meta
+++ b/UnityProject/Assets/Scripts/Outfits/JobOutfit.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0ef832313bc8da84b8fa31c209efe06e
+timeCreated: 1498592629
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
+++ b/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
@@ -37,33 +37,25 @@ public class GUI_PlayerJobs : MonoBehaviour
 			Destroy(child.gameObject);
 		}
 
-		foreach (OccupationRoster occupationGo in GameManager.Instance.Occupations)
+		foreach (GameObject occupationGo in GameManager.Instance.Occupations)
 		{
 
 			GameObject occupation = Instantiate(buttonPrefab);
-			JobType jobType = occupationGo.jobType;
+			JobType jobType = occupationGo.GetComponent<OccupationRoster>().Type;
 			//For nuke ops mode, syndis spawn via a different button
 			if(jobType == JobType.SYNDICATE){
 				continue;
 			}
 			int active = GameManager.Instance.GetOccupationsCount(jobType);
-			int maxCount = GameManager.Instance.GetOccupationMaxCount(jobType);
+			int available = GameManager.Instance.GetOccupationMaxCount(jobType);
 
 			occupation.name = jobType.ToString();
-			if(maxCount > 0)
-			{
-				occupation.GetComponentInChildren<Text>().text = $"{jobType} ({active} of {maxCount})";
-			}
-			else
-			{
-				occupation.GetComponentInChildren<Text>().text = $"{jobType} ({active})";
-			}
-
+			occupation.GetComponentInChildren<Text>().text = jobType + " (" + active + " of " + available + ")";
 			occupation.transform.SetParent(screen_Jobs.transform);
 			occupation.transform.localScale = new Vector3(1.0f, 1.0f, 1.0f);
 
 			//Disabled button for full jobs
-			if (active >= maxCount && maxCount != -1)
+			if (active >= available)
 			{
 				occupation.GetComponentInChildren<Button>().interactable = false;
 			}

--- a/UnityProject/Assets/Scripts/UI/SecurityRecords/GUI_SecurityRecords.cs
+++ b/UnityProject/Assets/Scripts/UI/SecurityRecords/GUI_SecurityRecords.cs
@@ -129,7 +129,7 @@ public class SecurityRecord
 	public string Fingerprints;
 	public SecurityStatus Status;
 	public List<SecurityRecordCrime> Crimes;
-	public OccupationRoster occupation;
+	public JobOutfit jobOutfit;
 	public CharacterSettings characterSettings;
 
 	public SecurityRecord()

--- a/UnityProject/Assets/Scripts/UI/SecurityRecords/GUI_SecurityRecordsEntryPage.cs
+++ b/UnityProject/Assets/Scripts/UI/SecurityRecords/GUI_SecurityRecordsEntryPage.cs
@@ -106,13 +106,13 @@ public class GUI_SecurityRecordsEntryPage : NetPage
 			beard.SetComplicatedValue("human_face", characterSettings.facialHairOffset, characterSettings.facialHairColor);
 			hair.SetComplicatedValue("human_face", characterSettings.hairStyleOffset, characterSettings.hairColor);
 
-			exosuit.SetComplicatedValue("suit", GetSpriteOffset(record.occupation.exosuit, ItemType.Suit));
-			jumpsuit.SetComplicatedValue("uniform", GetSpriteOffset(record.occupation.uniform, ItemType.Uniform));
-			belt.SetComplicatedValue("belt", GetSpriteOffset(record.occupation.belt, ItemType.Belt));
-			shoes.SetComplicatedValue("feet", GetSpriteOffset(record.occupation.shoes, ItemType.Shoes));
-			back.SetComplicatedValue("back", GetSpriteOffset(record.occupation.backpack, ItemType.Back));
-			neck.SetComplicatedValue("neck", GetSpriteOffset(record.occupation.neck, ItemType.Neck));
-			gloves.SetComplicatedValue("hands", GetSpriteOffset(record.occupation.gloves, ItemType.Gloves));
+			exosuit.SetComplicatedValue("suit", GetSpriteOffset(record.jobOutfit.suit, ItemType.Suit));
+			jumpsuit.SetComplicatedValue("uniform", GetSpriteOffset(record.jobOutfit.uniform, ItemType.Uniform));
+			belt.SetComplicatedValue("belt", GetSpriteOffset(record.jobOutfit.belt, ItemType.Belt));
+			shoes.SetComplicatedValue("feet", GetSpriteOffset(record.jobOutfit.shoes, ItemType.Shoes));
+			back.SetComplicatedValue("back", GetSpriteOffset(record.jobOutfit.backpack, ItemType.Back));
+			//neck.SetComplicatedValue("neck", GetSpriteOffset(record.jobOutfit.neck, ItemType.Neck)); //JobOutfits dont have neck slots yet (will need for lawyer)
+			gloves.SetComplicatedValue("hands", GetSpriteOffset(record.jobOutfit.gloves, ItemType.Gloves));
 			underwear.SetComplicatedValue("underwear", characterSettings.underwearOffset);
 			socks.SetComplicatedValue("underwear", characterSettings.socksOffset);
 		}

--- a/UnityProject/Assets/Scripts/UI/SecurityRecords/SecurityRecordsManager.cs
+++ b/UnityProject/Assets/Scripts/UI/SecurityRecords/SecurityRecordsManager.cs
@@ -33,7 +33,7 @@ public class SecurityRecordsManager : MonoBehaviour
 		record.EntryName = script.playerName;
 		record.Age = script.characterSettings.Age.ToString();
 		record.Rank = script.mind.jobType.JobString();
-		record.occupation = GameManager.Instance.GetOccupationRoster(jobType);
+		record.jobOutfit = GameManager.Instance.GetOccupationOutfit(jobType);
 		record.Sex = script.characterSettings.Gender.ToString();
 		//We don't have races yet. Or I didn't find them.
 		record.Species = "Human";


### PR DESCRIPTION
Reverts unitystation/unitystation#2056
Fixes #2079

I believe its a mistake to merge outfits and occupationrosters now, plus placing scripts on prefab references makes the editor do funky stuff like #2079