### PR TITLE
SoundManager's methods accept wildcards

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -107,7 +107,8 @@ public class SoundManager : MonoBehaviour
 	}
 
 	/// <summary>
-	/// Serverside: Play sound for all clients
+	/// Serverside: Play sound for all clients.
+	/// Accepts "#" wildcards for sound variations. (Example: "Punch#")
 	/// </summary>
 	public static void PlayNetworked( string sndName, float pitch = -1,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30 )
@@ -117,7 +118,8 @@ public class SoundManager : MonoBehaviour
 	}
 
 	/// <summary>
-	/// Serverside: Play sound at given position for all clients
+	/// Serverside: Play sound at given position for all clients.
+	/// Accepts "#" wildcards for sound variations. (Example: "Punch#")
 	/// </summary>
 	public static void PlayNetworkedAtPos( string sndName, Vector3 pos, float pitch = -1,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30 )
@@ -127,8 +129,9 @@ public class SoundManager : MonoBehaviour
 	}
 
 	/// <summary>
-	/// Serverside: Play sound for particular player
+	/// Serverside: Play sound for particular player.
 	/// ("Doctor, there are voices in my head!")
+	/// Accepts "#" wildcards for sound variations. (Example: "Punch#")
 	/// </summary>
 	public static void PlayNetworkedForPlayer( GameObject recipient, string sndName, float pitch = -1,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30 )
@@ -138,8 +141,9 @@ public class SoundManager : MonoBehaviour
 	}
 
 	/// <summary>
-	/// Serverside: Play sound at given position for particular player
+	/// Serverside: Play sound at given position for particular player.
 	/// ("Doctor, there are voices in my head!")
+	/// Accepts "#" wildcards for sound variations. (Example: "Punch#")
 	/// </summary>
 	public static void PlayNetworkedForPlayerAtPos( GameObject recipient, Vector3 pos, string sndName, float pitch = -1,
 		bool shakeGround = false, byte shakeIntensity = 64, int shakeRange = 30 )
@@ -149,7 +153,8 @@ public class SoundManager : MonoBehaviour
 	}
 
 	/// <summary>
-	/// Play sound locally
+	/// Play sound locally.
+	/// Accepts "#" wildcards for sound variations. (Example: "Punch#")
 	/// </summary>
 	public static void Play(string name, float volume, float pitch = -1, float time = 0)
 	{
@@ -164,7 +169,8 @@ public class SoundManager : MonoBehaviour
 	}
 
 	/// <summary>
-	/// Play sound locally
+	/// Play sound locally.
+	/// Accepts "#" wildcards for sound variations. (Example: "Punch#")
 	/// </summary>
 	public static void Play(string name)
 	{
@@ -173,7 +179,8 @@ public class SoundManager : MonoBehaviour
 	}
 
 	/// <summary>
-	/// Play sound locally at given world position
+	/// Play sound locally at given world position.
+	/// Accepts "#" wildcards for sound variations. (Example: "Punch#")
 	/// </summary>
 	public static void PlayAtPosition(string name, Vector3 pos, float pitch = -1)
 	{
@@ -192,6 +199,7 @@ public class SoundManager : MonoBehaviour
 
 	/// <summary>
 	/// Stops a given sound from playing locally.
+	/// Accepts "#" wildcards for sound variations. (Example: "Punch#")
 	/// </summary>
 	public static void Stop(string name)
 	{

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -143,7 +143,7 @@ public class PushPull : VisibleBehaviour, IRightClickable {
 		     && !pullable.isNotPushable && pullable != this && !IsBeingPulled ) {
 
 			if ( pullable.StartFollowing( this ) ) {
-				SoundManager.PlayNetworkedAtPos( "Rustle0" + Random.Range(1, 4), pullable.transform.position );
+				SoundManager.PlayNetworkedAtPos( "Rustle#", pullable.transform.position );
 
 				PulledObjectServer = pullable;
 

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_StorageHandler.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_StorageHandler.cs
@@ -18,7 +18,7 @@ public class UI_StorageHandler : MonoBehaviour
 		storageCache = storageObj;
 		storageCache.clientUpdatedDelegate += StorageUpdatedEvent;
 		PopulateInventorySlots();
-		SoundManager.PlayAtPosition("Rustle0" + UnityEngine.Random.Range(1, 6).ToString(), PlayerManager.LocalPlayer.transform.position);
+		SoundManager.PlayAtPosition("Rustle#", PlayerManager.LocalPlayer.transform.position);
 	}
 
 	private void PopulateInventorySlots()
@@ -47,7 +47,7 @@ public class UI_StorageHandler : MonoBehaviour
 
 	public void CloseStorageUI()
 	{
-		SoundManager.PlayAtPosition("Rustle0" + UnityEngine.Random.Range(1, 6).ToString(), PlayerManager.LocalPlayer.transform.position);
+		SoundManager.PlayAtPosition("Rustle#", PlayerManager.LocalPlayer.transform.position);
 
 		storageCache.clientUpdatedDelegate -= StorageUpdatedEvent;
 		storageCache = null;

--- a/UnityProject/Assets/Scripts/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Weapons/WeaponNetworkActions.cs
@@ -225,7 +225,7 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 			}
 
 			// Make a random punch hit sound.
-			SoundManager.PlayNetworkedAtPos("Punch"+rng.Next(1, 4), victimRegisterTile.WorldPosition);
+			SoundManager.PlayNetworkedAtPos("Punch#", victimRegisterTile.WorldPosition);
 
 			StartCoroutine(AttackCoolDown());
 		}


### PR DESCRIPTION
### Purpose
Allows the sound names passed to `SoundManager` to contain "#" wildcards which match any number. When multiple matches are found, one is chosen at random. This will make it easier to use sounds that have multiple variations, such as hit sounds.

Fixes #2029

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
Although perhaps redundant, the wildcard names are resolved ahead of time in the `PlayNetworked...` methods so that the clients will not choose the sound themselves. This is primarily intended to ensure that everyone hears the same sound.
