### PR TITLE
Updated UI_OxygenAlert to use UpdateManager

### DIFF
--- a/UnityProject/Assets/Scripts/UI/UI_OxygenAlert.cs
+++ b/UnityProject/Assets/Scripts/UI/UI_OxygenAlert.cs
@@ -5,8 +5,9 @@ using UnityEngine.UI;
 
 public class UI_OxygenAlert : MonoBehaviour {
 
+	private const float SpriteCycleTime = 1f; // cycle every 1 second
 	public Sprite[] statusImages; //images to cycle between when active
-	private int activeImageIndex = 0;
+	private int nextImageIndex = 1;
 
 	public Image img;
 	private Sprite sprite;
@@ -29,30 +30,37 @@ public class UI_OxygenAlert : MonoBehaviour {
 		{
 			UpdateManager.Instance.Remove(UpdateMe);
 		}
+		ResetImg();
 	}
 
 	void UpdateMe()
 	{
 		timeWait += Time.deltaTime;
-		// Cycle images every 1 second
-		if (timeWait > 1f)
+		if (timeWait > SpriteCycleTime)
 		{
 			CycleImg();
-			timeWait = 0f;
+			timeWait -= SpriteCycleTime;
 		}
 	}
 
 	void CycleImg()
 	{
-		sprite = statusImages[activeImageIndex];
-		activeImageIndex++;
+		sprite = statusImages[nextImageIndex];
+		nextImageIndex++;
 
 		//Restart "animation"
-		if (activeImageIndex >= statusImages.Length)
+		if (nextImageIndex >= statusImages.Length)
 		{
-			activeImageIndex = 0;
+			nextImageIndex = 0;
 		}
 
 		img.sprite = sprite;
+	}
+
+	void ResetImg() {
+		sprite = statusImages[0];
+		nextImageIndex = 1;
+		img.sprite = sprite;
+		timeWait = 0f;
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/UI_OxygenAlert.cs
+++ b/UnityProject/Assets/Scripts/UI/UI_OxygenAlert.cs
@@ -10,13 +10,11 @@ public class UI_OxygenAlert : MonoBehaviour {
 	private int nextImageIndex = 1;
 
 	public Image img;
-	private Sprite sprite;
 	private float timeWait;
 
 	void Start()
 	{
 		img = GetComponent<Image>();
-		sprite = img.sprite;
 	}
 
 	private void OnEnable()
@@ -45,22 +43,12 @@ public class UI_OxygenAlert : MonoBehaviour {
 
 	void CycleImg()
 	{
-		sprite = statusImages[nextImageIndex];
-		nextImageIndex++;
-
-		//Restart "animation"
-		if (nextImageIndex >= statusImages.Length)
-		{
-			nextImageIndex = 0;
-		}
-
-		img.sprite = sprite;
+		img.sprite = statusImages.Wrap( nextImageIndex++ );
 	}
 
 	void ResetImg() {
-		sprite = statusImages[0];
+		img.sprite = statusImages[0];
 		nextImageIndex = 1;
-		img.sprite = sprite;
 		timeWait = 0f;
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/UI_OxygenAlert.cs
+++ b/UnityProject/Assets/Scripts/UI/UI_OxygenAlert.cs
@@ -10,12 +10,36 @@ public class UI_OxygenAlert : MonoBehaviour {
 
 	public Image img;
 	private Sprite sprite;
+	private float timeWait;
 
-	void Start ()
+	void Start()
 	{
 		img = GetComponent<Image>();
 		sprite = img.sprite;
-		InvokeRepeating("CycleImg", 1f, 1f); //Cycle images every 1 second
+	}
+
+	private void OnEnable()
+	{
+		UpdateManager.Instance.Add(UpdateMe);
+	}
+
+	private void OnDisable()
+	{
+		if (UpdateManager.Instance != null)
+		{
+			UpdateManager.Instance.Remove(UpdateMe);
+		}
+	}
+
+	void UpdateMe()
+	{
+		timeWait += Time.deltaTime;
+		// Cycle images every 1 second
+		if (timeWait > 1f)
+		{
+			CycleImg();
+			timeWait = 0f;
+		}
 	}
 
 	void CycleImg()


### PR DESCRIPTION
### Purpose
Updated UI_OxygenAlert to use the UpdateManager to remove an instance of InvokeRepeating.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
While working on #2121 I found that the UI_OxygenAlert was using InvokeRepeating and saw a way to make this class use the UpdateManager instead based on the UI_HeartMonitor class.  I'm not sure what all the cons are for using InvokeRepeating but one I thought of was that the CycleImg function could have been called when the O2 alert was not on screen.  I believe using OnEnable and OnDisable to register the UpdateMe function will prevent that.
