### PR TITLE
Includes items in UI slots in the radial menus.

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Right click/RightclickManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Right click/RightclickManager.cs
@@ -75,11 +75,13 @@ public class RightclickManager : MonoBehaviour
 		{
 			List<GameObject> objects = null;
 			// Check if mouse point occluded by FoV system.
-			if (!lightingSystem.enabled || lightingSystem.IsScreenPointVisible(CommonInput.mousePosition)) {
+			if (!lightingSystem.enabled || lightingSystem.IsScreenPointVisible(CommonInput.mousePosition))
+			{
 				// Gets Items on the position of the mouse that are able to be right clicked
 				objects = GetRightClickableObjects();
 			}
-			else {
+			else
+			{
 				objects = new List<GameObject>();
 			}
 
@@ -90,8 +92,15 @@ public class RightclickManager : MonoBehaviour
 				position = CommonInput.mousePosition,
 			};
 			EventSystem.current.RaycastAll(pointerData, raycastResults);
+#pragma warning disable UEA0005 // Ignore warning about using GetComponent() inside Update()
 			// Searching for UI_ItemSwap instead of UI_ItemSlot for the larger and more consistent hitbox.
-			objects.AddRange(raycastResults.Select(rc => rc.gameObject.GetComponent<UI_ItemSwap>()?.GetComponentInChildren<UI_ItemSlot>()?.Item).Where(go => go != null));
+			objects.AddRange(raycastResults.Select(rc => {
+				// Verbose workaround since you should not use null propagation on Unity objects. Thanks, Unity.
+				var itemSwap = rc.gameObject.GetComponent<UI_ItemSwap>();
+				var itemSlot = itemSwap == null ? null : itemSwap.GetComponentInChildren<UI_ItemSlot>();
+				return itemSlot == null ? null : itemSlot.Item;
+				}).Where(go => go != null));
+#pragma warning restore UEA0005
 
 			//Generates menus
 			var options = Generate(objects);

--- a/UnityProject/Assets/Scripts/UI/Right click/RightclickManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Right click/RightclickManager.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 /// <summary>
 /// Main logic for managing right click behavior.
@@ -23,6 +24,7 @@ public class RightclickManager : MonoBehaviour
 
 	//cached methods attributed with RightClickMethod
 	private List<RightClickAttributedComponent> attributedTypes;
+	private List<RaycastResult> raycastResults = new List<RaycastResult>();
 
 	//defines a particular component that has one or more methods which have been attributed with RightClickMethod. Cached
 	// in the above list to avoid expensive lookup at click-time.
@@ -68,11 +70,29 @@ public class RightclickManager : MonoBehaviour
 
 	void Update()
 	{
-		// Get right mouse click and check if mouse point occluded by FoV system.
-		if (CommonInput.GetMouseButtonDown(1) &&  (!lightingSystem.enabled || lightingSystem.IsScreenPointVisible(CommonInput.mousePosition)))
+		// Get right mouse click
+		if (CommonInput.GetMouseButtonDown(1))
 		{
-			//gets Items on the position of the mouse that are able to be right clicked
-			List<GameObject> objects = GetRightClickableObjects();
+			List<GameObject> objects = null;
+			// Check if mouse point occluded by FoV system.
+			if (!lightingSystem.enabled || lightingSystem.IsScreenPointVisible(CommonInput.mousePosition)) {
+				// Gets Items on the position of the mouse that are able to be right clicked
+				objects = GetRightClickableObjects();
+			}
+			else {
+				objects = new List<GameObject>();
+			}
+
+			// Gets UI elements
+			var pointerData = new PointerEventData(EventSystem.current)
+			{
+				pointerId = -1, // Mouse
+				position = CommonInput.mousePosition,
+			};
+			EventSystem.current.RaycastAll(pointerData, raycastResults);
+			// Searching for UI_ItemSwap instead of UI_ItemSlot for the larger and more consistent hitbox.
+			objects.AddRange(raycastResults.Select(rc => rc.gameObject.GetComponent<UI_ItemSwap>()?.GetComponentInChildren<UI_ItemSlot>()?.Item).Where(go => go != null));
+
 			//Generates menus
 			var options = Generate(objects);
 			//Logger.Log ("yo", Category.UI);

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
@@ -333,7 +333,8 @@ public class UI_ItemSlot : TooltipMonoBehaviour, IDragHandler, IEndDragHandler
 
 	public void OnDrag(PointerEventData data)
 	{
-		UIManager.DragAndDrop.UI_ItemDrag(this);
+		if (data.button == PointerEventData.InputButton.Left)
+			UIManager.DragAndDrop.UI_ItemDrag(this);
 	}
 
 	public void OnEndDrag(PointerEventData data)

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
@@ -334,7 +334,9 @@ public class UI_ItemSlot : TooltipMonoBehaviour, IDragHandler, IEndDragHandler
 	public void OnDrag(PointerEventData data)
 	{
 		if (data.button == PointerEventData.InputButton.Left)
+		{
 			UIManager.DragAndDrop.UI_ItemDrag(this);
+		}
 	}
 
 	public void OnEndDrag(PointerEventData data)


### PR DESCRIPTION
### Purpose
Items in equipment slots on the UI would not appear in the right-click radial menus. This adds them to that list, and restricts drag/drop interaction to the left mouse button so that it does not interfere with the menu.

Fixes #1743 

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors __(It does add warnings, though. Should I suppress them?)__
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
This brings two light a couple other issues. First, the HUD UI renders above the radial menus. Second, the radial menu renders partially off-screen if near the edge. These are both problems for another issue.

We may consider implementing a type like `IItemProxy` to apply to `UI_ItemSwap` in order to allow other UI elements to represent items.