### PR TITLE
Pipe fix, pickup + IF2 enhancements

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Shuttle/ShuttleHeater.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Static_Placeholders/Shuttle/ShuttleHeater.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 114255515820156884}
   - component: {fileID: 114850447683734040}
   - component: {fileID: 114215226708324816}
+  - component: {fileID: 6991340977674600867}
   - component: {fileID: 114388043038700156}
   - component: {fileID: 114632911715988304}
   - component: {fileID: 3905972319176629353}
@@ -189,6 +190,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &6991340977674600867
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1547459616489196}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnDropServer:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114388043038700156
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/MouseDraggable.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/MouseDraggable.cs
@@ -116,7 +116,8 @@ public class MouseDraggable : MonoBehaviour
 			}
 
 			//call the mousedrop interaction methods on the dropped-on object if it has any
-			foreach (IInteractable<MouseDrop> mouseDropTarget in dropTarget.GetComponents<IInteractable<MouseDrop>>())
+			foreach (IInteractable<MouseDrop> mouseDropTarget in dropTarget.GetComponents<IInteractable<MouseDrop>>()
+				.Where(mb => mb != null && (mb as MonoBehaviour).enabled))
 			{
 				var interacted = mouseDropTarget.Interact(info);
 				if (interacted)

--- a/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
@@ -329,8 +329,8 @@ public class MouseInputController : MonoBehaviour
 		if (handApply.HandObject != null)
 		{
 			//get all components that can handapply or PositionalHandApply
-			var handAppliables = handApply.HandObject.GetComponents<Component>()
-				.Where(c => c is IInteractable<HandApply> || c is IInteractable<PositionalHandApply>);
+			var handAppliables = handApply.HandObject.GetComponents<MonoBehaviour>()
+				.Where(c => c != null && c.enabled && (c is IInteractable<HandApply> || c is IInteractable<PositionalHandApply>));
 
 			foreach (var handAppliable in handAppliables)
 			{
@@ -346,8 +346,8 @@ public class MouseInputController : MonoBehaviour
 		}
 
 		//call the hand apply interaction methods on the target object if it has any
-		var targetHandAppliables = handApply.TargetObject.GetComponents<Component>()
-			.Where(c => c is IInteractable<HandApply> || c is IInteractable<PositionalHandApply>);
+		var targetHandAppliables = handApply.TargetObject.GetComponents<MonoBehaviour>()
+			.Where(c => c.enabled && (c is IInteractable<HandApply> || c is IInteractable<PositionalHandApply>));
 		foreach (var targetHandAppliable in targetHandAppliables)
 		{
 			var interacted = targetHandAppliable is IInteractable<HandApply> ?
@@ -387,7 +387,8 @@ public class MouseInputController : MonoBehaviour
 			//it's being clicked down
 			triggeredAimApply = null;
 			//Checks for aim apply interactions which can trigger
-			foreach (var aimApply in handObj.GetComponents<IInteractable<AimApply>>())
+			foreach (var aimApply in handObj.GetComponents<IInteractable<AimApply>>()
+				.Where(mb => mb != null && (mb as MonoBehaviour).enabled))
 			{
 				var interacted = aimApply.Interact(aimApplyInfo);
 				if (interacted)
@@ -438,6 +439,7 @@ public class MouseInputController : MonoBehaviour
 		var draggable =
 			MouseUtils.GetOrderedObjectsUnderMouse(layerMask, go =>
 					go.GetComponent<MouseDraggable>() != null &&
+					go.GetComponent<MouseDraggable>().enabled &&
 					go.GetComponent<MouseDraggable>().CanBeginDrag(PlayerManager.LocalPlayer))
 				.FirstOrDefault();
 		if (draggable != null)

--- a/UnityProject/Assets/Scripts/Items/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Items/Pickupable.cs
@@ -10,6 +10,16 @@ using Random = UnityEngine.Random;
 /// </summary>
 public class Pickupable : NBHandApplyInteractable, IRightClickable
 {
+
+	//controls whether this can currently be picked up.
+	[SyncVar]
+	private bool canPickup = true;
+
+	/// <summary>
+	/// Whether this object can currently be picked up.
+	/// </summary>
+	public bool CanPickup => canPickup;
+
 	/// <summary>
 	/// Event fired after the object is picked up, on server only.
 	/// </summary>
@@ -32,8 +42,19 @@ public class Pickupable : NBHandApplyInteractable, IRightClickable
 		return Validations.ValidateWithServerRollback(interaction, side, CheckWillInteract, ServerInformClientRollback);
 	}
 
+	/// <summary>
+	/// Server-side method, sets whether this object can be picked up.
+	/// </summary>
+	/// <param name="canPickup"></param>
+	[Server]
+	public void ServerSetCanPickup(bool canPickup)
+	{
+		this.canPickup = canPickup;
+	}
+
 	private bool CheckWillInteract(HandApply interaction, NetworkSide side)
 	{
+		if (!canPickup) return false;
 		//we need to be the target
 		if (interaction.TargetObject != gameObject) return false;
 		//hand needs to be empty for pickup

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/InteractionMessageUtils.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/InteractionMessageUtils.cs
@@ -1,5 +1,6 @@
 
 
+using System.Linq;
 using UnityEngine;
 
 /// <summary>
@@ -75,8 +76,6 @@ public static class InteractionMessageUtils
 			return;
 		}
 
-		//TODO: Other types
-
 		//we didn't send anything
 		Logger.LogErrorFormat("Interaction type was {0} - we couldn't determine what to do for this interaction" +
 		                      " type, most likely because it hasn't been implemented yet." +
@@ -93,7 +92,8 @@ public static class InteractionMessageUtils
 	public static IInteractionProcessor<T>[] TryGetProcessors<T>(GameObject gameObject)
 		where T : Interaction
 	{
-		var processorComponents = gameObject.GetComponents<IInteractionProcessor<T>>();
+		var processorComponents = gameObject.GetComponents<IInteractionProcessor<T>>()
+			.Where(proc => proc != null && (proc as MonoBehaviour).enabled).ToArray();
 		if (processorComponents == null || processorComponents.Length == 0)
 		{
 			Logger.LogError("Processor component could not be looked up by the ID sent by the client, " +

--- a/UnityProject/Assets/Scripts/Shuttles/ShuttleHeater.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/ShuttleHeater.cs
@@ -18,6 +18,7 @@ public class ShuttleHeater : AdvancedPipe
 	public override void SetAnchored(bool value)
 	{
 		anchored = value;
+		pickupable.ServerSetCanPickup(!value);
 	}
 
 	public override void DirectionEast()		//shuttle sprites are upside down, turn direction

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
@@ -6,6 +6,7 @@ using UnityEngine.Networking;
 using Atmospherics;
 using Tilemaps.Behaviours.Meta;
 
+[RequireComponent(typeof(Pickupable))]
 public class Pipe : NetworkBehaviour
 {
 	public RegisterTile registerTile;
@@ -21,6 +22,8 @@ public class Pipe : NetworkBehaviour
 	public Sprite[] pipeSprites;
 	public SpriteRenderer spriteRenderer;
 	[SyncVar(hook = nameof(SyncSprite))] public int spriteSync;
+
+	protected Pickupable pickupable;
 
 	[Flags]
 	public enum Direction
@@ -38,6 +41,22 @@ public class Pipe : NetworkBehaviour
 		objectBehaviour = GetComponent<ObjectBehaviour>();
 		directional = GetComponent<Directional>();
 		directional.OnDirectionChange.AddListener(OnDirectionChange);
+		pickupable = GetComponent<Pickupable>();
+	}
+
+	private void ServerInit()
+	{
+		pickupable.ServerSetCanPickup(!anchored);
+	}
+
+	public override void OnStartServer()
+	{
+		ServerInit();
+	}
+
+	void OnSpawnedServer()
+	{
+		ServerInit();
 	}
 
 	public void Start(){
@@ -97,6 +116,8 @@ public class Pipe : NetworkBehaviour
 	{
 		anchored = value;
 		objectBehaviour.isNotPushable = value;
+		//now that it's anchored, it can't be picked up
+		pickupable.ServerSetCanPickup(!value);
 	}
 
 	public void SyncSprite(int value)

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
@@ -257,7 +258,8 @@ public class UI_ItemSlot : MonoBehaviour, IDragHandler, IEndDragHandler
 		if (Item != null && UIManager.Hands.CurrentSlot.eventName == eventName)
 		{
 			//check IF2 logic first
-			var interactables = Item.GetComponents<IInteractable<HandActivate>>();
+			var interactables = Item.GetComponents<IInteractable<HandActivate>>()
+				.Where(mb => mb != null && (mb as MonoBehaviour).enabled);
 			var activate = HandActivate.ByLocalPlayer();
 			foreach (var interactable in interactables)
 			{
@@ -291,7 +293,8 @@ public class UI_ItemSlot : MonoBehaviour, IDragHandler, IEndDragHandler
 			//check interactables in the active hand (if active hand occupied)
 			if (UIManager.Hands.CurrentSlot.Item != null)
 			{
-				var handInteractables = UIManager.Hands.CurrentSlot.Item.GetComponents<IInteractable<InventoryApply>>();
+				var handInteractables = UIManager.Hands.CurrentSlot.Item.GetComponents<IInteractable<InventoryApply>>()
+					.Where(mb => mb != null && (mb as MonoBehaviour).enabled);
 				foreach (var interactable in handInteractables)
 				{
 					if (interactable.Interact(combine))
@@ -303,7 +306,8 @@ public class UI_ItemSlot : MonoBehaviour, IDragHandler, IEndDragHandler
 			}
 
 			//check interactables in the target
-			var targetInteractables = Item.GetComponents<IInteractable<InventoryApply>>();
+			var targetInteractables = Item.GetComponents<IInteractable<InventoryApply>>()
+				.Where(mb => mb != null && (mb as MonoBehaviour).enabled);
 			foreach (var interactable in targetInteractables)
 			{
 				if (interactable.Interact(combine))


### PR DESCRIPTION
### Purpose
Fixes #2013 
Adds canPickup to allow preventing pickup  in Pickupable, network synced.

Pipe component sets canPickup based on when it is anchored / detached.

IF2 components will no longer be triggered when disabled (this is mostly unrelated to this fix and nothing currently relies on this behavior but seemed like the way it should work).

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
