### PR TITLE
Properly initialize shuttle console when it's spawned in runtime

### DIFF
--- a/UnityProject/Assets/Scripts/Shuttles/ShuttleConsole.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/ShuttleConsole.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.ComponentModel;
 using UnityEngine;
 using UnityEngine.Events;
@@ -10,6 +11,7 @@ using UnityEngine.UI;
 public class ShuttleConsole : NBHandApplyInteractable
 {
 	public MatrixMove ShuttleMatrixMove;
+	private RegisterTile registerTile;
 
     public TabStateEvent OnStateChange;
     private TabState state = TabState.Normal;
@@ -26,21 +28,43 @@ public class ShuttleConsole : NBHandApplyInteractable
 	    }
     }
 
+    private void Awake()
+    {
+	    if ( !registerTile )
+	    {
+		    registerTile = GetComponent<RegisterTile>();
+	    }
+    }
+
     private void OnEnable()
     {
 	    if ( ShuttleMatrixMove == null )
 	    {
-		    ShuttleMatrixMove = GetComponentInParent<MatrixMove>();
-
-		    if ( ShuttleMatrixMove == null )
-		    {
-			    Logger.LogError( $"{this} has no reference to MatrixMove, didn't find any in parents either", Category.Matrix );
-		    }
-		    else
-		    {
-			    Logger.Log( $"No MatrixMove reference set to {this}, found {ShuttleMatrixMove} automatically", Category.Matrix );
-		    }
+		    StartCoroutine( InitMatrixMove() );
 	    }
+    }
+
+    private IEnumerator InitMatrixMove()
+    {
+	    ShuttleMatrixMove = GetComponentInParent<MatrixMove>();
+
+        if ( ShuttleMatrixMove == null )
+        {
+            while ( !registerTile.Matrix )
+            {
+                yield return WaitFor.EndOfFrame;
+            }
+            ShuttleMatrixMove = MatrixManager.Get( registerTile.Matrix ).MatrixMove;
+        }
+
+        if ( ShuttleMatrixMove == null )
+        {
+            Logger.LogError( $"{this} has no reference to MatrixMove, current matrix doesn't seem to have it either", Category.Matrix );
+        }
+        else
+        {
+            Logger.Log( $"No MatrixMove reference set to {this}, found {ShuttleMatrixMove} automatically", Category.Matrix );
+        }
     }
 
 


### PR DESCRIPTION
### Purpose
Makes it possible to spawn a shuttle console on movable matrix in place of broken one and it will initialize properly

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
