### PR TITLE
Fix init logic for some powered objects.

### DIFF
--- a/UnityProject/Assets/Scripts/Consoles/ConsoleScreenAnimator.cs
+++ b/UnityProject/Assets/Scripts/Consoles/ConsoleScreenAnimator.cs
@@ -5,26 +5,6 @@ using UnityEngine;
 public class ConsoleScreenAnimator : MonoBehaviour, IAPCPowered
 {
 	private bool isOn = true;
-	public bool IsOn
-	{
-		get { return isOn; }
-		set
-		{
-			if (value)
-			{
-				if (!isOn)
-				{
-					isOn = value;
-					sIndex = 0;
-					StartCoroutine(Animator());
-				}
-				else
-				{
-					isOn = value;
-				}
-			}
-		}
-	}
 
 	public float timeBetweenFrames = 0.1f;
 	public SpriteRenderer spriteRenderer;
@@ -33,14 +13,22 @@ public class ConsoleScreenAnimator : MonoBehaviour, IAPCPowered
 
 	private int sIndex = 0;
 
-	void Start()
+	private void Start()
 	{
-		if (isOn)
+		ToggleOn(isOn, true);
+	}
+
+	private void ToggleOn(bool turnOn, bool forceToggle = false)
+	{
+		if (turnOn && (!isOn || forceToggle))
 		{
+			isOn = true;
+			sIndex = 0;
 			StartCoroutine(Animator());
 		}
-		else
+		else if (!turnOn && (isOn || forceToggle))
 		{
+			isOn = false;
 			spriteRenderer.enabled = false;
 			if (screenGlow != null)
 			{
@@ -56,10 +44,10 @@ public class ConsoleScreenAnimator : MonoBehaviour, IAPCPowered
 	{
 		if (State == PowerStates.Off || State == PowerStates.LowVoltage)
 		{
-			isOn = false;
+			ToggleOn(false);
 		}
-		else { 
-			isOn = true;
+		else {
+			ToggleOn(true);
 		}
 	}
 
@@ -79,12 +67,6 @@ public class ConsoleScreenAnimator : MonoBehaviour, IAPCPowered
 				sIndex = 0;
 			}
 			yield return WaitFor.Seconds(timeBetweenFrames);
-		}
-		yield return WaitFor.EndOfFrame;
-		spriteRenderer.enabled = false;
-		if (screenGlow != null)
-		{
-			screenGlow.SetActive(false);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Consoles/ConsoleScreenAnimator.cs
+++ b/UnityProject/Assets/Scripts/Consoles/ConsoleScreenAnimator.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
 public class ConsoleScreenAnimator : MonoBehaviour, IAPCPowered
 {
-	private bool isOn = true;
+	private bool isOn;
+	//whether we received our initial power state
+	private bool stateInit;
 
 	public float timeBetweenFrames = 0.1f;
 	public SpriteRenderer spriteRenderer;
@@ -13,23 +16,21 @@ public class ConsoleScreenAnimator : MonoBehaviour, IAPCPowered
 
 	private int sIndex = 0;
 
-	private void Start()
+	private void ToggleOn(bool turnOn)
 	{
-		ToggleOn(isOn, true);
-	}
-
-	private void ToggleOn(bool turnOn, bool forceToggle = false)
-	{
-		if (turnOn && (!isOn || forceToggle))
+		if (turnOn && (!isOn || !stateInit))
 		{
 			isOn = true;
 			sIndex = 0;
 			StartCoroutine(Animator());
 		}
-		else if (!turnOn && (isOn || forceToggle))
+		else if (!turnOn && (isOn || !stateInit))
 		{
 			isOn = false;
-			spriteRenderer.enabled = false;
+			//an unknown evil is enabling the spriteRenderer when power is initially off on client side
+			//even though we disable it in this component. So to turn off the screen we just clear the sprite
+			//rather than enabling / disabling the renderer.
+			spriteRenderer.sprite = null;
 			if (screenGlow != null)
 			{
 				screenGlow.SetActive(false);
@@ -49,6 +50,11 @@ public class ConsoleScreenAnimator : MonoBehaviour, IAPCPowered
 		else {
 			ToggleOn(true);
 		}
+
+		if (!stateInit)
+		{
+			stateInit = true;
+		}
 	}
 
 	IEnumerator Animator()
@@ -57,7 +63,7 @@ public class ConsoleScreenAnimator : MonoBehaviour, IAPCPowered
 		{
 			screenGlow.SetActive(true);
 		}
-		spriteRenderer.enabled = true;
+
 		while (isOn)
 		{
 			spriteRenderer.sprite = onSprites[sIndex];

--- a/UnityProject/Assets/Scripts/Electricity/PoweredDevices/APCPoweredDevice.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PoweredDevices/APCPoweredDevice.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -19,11 +20,22 @@ public class APCPoweredDevice : NetworkBehaviour
 
 	public override void OnStartClient()
 	{
-		UpdateSynchronisedState((State));
+		UpdateSynchronisedState(State);
+	}
+
+	public override void OnStartServer()
+	{
+		UpdateSynchronisedState(State);
+	}
+
+	private void Awake()
+	{
+		Powered = gameObject.GetComponent<IAPCPowered>();
 	}
 
 	void Start()
 	{
+		Logger.LogTraceFormat("{0}({1}) starting, state {2}", Category.Electrical, name, transform.position.To2Int(), State);
 		if (Wattusage > 0)
 		{
 			Resistance = 240 / (Wattusage / 240);
@@ -38,7 +50,6 @@ public class APCPoweredDevice : NetworkBehaviour
 				RelatedAPC.ConnectedDevices.Add(this);
 			}
 		}
-		Powered = gameObject.GetComponent<IAPCPowered>();
 	}
 	public void APCBroadcastToDevice(APC APC)
 	{
@@ -103,7 +114,12 @@ public class APCPoweredDevice : NetworkBehaviour
 			}
 		}
 	}
-	public void UpdateSynchronisedState(PowerStates _State) {
+	private void UpdateSynchronisedState(PowerStates _State) {
+		if (_State != State)
+		{
+			Logger.LogTraceFormat("{0}({1}) state changing {2} to {3}", Category.Electrical, name, transform.position.To2Int(), State, _State);
+		}
+
 		State = _State;
 		if (Powered != null)
 		{

--- a/UnityProject/Assets/Scripts/Electricity/PoweredDevices/APCPoweredDevice.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PoweredDevices/APCPoweredDevice.cs
@@ -17,6 +17,11 @@ public class APCPoweredDevice : NetworkBehaviour
 	[SyncVar(hook = nameof(UpdateSynchronisedState))]
 	public PowerStates State;
 
+	public override void OnStartClient()
+	{
+		UpdateSynchronisedState((State));
+	}
+
 	void Start()
 	{
 		if (Wattusage > 0)

--- a/UnityProject/Assets/Scripts/Lighting/EmergencyLightAnimator.cs
+++ b/UnityProject/Assets/Scripts/Lighting/EmergencyLightAnimator.cs
@@ -20,9 +20,6 @@ public class EmergencyLightAnimator : MonoBehaviour
 	{
 		lightSource = GetComponent<LightSource>();
 		lightSource.customColor = lightColor;
-	}
-	void Start()
-	{
 		spriteRenderer = GetComponentInChildren<SpriteRenderer>();
 	}
 

--- a/UnityProject/Assets/Scripts/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/Lighting/LightSource.cs
@@ -160,6 +160,9 @@ public class LightSource : ObjectTrigger
 
 	}
 
+	//broadcast target - invoked so lights can register themselves with this APC in
+	//LightSwitch.DetectLightsAndAction. There must be a better way to do this that doesn't rely
+	//on broadcasting.
 	public void EmergencyLight(LightSwitchData Received)
 	{
 		if (gameObject.tag == "EmergencyLight")
@@ -167,10 +170,8 @@ public class LightSource : ObjectTrigger
 			var emergLightAnim = gameObject.GetComponent<EmergencyLightAnimator>();
 			if (emergLightAnim != null)
 			{
-				if (!Received.RelatedAPC.ConnectedEmergencyLights.Contains(emergLightAnim))
-				{
-					Received.RelatedAPC.ConnectedEmergencyLights.Add(emergLightAnim);
-				}
+				Received.RelatedAPC.ConnectEmergencyLight(emergLightAnim);
+
 			}
 		}
 


### PR DESCRIPTION
### Purpose
Fixes #2126 
Fixes #1989 
Fixes #2014 

Cleans up SyncVar usage and init logic for some components to ensure they initialize more "robustly"

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)