### PR TITLE
Moves the SyncPlayerData from each body transfer to the clients login

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -318,17 +318,30 @@ public class CustomNetworkManager : NetworkManager
 		{
 			matrices[i].NotifyPlayer(playerGameObject, true);
 		}
+
 		//All transforms
 		CustomNetTransform[] scripts = FindObjectsOfType<CustomNetTransform>();
 		for (var i = 0; i < scripts.Length; i++)
 		{
 			scripts[i].NotifyPlayer(playerGameObject);
 		}
+
 		//All player bodies
 		PlayerSync[] playerBodies = FindObjectsOfType<PlayerSync>();
 		for (var i = 0; i < playerBodies.Length; i++)
 		{
-			playerBodies[i].NotifyPlayer(playerGameObject, true);
+			var playerBody = playerBodies[i];
+			playerBody.NotifyPlayer(playerGameObject, true);
+			var playerSprites = playerBody.GetComponent<PlayerSprites>();
+			if (playerSprites)
+			{
+				playerSprites.NotifyPlayer(playerGameObject);
+			}
+			var equipment = playerBody.GetComponent<Equipment>();
+			if (equipment)
+			{
+				equipment.NotifyPlayer(playerGameObject);
+			}
 		}
 
 		//StorageObject UUIDs
@@ -352,30 +365,6 @@ public class CustomNetworkManager : NetworkManager
 			doors[i].NotifyPlayer(playerGameObject);
 		}
 		Logger.Log($"Sent sync data ({matrices.Length} matrices, {scripts.Length} transforms, {playerBodies.Length} players) to {playerGameObject.name}", Category.Connections);
-	}
-
-	public void SyncCharSprites(GameObject recipient, bool newMob)
-	{
-		//All player bodies
-		PlayerSync[] playerBodies = FindObjectsOfType<PlayerSync>();
-		for (var i = 0; i < playerBodies.Length; i++)
-		{
-			var playerBody = playerBodies[i];
-			if(newMob && playerBody.gameObject == recipient)
-			{
-				continue;
-			}
-			var playerSprites = playerBody.GetComponent<PlayerSprites>();
-			if (playerSprites)
-			{
-				playerSprites.NotifyPlayer(recipient);
-			}
-			var equipment = playerBody.GetComponent<Equipment>();
-			if(equipment)
-			{
-				equipment.NotifyPlayer(recipient);
-			}
-		}
 	}
 
 	private IEnumerator WaitForSpawnListSetUp(NetworkConnection conn)

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -115,8 +115,6 @@ public static class SpawnHandler
 		{
 			healthStateMonitor.ProcessClientUpdateRequest(newBody);
 		}
-		CustomNetworkManager.Instance.SyncPlayerData(newBody);
-		CustomNetworkManager.Instance.SyncCharSprites(newBody, newMob);
 	}
 
 	private static GameObject CreateMob(GameObject spawnSpot, GameObject mobPrefab)

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -44,6 +44,7 @@ public class JoinedViewer : NetworkBehaviour
 			SteamId = steamId
 		});
 
+		CustomNetworkManager.Instance.SyncPlayerData(gameObject);
 		// If they have a player to rejoin send the client the player to rejoin, otherwise send a null gameobject.
 		TargetLocalPlayerSetupPlayer(connectionToClient, PlayerList.Instance.TakeLoggedOffPlayer(steamId));
 	}


### PR DESCRIPTION
### Purpose
Moves the SyncPlayerData from each body transfer to the clients login.

### Open Questions and Pre-Merge TODOs

- [X]  This fix is tested on the same branch it is PR'ed to.
- [X]  I correctly commented my code
- [X]  My code is indented with tabs and not spaces
- [X]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X]  This PR does not bring up any new compile errors
- [X]  This PR has been tested in editor
- [X]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)