### PR TITLE
Game modes part 1: pre-round lobby and game mode prefabs

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/GameModes.meta
+++ b/UnityProject/Assets/Resources/Prefabs/GameModes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f82eb9537af9d934ea7c8912ff631777
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/GameModes/Extended.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/GameModes/Extended.prefab
@@ -1,0 +1,50 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2748785564518238682
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6975667052078810342}
+  - component: {fileID: 6056850695404412691}
+  m_Layer: 0
+  m_Name: Extended
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6975667052078810342
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2748785564518238682}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6056850695404412691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2748785564518238682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2db38572150950458000be10f9db6a7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Name: Extended
+  Description: Relax on the station without any pesky antags bothering you.
+  CanRespawn: 0
+  MinPlayers: 0
+  MinAntags: 0

--- a/UnityProject/Assets/Resources/Prefabs/GameModes/Extended.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/GameModes/Extended.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ac05f47055420834486b0648604ca8c1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/GameModes/NukeOps.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/GameModes/NukeOps.prefab
@@ -1,0 +1,51 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2748785564518238682
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6975667052078810342}
+  - component: {fileID: 6749804331068339634}
+  m_Layer: 0
+  m_Name: NukeOps
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6975667052078810342
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2748785564518238682}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6749804331068339634
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2748785564518238682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c391e329f9f301b4c8bddb5b97ff5975, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Name: NukeOps
+  Description: Syndicate forces are approaching the station in an attempt to destroy
+    it!
+  CanRespawn: 1
+  MinPlayers: 1
+  MinAntags: 1

--- a/UnityProject/Assets/Resources/Prefabs/GameModes/NukeOps.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/GameModes/NukeOps.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a5a350c2efb76614da06ca1e4f130c4e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/GameModes/Traitor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/GameModes/Traitor.prefab
@@ -1,0 +1,51 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2748785564518238682
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6975667052078810342}
+  - component: {fileID: -4364293219081169765}
+  m_Layer: 0
+  m_Name: Traitor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6975667052078810342
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2748785564518238682}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-4364293219081169765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2748785564518238682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65e7d5ca18862e94dbf4ab39d7784295, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Name: Traitor
+  Description: Classic SS13 with traitors aboard the station trying to complete their
+    evil objectives.
+  CanRespawn: 0
+  MinPlayers: 0
+  MinAntags: 1

--- a/UnityProject/Assets/Resources/Prefabs/GameModes/Traitor.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/GameModes/Traitor.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: af62c330a47496f408e5de14039413e9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/SceneConstruction/NestedManagers/UIManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/SceneConstruction/NestedManagers/UIManager.prefab
@@ -56,7 +56,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8556012415927023653}
   m_Enabled: 0
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -65,8 +65,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 0
@@ -76,6 +74,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &8587267887451654735
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -97,7 +96,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8556012415927023653}
   m_Enabled: 0
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1573420865, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
@@ -157,7 +156,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8556067798757632551}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -166,8 +165,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 0
@@ -177,6 +174,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8556193154400067053
 GameObject:
   m_ObjectHideFlags: 0
@@ -231,7 +229,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8556193154400067053}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -240,8 +238,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: f27414a81d414171899f7c27a87abe3c, type: 3}
     m_FontSize: 16
@@ -356,7 +352,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8556326735668409341}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -365,8 +361,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 0
@@ -376,6 +370,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8556353176751866825
 GameObject:
   m_ObjectHideFlags: 0
@@ -556,7 +551,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8556704832668122391}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1980459831, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_UiScaleMode: 1
@@ -578,7 +573,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8556704832668122391}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1301386320, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
@@ -598,6 +593,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4921d535b014209820ae966644206ab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
   VariableViewer: {fileID: 9116065612801158685}
   BookshelfViewer: {fileID: 162722399631721757}
   actionControl: {fileID: 8587658629322085199}
@@ -650,10 +647,9 @@ MonoBehaviour:
   hudBottomHuman: {fileID: 8556172553787601039}
   hudBottomGhost: {fileID: 5132426982416102989}
   jobSelectWindow: {fileID: 8556394910883754237}
-  teamSelectionWindow: {fileID: 0}
+  preRoundWindow: {fileID: 3554966611529552006}
+  teamSelectionWindow: {fileID: 8554602371908804983}
   panelRight: {fileID: 8477425026631171861}
-  parentScript: {fileID: 8584949922202743415}
-  nukeOpsGameMode: {fileID: 8554602371908804983}
   uiAnimator: {fileID: 8640675164727423731}
 --- !u!114 &8587756890380419367
 MonoBehaviour:
@@ -817,6 +813,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7ae89d6105393c64bb4e43d5c870eaad, type: 3}
+--- !u!1 &3554966611529552006 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3643849538024845321, guid: 7ae89d6105393c64bb4e43d5c870eaad,
+    type: 3}
+  m_PrefabInstance: {fileID: 271423881433505935}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &8556394910883754237 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8465115023143424114, guid: 7ae89d6105393c64bb4e43d5c870eaad,
@@ -959,48 +961,6 @@ PrefabInstance:
       objectReference: {fileID: 4050590157662293267}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3c2b96c3f18c3cd4ebad42f3cc295c98, type: 3}
---- !u!114 &8587581819665217337 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8282048813706852469, guid: 3c2b96c3f18c3cd4ebad42f3cc295c98,
-    type: 3}
-  m_PrefabInstance: {fileID: 415043299511783244}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c2a726eeaef8432419b74dfe18ce9f81, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &8587885975964466007 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8281217453659649051, guid: 3c2b96c3f18c3cd4ebad42f3cc295c98,
-    type: 3}
-  m_PrefabInstance: {fileID: 415043299511783244}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8556172553787601039}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6805bdeef480645908801c265e9d7aaf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &8477720727309250037 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8098718680817705657, guid: 3c2b96c3f18c3cd4ebad42f3cc295c98,
-    type: 3}
-  m_PrefabInstance: {fileID: 415043299511783244}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8584811347524323065 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8278152406754150837, guid: 3c2b96c3f18c3cd4ebad42f3cc295c98,
-    type: 3}
-  m_PrefabInstance: {fileID: 415043299511783244}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: baa01c5af19143a68b4d486ec2d32ca4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &8556172553787601039 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8322412643209625539, guid: 3c2b96c3f18c3cd4ebad42f3cc295c98,
@@ -1053,6 +1013,48 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b4106466fff94decabf8f8353dd6edd9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8587581819665217337 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8282048813706852469, guid: 3c2b96c3f18c3cd4ebad42f3cc295c98,
+    type: 3}
+  m_PrefabInstance: {fileID: 415043299511783244}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c2a726eeaef8432419b74dfe18ce9f81, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8587885975964466007 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8281217453659649051, guid: 3c2b96c3f18c3cd4ebad42f3cc295c98,
+    type: 3}
+  m_PrefabInstance: {fileID: 415043299511783244}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8556172553787601039}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6805bdeef480645908801c265e9d7aaf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &8477720727309250037 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8098718680817705657, guid: 3c2b96c3f18c3cd4ebad42f3cc295c98,
+    type: 3}
+  m_PrefabInstance: {fileID: 415043299511783244}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8584811347524323065 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8278152406754150837, guid: 3c2b96c3f18c3cd4ebad42f3cc295c98,
+    type: 3}
+  m_PrefabInstance: {fileID: 415043299511783244}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: baa01c5af19143a68b4d486ec2d32ca4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &548259888961291974
@@ -1326,15 +1328,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8fad2bb29eacd43419afe1919a39360f, type: 3}
---- !u!1 &5132426982416102989 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8322412643209625539, guid: 8fad2bb29eacd43419afe1919a39360f,
-    type: 3}
-  m_PrefabInstance: {fileID: 3766466217258256782}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &4909276170178374455 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 8098718680817705657, guid: 8fad2bb29eacd43419afe1919a39360f,
+    type: 3}
+  m_PrefabInstance: {fileID: 3766466217258256782}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5132426982416102989 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8322412643209625539, guid: 8fad2bb29eacd43419afe1919a39360f,
     type: 3}
   m_PrefabInstance: {fileID: 3766466217258256782}
   m_PrefabAsset: {fileID: 0}
@@ -1465,16 +1467,6 @@ PrefabInstance:
       propertyPath: canvas
       value: 
       objectReference: {fileID: 8476288630107385809}
-    - target: {fileID: 5420804678553840072, guid: 7e170a9c9286e41469cecbe1717fdbd4,
-        type: 3}
-      propertyPath: panelImages.Array.data[0]
-      value: 
-      objectReference: {fileID: 8587557130420987989}
-    - target: {fileID: 5420804678553840072, guid: 7e170a9c9286e41469cecbe1717fdbd4,
-        type: 3}
-      propertyPath: tipText
-      value: 
-      objectReference: {fileID: 8587246508841551039}
     - target: {fileID: 3274885705528794751, guid: 7e170a9c9286e41469cecbe1717fdbd4,
         type: 3}
       propertyPath: m_IsActive
@@ -1600,6 +1592,16 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0.9999999
       objectReference: {fileID: 0}
+    - target: {fileID: 5420804678553840072, guid: 7e170a9c9286e41469cecbe1717fdbd4,
+        type: 3}
+      propertyPath: panelImages.Array.data[0]
+      value: 
+      objectReference: {fileID: 8587557130420987989}
+    - target: {fileID: 5420804678553840072, guid: 7e170a9c9286e41469cecbe1717fdbd4,
+        type: 3}
+      propertyPath: tipText
+      value: 
+      objectReference: {fileID: 8587246508841551039}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7e170a9c9286e41469cecbe1717fdbd4, type: 3}
 --- !u!224 &8477425026631171861 stripped
@@ -1739,12 +1741,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fdbe375fdb3e98b46b89b796f9d93dc8, type: 3}
---- !u!224 &8477139355589782671 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5287873272021720522, guid: fdbe375fdb3e98b46b89b796f9d93dc8,
-    type: 3}
-  m_PrefabInstance: {fileID: 4379352537053704517}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8587723967266190067 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5470515234576319414, guid: fdbe375fdb3e98b46b89b796f9d93dc8,
@@ -1757,6 +1753,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3033b5d39951d430299684ac3cd06d7e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &8477139355589782671 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5287873272021720522, guid: fdbe375fdb3e98b46b89b796f9d93dc8,
+    type: 3}
+  m_PrefabInstance: {fileID: 4379352537053704517}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4457154506671072268
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1764,6 +1766,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8477477531144828375}
     m_Modifications:
+    - target: {fileID: 4113822440349019706, guid: 60311bc6bf4173c42af3fe9662d3965c,
+        type: 3}
+      propertyPath: m_Name
+      value: DevClonerMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113822440349019706, guid: 60311bc6bf4173c42af3fe9662d3965c,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4183651651856864320, guid: 60311bc6bf4173c42af3fe9662d3965c,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1868,16 +1880,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4113822440349019706, guid: 60311bc6bf4173c42af3fe9662d3965c,
-        type: 3}
-      propertyPath: m_Name
-      value: DevClonerMenu
-      objectReference: {fileID: 0}
-    - target: {fileID: 4113822440349019706, guid: 60311bc6bf4173c42af3fe9662d3965c,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 60311bc6bf4173c42af3fe9662d3965c, type: 3}
@@ -2023,12 +2025,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 546b78d0ab8074340ac2b9dcdc66f33f, type: 3}
---- !u!224 &8256452581695853595 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4183651651856864320, guid: 546b78d0ab8074340ac2b9dcdc66f33f,
-    type: 3}
-  m_PrefabInstance: {fileID: 5231950085758189659}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6567297230070683167 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1420926274925499972, guid: 546b78d0ab8074340ac2b9dcdc66f33f,
@@ -2041,6 +2037,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac7721428199ab34582a40dba7a1bf59, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &8256452581695853595 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4183651651856864320, guid: 546b78d0ab8074340ac2b9dcdc66f33f,
+    type: 3}
+  m_PrefabInstance: {fileID: 5231950085758189659}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5740478491115101881
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2685,12 +2687,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6e3ab33d8ccc156409d6e8775fd2b7df, type: 3}
---- !u!224 &7556625434735528999 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4183651651856864320, guid: 6e3ab33d8ccc156409d6e8775fd2b7df,
-    type: 3}
-  m_PrefabInstance: {fileID: 5967788240586954855}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2100984367837110465 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5762890015363578022, guid: 6e3ab33d8ccc156409d6e8775fd2b7df,
@@ -2703,6 +2699,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 16dd49e4708d92e4da59acf9d20a831b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &7556625434735528999 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4183651651856864320, guid: 6e3ab33d8ccc156409d6e8775fd2b7df,
+    type: 3}
+  m_PrefabInstance: {fileID: 5967788240586954855}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6184216130338094774
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2822,6 +2824,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 38f86d80081975e479b53b82beb3b116, type: 3}
+--- !u!224 &8477579944802426995 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2338729149468139205, guid: 38f86d80081975e479b53b82beb3b116,
+    type: 3}
+  m_PrefabInstance: {fileID: 6184216130338094774}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2039997815268504786 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5304458584630495844, guid: 38f86d80081975e479b53b82beb3b116,
@@ -2831,19 +2839,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &8587246508841551039 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2521656241382242825, guid: 38f86d80081975e479b53b82beb3b116,
-    type: 3}
-  m_PrefabInstance: {fileID: 6184216130338094774}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &8587557130420987989 stripped
@@ -2855,15 +2851,21 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &8477579944802426995 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2338729149468139205, guid: 38f86d80081975e479b53b82beb3b116,
+--- !u!114 &8587246508841551039 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2521656241382242825, guid: 38f86d80081975e479b53b82beb3b116,
     type: 3}
   m_PrefabInstance: {fileID: 6184216130338094774}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &6676598447969116547
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2989,12 +2991,6 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 6676598447969116547}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &4050590157662293267 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7250404676577275024, guid: 8350b86f7602c4f40b70becb55bf231f,
-    type: 3}
-  m_PrefabInstance: {fileID: 6676598447969116547}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3869768115897617313 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7573972049147357730, guid: 8350b86f7602c4f40b70becb55bf231f,
@@ -3007,6 +3003,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 902f4d75de5c47cfbe5ff094d03c30ce, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &4050590157662293267 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7250404676577275024, guid: 8350b86f7602c4f40b70becb55bf231f,
+    type: 3}
+  m_PrefabInstance: {fileID: 6676598447969116547}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7171025565399343170
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3014,6 +3016,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8477477531144828375}
     m_Modifications:
+    - target: {fileID: 5322105462336844431, guid: 2cee823abaaaa4e4a853404330e4b8a1,
+        type: 3}
+      propertyPath: m_Name
+      value: Zoom&OptionsButtons
+      objectReference: {fileID: 0}
     - target: {fileID: 4660853724584916151, guid: 2cee823abaaaa4e4a853404330e4b8a1,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -3119,11 +3126,6 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5322105462336844431, guid: 2cee823abaaaa4e4a853404330e4b8a1,
-        type: 3}
-      propertyPath: m_Name
-      value: Zoom&OptionsButtons
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2cee823abaaaa4e4a853404330e4b8a1, type: 3}
 --- !u!224 &2533894943528703221 stripped
@@ -3139,6 +3141,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8477477531144828375}
     m_Modifications:
+    - target: {fileID: 4113822440349019706, guid: c8b49360e1a1c6045944338fc97aabd2,
+        type: 3}
+      propertyPath: m_Name
+      value: DevSpawnerMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 4113822440349019706, guid: c8b49360e1a1c6045944338fc97aabd2,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4183651651856864320, guid: c8b49360e1a1c6045944338fc97aabd2,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -3243,16 +3255,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4113822440349019706, guid: c8b49360e1a1c6045944338fc97aabd2,
-        type: 3}
-      propertyPath: m_Name
-      value: DevSpawnerMenu
-      objectReference: {fileID: 0}
-    - target: {fileID: 4113822440349019706, guid: c8b49360e1a1c6045944338fc97aabd2,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4128018427919184280, guid: c8b49360e1a1c6045944338fc97aabd2,
         type: 3}
@@ -3421,6 +3423,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8477477531144828375}
     m_Modifications:
+    - target: {fileID: 8153163913192884163, guid: 54fe31d4ce5448346b0dcb9952fc3754,
+        type: 3}
+      propertyPath: m_Name
+      value: Alert_UI_HUD
+      objectReference: {fileID: 0}
     - target: {fileID: 8232259481283617645, guid: 54fe31d4ce5448346b0dcb9952fc3754,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -3541,11 +3548,6 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1.2312503
       objectReference: {fileID: 0}
-    - target: {fileID: 8153163913192884163, guid: 54fe31d4ce5448346b0dcb9952fc3754,
-        type: 3}
-      propertyPath: m_Name
-      value: Alert_UI_HUD
-      objectReference: {fileID: 0}
     - target: {fileID: 8153215756600515221, guid: 54fe31d4ce5448346b0dcb9952fc3754,
         type: 3}
       propertyPath: m_IsActive
@@ -3578,6 +3580,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8477477531144828375}
     m_Modifications:
+    - target: {fileID: 1576420294694384, guid: 3c54abc70f262c64d821e77c9c70dc93, type: 3}
+      propertyPath: m_Name
+      value: VariableViewer
+      objectReference: {fileID: 0}
     - target: {fileID: 224979633078539924, guid: 3c54abc70f262c64d821e77c9c70dc93,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -3683,10 +3689,6 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 1576420294694384, guid: 3c54abc70f262c64d821e77c9c70dc93, type: 3}
-      propertyPath: m_Name
-      value: VariableViewer
-      objectReference: {fileID: 0}
     - target: {fileID: 8887718195483736180, guid: 3c54abc70f262c64d821e77c9c70dc93,
         type: 3}
       propertyPath: m_AnchorMin.y
@@ -3749,6 +3751,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3c54abc70f262c64d821e77c9c70dc93, type: 3}
+--- !u!224 &8735033633991698787 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 224979633078539924, guid: 3c54abc70f262c64d821e77c9c70dc93,
+    type: 3}
+  m_PrefabInstance: {fileID: 8801822609788518391}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &9116065612801158685 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 334566440375456234, guid: 3c54abc70f262c64d821e77c9c70dc93,
@@ -3761,12 +3769,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9c428450c226d624cb57d5b27d99cd96, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &8735033633991698787 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 224979633078539924, guid: 3c54abc70f262c64d821e77c9c70dc93,
-    type: 3}
-  m_PrefabInstance: {fileID: 8801822609788518391}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &162722399631721757 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8675129351143848682, guid: 3c54abc70f262c64d821e77c9c70dc93,

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/SceneConstruction/NestedManagers/UIManager/Windows (Put all window UI's in here).prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/SceneConstruction/NestedManagers/UIManager/Windows (Put all window UI's in here).prefab
@@ -1,5 +1,982 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &229740723746823538
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 681547311889608350}
+  m_Layer: 5
+  m_Name: AdminPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &681547311889608350
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 229740723746823538}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 926906640270179894}
+  m_Father: {fileID: 8980146822108390584}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 275.7, y: -68.35}
+  m_SizeDelta: {x: 278.6, y: 281.3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &367192564476735491
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4724409973411057827}
+  - component: {fileID: 4584283794111203018}
+  - component: {fileID: 4253824565473312429}
+  m_Layer: 5
+  m_Name: Title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4724409973411057827
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 367192564476735491}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8980146822108390584}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 254}
+  m_SizeDelta: {x: 580, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4584283794111203018
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 367192564476735491}
+  m_CullTransparentMesh: 0
+--- !u!114 &4253824565473312429
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 367192564476735491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 34
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 52
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Waiting for round to start
+--- !u!1 &2184336330775196335
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6525735152474530531}
+  m_Layer: 5
+  m_Name: CountdownPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6525735152474530531
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2184336330775196335}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7865731332718265989}
+  - {fileID: 5369311095874114912}
+  - {fileID: 2870411586905834045}
+  m_Father: {fileID: 8980146822108390584}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.00014930322, y: 123.00002}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2417244199770373552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2870411586905834045}
+  - component: {fileID: 3130604237703829780}
+  - component: {fileID: 4176617964315025153}
+  m_Layer: 5
+  m_Name: Timer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2870411586905834045
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2417244199770373552}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6525735152474530531}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.00024800823, y: -189.2001}
+  m_SizeDelta: {x: 487.1, y: 152}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3130604237703829780
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2417244199770373552}
+  m_CullTransparentMesh: 0
+--- !u!114 &4176617964315025153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2417244199770373552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 80
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 95
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: never
+--- !u!1 &3643849538024845321
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8980146822108390584}
+  - component: {fileID: 891159084902256781}
+  - component: {fileID: 6266153620081745286}
+  - component: {fileID: 7305299707594978616}
+  - component: {fileID: 8698550242779511782}
+  - component: {fileID: 671166175915957619}
+  m_Layer: 5
+  m_Name: PreRoundWindow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &8980146822108390584
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3643849538024845321}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.7469485, y: 0.7469485, z: 0.7469485}
+  m_Children:
+  - {fileID: 137153219764211882}
+  - {fileID: 4724409973411057827}
+  - {fileID: 9069369503410449923}
+  - {fileID: 6525735152474530531}
+  - {fileID: 3908853561893675851}
+  - {fileID: 8023924468122844894}
+  - {fileID: 681547311889608350}
+  m_Father: {fileID: 8530432162611861968}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 4.999939, y: 32.99994}
+  m_SizeDelta: {x: 899.8, y: 612.1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &891159084902256781
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3643849538024845321}
+  m_CullTransparentMesh: 0
+--- !u!114 &6266153620081745286
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3643849538024845321}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7305299707594978616
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3643849538024845321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 5
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 8698550242779511782}
+          m_MethodName: OnDrag
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - eventID: 13
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 8698550242779511782}
+          m_MethodName: BeginDrag
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+--- !u!114 &8698550242779511782
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3643849538024845321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a14ed3befbaf4893bc7f04d3a44e9639, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  disableDrag: 0
+  resetPositionOnDisable: 0
+--- !u!114 &671166175915957619
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3643849538024845321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4cfa17c47748c23449a253fcac613b1f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  currentGameMode: {fileID: 7580910042828541705}
+  timer: {fileID: 4176617964315025153}
+  playerCount: {fileID: 8254472895607154652}
+  adminPanel: {fileID: 229740723746823538}
+  playerWaitPanel: {fileID: 6604363314809837209}
+  countdownPanel: {fileID: 2184336330775196335}
+--- !u!1 &4708550625090008022
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7865731332718265989}
+  - component: {fileID: 73097280012616227}
+  - component: {fileID: 7580910042828541705}
+  m_Layer: 5
+  m_Name: CurrentGameMode
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7865731332718265989
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4708550625090008022}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6525735152474530531}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.00010161922, y: -0.000022888184}
+  m_SizeDelta: {x: 714.2, y: 101.4}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &73097280012616227
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4708550625090008022}
+  m_CullTransparentMesh: 0
+--- !u!114 &7580910042828541705
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4708550625090008022}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 50
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 61
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Game Mode
+--- !u!1 &5503463943050808063
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 926906640270179894}
+  - component: {fileID: 7257209991668303186}
+  - component: {fileID: 1815779847912476600}
+  - component: {fileID: 7752590619402293410}
+  m_Layer: 5
+  m_Name: StartNow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &926906640270179894
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5503463943050808063}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.1165361, y: 1.1165361, z: 1.1165361}
+  m_Children:
+  - {fileID: 1840453630934168448}
+  m_Father: {fileID: 681547311889608350}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: -0.30000305, y: 44}
+  m_SizeDelta: {x: 180, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7257209991668303186
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5503463943050808063}
+  m_CullTransparentMesh: 0
+--- !u!114 &1815779847912476600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5503463943050808063}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3278302, g: 0.41883424, b: 0.5, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: cc3b2d94fa0a81a42899ff1375633780, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7752590619402293410
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5503463943050808063}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1815779847912476600}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 671166175915957619}
+        m_MethodName: StartNowButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 1
+--- !u!1 &5544928268946867815
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8023924468122844894}
+  - component: {fileID: 6589551157042730602}
+  - component: {fileID: 8254472895607154652}
+  m_Layer: 5
+  m_Name: PlayerCount
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8023924468122844894
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5544928268946867815}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8980146822108390584}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 61.58, y: -166}
+  m_SizeDelta: {x: 83.75, y: 38}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6589551157042730602
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5544928268946867815}
+  m_CullTransparentMesh: 0
+--- !u!114 &8254472895607154652
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5544928268946867815}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 32
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 61
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 0
+--- !u!1 &6292923812553778394
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3908853561893675851}
+  - component: {fileID: 3725486228026350820}
+  - component: {fileID: 3144491126245883648}
+  m_Layer: 5
+  m_Name: PlayerTitle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3908853561893675851
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6292923812553778394}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8980146822108390584}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -45.4, y: -166}
+  m_SizeDelta: {x: 130.21, y: 38}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3725486228026350820
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6292923812553778394}
+  m_CullTransparentMesh: 0
+--- !u!114 &3144491126245883648
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6292923812553778394}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9764151, g: 0.9921384, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 32
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 61
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Players:'
+--- !u!1 &6604363314809837209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9069369503410449923}
+  - component: {fileID: 7135500482013321541}
+  - component: {fileID: 2212321439830843651}
+  m_Layer: 5
+  m_Name: PlayerWaitPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9069369503410449923
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6604363314809837209}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8980146822108390584}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.000061037, y: -0.000015259}
+  m_SizeDelta: {x: 714.2, y: 101.4}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7135500482013321541
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6604363314809837209}
+  m_CullTransparentMesh: 0
+--- !u!114 &2212321439830843651
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6604363314809837209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 50
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 61
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Waiting for players...
+--- !u!1 &6660570417978423861
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5369311095874114912}
+  - component: {fileID: 5342511833544991959}
+  - component: {fileID: 4102544647007985718}
+  m_Layer: 5
+  m_Name: StartingIn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5369311095874114912
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6660570417978423861}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6525735152474530531}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.00018139622, y: -93.20003}
+  m_SizeDelta: {x: 406.69, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5342511833544991959
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6660570417978423861}
+  m_CullTransparentMesh: 0
+--- !u!114 &4102544647007985718
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6660570417978423861}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 32
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Starting in...
+--- !u!1 &7517261535306248244
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1840453630934168448}
+  - component: {fileID: 8983406654936056880}
+  - component: {fileID: 7046250411467539552}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1840453630934168448
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7517261535306248244}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 926906640270179894}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8983406654936056880
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7517261535306248244}
+  m_CullTransparentMesh: 0
+--- !u!114 &7046250411467539552
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7517261535306248244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 26
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Start now!
 --- !u!1 &8464717613403599426
 GameObject:
   m_ObjectHideFlags: 0
@@ -54,7 +1031,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8464717613403599426}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -63,8 +1040,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
     m_FontSize: 34
@@ -135,7 +1110,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8464851875318080686}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -144,8 +1119,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: 8b7e517bb47c240059b738381299a570, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
@@ -155,6 +1128,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &8423933327320634390
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -164,7 +1138,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8464851875318080686}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1573420865, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.46666667}
@@ -179,7 +1153,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8464851875318080686}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -193,17 +1167,20 @@ MonoBehaviour:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
     m_HighlightedSprite: {fileID: 0}
     m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
     m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
     m_DisabledTrigger: Disabled
   m_Interactable: 1
   m_TargetGraphic: {fileID: 8424685144383557230}
@@ -221,8 +1198,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &8465086080605742610
 GameObject:
   m_ObjectHideFlags: 0
@@ -277,7 +1252,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465086080605742610}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -286,8 +1261,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 0
@@ -297,6 +1270,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8465115023143424114
 GameObject:
   m_ObjectHideFlags: 0
@@ -358,7 +1332,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465115023143424114}
   m_Enabled: 0
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -367,8 +1341,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 0
@@ -378,6 +1350,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &8424393899148096098
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -387,7 +1360,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465115023143424114}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -1862395651, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Delegates:
@@ -406,8 +1379,6 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
-        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   - eventID: 13
     callback:
       m_PersistentCalls:
@@ -423,9 +1394,6 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
-        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  delegates: []
 --- !u!114 &8424072878391558612
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -512,7 +1480,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465122399017204840}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -521,8 +1489,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
     m_FontSize: 24
@@ -592,7 +1558,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465125087533799994}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -601,8 +1567,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300012, guid: 456b3993efaf4018ab1d98293d1d592b, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
@@ -612,6 +1576,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &8423875930947391888
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -621,7 +1586,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465125087533799994}
   m_Enabled: 0
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1573420865, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.428}
@@ -681,7 +1646,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465217398434441974}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -690,8 +1655,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
     m_FontSize: 14
@@ -735,6 +1698,7 @@ RectTransform:
   m_Children:
   - {fileID: 8530830130350325408}
   - {fileID: 8530562246598747092}
+  - {fileID: 8980146822108390584}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -797,7 +1761,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465393129647900694}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -806,8 +1770,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
     m_FontSize: 14
@@ -878,7 +1840,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465415755265136884}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -887,8 +1849,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: af20367e8cd964d82a9d30ba5f34eb8a, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
@@ -898,6 +1858,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &8424278870485877132
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -907,7 +1868,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465415755265136884}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1573420865, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.46666667}
@@ -922,7 +1883,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465415755265136884}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -936,17 +1897,20 @@ MonoBehaviour:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
     m_HighlightedSprite: {fileID: 0}
     m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
     m_HighlightedTrigger: Highlighted
     m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
     m_DisabledTrigger: Disabled
   m_Interactable: 1
   m_TargetGraphic: {fileID: 8424126078824963898}
@@ -964,8 +1928,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &8465421381632395790
 GameObject:
   m_ObjectHideFlags: 0
@@ -1021,7 +1983,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465421381632395790}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1030,8 +1992,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: 456b3993efaf4018ab1d98293d1d592b, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
@@ -1041,6 +2001,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &8424276914070182710
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1050,7 +2011,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465421381632395790}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1573420865, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.428}
@@ -1110,7 +2071,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465448479710465260}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1119,8 +2080,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
     m_FontSize: 16
@@ -1182,7 +2141,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465448598027235102}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -2095666955, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
@@ -1251,7 +2210,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465529296130297288}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1260,8 +2219,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
     m_FontSize: 32
@@ -1341,7 +2298,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465719591311524344}
   m_Enabled: 0
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1350,8 +2307,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 0
@@ -1361,6 +2316,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &8424457383330814410
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1370,7 +2326,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8465719591311524344}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -1862395651, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Delegates:
@@ -1389,8 +2345,6 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
-        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   - eventID: 13
     callback:
       m_PersistentCalls:
@@ -1406,9 +2360,6 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-      m_TypeName: UnityEngine.EventSystems.EventTrigger+TriggerEvent, UnityEngine.UI,
-        Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  delegates: []
 --- !u!114 &8424028257864243414
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1438,3 +2389,92 @@ MonoBehaviour:
   nukeOpsCount: {fileID: 8424166260938405652}
   nanoCount: {fileID: 8424607803347514888}
   nukeOpsbtn: {fileID: 8424063682865349690}
+--- !u!1 &9179736898045567891
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 137153219764211882}
+  - component: {fileID: 3977807849115185063}
+  - component: {fileID: 7834283317029255062}
+  - component: {fileID: 5978063812122782963}
+  m_Layer: 5
+  m_Name: bg
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &137153219764211882
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9179736898045567891}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8980146822108390584}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.000005722, y: 29.8}
+  m_SizeDelta: {x: 899.8, y: 528.6}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3977807849115185063
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9179736898045567891}
+  m_CullTransparentMesh: 0
+--- !u!114 &7834283317029255062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9179736898045567891}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.7490196}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300012, guid: 456b3993efaf4018ab1d98293d1d592b, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5978063812122782963
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9179736898045567891}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.428}
+  m_EffectDistance: {x: -15, y: -15}
+  m_UseGraphicAlpha: 1

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/SceneConstruction/NestedManagers/UIManager/Windows (Put all window UI's in here).prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/SceneConstruction/NestedManagers/UIManager/Windows (Put all window UI's in here).prefab
@@ -227,7 +227,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: never
+  m_Text: 
 --- !u!1 &3643849538024845321
 GameObject:
   m_ObjectHideFlags: 0
@@ -462,7 +462,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Game Mode
+  m_Text: 
 --- !u!1 &5503463943050808063
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
@@ -69,8 +69,8 @@ public class ChatEvent
 		var player = speaker.Script;
 		this.channels = channels;
 		this.modifiers = (player == null) ? ChatModifier.None : player.GetCurrentChatModifiers();
-		this.speaker = (player == null) ? speaker.Name : player.name;
-		this.position = ( Vector2 ) ((player == null) ?  speaker.GameObject.transform.position : player.gameObject.transform.position);
+		this.speaker = ((channels & ChatChannel.OOC) == ChatChannel.OOC) ? speaker.Username : player.name;
+		this.position = ((player == null) ? Vector2.zero : (Vector2) player.gameObject.transform.position);
 		this.message = ProcessMessage(message, this.speaker, this.channels, modifiers);
 	}
 

--- a/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
@@ -68,9 +68,9 @@ public class ChatEvent
 	{
 		var player = speaker.Script;
 		this.channels = channels;
-		this.modifiers = player.GetCurrentChatModifiers();
-		this.speaker = player.name;
-		this.position = ( Vector2 ) player.gameObject.transform.position;
+		this.modifiers = (player == null) ? ChatModifier.None : player.GetCurrentChatModifiers();
+		this.speaker = (player == null) ? speaker.Name : player.name;
+		this.position = ( Vector2 ) ((player == null) ?  speaker.GameObject.transform.position : player.gameObject.transform.position);
 		this.message = ProcessMessage(message, this.speaker, this.channels, modifiers);
 	}
 

--- a/UnityProject/Assets/Scripts/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatRelay.cs
@@ -78,7 +78,7 @@ public class ChatRelay : NetworkBehaviour
 		}
 		else
 		{
-			players = PlayerList.Instance.InGamePlayers;
+			players = PlayerList.Instance.AllPlayers;
 		}
 
 		//Local chat range checks:
@@ -93,7 +93,7 @@ public class ChatRelay : NetworkBehaviour
 					players.Remove(players[i]);
 				} else {
 					//within range, but check if they are in another room or hiding behind a wall
-					if (Physics2D.Linecast(chatEvent.position,//speaker.GameObject.transform.position, 
+					if (Physics2D.Linecast(chatEvent.position,//speaker.GameObject.transform.position,
 										  players[i].GameObject.transform.position, layerMask)) {
 						//if it hit a wall remove that player
 						players.Remove(players[i]);
@@ -103,7 +103,15 @@ public class ChatRelay : NetworkBehaviour
 		}
 
 		for (var i = 0; i < players.Count; i++) {
-			ChatChannel channels = players[i].Script.GetAvailableChannelsMask(false) & chatEvent.channels;
+			ChatChannel channels = chatEvent.channels;
+			if (players[i].Script == null)
+			{
+				channels &= ChatChannel.OOC;
+			}
+			else
+			{
+				channels &= players[i].Script.GetAvailableChannelsMask(false);
+			}
 			UpdateChatMessage.Send(players[i].GameObject, channels, chatEvent.message);
 		}
 
@@ -131,7 +139,7 @@ public class ChatRelay : NetworkBehaviour
 			}
 		}
 
-        ChatEvent chatEvent = new ChatEvent(message, channels, true);
+		ChatEvent chatEvent = new ChatEvent(message, channels, true);
 
 		if (channels == ChatChannel.None) {
 			return;
@@ -142,16 +150,26 @@ public class ChatRelay : NetworkBehaviour
 			name = "<b>[" + channels + "]</b> ";
 		}
 
-		if ((PlayerManager.LocalPlayerScript.GetAvailableChannelsMask(false) & channels) == channels && (chatEvent.channels & channels) == channels) {
-            //Chatevent UI entry:
+		ChatChannel checkChannels;
+		if (PlayerManager.LocalPlayerScript == null)
+		{
+			checkChannels = ChatChannel.OOC;
+		}
+		else
+		{
+			checkChannels = PlayerManager.LocalPlayerScript.GetAvailableChannelsMask(false);
+		}
+
+		if ((checkChannels & channels) == channels && (chatEvent.channels & channels) == channels) {
+			//Chatevent UI entry:
 			//FIXME at the moment all chat entries are white because of the new system, its a WIP
 			//string colorMessage = "<color=#" + GetCannelColor(channels) + ">" + name + message + "</color>";
-            string colorMessage = "<color=white>" + name + message + "</color>";
-            GameObject chatEntry = Instantiate(ControlChat.Instance.chatEntryPrefab, Vector3.zero, Quaternion.identity);
-            Text text = chatEntry.GetComponent<Text>();
-            text.text = colorMessage;
+			string colorMessage = "<color=white>" + name + message + "</color>";
+			GameObject chatEntry = Instantiate(ControlChat.Instance.chatEntryPrefab, Vector3.zero, Quaternion.identity);
+			Text text = chatEntry.GetComponent<Text>();
+			text.text = colorMessage;
 			chatEntry.transform.SetParent(ControlChat.Instance.content, false);
-            chatEntry.transform.localScale = Vector3.one;
-        }
-    }
+			chatEntry.transform.localScale = Vector3.one;
+		}
+	}
 }

--- a/UnityProject/Assets/Scripts/Database/ServerData.ServerStatus.cs
+++ b/UnityProject/Assets/Scripts/Database/ServerData.ServerStatus.cs
@@ -125,7 +125,7 @@ namespace DatabaseAPI
             status.ForkName = buildInfo.ForkName;
             status.BuildVersion = buildInfo.BuildNumber;
             status.CurrentMap = SceneManager.GetActiveScene().name;
-            status.GameMode = GameManager.Instance.gameMode.ToString();
+            status.GameMode = GameManager.Instance.GetGameModeName();
             status.IngameTime = GameManager.Instance.roundTimer.text;
             if (PlayerList.Instance != null)
             {

--- a/UnityProject/Assets/Scripts/Debug/Logger.cs
+++ b/UnityProject/Assets/Scripts/Debug/Logger.cs
@@ -238,7 +238,8 @@ public enum Category
 	Editor,
 	VariableViewer,
 	Themes,
-	SpriteHandler
+	SpriteHandler,
+	GameMode
 }
 
 [Serializable]

--- a/UnityProject/Assets/Scripts/GameModes.meta
+++ b/UnityProject/Assets/Scripts/GameModes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 14e2f3d5ed0f24949a05abdf0128cb34
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/GameModes/Extended.cs
+++ b/UnityProject/Assets/Scripts/GameModes/Extended.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class Extended : GameMode
+{
+	/// <summary>
+	/// Set up the station for the game mode
+	/// </summary>
+	public override void SetupRound() {}
+	/// <summary>
+	/// Begin the round
+	/// </summary>
+	public override void StartRound()
+	{
+		Logger.Log("Starting extended round!", Category.GameMode);
+		base.StartRound();
+	}
+	/// <summary>
+	/// Check if the round should end yet
+	/// </summary>
+	public override void CheckEndCondition() {}
+	/// <summary>
+	/// End the round and display any relevant reports
+	/// </summary>
+	public override void EndRound() {}
+}

--- a/UnityProject/Assets/Scripts/GameModes/Extended.cs.meta
+++ b/UnityProject/Assets/Scripts/GameModes/Extended.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2db38572150950458000be10f9db6a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/GameModes/GameMode.cs
@@ -1,0 +1,86 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+/// <summary>
+/// Contains the definition of a game mode. To create a new one you should
+/// make a new class which inherits this one. Make a prefab with this script
+/// attached so you can define the values in the editor and define your
+/// game mode functions in the child class.
+/// </summary>
+public abstract class GameMode : MonoBehaviour
+{
+	/// <summary>
+	/// The name of the game mode
+	/// </summary>
+	[Tooltip("The name of the game mode")]
+	public string Name;
+
+	/// <summary>
+	/// The description of the game mode
+	/// </summary>
+	[Tooltip("A description of the game mode")]
+	public string Description;
+
+	/// <summary>
+	/// Is respawning enabled in this game mode
+	/// </summary>
+	[Tooltip("Should players be allowed to respawn?")]
+	public bool CanRespawn;
+
+	/// <summary>
+	/// The minimum amount of players needed for the game mode
+	/// </summary>
+	[Tooltip("What is the minimum amount of players needed for this game mode?")]
+	public int MinPlayers;
+
+	/// <summary>
+	/// The minimum amount of antags needed in the game mode
+	/// </summary>
+	[Tooltip("What is the minimum amount of antagonists needed for this game mode?")]
+	public int MinAntags;
+
+	// ================= Game Mode Methods =================
+
+	/// <summary>
+	/// Check if the game mode meets the minimum player requirements
+	/// </summary>
+	public virtual bool IsPossible()
+	{
+		//TODO add more checks in future
+		return PlayerList.Instance.ConnectionCount >= MinPlayers;
+	}
+
+	/// <summary>
+	/// Set up everything for the game mode
+	/// </summary>
+	public abstract void SetupRound();
+
+	/// <summary>
+	/// Determine what to do with new players that join
+	/// </summary>
+	// public virtual void SetupNewPlayer()
+	// {
+	// 	if (GameManager.Instance.RoundStarted)
+	// 	{
+	// 		UIManager.Display.SetScreenForJobSelect();
+	// 	}
+	// }
+
+	/// <summary>
+	/// Start the round
+	/// </summary>
+	public virtual void StartRound()
+	{
+		UIManager.Instance.RpcSelectJobs();
+	}
+
+	/// <summary>
+	/// Check if the round should end yet
+	/// </summary>
+	public abstract void CheckEndCondition();
+
+	/// <summary>
+	/// End the round and display any relevant reports
+	/// </summary>
+	public abstract void EndRound();
+}

--- a/UnityProject/Assets/Scripts/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/GameModes/GameMode.cs
@@ -84,4 +84,7 @@ public abstract class GameMode : MonoBehaviour
 	/// End the round and display any relevant reports
 	/// </summary>
 	public abstract void EndRound();
+
+	// TODO
+	// public abstract void ChooseAntags();
 }

--- a/UnityProject/Assets/Scripts/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/GameModes/GameMode.cs
@@ -71,7 +71,7 @@ public abstract class GameMode : MonoBehaviour
 	/// </summary>
 	public virtual void StartRound()
 	{
-		UIManager.Instance.RpcSelectJobs();
+		// UIManager.Instance.RpcSelectJobs();
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/GameModes/GameMode.cs
@@ -71,7 +71,8 @@ public abstract class GameMode : MonoBehaviour
 	/// </summary>
 	public virtual void StartRound()
 	{
-		// UIManager.Instance.RpcSelectJobs();
+		// TODO remove once random job allocation is done
+		UpdateUIMessage.Send(ControlDisplays.Screens.JobSelect);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/GameModes/GameMode.cs.meta
+++ b/UnityProject/Assets/Scripts/GameModes/GameMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15ff5ba6f46256d4b982b5608cb05b4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/GameModes/NukeOps.cs
+++ b/UnityProject/Assets/Scripts/GameModes/NukeOps.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+public class NukeOps : GameMode
+{
+	/// <summary>
+	/// Set up the station for the game mode
+	/// </summary>
+	public override void SetupRound()
+	{
+		Logger.Log("Setting up NukeOps round!", Category.GameMode);
+	}
+	/// <summary>
+	/// Begin the round
+	/// </summary>
+	public override void StartRound()
+	{
+		Logger.Log("Starting NukeOps round!", Category.GameMode);
+		// TODO remove once random antag allocation is done
+		UpdateUIMessage.Send(ControlDisplays.Screens.TeamSelect);
+	}
+	/// <summary>
+	/// Check if the round should end yet
+	/// </summary>
+	public override void CheckEndCondition()
+	{
+		Logger.Log("Check end round conditions!", Category.GameMode);
+	}
+	/// <summary>
+	/// End the round and display any relevant reports
+	/// </summary>
+	public override void EndRound()
+	{
+		Logger.Log("Ending round!", Category.GameMode);
+	}
+
+	// TODO
+	// private void ChooseNukeOps()
+	// {
+
+	// }
+}

--- a/UnityProject/Assets/Scripts/GameModes/NukeOps.cs.meta
+++ b/UnityProject/Assets/Scripts/GameModes/NukeOps.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c391e329f9f301b4c8bddb5b97ff5975
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/GameModes/Traitor.cs
+++ b/UnityProject/Assets/Scripts/GameModes/Traitor.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+public class Traitor : GameMode
+{
+	/// <summary>
+	/// Set up the station for the game mode
+	/// </summary>
+	public override void SetupRound()
+	{
+		Logger.Log("Setting up traitor round!", Category.GameMode);
+	}
+	/// <summary>
+	/// Begin the round
+	/// </summary>
+	public override void StartRound()
+	{
+		Logger.Log("Starting traitor round!", Category.GameMode);
+		base.StartRound();
+	}
+	/// <summary>
+	/// Check if the round should end yet
+	/// </summary>
+	public override void CheckEndCondition()
+	{
+		Logger.Log("Check end round conditions!", Category.GameMode);
+	}
+	/// <summary>
+	/// End the round and display any relevant reports
+	/// </summary>
+	public override void EndRound()
+	{
+		Logger.Log("Ending round!", Category.GameMode);
+	}
+
+	// TODO
+	// private void ChooseTraitors()
+	// {
+
+	// }
+}

--- a/UnityProject/Assets/Scripts/GameModes/Traitor.cs.meta
+++ b/UnityProject/Assets/Scripts/GameModes/Traitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65e7d5ca18862e94dbf4ab39d7784295
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Managers/CentComm.cs
+++ b/UnityProject/Assets/Scripts/Managers/CentComm.cs
@@ -46,26 +46,23 @@ public class CentComm : MonoBehaviour
 
 	private void OnEnable()
 	{
-		SceneManager.sceneLoaded += OnLevelFinishedLoading;
+		EventManager.AddHandler(EVENT.RoundStarted, OnRoundStart);
 	}
 
 	private void OnDisable()
 	{
-		SceneManager.sceneLoaded -= OnLevelFinishedLoading;
+		EventManager.RemoveHandler(EVENT.RoundStarted, OnRoundStart);
 	}
 
-	private void OnLevelFinishedLoading(Scene scene, LoadSceneMode mode)
+	private void OnRoundStart()
 	{
 		AsteroidLocations.Clear();
-		if (!scene.name.Contains("Lobby"))
-		{
-			StartCoroutine(WaitToPrepareReport());
-		}
+		StartCoroutine(WaitToPrepareReport());
 	}
 
 	IEnumerator WaitToPrepareReport()
 	{
-		yield return WaitFor.EndOfFrame; //OnStartServer starts one frame after OnLevelFinishedLoading
+		yield return WaitFor.EndOfFrame; //OnStartServer starts one frame after OnRoundStart
 		//Server only:
 		if (!CustomNetworkManager.Instance._isServer)
 		{

--- a/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
+++ b/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
@@ -9,6 +9,7 @@ public class ConnectedPlayer
     private ulong steamId;
     private GameObject gameObject;
     private PlayerScript playerScript;
+    private JoinedViewer viewerScript;
     private NetworkConnection connection;
     private string clientID;
 
@@ -46,6 +47,7 @@ public class ConnectedPlayer
     }
 
     public PlayerScript Script => playerScript;
+    public JoinedViewer ViewerScript => viewerScript;
 
     public NetworkConnection Connection
     {
@@ -65,6 +67,7 @@ public class ConnectedPlayer
             }
             gameObject = value;
             playerScript = value.GetComponent<PlayerScript>();
+            viewerScript = value.GetComponent<JoinedViewer>();
         }
     }
 

--- a/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
+++ b/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
@@ -4,130 +4,130 @@ using Mirror;
 /// Server-only full player information class
 public class ConnectedPlayer
 {
-    private string username;
-    private string name;
-    private JobType job;
-    private ulong steamId;
-    private GameObject gameObject;
-    private PlayerScript playerScript;
-    private JoinedViewer viewerScript;
-    private NetworkConnection connection;
-    private string clientID;
+	private string username;
+	private string name;
+	private JobType job;
+	private ulong steamId;
+	private GameObject gameObject;
+	private PlayerScript playerScript;
+	private JoinedViewer viewerScript;
+	private NetworkConnection connection;
+	private string clientID;
 
-    /// Flags if player received a bunch of sync messages upon joining
-    private bool synced;
+	/// Flags if player received a bunch of sync messages upon joining
+	private bool synced;
 
 	//Name that is used if the client's character name is empty
 	private const string DEFAULT_NAME = "Anonymous Spessman";
 
 	public bool IsAuthenticated => steamId != 0;
 
-    public static readonly ConnectedPlayer Invalid = new ConnectedPlayer
-    {
-        connection = new NetworkConnection("0.0.0.0"),
-        gameObject = null,
-        username = null,
-        name = "kek",
-        job = JobType.NULL,
-        steamId = 0,
-        synced = true,
-        clientID = ""
-    };
+	public static readonly ConnectedPlayer Invalid = new ConnectedPlayer
+	{
+		connection = new NetworkConnection("0.0.0.0"),
+		gameObject = null,
+		username = null,
+		name = "kek",
+		job = JobType.NULL,
+		steamId = 0,
+		synced = true,
+		clientID = ""
+	};
 
-    public static ConnectedPlayer ArchivedPlayer( ConnectedPlayer player )
-    {
-        return new ConnectedPlayer
-        {
-            connection = Invalid.Connection,
-            gameObject = player.GameObject,
-            username = player.Username,
-            name = player.Name,
-            job = player.Job,
-            steamId = player.SteamId,
-            synced = player.synced,
-            clientID = player.clientID
-        };
-    }
+	public static ConnectedPlayer ArchivedPlayer( ConnectedPlayer player )
+	{
+		return new ConnectedPlayer
+		{
+			connection = Invalid.Connection,
+			gameObject = player.GameObject,
+			username = player.Username,
+			name = player.Name,
+			job = player.Job,
+			steamId = player.SteamId,
+			synced = player.synced,
+			clientID = player.clientID
+		};
+	}
 
-    public PlayerScript Script => playerScript;
-    public JoinedViewer ViewerScript => viewerScript;
+	public PlayerScript Script => playerScript;
+	public JoinedViewer ViewerScript => viewerScript;
 
-    public NetworkConnection Connection
-    {
-        get { return connection; }
-        set { connection = value ?? Invalid.Connection; }
-    }
+	public NetworkConnection Connection
+	{
+		get { return connection; }
+		set { connection = value ?? Invalid.Connection; }
+	}
 
-    public GameObject GameObject
-    {
-        get { return gameObject; }
-        set
-        {
-            if ( PlayerList.Instance != null && gameObject )
-            {
-                //Add to history if player had different body previously
-                PlayerList.Instance.AddPrevious( this );
-            }
-            gameObject = value;
-            playerScript = value.GetComponent<PlayerScript>();
-            viewerScript = value.GetComponent<JoinedViewer>();
-        }
-    }
+	public GameObject GameObject
+	{
+		get { return gameObject; }
+		set
+		{
+			if ( PlayerList.Instance != null && gameObject )
+			{
+				//Add to history if player had different body previously
+				PlayerList.Instance.AddPrevious( this );
+			}
+			gameObject = value;
+			playerScript = value.GetComponent<PlayerScript>();
+			viewerScript = value.GetComponent<JoinedViewer>();
+		}
+	}
 
-    public string Username
-    {
-	    get => username;
-	    set => username = value;
-    }
+	public string Username
+	{
+		get => username;
+		set => username = value;
+	}
 
-    public string Name
-    {
-        get { return name; }
-        set
-        {
-            TryChangeName(value);
-            TrySendUpdate();
-        }
-    }
+	public string Name
+	{
+		get { return name; }
+		set
+		{
+			TryChangeName(value);
+			TrySendUpdate();
+		}
+	}
 
-    public ulong SteamId
-    {
-        get { return steamId; }
-        set
-        {
-            if ( value != 0 )
-            {
-                steamId = value;
+	public ulong SteamId
+	{
+		get { return steamId; }
+		set
+		{
+			if ( value != 0 )
+			{
+				steamId = value;
 				Logger.Log( $"Updated steamID! {this}" , Category.Steam);
-            }
-        }
-    }
+			}
+		}
+	}
 
-    public JobType Job
-    {
-        get { return job; }
-        set
-        {
-            job = value;
-            TrySendUpdate();
-        }
-    }
+	public JobType Job
+	{
+		get { return job; }
+		set
+		{
+			job = value;
+			TrySendUpdate();
+		}
+	}
 
-    public bool Synced {
-        get { return synced; }
-        set { synced = value; }
-    }
+	public bool Synced {
+		get { return synced; }
+		set { synced = value; }
+	}
 
-    public string ClientId
-    {
-	    get => clientID;
-	    set => clientID = value;
-    }
+	public string ClientId
+	{
+		get => clientID;
+		set => clientID = value;
+	}
 
-    public bool HasNoName()
-    {
-        return name == null || name.Trim().Equals("") || name == DEFAULT_NAME;
-    }
+	public bool HasNoName()
+	{
+		return name == null || name.Trim().Equals("") || name == DEFAULT_NAME;
+	}
 
 	/// <summary>
 	/// Checks against a set of rules for user names like Null or whitespace
@@ -144,8 +144,8 @@ public class ConnectedPlayer
 		}
 	}
 
-    private void TryChangeName(string playerName)
-    {
+	private void TryChangeName(string playerName)
+	{
 		//When a ConnectedPlayer object is initialised it has a null value
 		//We want to make sure that it gets set to something if the client requested something bad
 		//Issue #1377
@@ -161,52 +161,52 @@ public class ConnectedPlayer
 			return;
 		}
 
-        var playerList = PlayerList.Instance;
-        if ( playerList == null )
-        {
+		var playerList = PlayerList.Instance;
+		if ( playerList == null )
+		{
 //			Logger.Log("PlayerList not instantiated, setting name blindly");
-            name = playerName;
-            return;
-        }
+			name = playerName;
+			return;
+		}
 
-        string uniqueName = GetUniqueName(playerName);
-        name = uniqueName;
+		string uniqueName = GetUniqueName(playerName);
+		name = uniqueName;
 
 //        if ( !playerList.playerScores.ContainsKey(uniqueName) )
 //        {
 //            playerList.playerScores.Add(uniqueName, 0);
 //        }
-    }
+	}
 
-    /// Generating a unique name (Player -> Player2 -> Player3 ...)
-    private static string GetUniqueName(string name, int sameNames = 0)
-    {
-        string proposedName = name;
-        if ( sameNames != 0 )
-        {
-            proposedName = $"{name}{sameNames + 1}";
-            Logger.LogTrace($"TRYING: {proposedName}", Category.Connections);
-        }
-        if ( PlayerList.Instance.ContainsName(proposedName) )
-        {
-            Logger.LogTrace($"NAME ALREADY EXISTS: {proposedName}", Category.Connections);
-            sameNames++;
-            return GetUniqueName(name, sameNames);
-        }
+	/// Generating a unique name (Player -> Player2 -> Player3 ...)
+	private static string GetUniqueName(string name, int sameNames = 0)
+	{
+		string proposedName = name;
+		if ( sameNames != 0 )
+		{
+			proposedName = $"{name}{sameNames + 1}";
+			Logger.LogTrace($"TRYING: {proposedName}", Category.Connections);
+		}
+		if ( PlayerList.Instance.ContainsName(proposedName) )
+		{
+			Logger.LogTrace($"NAME ALREADY EXISTS: {proposedName}", Category.Connections);
+			sameNames++;
+			return GetUniqueName(name, sameNames);
+		}
 
-        return proposedName;
-    }
+		return proposedName;
+	}
 
-    private static void TrySendUpdate()
-    {
-        if ( CustomNetworkManager.Instance != null && CustomNetworkManager.Instance._isServer && PlayerList.Instance != null )
-        {
-            UpdateConnectedPlayersMessage.Send();
-        }
-    }
+	private static void TrySendUpdate()
+	{
+		if ( CustomNetworkManager.Instance != null && CustomNetworkManager.Instance._isServer && PlayerList.Instance != null )
+		{
+			UpdateConnectedPlayersMessage.Send();
+		}
+	}
 
-    public override string ToString()
-    {
-        return $"[conn={Connection.connectionId}|go={gameObject}|name='{name}'|job={job}|steamId={steamId}|synced={synced}]";
-    }
+	public override string ToString()
+	{
+		return $"[conn={Connection.connectionId}|go={gameObject}|name='{name}'|job={job}|steamId={steamId}|synced={synced}]";
+	}
 }

--- a/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
+++ b/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
@@ -4,6 +4,7 @@ using Mirror;
 /// Server-only full player information class
 public class ConnectedPlayer
 {
+    private string username;
     private string name;
     private JobType job;
     private ulong steamId;
@@ -25,6 +26,7 @@ public class ConnectedPlayer
     {
         connection = new NetworkConnection("0.0.0.0"),
         gameObject = null,
+        username = null,
         name = "kek",
         job = JobType.NULL,
         steamId = 0,
@@ -38,6 +40,7 @@ public class ConnectedPlayer
         {
             connection = Invalid.Connection,
             gameObject = player.GameObject,
+            username = player.Username,
             name = player.Name,
             job = player.Job,
             steamId = player.SteamId,
@@ -69,6 +72,12 @@ public class ConnectedPlayer
             playerScript = value.GetComponent<PlayerScript>();
             viewerScript = value.GetComponent<JoinedViewer>();
         }
+    }
+
+    public string Username
+    {
+	    get => username;
+	    set => username = value;
     }
 
     public string Name

--- a/UnityProject/Assets/Scripts/Managers/EventManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/EventManager.cs
@@ -26,7 +26,8 @@ public enum EVENT
 	LogLevelAdjusted,
 	UpdateChatChannels,
 	ToggleChatBubbles,
-	PlayerRejoined
+	PlayerRejoined,
+	PreRoundStarted
 } // + other events. Add them as you need them
 
 [ExecuteInEditMode]

--- a/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
@@ -1,0 +1,99 @@
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+/// <summary>
+/// Represents what state the round is in: PreRound, Started or Ended
+/// </summary>
+public enum RoundState
+{
+	PreRound,
+	Started,
+	Ended
+}
+
+/// <summary>
+/// Game mode related part of GameManager
+/// </summary>
+public partial class GameManager
+{
+	public List<GameMode> AllGameModes = new List<GameMode>();
+
+	/// <summary>
+	/// Is the current game mode being kept secret?
+	/// </summary>
+	public bool SecretGameMode = true;
+
+	/// <summary>
+	/// The state of the current round
+	/// </summary>
+	public RoundState CurrentRoundState;
+
+	/// <summary>
+	/// The current game mode
+	/// </summary>
+	private GameMode GameMode;
+
+	/// <summary>
+	/// Find all gamemode prefabs and add them to AllGameModes for selection
+	/// </summary>
+	private void RefreshAllGameModes()
+	{
+		// Only do this stuff on the server
+		if (CustomNetworkManager.Instance._isServer)
+		{
+			AllGameModes.Clear();
+			Logger.Log("Finding available gamemodes...", Category.GameMode);
+			var prefabs = Resources.LoadAll("Prefabs/GameModes", typeof(GameObject));
+			foreach(Object obj in prefabs)
+			{
+				var gm = ((GameObject) obj).GetComponent<GameMode>();
+				Logger.Log($"Found GM: {gm.Name}", Category.GameMode);
+				AllGameModes.Add(gm);
+			}
+		}
+	}
+
+	public void SelectGameMode(string gmName)
+	{
+		// TODO add precondition checks
+		foreach(GameMode gm in AllGameModes)
+		{
+			if (gm.Name == gmName)
+			{
+				Logger.Log($"Set game mode to: {gmName}", Category.GameMode);
+				GameMode = gm;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Gets the current game mode name. Will return Secret if it is being hidden.
+	/// </summary>
+	public string GetGameModeName()
+	{
+		return SecretGameMode ? "Secret" : GameMode.Name;
+	}
+
+	/// <summary>
+	/// Finds all possible game modes and randomly chooses one that is possible with the current number of players
+	/// </summary>
+	private void ChooseGameMode()
+	{
+		// TODO hard coding traitor for testing purposes
+		// List<GameMode> possibleGMs = new List<GameMode>();
+		// foreach (var gm in AllGameModes)
+		// {
+		// 	if (gm.IsPossible())
+		// 	{
+		// 		possibleGMs.Add(gm);
+		// 	}
+		// }
+		// int index = Random.Range(0, possibleGMs.Count);
+		// GameMode = possibleGMs[index];
+		SelectGameMode("Traitor");
+		Logger.Log($"Selected game mode: {GameMode.Name}", Category.GameMode);
+	}
+}

--- a/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
@@ -9,6 +9,7 @@ using Random = UnityEngine.Random;
 /// </summary>
 public enum RoundState
 {
+	None,
 	PreRound,
 	Started,
 	Ended

--- a/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
@@ -43,17 +43,19 @@ public partial class GameManager
 	private void RefreshAllGameModes()
 	{
 		// Only do this stuff on the server
-		if (CustomNetworkManager.Instance._isServer)
+		if (!CustomNetworkManager.Instance._isServer)
 		{
-			AllGameModes.Clear();
-			Logger.Log("Finding available gamemodes...", Category.GameMode);
-			var prefabs = Resources.LoadAll("Prefabs/GameModes", typeof(GameObject));
-			foreach(Object obj in prefabs)
-			{
-				var gm = ((GameObject) obj).GetComponent<GameMode>();
-				Logger.Log($"Found GM: {gm.Name}", Category.GameMode);
-				AllGameModes.Add(gm);
-			}
+			return;
+		}
+
+		AllGameModes.Clear();
+		Logger.Log("Finding available gamemodes...", Category.GameMode);
+		var prefabs = Resources.LoadAll("Prefabs/GameModes", typeof(GameObject));
+		foreach(Object obj in prefabs)
+		{
+			var gm = ((GameObject) obj).GetComponent<GameMode>();
+			Logger.Log($"Found GM: {gm.Name}", Category.GameMode);
+			AllGameModes.Add(gm);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
@@ -83,18 +83,16 @@ public partial class GameManager
 	/// </summary>
 	private void ChooseGameMode()
 	{
-		// TODO hard coding traitor for testing purposes
-		// List<GameMode> possibleGMs = new List<GameMode>();
-		// foreach (var gm in AllGameModes)
-		// {
-		// 	if (gm.IsPossible())
-		// 	{
-		// 		possibleGMs.Add(gm);
-		// 	}
-		// }
-		// int index = Random.Range(0, possibleGMs.Count);
-		// GameMode = possibleGMs[index];
-		SelectGameMode("Traitor");
+		List<GameMode> possibleGMs = new List<GameMode>();
+		foreach (var gm in AllGameModes)
+		{
+			if (gm.IsPossible())
+			{
+				possibleGMs.Add(gm);
+			}
+		}
+		int index = Random.Range(0, possibleGMs.Count);
+		GameMode = possibleGMs[index];
 		Logger.Log($"Selected game mode: {GameMode.Name}", Category.GameMode);
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs.meta
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8899f0110847d84688570adcf3d4848
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -287,6 +287,7 @@ public partial class GameManager : MonoBehaviour
 	{
 		if (CustomNetworkManager.Instance._isServer)
 		{
+			// TODO this is broken for some reason
 			while (PlayerList.Instance.ConnectionCount < MinPlayersForCountdown)
 			{
 				yield return WaitFor.EndOfFrame;
@@ -299,7 +300,7 @@ public partial class GameManager : MonoBehaviour
 	{
 		startTime = PreRoundTime;
 		waitForStart = true;
-		UIManager.Instance.RpcStartCountdown(startTime);
+		UpdateCountdownMessage.Send(waitForStart, startTime);
 	}
 
 	public int GetOccupationsCount(JobType jobType)

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -229,8 +229,8 @@ public partial class GameManager : MonoBehaviour
 			CurrentRoundState = RoundState.PreRound;
 			EventManager.Broadcast(EVENT.PreRoundStarted);
 
-			// Wait for the minimum amount of players to join before starting countdown
-			StartCoroutine(WaitForPlayers());
+			// Wait for the PlayerList instance to init before checking player count
+			StartCoroutine(WaitToCheckPlayers());
 		}
 	}
 
@@ -283,15 +283,25 @@ public partial class GameManager : MonoBehaviour
 		}
 	}
 
-	private IEnumerator WaitForPlayers()
+	/// <summary>
+	/// Wait for the PlayerList Instance to init before checking
+	/// </summary>
+	private IEnumerator WaitToCheckPlayers()
 	{
-		if (CustomNetworkManager.Instance._isServer)
+		while (PlayerList.Instance == null)
 		{
-			// TODO this is broken for some reason
-			while (PlayerList.Instance.ConnectionCount < MinPlayersForCountdown)
-			{
-				yield return WaitFor.EndOfFrame;
-			}
+			yield return WaitFor.EndOfFrame;
+		}
+		CheckPlayerCount();
+	}
+
+	/// <summary>
+	/// Checks if there are enough players to start the pre-round countdown
+	/// </summary>
+	public void CheckPlayerCount()
+	{
+		if (CustomNetworkManager.Instance._isServer && PlayerList.Instance.ConnectionCount >= MinPlayersForCountdown)
+		{
 			StartCountdown();
 		}
 	}

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -422,6 +422,7 @@ public partial class GameManager : MonoBehaviour
 		{
 			//TODO allow map change from admin portal
 
+			CurrentRoundState = RoundState.Ended;
 			EventManager.Broadcast(EVENT.RoundEnded);
 			CustomNetworkManager.Instance.ServerChangeScene(Maps[0]);
 		}

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -12,11 +12,17 @@ using UnityEngine.UI;
 public partial class GameManager : MonoBehaviour
 {
 	public static GameManager Instance;
-
-	//TODO: How to network this and change before connecting:
-	public GameMode gameMode = GameMode.nukeops; //for demo
 	public bool counting;
 	public List<GameObject> Occupations = new List<GameObject>();
+	/// <summary>
+	/// The minimum number of players needed to start the pre-round countdown
+	/// </summary>
+	public int MinPlayersForCountdown = 1;
+	/// <summary>
+	/// How long the pre-round stage should last
+	/// </summary>
+	public float PreRoundTime = 30f;
+	public float startTime;
 	public float restartTime = 10f;
 	/// <summary>
 	/// Is respawning currently allowed? Can be set during a game to disable, such as when a nuke goes off.
@@ -33,6 +39,7 @@ public partial class GameManager : MonoBehaviour
 	public Text roundTimer;
 
 	public GameObject StandardOutfit;
+	public bool waitForStart;
 	public bool waitForRestart;
 
 	public DateTime stationTime;
@@ -43,8 +50,6 @@ public partial class GameManager : MonoBehaviour
 
 	private int MapRotationCount = 0;
 	private int MapRotationMapsCounter = 0;
-
-	public bool GameOver = false;
 
 	//Space bodies in the solar system <Only populated ServerSide>:
 	//---------------------------------
@@ -147,24 +152,9 @@ public partial class GameManager : MonoBehaviour
 	{
 		if (CustomNetworkManager.Instance._isServer && newScene.name != "Lobby")
 		{
-			stationTime = DateTime.Today.AddHours(12);
-			SpaceBodies.Clear();
-			PendingSpaceBodies = new Queue<MatrixMove>();
-			counting = true;
-			RespawnCurrentlyAllowed = RespawnAllowed;
-			StartCoroutine(WaitToInitEscape());
+			PreRoundStart();
 		}
-		GameOver = false;
 	}
-
-	//this could all still be used in the future for selecting traitors/culties/revs at game start:
-	// private void SetUpGameMode()
-	// {
-	// 	if(gameMode == GameMode.nukeops){
-	// 		//Show nuke opes selection
-	// 		Debug.Log("TODO Set up UI for nuke ops game");
-	// 	}
-	// }
 
 	public void SyncTime(string currentTime)
 	{
@@ -200,12 +190,18 @@ public partial class GameManager : MonoBehaviour
 
 		if (waitForRestart)
 		{
-
 			restartTime -= Time.deltaTime;
 			if (restartTime <= 0f)
 			{
-				waitForRestart = false;
 				RestartRound();
+			}
+		}
+		else if (waitForStart)
+		{
+			startTime -= Time.deltaTime;
+			if (startTime <= 0f)
+			{
+				RoundStart();
 			}
 		}
 		else if (counting)
@@ -215,8 +211,60 @@ public partial class GameManager : MonoBehaviour
 		}
 	}
 
+
 	/// <summary>
-	/// Calls the end of the round.true Server only
+	/// Calls the start of the preround
+	/// </summary>
+	public void PreRoundStart()
+	{
+		if (CustomNetworkManager.Instance._isServer)
+		{
+			// Clear up any space bodies
+			SpaceBodies.Clear();
+			PendingSpaceBodies = new Queue<MatrixMove>();
+
+			// Find all available game modes
+			RefreshAllGameModes();
+
+			CurrentRoundState = RoundState.PreRound;
+			EventManager.Broadcast(EVENT.PreRoundStarted);
+
+			// Wait for the minimum amount of players to join before starting countdown
+			StartCoroutine(WaitForPlayers());
+		}
+	}
+
+	/// <summary>
+	/// Setup the station and then begin the round for the selected game mode
+	/// </summary>
+	public void RoundStart()
+	{
+		waitForStart = false;
+		// Only do this stuff on the server
+		if (CustomNetworkManager.Instance._isServer)
+		{
+			if (SecretGameMode && GameMode == null)
+			{
+				ChooseGameMode();
+			}
+			// Game mode specific setup
+			GameMode.SetupRound();
+			GameMode.StartRound();
+			// TODO make job selection stuff
+
+			// Standard round start setup
+			stationTime = DateTime.Today.AddHours(12);
+			counting = true;
+			RespawnCurrentlyAllowed = GameMode.CanRespawn;
+			StartCoroutine(WaitToInitEscape());
+
+			CurrentRoundState = RoundState.Started;
+			EventManager.Broadcast(EVENT.RoundStarted);
+		}
+	}
+
+	/// <summary>
+	/// Calls the end of the round. Server only
 	/// </summary>
 	public void RoundEnd()
 	{
@@ -233,6 +281,25 @@ public partial class GameManager : MonoBehaviour
 			waitForRestart = true;
 			PlayerList.Instance.ReportScores();
 		}
+	}
+
+	private IEnumerator WaitForPlayers()
+	{
+		if (CustomNetworkManager.Instance._isServer)
+		{
+			while (PlayerList.Instance.ConnectionCount < MinPlayersForCountdown)
+			{
+				yield return WaitFor.EndOfFrame;
+			}
+			StartCountdown();
+		}
+	}
+
+	public void StartCountdown()
+	{
+		startTime = PreRoundTime;
+		waitForStart = true;
+		UIManager.Instance.RpcStartCountdown(startTime);
 	}
 
 	public int GetOccupationsCount(JobType jobType)
@@ -339,6 +406,7 @@ public partial class GameManager : MonoBehaviour
 
 	public void RestartRound()
 	{
+		waitForRestart = false;
 		if (CustomNetworkManager.Instance._isServer)
 		{
 			//TODO allow map change from admin portal
@@ -347,10 +415,4 @@ public partial class GameManager : MonoBehaviour
 			CustomNetworkManager.Instance.ServerChangeScene(Maps[0]);
 		}
 	}
-}
-
-public enum GameMode
-{
-	extended,
-	nukeops
 }

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -243,10 +243,12 @@ public partial class GameManager : MonoBehaviour
 		// Only do this stuff on the server
 		if (CustomNetworkManager.Instance._isServer)
 		{
-			if (SecretGameMode && GameMode == null)
-			{
-				ChooseGameMode();
-			}
+			// TODO hard coding gamemode for testing purposes
+			SelectGameMode("NukeOps");
+			// if (SecretGameMode && GameMode == null)
+			// {
+			// 	ChooseGameMode();
+			// }
 			// Game mode specific setup
 			GameMode.SetupRound();
 			GameMode.StartRound();

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -350,7 +350,8 @@ public class CustomNetworkManager : NetworkManager
 		if (newScene.name != "Lobby")
 		{
 			//INGAME:
-			EventManager.Broadcast(EVENT.RoundStarted);
+			// TODO check if this is needed
+			// EventManager.Broadcast(EVENT.RoundStarted);
 			if (PoolManager.Instance == null)
 			{
 				ObjectManager.StartPoolManager();

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -109,6 +109,11 @@ public class CustomNetworkManager : NetworkManager
 		{
 			SteamServerStart();
 		}
+		// Fixes loading directly into the station scene
+		if (GameManager.Instance.CurrentRoundState == RoundState.None)
+		{
+			GameManager.Instance.PreRoundStart();
+		}
 	}
 
 	public void SteamServerStart()

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -22,7 +22,7 @@ public class PlayerList : NetworkBehaviour
 	public static PlayerList Instance;
 	public int ConnectionCount => values.Count;
 	public List<ConnectedPlayer> InGamePlayers => values.FindAll( player => player.Script != null );
-
+	public List<ConnectedPlayer> AllPlayers => values.FindAll( player => (player.Script != null || player.ViewerScript != null));
 	public bool reportDone = false;
 
 	//For TDM demo

--- a/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs
@@ -126,9 +126,17 @@ public class PostToChatMessage : ClientMessage
 
 	public bool ValidRequest(ConnectedPlayer player)
 	{
-		PlayerScript playerScript = player.Script;
 		//Need to add system channel here so player can transmit system level events but not select it in the UI
-		ChatChannel availableChannels = playerScript.GetAvailableChannelsMask() | ChatChannel.System;
+		ChatChannel availableChannels = ChatChannel.System;
+		if (player.Script == null)
+		{
+			availableChannels |= ChatChannel.OOC;
+		}
+		else
+		{
+			availableChannels |= player.Script.GetAvailableChannelsMask();
+		}
+
 		if ((availableChannels & Channels) == Channels)
 		{
 			return true;

--- a/UnityProject/Assets/Scripts/Messages/MessageTypes.cs
+++ b/UnityProject/Assets/Scripts/Messages/MessageTypes.cs
@@ -45,6 +45,7 @@ internal enum MessageTypes : short
 	BookNetMessage = 1041,
 	BookshelfNetMessage = 1042,
 	SubBookshelfNetMessage = 1043,
+	UpdateCountdownMessage = 1044,
 
 	//Client messages - 2xxx
 	UpdateHeadsetKeyMessage = 2000,

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateCountdownMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateCountdownMessage.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections;
 
 /// <summary>
-///     Message that tells client what is the current round time
+///     Message that tells client the status of the preround countdown
 /// </summary>
 public class UpdateCountdownMessage : ServerMessage
 {

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateCountdownMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateCountdownMessage.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections;
+
+/// <summary>
+///     Message that tells client what is the current round time
+/// </summary>
+public class UpdateCountdownMessage : ServerMessage
+{
+	public static short MessageType = (short) MessageTypes.UpdateCountdownMessage;
+	public bool Started;
+	public float Time;
+
+	public override IEnumerator Process()
+	{
+		UIManager.Display.preRoundWindow.GetComponent<GUI_PreRoundWindow>().SyncCountdown(Started, Time);
+		yield return null;
+	}
+
+	public static UpdateCountdownMessage Send(bool started, float time)
+	{
+		UpdateCountdownMessage msg = new UpdateCountdownMessage
+		{
+			Started = started,
+			Time = time
+		};
+		msg.SendToAll();
+		return msg;
+	}
+
+	public override string ToString()
+	{
+		return $"[UpdateCountdownMessage Type={MessageType} Started={Started} Time={Time}]";
+	}
+}

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateCountdownMessage.cs.meta
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateCountdownMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b8c5dbc7c79a9046b1286882c6c563e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateUIMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateUIMessage.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections;
+
+/// <summary>
+///     Message that tells client which UI action to perform
+/// </summary>
+public class UpdateUIMessage : ServerMessage
+{
+	public static short MessageType = (short) MessageTypes.UpdateUIMessage;
+
+	public ControlDisplays.Screens Screen;
+
+	public override IEnumerator Process()
+	{
+		UIManager.Display.SetScreenFor(Screen);
+		yield return null;
+	}
+
+	public static UpdateUIMessage Send(ControlDisplays.Screens screen)
+	{
+		UpdateUIMessage msg = new UpdateUIMessage
+		{
+			Screen = screen
+		};
+		msg.SendToAll();
+		return msg;
+	}
+
+	public override string ToString()
+	{
+		return $"[UpdateUIMessage Type={MessageType} Screen={Screen}]";
+	}
+}

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateUIMessage.cs.meta
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateUIMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: feda211a68f2854449714cc58fe22161
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/Nuke.cs
+++ b/UnityProject/Assets/Scripts/Objects/Nuke.cs
@@ -84,7 +84,6 @@ public class Nuke : NetworkBehaviour
 		UIManager.Display.hudBottomHuman.gameObject.SetActive(false);
 		UIManager.Display.hudBottomGhost.gameObject.SetActive(false);
 		ControlChat.Instance.CloseChatWindow();
-		GameManager.Instance.GameOver = true;
 		GameManager.Instance.RoundEnd();
 		//		UIManager.Display.logInWindow.SetActive(false);
 		//		UIManager.Display.infoWindow.SetActive(false);

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -182,4 +182,14 @@ public class JoinedViewer : NetworkBehaviour
 		Logger.Log("Syncing countdown!", Category.Round);
 		UIManager.Instance.displayControl.preRoundWindow.GetComponent<GUI_PreRoundWindow>().SyncCountdown(started, countdownTime);
 	}
+
+	/// <summary>
+	/// Tells the server to start the round
+	/// </summary>
+	[Command]
+	public void CmdStartRound()
+	{
+		GameManager.Instance.RoundStart();
+	}
+
 }

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -62,9 +62,16 @@ public class JoinedViewer : NetworkBehaviour
 		}
 
 		// Only sync the pre-round countdown if it's already started
-		if (GameManager.Instance.CurrentRoundState == RoundState.PreRound && GameManager.Instance.waitForStart)
+		if (GameManager.Instance.CurrentRoundState == RoundState.PreRound)
 		{
-			TargetSyncCountdown(connectionToClient, GameManager.Instance.waitForStart, GameManager.Instance.startTime);
+			if (GameManager.Instance.waitForStart)
+			{
+				TargetSyncCountdown(connectionToClient, GameManager.Instance.waitForStart, GameManager.Instance.startTime);
+			}
+			else
+			{
+				GameManager.Instance.CheckPlayerCount();
+			}
 		}
 
 		TargetLocalPlayerSetupPlayer(connectionToClient, loggedOffPlayer, clientID, GameManager.Instance.CurrentRoundState);

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -100,7 +100,9 @@ public class JoinedViewer : NetworkBehaviour
 				// Round hasn't yet started, give players the pre-game screen
 				UIManager.Display.SetScreenForPreRound();
 				break;
-			case RoundState.Started:
+			// case RoundState.Started:
+			// TODO spawn a ghost if round has already ended?
+			default:
 				// If player is joining for the first time let them pick a job, otherwise rejoin character.
 				if (loggedOffPlayer == null)
 				{
@@ -111,9 +113,6 @@ public class JoinedViewer : NetworkBehaviour
 					loggedOffPlayer.GetComponent<NetworkIdentity>().SetLocal();
 					CmdRejoin(loggedOffPlayer);
 				}
-				break;
-			default:
-				// TODO spawn a ghost?
 				break;
 		}
 	}

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -182,14 +182,4 @@ public class JoinedViewer : NetworkBehaviour
 		Logger.Log("Syncing countdown!", Category.Round);
 		UIManager.Instance.displayControl.preRoundWindow.GetComponent<GUI_PreRoundWindow>().SyncCountdown(started, countdownTime);
 	}
-
-	/// <summary>
-	/// Tells the server to start the round
-	/// </summary>
-	[Command]
-	public void CmdStartRound()
-	{
-		GameManager.Instance.RoundStart();
-	}
-
 }

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -26,21 +26,22 @@ public class JoinedViewer : NetworkBehaviour
 		// Send steamId to server for player setup.
 		if (BuildPreferences.isSteamServer)
 		{
-			CmdServerSetupPlayer(Client.Instance.SteamId, PlayerPrefs.GetString(PlayerPrefKeys.ClientID));
+			CmdServerSetupPlayer(Client.Instance.SteamId, PlayerPrefs.GetString(PlayerPrefKeys.ClientID), PlayerManager.CurrentCharacterSettings.username);
 		}
 		else
 		{
-			CmdServerSetupPlayer(0, PlayerPrefs.GetString(PlayerPrefKeys.ClientID));
+			CmdServerSetupPlayer(0, PlayerPrefs.GetString(PlayerPrefKeys.ClientID), PlayerManager.CurrentCharacterSettings.username);
 		}
 	}
 
 	[Command]
-	private void CmdServerSetupPlayer(ulong steamId, string clientID)
+	private void CmdServerSetupPlayer(ulong steamId, string clientID, string username)
 	{
 		var connPlayer = new ConnectedPlayer
 		{
 			Connection = connectionToClient,
 			GameObject = gameObject,
+			Username = username,
 			Job = JobType.NULL,
 			SteamId = steamId,
 			ClientId = clientID

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -19,8 +19,6 @@ public class PlayerScript : ManagedNetworkBehaviour
 
 	[SyncVar(hook = nameof(SyncPlayerName))] public string playerName = " ";
 
-	private ChatChannel selectedChannels;
-
 	public PlayerNetworkActions playerNetworkActions { get; set; }
 
 	public WeaponNetworkActions weaponNetworkActions { get; set; }
@@ -51,15 +49,6 @@ public class PlayerScript : ManagedNetworkBehaviour
 	public HitIcon hitIcon { get; set; }
 
 	public Vector3Int WorldPos => registerTile.WorldPositionServer;
-
-	/// <summary>
-	/// The currently selected chat channels. Prunes all unavailable ones on get.
-	/// </summary>
-	public ChatChannel SelectedChannels
-	{
-		get { return selectedChannels & GetAvailableChannelsMask(); }
-		set { selectedChannels = value; }
-	}
 
 	private static bool verified;
 	private static ulong SteamID;
@@ -237,10 +226,6 @@ public class PlayerScript : ManagedNetworkBehaviour
 
 	public ChatChannel GetAvailableChannelsMask(bool transmitOnly = true)
 	{
-		if (this == null)
-		{
-			return ChatChannel.OOC;
-		}
 		if (IsGhost)
 		{
 			ChatChannel ghostTransmitChannels = ChatChannel.Ghost | ChatChannel.OOC;

--- a/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
@@ -57,20 +57,18 @@ public class ControlDisplays : MonoBehaviour
 
 	void HumanUI()
 	{
-		if (hudBottomGhost != null && hudBottomGhost != null)
-		{
-			hudBottomHuman.gameObject.SetActive(true);
-			hudBottomGhost.gameObject.SetActive(false);
-		}
+		hudBottomHuman.gameObject.SetActive(true);
+		hudBottomGhost.gameObject.SetActive(false);
+		UIManager.PlayerHealthUI.gameObject.SetActive(true);
+		panelRight.gameObject.SetActive(true);
 	}
 
 	void GhostUI()
 	{
-		if (hudBottomGhost != null && hudBottomGhost != null)
-		{
-			hudBottomHuman.gameObject.SetActive(false);
-			hudBottomGhost.gameObject.SetActive(true);
-		}
+		hudBottomHuman.gameObject.SetActive(false);
+		hudBottomGhost.gameObject.SetActive(true);
+		UIManager.PlayerHealthUI.gameObject.SetActive(true);
+		panelRight.gameObject.SetActive(true);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
@@ -13,6 +13,7 @@ public class ControlDisplays : MonoBehaviour
 		Lobby,
 		Game,
 		PreRound,
+		TeamSelect,
 		JobSelect
 	}
 	public GameObject hudBottomHuman;
@@ -93,6 +94,9 @@ public class ControlDisplays : MonoBehaviour
 			case Screens.PreRound:
 				SetScreenForPreRound();
 				break;
+			case Screens.TeamSelect:
+				SetScreenForTeamSelect();
+				break;
 			case Screens.JobSelect:
 				SetScreenForJobSelect();
 				break;
@@ -137,7 +141,20 @@ public class ControlDisplays : MonoBehaviour
 
 	public void SetScreenForPreRound()
 	{
+		ResetUI(); //Make sure UI is back to default for next play
+		UIManager.PlayerHealthUI.gameObject.SetActive(false);
+		hudBottomHuman.gameObject.SetActive(false);
+		hudBottomGhost.gameObject.SetActive(false);
+		panelRight.gameObject.SetActive(false);
+		jobSelectWindow.SetActive(false);
+		teamSelectionWindow.SetActive(false);
 		preRoundWindow.SetActive(true);
+	}
+
+	public void SetScreenForTeamSelect()
+	{
+		preRoundWindow.SetActive(false);
+		teamSelectionWindow.SetActive(true);
 	}
 
 	public void SetScreenForJobSelect()

--- a/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
@@ -1,15 +1,15 @@
 ﻿using UnityEngine;
 using System.Collections;
+using UnityEngine.Serialization;
 
 public class ControlDisplays : MonoBehaviour
 {
 	public GameObject hudBottomHuman;
 	public GameObject hudBottomGhost;
 	public GameObject jobSelectWindow;
+	public GameObject preRoundWindow;
 	public GameObject teamSelectionWindow;
 	public RectTransform panelRight;
-
-	public GameObject nukeOpsGameMode;
 
 	[SerializeField] private Animator uiAnimator;
 
@@ -83,6 +83,7 @@ public class ControlDisplays : MonoBehaviour
 		panelRight.gameObject.SetActive(false);
 		jobSelectWindow.SetActive(false);
 		teamSelectionWindow.SetActive(false);
+		preRoundWindow.SetActive(false);
 	}
 
 	public void SetScreenForGame()
@@ -96,15 +97,20 @@ public class ControlDisplays : MonoBehaviour
 		SoundManager.StopMusic();
 	}
 
+	public void SetScreenForPreRound()
+	{
+		preRoundWindow.SetActive(true);
+	}
+
+	public void SetScreenForJobSelect()
+	{
+		preRoundWindow.SetActive(false);
+		jobSelectWindow.SetActive(true);
+	}
+
 	public void PlayNukeDetVideo()
 	{
 		uiAnimator.Play("NukeDetVideo");
 	}
 
-	public void DetermineGameMode()
-	{
-		//if(GameManager.Instance.gameMode == GameMode.nukeops){
-		nukeOpsGameMode.SetActive(true);
-		//}
-	}
 }

--- a/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
@@ -4,6 +4,17 @@ using UnityEngine.Serialization;
 
 public class ControlDisplays : MonoBehaviour
 {
+	/// <summary>
+	/// Represents which screen to open with generic function
+	/// </summary>
+	public enum Screens
+	{
+		SlotReset,
+		Lobby,
+		Game,
+		PreRound,
+		JobSelect
+	}
 	public GameObject hudBottomHuman;
 	public GameObject hudBottomGhost;
 	public GameObject jobSelectWindow;
@@ -58,6 +69,33 @@ public class ControlDisplays : MonoBehaviour
 		{
 			hudBottomHuman.gameObject.SetActive(false);
 			hudBottomGhost.gameObject.SetActive(true);
+		}
+	}
+
+	/// <summary>
+	/// Generic UI changing function for net messages
+	/// </summary>
+	/// <param name="screen">The UI action to perform</param>
+	public void SetScreenFor(Screens screen)
+	{
+		Logger.Log($"Setting screen for {screen}", Category.UI);
+		switch (screen)
+		{
+			case Screens.SlotReset:
+				ResetUI();
+				break;
+			case Screens.Lobby:
+				SetScreenForLobby();
+				break;
+			case Screens.Game:
+				SetScreenForGame();
+				break;
+			case Screens.PreRound:
+				SetScreenForPreRound();
+				break;
+			case Screens.JobSelect:
+				SetScreenForJobSelect();
+				break;
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
@@ -57,16 +57,22 @@ public class ControlDisplays : MonoBehaviour
 
 	void HumanUI()
 	{
-		hudBottomHuman.gameObject.SetActive(true);
-		hudBottomGhost.gameObject.SetActive(false);
+		if (hudBottomHuman != null && hudBottomGhost != null)
+		{
+			hudBottomHuman.gameObject.SetActive(true);
+			hudBottomGhost.gameObject.SetActive(false);
+		}
 		UIManager.PlayerHealthUI.gameObject.SetActive(true);
 		panelRight.gameObject.SetActive(true);
 	}
 
 	void GhostUI()
 	{
-		hudBottomHuman.gameObject.SetActive(false);
-		hudBottomGhost.gameObject.SetActive(true);
+		if (hudBottomHuman != null && hudBottomGhost != null)
+		{
+			hudBottomHuman.gameObject.SetActive(false);
+			hudBottomGhost.gameObject.SetActive(true);
+		}
 		UIManager.PlayerHealthUI.gameObject.SetActive(true);
 		panelRight.gameObject.SetActive(true);
 	}

--- a/UnityProject/Assets/Scripts/UI/PreRound.meta
+++ b/UnityProject/Assets/Scripts/UI/PreRound.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 519bded788ffe724e94c76c3b59dc1a0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
+++ b/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
@@ -59,7 +59,12 @@ public class GUI_PreRoundWindow : MonoBehaviour
 
 	public void StartNowButton()
 	{
-		PlayerManager.LocalViewerScript.CmdStartRound();
+		if (CustomNetworkManager.Instance._isServer == false)
+		{
+			Logger.LogError("Can only execute command from server.", Category.DebugConsole);
+			return;
+		}
+		GameManager.Instance.RoundStart();
 	}
 
 	public void SyncCountdown(bool started, float time)

--- a/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
+++ b/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class GUI_PreRoundWindow : MonoBehaviour
+{
+	[SerializeField]
+	private Text currentGameMode;
+	[SerializeField]
+	private Text timer;
+	[SerializeField]
+	private Text playerCount;
+
+	[SerializeField]
+	private GameObject adminPanel;
+	[SerializeField]
+	private GameObject playerWaitPanel;
+	[SerializeField]
+	private GameObject countdownPanel;
+
+	private bool doCountdown;
+	private float countdownTime;
+
+	void OnDisable()
+	{
+		doCountdown = false;
+	}
+
+	void Update()
+	{
+		// TODO: remove once admin system is in
+		if (Input.GetKeyDown(KeyCode.F7) && !BuildPreferences.isForRelease)
+		{
+			adminPanel.SetActive(true);
+		}
+
+		if (doCountdown)
+		{
+			countdownTime -= Time.deltaTime;
+		}
+
+		playerCount.text = PlayerList.Instance.ClientConnectedPlayers.Count.ToString();
+		currentGameMode.text = GameManager.Instance.GetGameModeName();
+		timer.text = TimeSpan.FromSeconds(this.countdownTime).ToString(@"mm\:ss");
+	}
+
+	public void StartNowButton()
+	{
+		GameManager.Instance.RoundStart();
+	}
+
+	public void SyncCountdown(bool started, float time)
+	{
+		Logger.Log($"SyncCountdown called with: started={started}, time={time}", Category.Round);
+		countdownTime = time;
+		doCountdown = started;
+		countdownPanel.SetActive(started);
+		playerWaitPanel.SetActive(!started);
+	}
+}

--- a/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
+++ b/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
@@ -47,6 +47,11 @@ public class GUI_PreRoundWindow : MonoBehaviour
 			}
 		}
 
+		UpdateUI();
+	}
+
+	public void UpdateUI()
+	{
 		playerCount.text = PlayerList.Instance.ClientConnectedPlayers.Count.ToString();
 		currentGameMode.text = GameManager.Instance.GetGameModeName();
 		timer.text = TimeSpan.FromSeconds(this.countdownTime).ToString(@"mm\:ss");
@@ -62,6 +67,7 @@ public class GUI_PreRoundWindow : MonoBehaviour
 		Logger.Log($"SyncCountdown called with: started={started}, time={time}", Category.Round);
 		countdownTime = time;
 		doCountdown = started;
+		UpdateUI();
 		countdownPanel.SetActive(started);
 		playerWaitPanel.SetActive(!started);
 	}

--- a/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
+++ b/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
@@ -26,6 +26,7 @@ public class GUI_PreRoundWindow : MonoBehaviour
 	void OnDisable()
 	{
 		doCountdown = false;
+		adminPanel.SetActive(false);
 	}
 
 	void Update()
@@ -39,6 +40,12 @@ public class GUI_PreRoundWindow : MonoBehaviour
 		if (doCountdown)
 		{
 			countdownTime -= Time.deltaTime;
+			if (countdownTime <= 0)
+			{
+				doCountdown = false;
+				// Let the players choose their job after the countdown for now
+				UIManager.Display.SetScreenForJobSelect();
+			}
 		}
 
 		playerCount.text = PlayerList.Instance.ClientConnectedPlayers.Count.ToString();

--- a/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
+++ b/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
@@ -43,8 +43,7 @@ public class GUI_PreRoundWindow : MonoBehaviour
 			if (countdownTime <= 0)
 			{
 				doCountdown = false;
-				// Let the players choose their job after the countdown for now
-				UIManager.Display.SetScreenForJobSelect();
+				// Server should tell client what to do at the end of the countdown
 			}
 		}
 
@@ -55,7 +54,7 @@ public class GUI_PreRoundWindow : MonoBehaviour
 
 	public void StartNowButton()
 	{
-		GameManager.Instance.RoundStart();
+		PlayerManager.LocalViewerScript.CmdStartRound();
 	}
 
 	public void SyncCountdown(bool started, float time)

--- a/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4cfa17c47748c23449a253fcac613b1f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/UIManager.cs
@@ -3,9 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
-using Mirror;
 
-public class UIManager : NetworkBehaviour
+public class UIManager : MonoBehaviour
 {
 	private static UIManager uiManager;
 	public GUI_VariableViewer VariableViewer;
@@ -230,24 +229,4 @@ public class UIManager : NetworkBehaviour
 		}
 		return true;
 	}
-
-	/// <summary>
-	/// Tells all clients to open the job selection window
-	/// </summary>
-	[ClientRpc]
-	public void RpcSelectJobs()
-	{
-		Display.SetScreenForJobSelect();
-	}
-
-	/// <summary>
-	/// Tells all clients to start the pre-round countdown
-	/// </summary>
-	[ClientRpc]
-	public void RpcStartCountdown(float countdownTime)
-	{
-		Logger.Log("Starting countdown!", Category.Round);
-		Instance.displayControl.preRoundWindow.GetComponent<GUI_PreRoundWindow>().SyncCountdown(true, countdownTime);
-	}
-
 }

--- a/UnityProject/Assets/Scripts/UI/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/UIManager.cs
@@ -230,4 +230,24 @@ public class UIManager : NetworkBehaviour
 		}
 		return true;
 	}
+
+	/// <summary>
+	/// Tells all clients to open the job selection window
+	/// </summary>
+	[ClientRpc]
+	public void RpcSelectJobs()
+	{
+		Display.SetScreenForJobSelect();
+	}
+
+	/// <summary>
+	/// Tells all clients to start the pre-round countdown
+	/// </summary>
+	[ClientRpc]
+	public void RpcStartCountdown(float countdownTime)
+	{
+		Logger.Log("Starting countdown!", Category.Round);
+		Instance.displayControl.preRoundWindow.GetComponent<GUI_PreRoundWindow>().SyncCountdown(true, countdownTime);
+	}
+
 }


### PR DESCRIPTION
### Purpose
Adds:
- Networked pre-round stage between the lobby and the round starting.
- GameMode prefabs which get loaded automatically on the server
- GameMode scripts to customise setup, round start and end (still WIP)
- Fixes loading directly into OutpostStation
- Press F7 in the pre-round to reveal the start now button
- Pre-round OOC chat also works
- ConnectedPlayer now stores the username
- OOC always uses username instead of character name

![p1u7K1JEEL](https://user-images.githubusercontent.com/4493127/65839443-8eb3cb00-e305-11e9-92b5-9574f59146a9.gif)


The pre-round stage has a countdown timer which starts when the min number of players have joined (currently set to be 1 player with a 30 second timer).

The game mode has been hardcoded to NukeOps and players still choose their teams for now, but I'm working on it.

Tested with round restarts and it works.

Let me know what you think of it so far.

Related to #2138 

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
