### PR TITLE
Added Paper Bins

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Items/Other/Resources/Paper Bin.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Items/Other/Resources/Paper Bin.prefab
@@ -1,0 +1,438 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4311291612152022209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6673606106450532476}
+  - component: {fileID: 6688623241046967153}
+  m_Layer: 10
+  m_Name: Pen Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6673606106450532476
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4311291612152022209}
+  m_LocalRotation: {x: -0, y: -0, z: 0.00000014901144, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.1}
+  m_LocalScale: {x: 0.8, y: 0.8, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3315602397542475205}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6688623241046967153
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4311291612152022209}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 142874271
+  m_SortingLayer: 10
+  m_SortingOrder: 550
+  m_Sprite: {fileID: 21300000, guid: 221d473300b1ef54da59f55e53b9a00d, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &6258242089137662919
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3315602397542475205}
+  - component: {fileID: 1184034389280667621}
+  - component: {fileID: 1829736207480276922}
+  - component: {fileID: 6441605053452467712}
+  - component: {fileID: 2677451350077854373}
+  - component: {fileID: 4089351644393261817}
+  - component: {fileID: 146779046979709823}
+  - component: {fileID: 4149125379476819137}
+  - component: {fileID: 2818992286365646655}
+  - component: {fileID: 4321281566600050422}
+  - component: {fileID: 781523606564751371}
+  - component: {fileID: 8918271915433250682}
+  - component: {fileID: 5600470873996663622}
+  m_Layer: 10
+  m_Name: Paper Bin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3315602397542475205
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 873704746938030275}
+  - {fileID: 6673606106450532476}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1184034389280667621
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &1829736207480276922
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &6441605053452467712
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  registerTile: {fileID: 0}
+  isNotPushable: 0
+--- !u!114 &2677451350077854373
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteDataHandler: {fileID: 0}
+  InventoryIcon: {fileID: 0}
+  itemName: Paper Bin
+  itemDescription: Contains all the paper you'll never need.
+  itemType: 0
+  size: 3
+  spriteType: 0
+  CanConnectToTank: 0
+  hitDamage: 0
+  damageType: 0
+  throwDamage: 0
+  throwSpeed: 3
+  throwRange: 7
+  hitSound: GenericHit
+  attackVerb: []
+--- !u!114 &4089351644393261817
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 532caaf8551f46489d81372777a7c8b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  initialPaperCount: 20
+  blankPaper: {fileID: 1320386684021000, guid: 4ad202d5ed2ef44f0b3363b5fd90a066, type: 3}
+  blankPaperCount: 20
+  storedPen: {fileID: 0}
+--- !u!114 &146779046979709823
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  OnDropServer:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &4149125379476819137
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteMatrixRotationBehavior: 1
+--- !u!114 &2818992286365646655
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  layer: {fileID: 0}
+  ObjectType: 0
+  crossed:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &4321281566600050422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &781523606564751371
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24590037b6b486082fc874d1bfd9d95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  Armor:
+    Melee: 0
+    Bullet: 0
+    Laser: 0
+    Energy: 0
+    Bomb: 0
+    Rad: 0
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 1
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+--- !u!114 &8918271915433250682
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Infos:
+    spriteIndex: 0
+    VariantIndex: 0
+    AID: 0
+    Serialized: []
+  spriteList: []
+--- !u!114 &5600470873996663622
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  serverOnly: 0
+  localPlayerAuthority: 0
+  m_AssetId: 3bd2990f951e6461199f678384ca1866
+  m_SceneId: 0
+--- !u!1 &6541166396586915311
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 873704746938030275}
+  - component: {fileID: 2375051678613724523}
+  m_Layer: 10
+  m_Name: Base Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &873704746938030275
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6541166396586915311}
+  m_LocalRotation: {x: -0, y: -0, z: 0.00000014901144, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.8, y: 0.8, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3315602397542475205}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2375051678613724523
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6541166396586915311}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 142874271
+  m_SortingLayer: 10
+  m_SortingOrder: 550
+  m_Sprite: {fileID: 21300000, guid: 70e8f68529bd0574ab1d595fba281f91, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Items/Other/Resources/Paper Bin.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Items/Other/Resources/Paper Bin.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3bd2990f951e6461199f678384ca1866
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
@@ -27,7 +27,8 @@ public enum ChatChannel
 	[Description(":t")] Syndicate 	= 1 << 13,
 	[Description("")] 	System 		= 1 << 14,
 	[Description(":g")] Ghost 		= 1 << 15,
-	[Description("")] 	Combat 		= 1 << 16
+	[Description("")] 	Combat 		= 1 << 16,
+	[Description("")]	Warning		= 1 << 17
 }
 
 /// <summary>
@@ -119,6 +120,14 @@ public class ChatEvent
 			this.channels = ChatChannel.Examine;
 			this.modifiers = ChatModifier.None;
 			return $"<b><i>{message}</i></b>";
+		}
+
+		// Skip everything if the message is a local warning
+		if ((channels & ChatChannel.Warning) == ChatChannel.Warning)
+		{
+			this.channels = ChatChannel.Warning;
+			this.modifiers = ChatModifier.None;
+			return $"<i>{message}</i>";
 		}
 
 		//Check for emote. If found skip chat modifiers, make sure emote is only in Local channel

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/InteractionComponentUtils.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/InteractionComponentUtils.cs
@@ -1,5 +1,6 @@
 
 using System;
+using UnityEngine;
 
 /// <summary>
 /// Utilities used in IF2 for various core interaction components
@@ -35,10 +36,10 @@ public static class InteractionComponentUtils
 	/// <returns>If validation succeeds and coordinator sends the interaciton msg, invokes
 	/// onValidationSuccess and returns STOP_PROCESSING. Otherwise returns CONTINUE_PROCESSING.</returns>
 	public static bool CoordinatedInteract<T>(T info, InteractionCoordinator<T> coordinator,
-		Action<T> onValidationSuccess)
+		Action<T> onValidationSuccess, string specificComponent = null)
 		where T : Interaction
 	{
-		var validated = coordinator.ClientValidateAndRequest(info);
+		var validated = coordinator.ClientValidateAndRequest(info, specificComponent);
 		if (validated)
 		{
 			//success, so do client prediction if not server player

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBHandApplyInteractable.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBHandApplyInteractable.cs
@@ -63,6 +63,12 @@ public abstract class NBHandApplyInteractable
 		return InteractionComponentUtils.CoordinatedInteract(info, coordinator, ClientPredictInteraction);
 	}
 
+	public bool Interact(HandApply info, string specificComponent)
+	{
+		EnsureCoordinatorInit();
+		return InteractionComponentUtils.CoordinatedInteract(info, coordinator, ClientPredictInteraction, specificComponent);
+	}
+
 	public bool ServerProcessInteraction(HandApply info)
 	{
 		EnsureCoordinatorInit();

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/Helpers/InteractionCoordinator.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/Helpers/InteractionCoordinator.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 /// <summary>
 /// Helper class for coordinating an interaction between client / server.
@@ -50,11 +51,12 @@ public class InteractionCoordinator<T>
 	/// to perform the interaction.
 	/// </summary>
 	/// <param name="interaction">interaction being performed.</param>
+	/// <param name="specificComponent">Name of specific component on the object to be targeted by the interaction.</param>
 	/// <returns>if validation succeeded</returns>
-	public bool ClientValidateAndRequest(T interaction)
+	public bool ClientValidateAndRequest(T interaction, string specificComponent = null)
 	{
 		if (willInteract != null && !willInteract.Invoke(interaction, NetworkSide.Client)) return false;
-		InteractionMessageUtils.SendRequest(interaction, processor);
+		InteractionMessageUtils.SendRequest(interaction, processor, specificComponent);
 		return true;
 
 	}

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy.meta
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 874818994908440d9fb6689aaff43a1e
+timeCreated: 1569702851

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/PaperBin.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/PaperBin.cs
@@ -212,8 +212,8 @@ namespace Items.Bureaucracy
 			// First, get the papers that players have put in the bin
 			if (storedPaper.Count > 0)
 			{
-				paper = storedPaper[0];
-				storedPaper.RemoveAt(0);
+				paper = storedPaper[storedPaper.Count - 1];
+				storedPaper.RemoveAt(storedPaper.Count - 1);
 				SyncBlankPaperCount(blankPaperCount);
 			}
 			else // Otherwise, take from blank paper stash

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/PaperBin.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/PaperBin.cs
@@ -1,0 +1,250 @@
+using System;
+using Mirror;
+using UnityEngine;
+
+namespace Items.Bureaucracy
+{
+	public class PaperBin : NBHandApplyInteractable, IOnStageServer
+	{
+
+		public int initialPaperCount = 20;
+		public GameObject blankPaper;
+
+		[SyncVar (hook = nameof(SyncBlankPaperCount))]
+		private int blankPaperCount;
+
+		private readonly SyncListPaper storedPaper = new SyncListPaper();
+
+		[SyncVar (hook = nameof(SyncStoredPen))]
+		private GameObject storedPen;
+
+		private SpriteRenderer binRenderer;
+		private SpriteRenderer penRenderer;
+		private Sprite binEmpty;
+		private Sprite binLoaded;
+
+		#region Networking and Sync
+
+		private void SyncBlankPaperCount(int newCount)
+		{
+			blankPaperCount = newCount;
+
+			UpdateSpriteState();
+		}
+
+		private void SyncStoredPen(GameObject pen)
+		{
+			storedPen = pen;
+
+			UpdateSpriteState();
+		}
+
+		public override void OnStartClient()
+		{
+			SyncEverything();
+			base.OnStartClient();
+		}
+
+		public override void OnStartServer()
+		{
+			SyncEverything();
+			base.OnStartServer();
+		}
+
+		private void SyncEverything()
+		{
+			var renderers = GetComponentsInChildren<SpriteRenderer>();
+			binRenderer = renderers[0];
+			penRenderer = renderers[1];
+			binEmpty = Resources.Load<Sprite>("textures/items/bureaucracy/bureaucracy_paper_bin0");
+			binLoaded = Resources.Load<Sprite>("textures/items/bureaucracy/bureaucracy_paper_bin1");
+
+			SyncBlankPaperCount(blankPaperCount);
+			SyncStoredPen(storedPen);
+		}
+
+		#endregion
+
+		public void GoingOnStageServer(OnStageInfo info)
+		{
+			blankPaperCount = initialPaperCount;
+			storedPaper.Clear();
+			storedPen = null;
+
+			SyncEverything();
+		}
+
+		public void OnExamine()
+		{
+			var count = PaperCount();
+			var message = "It doesn't contain any paper.";
+
+			if (count > 0)
+			{
+				if (count == 1)
+				{
+					message = "It contains one piece of paper.";
+				}
+				else if (count > 1)
+				{
+					message = "It contains " + count + " total pieces of paper.";
+				}
+
+				if (storedPen)
+				{
+					message += " A pen sits on top.";
+				}
+			}
+			else if (storedPen)
+			{
+				message += " There is a pen inside.";
+			}
+
+			ChatRelay.Instance.AddToChatLogClient(message, ChatChannel.Examine);
+		}
+
+		protected override bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			if (!base.WillInteract(interaction, side))
+			{
+				return false;
+			}
+
+			var ps = interaction.Performer.GetComponent<PlayerScript>();
+			var cnt = GetComponent<CustomNetTransform>();
+			if (!ps || !cnt || !ps.IsInReach(cnt.RegisterTile, side == NetworkSide.Server))
+			{
+				return false;
+			}
+
+			if (interaction.HandObject != null)
+			{
+				// If hand slot contains paper, we can place it into the bin.
+				if (interaction.HandObject.GetComponent<Paper>())
+				{
+					return true;
+				}
+
+				// If hand slot contains a pen, we can try to put it in the bin.
+				if (!storedPen && interaction.HandObject.GetComponent<Pen>())
+				{
+					return true;
+				}
+
+				// If we're not putting paper in the bin, we're picking it up- make sure the hand is empty
+				return false;
+			}
+
+			return true;
+		}
+
+		// Interaction when clicking the bin
+		protected override void ServerPerformInteraction(HandApply interaction)
+		{
+			var handObj = interaction.HandObject;
+			if (handObj == null)
+			{
+				var pna = interaction.Performer.GetComponent<PlayerNetworkActions>();
+
+				// Pen comes out before the paper
+				if (storedPen)
+				{
+					UpdateChatMessage.Send(interaction.Performer, ChatChannel.Examine,
+						"You take the pen out of the paper bin.");
+					InventoryManager.EquipInInvSlot(pna.Inventory[pna.activeHand], GetStoredPen());
+					return;
+				}
+
+				// Player is picking up a piece of paper
+				if (!HasPaper())
+				{
+					UpdateChatMessage.Send(interaction.Performer, ChatChannel.Examine,"The paper bin is empty!");
+					return;
+				}
+
+				UpdateChatMessage.Send(interaction.Performer, ChatChannel.Examine, "You take the paper out of the paper bin.");
+				InventoryManager.EquipInInvSlot(pna.Inventory[pna.activeHand], GetPaperFromStack());
+			}
+			else
+			{
+				// Player is adding a piece of paper or a pen
+				var slot = InventoryManager.GetSlotFromOriginatorHand(interaction.Performer,
+					interaction.HandSlot.equipSlot);
+				handObj.GetComponent<Pickupable>().DisappearObject(slot);
+
+				if (handObj.GetComponent<Pen>())
+				{
+					SyncStoredPen(handObj);
+					UpdateChatMessage.Send(interaction.Performer, ChatChannel.Examine, "You put the pen in the paper bin.");
+					return;
+				}
+
+				UpdateChatMessage.Send(interaction.Performer, ChatChannel.Examine, "You put the paper in the paper bin.");
+				AddPaperToStack(handObj);
+			}
+		}
+
+		private bool HasPaper()
+		{
+			return blankPaperCount > 0 || storedPaper.Count > 0;
+		}
+
+		private int PaperCount()
+		{
+			return blankPaperCount + storedPaper.Count;
+		}
+
+		private void AddPaperToStack(GameObject paper)
+		{
+			storedPaper.Add(paper);
+			SyncBlankPaperCount(blankPaperCount);
+		}
+
+		private GameObject GetPaperFromStack()
+		{
+			GameObject paper;
+
+			if (!HasPaper())
+			{
+				throw new InvalidOperationException();
+			}
+
+			// First, get the papers that players have put in the bin
+			if (storedPaper.Count > 0)
+			{
+				paper = storedPaper[0];
+				storedPaper.RemoveAt(0);
+				SyncBlankPaperCount(blankPaperCount);
+			}
+			else // Otherwise, take from blank paper stash
+			{
+				SyncBlankPaperCount(blankPaperCount - 1);
+				paper = PoolManager.PoolNetworkInstantiate(blankPaper);
+			}
+
+			return paper;
+		}
+
+		private GameObject GetStoredPen()
+		{
+			var pen = storedPen;
+			SyncStoredPen(null);
+			return pen;
+		}
+
+		private void UpdateSpriteState()
+		{
+			if (binRenderer)
+			{
+				binRenderer.sprite = HasPaper() ? binLoaded : binEmpty;
+			}
+
+			if (penRenderer)
+			{
+				penRenderer.sprite = storedPen ? storedPen.GetComponentInChildren<SpriteRenderer>().sprite : null;
+			}
+		}
+	}
+
+	class SyncListPaper : SyncList<GameObject> {}
+}

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/PaperBin.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/PaperBin.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 532caaf8551f46489d81372777a7c8b5
+timeCreated: 1569702865

--- a/UnityProject/Assets/Scripts/Items/Others/Paper.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Paper.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using Mirror;
 
 public class Paper : NetworkBehaviour

--- a/UnityProject/Assets/Scripts/Items/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Items/Pickupable.cs
@@ -145,7 +145,7 @@ public class Pickupable : NBHandApplyInteractable, IRightClickable
 	private void RightClickInteract()
 	{
 		//trigger the interaction manually, triggered via the right click menu
-		Interact(HandApply.ByLocalPlayer(gameObject));
+		Interact(HandApply.ByLocalPlayer(gameObject), "Pickupable");
 	}
 
 	//Broadcast from InventoryManager on server

--- a/UnityProject/Assets/Scripts/Items/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Items/Pickupable.cs
@@ -145,7 +145,7 @@ public class Pickupable : NBHandApplyInteractable, IRightClickable
 	private void RightClickInteract()
 	{
 		//trigger the interaction manually, triggered via the right click menu
-		Interact(HandApply.ByLocalPlayer(gameObject), "Pickupable");
+		Interact(HandApply.ByLocalPlayer(gameObject), nameof(Pickupable));
 	}
 
 	//Broadcast from InventoryManager on server

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/InteractionMessageUtils.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/InteractionMessageUtils.cs
@@ -26,7 +26,8 @@ public static class InteractionMessageUtils
 	/// <typeparamref name="T">Interaction subtype
 	/// for the interaction that the processor can handle (such as MouseDrop for a mouse drop interaction).
 	/// Must be a subtype of Interaction.</typeparamref>
-	public static void SendRequest<T>(T info, IInteractionProcessor<T> processor)
+	/// <param name="specificComponent"> Name of specific Component on the gameobject to be targeted by the interaction. </param>
+	public static void SendRequest<T>(T info, IInteractionProcessor<T> processor, string specificComponent = null)
 		where T : Interaction
 	{
 		if (!info.Performer.Equals(PlayerManager.LocalPlayer))
@@ -52,7 +53,7 @@ public static class InteractionMessageUtils
 		}
 		else if (typeof(T) == typeof(HandApply))
 		{
-			RequestHandApplyMessage.Send(info as HandApply, processorObject);
+			RequestHandApplyMessage.Send(info as HandApply, processorObject, specificComponent);
 			return;
 		}
 		else if (typeof(T) == typeof(AimApply))
@@ -82,13 +83,17 @@ public static class InteractionMessageUtils
 	/// the specified type.
 	/// </summary>
 	/// <param name="gameObject">object to check</param>
+	/// <param name="specificComponent">Component name to match</param>
 	/// <typeparam name="T">type of interaction whose processors should be retrieved</typeparam>
 	/// <returns>the processors found. Null if none found.</returns>
-	public static IInteractionProcessor<T>[] TryGetProcessors<T>(GameObject gameObject)
+	public static IInteractionProcessor<T>[] TryGetProcessors<T>(GameObject gameObject, string specificComponent = null)
 		where T : Interaction
 	{
 		var processorComponents = gameObject.GetComponents<IInteractionProcessor<T>>()
-			.Where(proc => proc != null && (proc as MonoBehaviour).enabled).ToArray();
+			.Where(proc => proc != null && (proc as MonoBehaviour).enabled)
+			.Where(proc => specificComponent == null ? true : (proc as Component).GetType().ToString() == specificComponent)
+			.ToArray();
+
 		if (processorComponents == null || processorComponents.Length == 0)
 		{
 			Logger.LogError("Processor component could not be looked up by the ID sent by the client, " +


### PR DESCRIPTION
### Purpose
Starting to add pointless bureaucracy to the station, starting with Paper Bins. Paper bins can hold an unlimited amount of paper, dispensing user placed paper first as a stack. Can also hold a single pen on top. Can be picked up on right click.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
I did not implement drag to pick up. It seems with the radial right click menu, it might be more standardized than having a few different behaviors depending on the item. I wanted to add more bureaucratic stuff, but I wasn't sure if I was making questionable design decisions with this or not, so wanted to have this in before having to debug a bunch of different features.
