### PR TITLE
2173 Fix dummy player spawn point, dummy player pulling

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnHandler.cs
@@ -65,10 +65,13 @@ public static class SpawnHandler
 	/// <param name="eventType">Event type for the player sync.</param>
 	public static void TransferPlayer(NetworkConnection conn, GameObject newBody, GameObject oldBody, EVENT eventType, CharacterSettings characterSettings)
 	{
-		var oldPlayerNetworkActions = oldBody.GetComponent<PlayerNetworkActions>();
-		if(oldPlayerNetworkActions)
+		if (oldBody)
 		{
-			oldPlayerNetworkActions.RpcBeforeBodyTransfer();
+			var oldPlayerNetworkActions = oldBody.GetComponent<PlayerNetworkActions>();
+			if(oldPlayerNetworkActions)
+			{
+				oldPlayerNetworkActions.RpcBeforeBodyTransfer();
+			}
 		}
 
 		var connectedPlayer = PlayerList.Instance.Get(conn);

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -178,7 +178,12 @@ public partial class PlayerSync
 		if ( followMode ) {
 			playerDirectional.FaceDirection(Orientation.From(direction));
 			//force directional update of client, since it can't predict where it's being pulled
-			playerDirectional.TargetForceSyncDirection(playerScript.connectionToClient);
+			var conn = playerScript.connectionToClient;
+			if (conn != null)
+			{
+				playerDirectional.TargetForceSyncDirection(conn);
+			}
+
 		}
 		else if ( !float.IsNaN( speed ) && speed >= playerMove.PushFallSpeed )
 		{


### PR DESCRIPTION
### Purpose
Fixes #2173. Dummy players now spawn in the assistant position. Additionally, now checks for a connection before attempting to tell a player they are being pulled- this was not letting the dummy player be pulled around.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

