### PR TITLE
stopped chat bubble showing when talking on ooc

### DIFF
--- a/UnityProject/Assets/Scripts/UI/ControlChat.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlChat.cs
@@ -198,10 +198,11 @@ public class ControlChat : MonoBehaviour
 	/// </summary>
 	private bool PlayerChatShown()
 	{
-		// Don't show if player is dead, crit or sent an empty message
+		// Don't show if player is dead, crit, talking in OOC or sent an empty message
 		if (PlayerManager.LocalPlayerScript.IsGhost ||
 			PlayerManager.LocalPlayerScript.playerHealth.IsCrit ||
-			InputFieldChat.text == ""
+			InputFieldChat.text == "" ||
+			PlayerManager.LocalPlayerScript.SelectedChannels.Equals(ChatChannel.OOC)
 			)
 		{
 			return false;


### PR DESCRIPTION
### Purpose
stops the chat bubble showing when player is talking in ooc fixes #2088 

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
this is my first PR and i'm pretty new to unity so if i've messed up please let me know
