### PR TITLE
Issue #1804 Organize Job Selection Screen

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/SceneConstruction/NestedManagers/UIManager/Windows (Put all window UI's in here).prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/SceneConstruction/NestedManagers/UIManager/Windows (Put all window UI's in here).prefab
@@ -438,6 +438,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a14ed3befbaf4893bc7f04d3a44e9639, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  disableDrag: 0
   resetPositionOnDisable: 0
 --- !u!114 &8424668702801436378
 MonoBehaviour:
@@ -451,7 +452,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 32b48dc017580ce4295bfd44c0dd12eb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  buttonPrefab: {fileID: 1812040679061594, guid: d443494833c3bf746b9e1f25c17eaf77,
+  buttonPrefab: {fileID: 6841219424616931615, guid: f911aba3224cf47bcb38ce2c82b53c19,
     type: 3}
   hasPickedAJob: 0
   isUpToDate: 0
@@ -1191,7 +1192,7 @@ MonoBehaviour:
     m_Bottom: 0
   m_ChildAlignment: 1
   m_StartCorner: 0
-  m_StartAxis: 0
+  m_StartAxis: 1
   m_CellSize: {x: 250, y: 30}
   m_Spacing: {x: 10, y: 8}
   m_Constraint: 1
@@ -1420,6 +1421,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a14ed3befbaf4893bc7f04d3a44e9639, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  disableDrag: 0
   resetPositionOnDisable: 0
 --- !u!114 &8424100502890186148
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/UI/GUI/ButtonWhite.prefab
+++ b/UnityProject/Assets/Resources/UI/GUI/ButtonWhite.prefab
@@ -1,0 +1,199 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2508498503116537394
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7696547053490266782}
+  - component: {fileID: 3188131205876141570}
+  - component: {fileID: 3560894276237678514}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7696547053490266782
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2508498503116537394}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1818780156763174057}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20.87, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3188131205876141570
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2508498503116537394}
+  m_CullTransparentMesh: 0
+--- !u!114 &3560894276237678514
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2508498503116537394}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 20
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 2
+    m_MaxSize: 20
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: SECURITY_OFFICER (1 of 3)
+--- !u!1 &6841219424616931615
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1818780156763174057}
+  - component: {fileID: 6398211878608408123}
+  - component: {fileID: 729007072214009134}
+  - component: {fileID: 5432650689739646572}
+  m_Layer: 5
+  m_Name: ButtonWhite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1818780156763174057
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6841219424616931615}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7696547053490266782}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 180, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6398211878608408123
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6841219424616931615}
+  m_CullTransparentMesh: 0
+--- !u!114 &729007072214009134
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6841219424616931615}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: cc3b2d94fa0a81a42899ff1375633780, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!114 &5432650689739646572
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6841219424616931615}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 729007072214009134}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null

--- a/UnityProject/Assets/Resources/UI/GUI/ButtonWhite.prefab.meta
+++ b/UnityProject/Assets/Resources/UI/GUI/ButtonWhite.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f911aba3224cf47bcb38ce2c82b53c19
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Jobs/JobType.cs
+++ b/UnityProject/Assets/Scripts/Jobs/JobType.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using UnityEngine;
 
 [Serializable]
 public enum JobType
@@ -40,4 +43,193 @@ public enum JobType
 	VIROLOGIST,
 	WARDEN,
 	SYNDICATE
+}
+
+public static class JobTypeExtensions
+{
+	public static JobType[] DisplayOrder =
+	{
+		JobType.ASSISTANT, JobType.CAPTAIN, JobType.HOP, JobType.QUARTERMASTER, JobType.CARGOTECH, JobType.MINER,
+		JobType.BARTENDER, JobType.COOK, JobType.BOTANIST, JobType.JANITOR, JobType.CLOWN, JobType.MIME,
+		JobType.CURATOR, JobType.LAWYER, JobType.CHAPLAIN, JobType.CHIEF_ENGINEER, JobType.ENGINEER, JobType.ATMOSTECH,
+		JobType.CMO, JobType.DOCTOR, JobType.CHEMIST, JobType.GENETICIST, JobType.VIROLOGIST, JobType.RD,
+		JobType.SCIENTIST, JobType.ROBOTICIST, JobType.HOS, JobType.WARDEN, JobType.DETECTIVE, JobType.SECURITY_OFFICER,
+		JobType.AI, JobType.CYBORG
+	};
+	public static string ToDisplayString(this JobType me)
+	{
+		var ret = string.Empty;
+
+		switch (me)
+		{
+			case JobType.NULL:
+			case JobType.AI:
+			case JobType.ASSISTANT:
+			case JobType.BARTENDER:
+			case JobType.BOTANIST:
+			case JobType.CAPTAIN:
+			case JobType.CHAPLAIN:
+			case JobType.CHEMIST:
+			case JobType.CIVILIAN:
+			case JobType.CLOWN:
+			case JobType.COOK:
+			case JobType.CURATOR:
+			case JobType.CYBORG:
+			case JobType.DETECTIVE:
+			case JobType.ENGINEER:
+			case JobType.GENETICIST:
+			case JobType.JANITOR:
+			case JobType.LAWYER:
+			case JobType.MIME:
+			case JobType.QUARTERMASTER:
+			case JobType.ROBOTICIST:
+			case JobType.SCIENTIST:
+			case JobType.VIROLOGIST:
+			case JobType.WARDEN:
+			case JobType.SYNDICATE:
+				ret = me.ToString();
+				ret = ret.Substring(0, 1) + ret.Substring(1).ToLower();
+				break;
+
+			case JobType.ATMOSTECH:
+				ret = "Atmospheric Technician";
+				break;
+
+			case JobType.CARGOTECH:
+				ret = "Cargo Technician";
+				break;
+
+			case JobType.CHIEF_ENGINEER:
+				ret = "Chief Engineer";
+				break;
+
+			case JobType.CMO:
+				ret = "Chief Medical Officer";
+				break;
+
+			case JobType.DOCTOR:
+				ret = "Medical Doctor";
+				break;
+
+			case JobType.ENGSEC:
+				ret = "Engineering Security";
+				break;
+
+			case JobType.HOP:
+				ret = "Head of Personnel";
+				break;
+
+			case JobType.HOS:
+				ret = "Head of Security";
+				break;
+
+			case JobType.MEDSCI:
+				ret = "Medical Scientist";
+				break;
+
+			case JobType.MINER:
+				ret = "Shaft Miner";
+				break;
+
+			case JobType.RD:
+				ret = "Research Director";
+				break;
+
+			case JobType.SECURITY_OFFICER:
+				ret = "Security Officer";
+				break;
+		}
+
+		return ret;
+	}
+
+	public static Color GetDisplayColor(this JobType me)
+	{
+		var ret = Color.white;
+
+		switch (me)
+		{
+			case JobType.ASSISTANT:
+			case JobType.CLOWN:
+			case JobType.MIME:
+			case JobType.CURATOR:
+			case JobType.LAWYER:
+			case JobType.CHAPLAIN:
+				ret = new Color32(221, 221, 221, 255); // #dddddd
+				break;
+
+			case JobType.CAPTAIN:
+				ret = new Color32(204,204,255, 255); // #ccccff
+				break;
+
+			case JobType.HOP:
+				ret = new Color32(221,221,255, 255); // #ddddff
+				break;
+
+			case JobType.QUARTERMASTER:
+				ret = new Color32(215, 176, 136, 255); // #d7b088
+				break;
+
+			case JobType.CARGOTECH:
+			case JobType.MINER:
+				ret = new Color32(220, 186, 151, 255); // #dcba97
+				break;
+
+			case JobType.BARTENDER:
+			case JobType.COOK:
+			case JobType.BOTANIST:
+			case JobType.JANITOR:
+				ret = new Color32(187,226,145, 255); // #bbe291
+				break;
+
+			case JobType.CHIEF_ENGINEER:
+				ret = new Color32(255,238,170, 255); // #ffeeaa
+				break;
+
+			case JobType.ENGINEER:
+			case JobType.ATMOSTECH:
+				ret = new Color32(255,245,204, 255); // #fff5cc
+				break;
+
+			case JobType.CMO:
+				ret = new Color32(255,221,240, 255); // #ffddf0
+				break;
+
+			case JobType.DOCTOR:
+			case JobType.CHEMIST:
+			case JobType.GENETICIST:
+			case JobType.VIROLOGIST:
+				ret = new Color32(255, 238, 240, 255); // #ffeef0
+				break;
+
+			case JobType.RD:
+				ret = new Color32(255,221,255, 255); // #ffddff
+				break;
+
+			case JobType.SCIENTIST:
+			case JobType.ROBOTICIST:
+				ret = new Color32(255, 238, 255, 255); // #ffeeff
+				break;
+
+			case JobType.HOS:
+				ret = new Color32(255,221,221, 255); // #ffdddd
+				break;
+
+			case JobType.WARDEN:
+			case JobType.DETECTIVE:
+			case JobType.SECURITY_OFFICER:
+				ret = new Color32(255,238,238, 255); // #ffeeee
+				break;
+
+			case JobType.AI:
+				ret = new Color32(204,255,204, 255); // #ccffcc
+				break;
+
+			case JobType.CYBORG:
+				ret = new Color32(221, 255, 221, 255); // #ddffdd
+				break;
+		}
+
+		return ret;
+	}
 }

--- a/UnityProject/ProjectSettings/GraphicsSettings.asset
+++ b/UnityProject/ProjectSettings/GraphicsSettings.asset
@@ -39,6 +39,7 @@ GraphicsSettings:
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 4800000, guid: 941c854b8306dab48b376ed6d37ac05f, type: 3}
+  - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
### Purpose
Fixes #1804. Organizes the Job Selection screen- arranges the jobs based on /tg/ arrangement, gives method for display names for Job Enum, colors the background of the buttons.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
_Please enter any other relevant information here_
