### PR TITLE
Delete colliding obj.meta file

### DIFF
--- a/UnityProject/Assets/Textures/obj.meta
+++ b/UnityProject/Assets/Textures/obj.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 55f3a5e19a7025e419229ce8070f9bc2
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Both files are the same so shouldn't affect anything.

When I did a fresh checkout the obj.meta file gets deleted anyways so it's not needed at all.