### PR TITLE
Fixed hiding tabs to rollup the window

### DIFF
--- a/UnityProject/Assets/Scripts/UI/ControlTabs.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlTabs.cs
@@ -356,9 +356,18 @@ public class ControlTabs : MonoBehaviour
 	private void HideTab(Tab tab)
 	{
 		tab.Hidden = true;
+		bool wasActive = tab.gameObject.activeSelf;
 		tab.gameObject.SetActive(false);
 		RefreshTabHeaders();
-		SelectTab(ClientTabType.Stats, false);
+		if(wasActive)
+		{
+			SelectTab(ClientTabType.Stats, false);
+			var netTab = tab as NetTab;
+			if (rolledOut && (netTab == null || !netTab.isPopOut))
+			{
+				ToggleTabRollOut();
+			}
+		}
 	}
 
 	private void HideTab(ClientTabType type)
@@ -395,6 +404,10 @@ public class ControlTabs : MonoBehaviour
 		if (!UITileList.IsEmpty())
 		{
 			Instance.SelectTab(ClientTabType.ItemList);
+		}
+		if (!Instance.rolledOut)
+		{
+			Instance.ToggleTabRollOut();
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/UI/ControlTabs.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlTabs.cs
@@ -365,7 +365,7 @@ public class ControlTabs : MonoBehaviour
 			var netTab = tab as NetTab;
 			if (rolledOut && (netTab == null || !netTab.isPopOut))
 			{
-				ToggleTabRollOut();
+				CloseTabWindow();
 			}
 		}
 	}
@@ -407,7 +407,7 @@ public class ControlTabs : MonoBehaviour
 		}
 		if (!Instance.rolledOut)
 		{
-			Instance.ToggleTabRollOut();
+			Instance.OpenTabWindow();
 		}
 	}
 
@@ -443,7 +443,7 @@ public class ControlTabs : MonoBehaviour
 
 		if (!Instance.rolledOut && !isPopOut)
 		{
-			Instance.StartCoroutine(Instance.AnimTabRoll());
+			Instance.OpenTabWindow();
 		}
 
 		//try to dig out a hidden tab with matching parameters and enable it:
@@ -590,26 +590,55 @@ public class ControlTabs : MonoBehaviour
 		}
 	}
 
-	//For hiding or showing the tab window
+	public void OpenTabWindow()
+	{
+		StartCoroutine(AnimTabRoll(true, true));
+	}
+	public void CloseTabWindow()
+	{
+		StartCoroutine(AnimTabRoll(true, false));
+	}
+	// Used by UI to open/close tab window
+	// Code should use Open/Close method to set expectation and wait for current anim to finish
 	public void ToggleTabRollOut()
 	{
-		StartCoroutine(AnimTabRoll());
+		StartCoroutine(AnimTabRoll(false, null));
 	}
 
 	//Tab roll in and out animation
-	IEnumerator AnimTabRoll()
+	IEnumerator AnimTabRoll(bool wait, bool? shouldOpen)
 	{
+		if (shouldOpen == true && rolledOut)
+		{
+			yield break;
+		}
+		else if (shouldOpen == false && !rolledOut)
+		{
+			yield break;
+		}
 		if (!preventRoll)
 		{
 			preventRoll = true;
 		}
 		else
 		{
-			yield break;
+			if (wait)
+			{
+				while (preventRoll)
+				{
+					yield return WaitFor.Seconds(0.1f);
+				}
+				preventRoll = true;
+			}
+			else
+			{
+				yield break;
+			}
 		}
+		rolledOut = !rolledOut;
 		Vector3 currentPos = transform.position;
 		Vector3 targetPos = currentPos;
-		if (rolledOut)
+		if (!rolledOut)
 		{
 			//go up
 			targetPos.y += (382f * canvas.scaleFactor);
@@ -630,7 +659,6 @@ public class ControlTabs : MonoBehaviour
 		Vector3 newScale = rolloutIcon.localScale;
 		newScale.y = -newScale.y;
 		rolloutIcon.localScale = newScale;
-		rolledOut = !rolledOut;
 		preventRoll = false;
 	}
 

--- a/UnityProject/Assets/Scripts/UI/TabHeaderButton.cs
+++ b/UnityProject/Assets/Scripts/UI/TabHeaderButton.cs
@@ -27,9 +27,9 @@ public class TabHeaderButton : MonoBehaviour {
 		if(mouseOver){
 			//Tab roll out
 			if (!ControlTabs.Instance.rolledOut) {
-				ControlTabs.Instance.ToggleTabRollOut();
+				ControlTabs.Instance.OpenTabWindow();
 			}
-		} 
+		}
 	}
 
 	public void PointerEnter(){


### PR DESCRIPTION
### Purpose
Fixes #1750, hides the tab window if the tab that was selected is being hidden.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:

- Fixed Item List tab to rollout tab window if not visible
- Changed to not always select the Stats tab, only select it if the tab selected is being hidden

This fix does not remember the state of the window or the tab that was selected before opening a contextual tab so it could still be improved.  It does handle when a user has a different tab open walking away from a object though.