### PR TITLE
Fixes a ThemeManager config dictionary problem

### DIFF
--- a/UnityProject/Assets/Scripts/UI/OptionsMenu/ThemeOptions/ThemeManager.cs
+++ b/UnityProject/Assets/Scripts/UI/OptionsMenu/ThemeOptions/ThemeManager.cs
@@ -117,6 +117,8 @@ namespace Unitystation.Options
         [ContextMenu("Load All Configs")]
         public void LoadAllThemes()
         {
+            configs.Clear();
+            
             foreach (DirectoryInfo di in diPaths)
             {
                 if (di.Exists)
@@ -168,11 +170,7 @@ namespace Unitystation.Options
                 {
                     configs.Add(theme, new List<ThemeConfig>());
                 }
-                else
-                {
-                    configs[theme].Clear();
-                }
-
+                
                 //Get all the config names and their settings associated with this Theme type in this file
                 var settings = (YamlMappingNode) entry.Value;
                 foreach (var c in settings.Children)


### PR DESCRIPTION
### Purpose
Fixed a problem where config dictionary would clear on multiple config files removing any themes loaded from a previous config file for the same ThemeType
