### PR TITLE
#2103 sync player up / down status on join.

### DIFF
--- a/UnityProject/Assets/Scripts/Editor/Tools/Networking.cs
+++ b/UnityProject/Assets/Scripts/Editor/Tools/Networking.cs
@@ -87,7 +87,7 @@ public class Networking : Editor
 	{
 		if (CustomNetworkManager.Instance._isServer)
 		{
-			PlayerManager.LocalPlayerScript.playerHealth.Death();
+			PlayerManager.LocalPlayerScript.playerHealth.ApplyDamage(null, 99999f, AttackType.Internal, DamageType.Brute);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Messages/Server/PlayerUprightMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/PlayerUprightMessage.cs
@@ -56,6 +56,21 @@ public class PlayerUprightMessage : ServerMessage
 		msg.SendTo( subjectPlayer );
 	}
 
+	/// <summary>
+	/// Sends the info on the subject's current status to a specific client.
+	/// </summary>
+	/// <param name="recipient">player who should recieve the message</param>
+	/// <param name="subjectPlayer">player whose status is being communicated</param>
+	public static void Sync(GameObject recipient, GameObject subjectPlayer)
+	{
+		var msg = new PlayerUprightMessage
+		{
+			SubjectPlayer = subjectPlayer.NetId(),
+			Upright = !subjectPlayer.GetComponent<RegisterPlayer>().IsDownServer
+		};
+		msg.SendTo(recipient);
+	}
+
 	private static bool IsValid(GameObject subjectPlayer, bool upright, bool buckling)
 	{
 		if(buckling)

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -264,6 +264,7 @@ public partial class PlayerSync
 	{
 		serverState.NoLerp = noLerp;
 		var msg = PlayerMoveMessage.Send(recipient, gameObject, serverState);
+		PlayerUprightMessage.Sync(recipient, gameObject);
 		Logger.LogTraceFormat("Sent {0}", Category.Movement, msg);
 	}
 


### PR DESCRIPTION
### Purpose
Fixes #2103 

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
