### PR TITLE
Add renamable capability

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/GUI/Resources/TabRename.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/GUI/Resources/TabRename.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 2819703556361952705}
   - component: {fileID: 2821689132945000415}
   - component: {fileID: 3161832186800958673}
+  - component: {fileID: 58354034651084878}
   m_Layer: 5
   m_Name: InputField
   m_TagString: Untagged
@@ -205,6 +206,18 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
+--- !u!114 &58354034651084878
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1909140332986231003}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac8f82ad7ed44f94843fbafd1cf5606c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2157657476224331566
 GameObject:
   m_ObjectHideFlags: 0
@@ -372,6 +385,7 @@ MonoBehaviour:
   Provider: {fileID: 0}
   Type: 13
   textField: {fileID: 2819703556361952705}
+  networkedInputField: {fileID: 58354034651084878}
   contentSizeFitter: {fileID: 2821689132945000415}
 --- !u!114 &7794208085403295157
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/GUI/Resources/TabRename.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/GUI/Resources/TabRename.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &1073871676340802
+--- !u!1 &1909140332986231003
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,12 +8,12 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 224046292090504698}
-  - component: {fileID: 222622871631726896}
-  - component: {fileID: 114769899820182462}
-  - component: {fileID: 114575598953811100}
-  - component: {fileID: 114459991742813864}
-  - component: {fileID: 114955105891380638}
+  - component: {fileID: 5694757495703081971}
+  - component: {fileID: 4728014910315884220}
+  - component: {fileID: 3750400191563800581}
+  - component: {fileID: 2819703556361952705}
+  - component: {fileID: 2821689132945000415}
+  - component: {fileID: 3161832186800958673}
   m_Layer: 5
   m_Name: InputField
   m_TagString: Untagged
@@ -21,20 +21,20 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &224046292090504698
+--- !u!224 &5694757495703081971
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1073871676340802}
+  m_GameObject: {fileID: 1909140332986231003}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 224302566920053472}
-  - {fileID: 224026978416182424}
-  m_Father: {fileID: 224663602153563088}
+  - {fileID: 6559189496072082475}
+  - {fileID: 3639145091097194020}
+  m_Father: {fileID: 1246103898228069035}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
@@ -42,21 +42,21 @@ RectTransform:
   m_AnchoredPosition: {x: -3.3, y: -101}
   m_SizeDelta: {x: 648.1, y: 0}
   m_Pivot: {x: 0.5, y: 1.000001}
---- !u!222 &222622871631726896
+--- !u!222 &4728014910315884220
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1073871676340802}
+  m_GameObject: {fileID: 1909140332986231003}
   m_CullTransparentMesh: 0
---- !u!114 &114769899820182462
+--- !u!114 &3750400191563800581
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1073871676340802}
+  m_GameObject: {fileID: 1909140332986231003}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -78,13 +78,13 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &114575598953811100
+--- !u!114 &2819703556361952705
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1073871676340802}
+  m_GameObject: {fileID: 1909140332986231003}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d199490a83bb2b844b9695cbf13b01ef, type: 3}
@@ -117,9 +117,9 @@ MonoBehaviour:
     m_SelectedTrigger: Highlighted
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 114769899820182462}
-  m_TextComponent: {fileID: 114347988238203114}
-  m_Placeholder: {fileID: 114813156132331224}
+  m_TargetGraphic: {fileID: 3750400191563800581}
+  m_TextComponent: {fileID: 7163816704148890039}
+  m_Placeholder: {fileID: 7931850258340504842}
   m_ContentType: 0
   m_InputType: 0
   m_AsteriskChar: 42
@@ -131,7 +131,7 @@ MonoBehaviour:
   m_OnEndEdit:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 114356089685367662}
+      - m_Target: {fileID: 6446050211551743880}
         m_MethodName: OnTextEditEnd
         m_Mode: 1
         m_Arguments:
@@ -145,7 +145,7 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 114356089685367662}
+      - m_Target: {fileID: 6446050211551743880}
         m_MethodName: OnTextValueChange
         m_Mode: 1
         m_Arguments:
@@ -163,13 +163,13 @@ MonoBehaviour:
   m_CaretBlinkRate: 0.85
   m_CaretWidth: 5
   m_ReadOnly: 0
---- !u!114 &114459991742813864
+--- !u!114 &2821689132945000415
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1073871676340802}
+  m_GameObject: {fileID: 1909140332986231003}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
@@ -177,13 +177,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
---- !u!114 &114955105891380638
+--- !u!114 &3161832186800958673
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1073871676340802}
+  m_GameObject: {fileID: 1909140332986231003}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
@@ -194,7 +194,7 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 114356089685367662}
+        - m_Target: {fileID: 6446050211551743880}
           m_MethodName: OnEditStart
           m_Mode: 1
           m_Arguments:
@@ -205,7 +205,7 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
---- !u!1 &1155826666078090
+--- !u!1 &2157657476224331566
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -213,10 +213,272 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 224026978416182424}
-  - component: {fileID: 222842931053061846}
-  - component: {fileID: 114347988238203114}
-  - component: {fileID: 114143921897934410}
+  - component: {fileID: 7556532547454686799}
+  - component: {fileID: 4819448437002185242}
+  - component: {fileID: 4531440611729448929}
+  - component: {fileID: 2291132796423933020}
+  m_Layer: 5
+  m_Name: CloseButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7556532547454686799
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2157657476224331566}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1246103898228069035}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -663, y: -39}
+  m_SizeDelta: {x: 28.570007, y: 28.570007}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4819448437002185242
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2157657476224331566}
+  m_CullTransparentMesh: 0
+--- !u!114 &4531440611729448929
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2157657476224331566}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300016, guid: 456b3993efaf4018ab1d98293d1d592b, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2291132796423933020
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2157657476224331566}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 2
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 6446050211551743880}
+          m_MethodName: CloseDialog
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+--- !u!1 &2553128447893726793
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8439179155869062525}
+  - component: {fileID: 1256394967349985084}
+  - component: {fileID: 6446050211551743880}
+  - component: {fileID: 7794208085403295157}
+  - component: {fileID: 6019921654276041890}
+  m_Layer: 5
+  m_Name: TabRename
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8439179155869062525
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2553128447893726793}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7684280599767768402}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.00012207031, y: 0.00012207031}
+  m_SizeDelta: {x: 700, y: 800}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1256394967349985084
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2553128447893726793}
+  m_CullTransparentMesh: 0
+--- !u!114 &6446050211551743880
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2553128447893726793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba01c3d6c2a1439a861404617bfd7cba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Hidden: 0
+  isPopOut: 1
+  Provider: {fileID: 0}
+  Type: 13
+  textField: {fileID: 2819703556361952705}
+  contentSizeFitter: {fileID: 2821689132945000415}
+--- !u!114 &7794208085403295157
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2553128447893726793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a14ed3befbaf4893bc7f04d3a44e9639, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  disableDrag: 0
+  resetPositionOnDisable: 0
+--- !u!114 &6019921654276041890
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2553128447893726793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 13
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 7794208085403295157}
+          m_MethodName: BeginDrag
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - eventID: 5
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 7794208085403295157}
+          m_MethodName: OnDrag
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+--- !u!1 &4147593603783758463
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7684280599767768402}
+  m_Layer: 5
+  m_Name: Window
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7684280599767768402
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4147593603783758463}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5007476997732782106}
+  - {fileID: 1246103898228069035}
+  m_Father: {fileID: 8439179155869062525}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 28.2}
+  m_SizeDelta: {x: 0, y: -623.1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4567130716029781012
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3639145091097194020}
+  - component: {fileID: 6479034338678921228}
+  - component: {fileID: 7163816704148890039}
+  - component: {fileID: 3850719857319393202}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -224,18 +486,18 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &224026978416182424
+--- !u!224 &3639145091097194020
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1155826666078090}
+  m_GameObject: {fileID: 4567130716029781012}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 224046292090504698}
+  m_Father: {fileID: 5694757495703081971}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -243,21 +505,21 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 4.9000015}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &222842931053061846
+--- !u!222 &6479034338678921228
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1155826666078090}
+  m_GameObject: {fileID: 4567130716029781012}
   m_CullTransparentMesh: 0
---- !u!114 &114347988238203114
+--- !u!114 &7163816704148890039
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1155826666078090}
+  m_GameObject: {fileID: 4567130716029781012}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
@@ -283,13 +545,13 @@ MonoBehaviour:
     m_VerticalOverflow: 1
     m_LineSpacing: 1
   m_Text: 
---- !u!114 &114143921897934410
+--- !u!114 &3850719857319393202
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1155826666078090}
+  m_GameObject: {fileID: 4567130716029781012}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
@@ -297,7 +559,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
---- !u!1 &1297454887248136
+--- !u!1 &5493966319932729923
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -305,257 +567,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 224663602153563088}
-  - component: {fileID: 222238763163298178}
-  - component: {fileID: 114892278386682890}
-  - component: {fileID: 114363384894663846}
-  m_Layer: 5
-  m_Name: Mask
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &224663602153563088
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1297454887248136}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.9999994, y: 0.9999994, z: 0.9999994}
-  m_Children:
-  - {fileID: 224868005608327740}
-  - {fileID: 224046292090504698}
-  m_Father: {fileID: 224120160830574892}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &222238763163298178
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1297454887248136}
-  m_CullTransparentMesh: 0
---- !u!114 &114892278386682890
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1297454887248136}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.8396226, g: 0.8396226, b: 0.8396226, a: 0}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 336da4a5fda7493ebd53fa0e22e735b7, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &114363384894663846
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1297454887248136}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &1502172408805726
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 224096793523660850}
-  - component: {fileID: 222946214041701798}
-  - component: {fileID: 114356089685367662}
-  - component: {fileID: 114055117178974294}
-  - component: {fileID: 114385320989314586}
-  m_Layer: 5
-  m_Name: TabPaper
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &224096793523660850
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1502172408805726}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.5625}
-  m_LocalScale: {x: 0.6953704, y: 0.6953704, z: 0.6953704}
-  m_Children:
-  - {fileID: 224120160830574892}
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 956, y: 550}
-  m_SizeDelta: {x: 700, y: 800}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &222946214041701798
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1502172408805726}
-  m_CullTransparentMesh: 0
---- !u!114 &114356089685367662
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1502172408805726}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bc7ef70b4a4ea4567b0d23855b5c660c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Hidden: 0
-  isPopOut: 1
-  Provider: {fileID: 0}
-  Type: 4
-  textField: {fileID: 114575598953811100}
-  contentSizeFitter: {fileID: 114459991742813864}
---- !u!114 &114055117178974294
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1502172408805726}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a14ed3befbaf4893bc7f04d3a44e9639, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  disableDrag: 0
-  resetPositionOnDisable: 0
---- !u!114 &114385320989314586
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1502172408805726}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Delegates:
-  - eventID: 13
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 114055117178974294}
-          m_MethodName: BeginDrag
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
-  - eventID: 5
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 114055117178974294}
-          m_MethodName: OnDrag
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
---- !u!1 &1571967781877764
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 224120160830574892}
-  m_Layer: 5
-  m_Name: Window
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &224120160830574892
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1571967781877764}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 224950370593069080}
-  - {fileID: 224663602153563088}
-  m_Father: {fileID: 224096793523660850}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1685889635782248
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 224302566920053472}
-  - component: {fileID: 222074925701012412}
-  - component: {fileID: 114813156132331224}
+  - component: {fileID: 6559189496072082475}
+  - component: {fileID: 816984038366340250}
+  - component: {fileID: 7931850258340504842}
   m_Layer: 5
   m_Name: PlaceHolder
   m_TagString: Untagged
@@ -563,18 +577,18 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &224302566920053472
+--- !u!224 &6559189496072082475
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1685889635782248}
+  m_GameObject: {fileID: 5493966319932729923}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 224046292090504698}
+  m_Father: {fileID: 5694757495703081971}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -582,21 +596,21 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 4.9000015}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &222074925701012412
+--- !u!222 &816984038366340250
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1685889635782248}
+  m_GameObject: {fileID: 5493966319932729923}
   m_CullTransparentMesh: 0
---- !u!114 &114813156132331224
+--- !u!114 &7931850258340504842
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1685889635782248}
+  m_GameObject: {fileID: 5493966319932729923}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
@@ -621,8 +635,8 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: click to edit (requires pen)..
---- !u!1 &1718948510130994
+  m_Text: click to change name
+--- !u!1 &5516276113373377156
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -630,10 +644,10 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 224950370593069080}
-  - component: {fileID: 222877028515050584}
-  - component: {fileID: 114673774271609302}
-  - component: {fileID: 114038496128578582}
+  - component: {fileID: 5007476997732782106}
+  - component: {fileID: 6123218679793539741}
+  - component: {fileID: 4936451157246202560}
+  - component: {fileID: 5328960293530882256}
   m_Layer: 5
   m_Name: BG
   m_TagString: Untagged
@@ -641,18 +655,18 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &224950370593069080
+--- !u!224 &5007476997732782106
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1718948510130994}
+  m_GameObject: {fileID: 5516276113373377156}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 224120160830574892}
+  m_Father: {fileID: 7684280599767768402}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -660,21 +674,21 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &222877028515050584
+--- !u!222 &6123218679793539741
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1718948510130994}
+  m_GameObject: {fileID: 5516276113373377156}
   m_CullTransparentMesh: 0
---- !u!114 &114673774271609302
+--- !u!114 &4936451157246202560
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1718948510130994}
+  m_GameObject: {fileID: 5516276113373377156}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -696,13 +710,13 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &114038496128578582
+--- !u!114 &5328960293530882256
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1718948510130994}
+  m_GameObject: {fileID: 5516276113373377156}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
@@ -711,7 +725,7 @@ MonoBehaviour:
   m_EffectColor: {r: 0.0754717, g: 0.0754717, b: 0.0754717, a: 0.5}
   m_EffectDistance: {x: 20, y: -20}
   m_UseGraphicAlpha: 1
---- !u!1 &1741531363287468
+--- !u!1 &8025187808838228693
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -719,65 +733,67 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 224868005608327740}
-  - component: {fileID: 222096006444898966}
-  - component: {fileID: 114706735006282418}
-  - component: {fileID: 114401453316706992}
+  - component: {fileID: 1246103898228069035}
+  - component: {fileID: 4232854488780193645}
+  - component: {fileID: 6280433816948344490}
+  - component: {fileID: 5758875075508200831}
   m_Layer: 5
-  m_Name: CloseButton
+  m_Name: Mask
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &224868005608327740
+--- !u!224 &1246103898228069035
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1741531363287468}
+  m_GameObject: {fileID: 8025187808838228693}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 224663602153563088}
-  m_RootOrder: 0
+  m_LocalScale: {x: 0.9999994, y: 0.9999994, z: 0.9999994}
+  m_Children:
+  - {fileID: 7556532547454686799}
+  - {fileID: 5694757495703081971}
+  m_Father: {fileID: 7684280599767768402}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -663, y: -39}
-  m_SizeDelta: {x: 28.570007, y: 28.570007}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &222096006444898966
+--- !u!222 &4232854488780193645
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1741531363287468}
+  m_GameObject: {fileID: 8025187808838228693}
   m_CullTransparentMesh: 0
---- !u!114 &114706735006282418
+--- !u!114 &6280433816948344490
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1741531363287468}
+  m_GameObject: {fileID: 8025187808838228693}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_Color: {r: 0.8396226, g: 0.8396226, b: 0.8396226, a: 0}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300016, guid: 456b3993efaf4018ab1d98293d1d592b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 336da4a5fda7493ebd53fa0e22e735b7, type: 3}
   m_Type: 0
-  m_PreserveAspect: 1
+  m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1
@@ -785,31 +801,15 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &114401453316706992
+--- !u!114 &5758875075508200831
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1741531363287468}
+  m_GameObject: {fileID: 8025187808838228693}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Delegates:
-  - eventID: 2
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 114356089685367662}
-          m_MethodName: ClosePaper
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/GUI/Resources/TabRename.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/GUI/Resources/TabRename.prefab
@@ -540,7 +540,7 @@ MonoBehaviour:
     m_MaxSize: 30
     m_Alignment: 0
     m_AlignByGeometry: 0
-    m_RichText: 1
+    m_RichText: 0
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 1
     m_LineSpacing: 1

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/GUI/Resources/TabRename.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/GUI/Resources/TabRename.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 032f09fd5a8554d38a99225d7c404b12
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Items/Other/Resources/Paper.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Items/Other/Resources/Paper.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 114741019056190926}
   - component: {fileID: 114843876647253344}
   - component: {fileID: 114559639511531318}
+  - component: {fileID: 7616435447516161641}
   - component: {fileID: 114930140412175382}
   - component: {fileID: 114414318728299190}
   - component: {fileID: 114455083295167806}
@@ -99,7 +100,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  parentContainer: {fileID: 0}
   isNotPushable: 0
 --- !u!114 &114741019056190926
 MonoBehaviour:
@@ -115,7 +115,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  spriteHandlerData: {fileID: 0}
+  spriteDataHandler: {fileID: 0}
   InventoryIcon: {fileID: 0}
   itemName: Paper
   itemDescription: A piece of paper
@@ -163,6 +163,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   NetTabType: 4
   paper: {fileID: 114843876647253344}
+--- !u!114 &7616435447516161641
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1320386684021000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c41af2d53114e99b2142b2b126717c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 1320386684021000}
 --- !u!114 &114930140412175382
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -180,8 +193,6 @@ MonoBehaviour:
   OnDropServer:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114414318728299190
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -214,7 +225,6 @@ MonoBehaviour:
   crossed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 --- !u!114 &1551927132294530552
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -273,8 +283,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   Infos:
     spriteIndex: 0
     VariantIndex: 0
@@ -295,8 +303,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3001592640
+  m_AssetId: 4ad202d5ed2ef44f0b3363b5fd90a066
+  m_SceneId: 0
 --- !u!1 &1731708282254700
 GameObject:
   m_ObjectHideFlags: 0
@@ -353,6 +361,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/Interactable.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/Interactable.cs
@@ -81,6 +81,12 @@ public abstract class Interactable<T>
 		return InteractionComponentUtils.CoordinatedInteract(info, coordinator, ClientPredictInteraction);
 	}
 
+	public bool Interact(T info, string specificComponent)
+	{
+		EnsureCoordinatorInit();
+		return InteractionComponentUtils.CoordinatedInteract(info, coordinator, ClientPredictInteraction, specificComponent);
+	}
+
 	public bool ServerProcessInteraction(T info)
 	{
 		EnsureCoordinatorInit();

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBHandActivateInteractable.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/CoreComponents/NBHandActivateInteractable.cs
@@ -63,6 +63,12 @@ public abstract class NBHandActivateInteractable
 		return InteractionComponentUtils.CoordinatedInteract(info, coordinator, ClientPredictInteraction);
 	}
 
+	public bool Interact(HandActivate info, string specificComponent)
+	{
+		EnsureCoordinatorInit();
+		return InteractionComponentUtils.CoordinatedInteract(info, coordinator, ClientPredictInteraction, specificComponent);
+	}
+
 	public bool ServerProcessInteraction(HandActivate info)
 	{
 		EnsureCoordinatorInit();

--- a/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributes.cs
@@ -24,6 +24,7 @@ public class ItemAttributes : NetworkBehaviour, IRightClickable
 
 	public SpriteHandler InventoryIcon;
 
+	[SyncVar(hook = nameof(SyncItemName))]
 	public string itemName;
 	public string itemDescription;
 
@@ -36,7 +37,6 @@ public class ItemAttributes : NetworkBehaviour, IRightClickable
 	/// </summary>
 	[FormerlySerializedAs("ConnectedToTank")]
 	public bool CanConnectToTank;
-
 
 	/// throw-related fields
 	[Tooltip("Damage when we click someone with harm intent")] [Range(0, 100)]
@@ -62,6 +62,38 @@ public class ItemAttributes : NetworkBehaviour, IRightClickable
 
 	public List<string> attackVerb = new List<string>();
 
+	public void SetItemName(string newName)
+	{
+		SyncItemName(newName);
+	}
+
+	private void SyncItemName(string newName)
+	{
+		itemName = newName;
+	}
+
+	public override void OnStartClient()
+	{
+		SyncItemName(itemName);
+		base.OnStartClient();
+	}
+
+	public override void OnStartServer()
+	{
+		SyncItemName(itemName);
+		base.OnStartServer();
+	}
+
+	private void Awake()
+	{
+		SyncItemName(itemName);
+	}
+
+	public void GoingOnStageServer(OnStageInfo info)
+	{
+		SyncItemName(itemName);
+	}
+
 	private void OnEnable()
 	{
 		spriteDataHandler = GetComponentInChildren<SpriteDataHandler>();
@@ -81,7 +113,7 @@ public class ItemAttributes : NetworkBehaviour, IRightClickable
 
 	public void AttributesFromCD(ItemAttributesData ItemAttributes)
 	{
-		itemName = ItemAttributes.itemName;
+		SyncItemName(ItemAttributes.itemName);
 		itemDescription = ItemAttributes.itemDescription;
 		itemType = ItemAttributes.itemType;
 		size = ItemAttributes.size;

--- a/UnityProject/Assets/Scripts/Items/Renameable.cs
+++ b/UnityProject/Assets/Scripts/Items/Renameable.cs
@@ -5,9 +5,16 @@ using WebSocketSharp;
 public class Renameable : NBHandActivateInteractable, IRightClickable
 {
 	public NetTabType NetTabType = NetTabType.Rename;
+	[SerializeField]
+	private string originalName;
+	[SerializeField]
+	private string customName;
 
-	public string originalName;
-	public string customName;
+	public string CustomName
+	{
+		get => customName;
+		private set => SetCustomName( value );
+	}
 
 	private ItemAttributes attributes;
 
@@ -23,7 +30,7 @@ public class Renameable : NBHandActivateInteractable, IRightClickable
 		base.OnStartServer();
 	}
 
-	public void SetCustomName(string custom, string original)
+	public void SetCustomName(string custom)
 	{
 		var itemName = originalName;
 
@@ -38,10 +45,6 @@ public class Renameable : NBHandActivateInteractable, IRightClickable
 		if (!string.IsNullOrEmpty(custom))
 		{
 			itemName += " - '" + custom + "'";
-		}
-		else
-		{
-			itemName = original;
 		}
 
 		attributes.SetItemName(itemName);

--- a/UnityProject/Assets/Scripts/Items/Renameable.cs
+++ b/UnityProject/Assets/Scripts/Items/Renameable.cs
@@ -6,66 +6,50 @@ public class Renameable : NBHandActivateInteractable, IRightClickable
 {
 	public NetTabType NetTabType = NetTabType.Rename;
 
-	[SyncVar(hook = nameof(SyncOriginalName))]
 	public string originalName;
-
-	[SyncVar(hook = nameof(SyncCustomName))]
 	public string customName;
 
 	private ItemAttributes attributes;
 
-	private void SyncOriginalName(string original)
-	{
-		originalName = original;
-	}
-
-	private void SyncCustomName(string custom)
-	{
-		customName = custom;
-
-		var itemName = originalName;
-
-		if (itemName.IsNullOrEmpty())
-		{
-			itemName = attributes.itemName;
-			SyncOriginalName(itemName);
-		}
-
-		if (!string.IsNullOrEmpty(custom))
-		{
-			itemName += " - '" + custom + "'";
-		}
-
-		attributes.SetItemName(itemName);
-	}
-
 	public override void OnStartClient()
 	{
-		SyncEverything();
+		attributes = gameObject.GetComponent<ItemAttributes>();
 		base.OnStartClient();
 	}
 
 	public override void OnStartServer()
 	{
-		SyncEverything();
+		attributes = gameObject.GetComponent<ItemAttributes>();
 		base.OnStartServer();
 	}
 
-	public void SetCustomName(string msg)
+	public void SetCustomName(string custom, string original)
 	{
-		SyncCustomName(msg);
+		var itemName = originalName;
+
+		if (itemName.IsNullOrEmpty())
+		{
+			itemName = attributes.itemName;
+			originalName = itemName;
+		}
+
+		customName = custom;
+
+		if (!string.IsNullOrEmpty(custom))
+		{
+			itemName += " - '" + custom + "'";
+		}
+		else
+		{
+			itemName = original;
+		}
+
+		attributes.SetItemName(itemName);
 	}
 
 	public string GetCustomName()
 	{
 		return customName;
-	}
-
-	private void SyncEverything()
-	{
-		attributes = gameObject.GetComponent<ItemAttributes>();
-		SyncOriginalName(originalName);
-		SyncCustomName(customName);
 	}
 
 	protected override bool WillInteract(HandActivate interaction, NetworkSide side)

--- a/UnityProject/Assets/Scripts/Items/Renameable.cs
+++ b/UnityProject/Assets/Scripts/Items/Renameable.cs
@@ -1,0 +1,80 @@
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+public class Renameable : Interactable<HandActivate>, IRightClickable
+{
+	public NetTabType NetTabType = NetTabType.Rename;
+
+	protected override bool WillInteract(HandActivate interaction, NetworkSide side)
+	{
+		if (!base.WillInteract(interaction, side)) return false;
+
+		var cnt = GetComponent<CustomNetTransform>();
+		var ps = interaction.Performer.GetComponent<PlayerScript>();
+		var pna = interaction.Performer.GetComponent<PlayerNetworkActions>();
+
+		if (pna.GetActiveHandItem() == gameObject)
+		{
+			return true;
+		}
+
+		if (!ps.IsInReach(cnt.RegisterTile, side == NetworkSide.Server))
+		{
+
+			return false;
+		}
+
+		return true;
+	}
+
+	protected override void ServerPerformInteraction(HandActivate interaction)
+	{
+		OpenRenameDialog(interaction.Performer);
+	}
+
+	public RightClickableResult GenerateRightClickOptions()
+	{
+		var result = RightClickableResult.Create();
+
+		if (WillInteract(HandActivate.ByLocalPlayer(), NetworkSide.Client))
+		{
+			result.AddElement("Rename", RightClickInteract);
+		}
+
+		return result;
+	}
+
+	private void RightClickInteract()
+	{
+		Interact(HandActivate.ByLocalPlayer(), nameof(Renameable));
+	}
+
+	private void OpenRenameDialog(GameObject player)
+	{
+		TabUpdateMessage.Send(player, gameObject, NetTabType, TabAction.Open);
+	}
+
+	public void SetCustomName(string msg)
+	{
+		var attributes = gameObject.GetComponent<ItemAttributes>();
+		var customName = attributes.itemName.Split('-')[0].Trim();
+		if (!string.IsNullOrEmpty(msg))
+		{
+			customName += " - '" + msg + "'";
+		}
+		attributes.SetItemName(customName);
+	}
+
+	public string GetCustomName()
+	{
+		var attributes = gameObject.GetComponent<ItemAttributes>();
+		var customName = "";
+		var match = Regex.Match(attributes.itemName, @"'(.*)'");
+		if (match.Groups.Count > 1)
+		{
+			customName = match.Groups[1].Value;
+		}
+
+		return customName;
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Renameable.cs
+++ b/UnityProject/Assets/Scripts/Items/Renameable.cs
@@ -50,11 +50,6 @@ public class Renameable : NBHandActivateInteractable, IRightClickable
 		attributes.SetItemName(itemName);
 	}
 
-	public string GetCustomName()
-	{
-		return customName;
-	}
-
 	protected override bool WillInteract(HandActivate interaction, NetworkSide side)
 	{
 		if (!base.WillInteract(interaction, side)) return false;

--- a/UnityProject/Assets/Scripts/Items/Renameable.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Renameable.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6c41af2d53114e99b2142b2b126717c0
+timeCreated: 1570278247

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/InteractionMessageUtils.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/InteractionMessageUtils.cs
@@ -68,7 +68,7 @@ public static class InteractionMessageUtils
 		}
 		else if (typeof(T) == typeof(HandActivate))
 		{
-			RequestHandActivateMessage.Send(info as HandActivate, processorObject);
+			RequestHandActivateMessage.Send(info as HandActivate, processorObject, specificComponent);
 			return;
 		}
 

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestHandActivateMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestHandActivateMessage.cs
@@ -19,6 +19,7 @@ public class RequestHandActivateMessage : ClientMessage
 
 	//object that will process the interaction
 	public uint ProcessorObject;
+	public string TargetComponent;
 
 	public override IEnumerator Process()
 	{
@@ -37,7 +38,7 @@ public class RequestHandActivateMessage : ClientMessage
 	private void ProcessActivate(GameObject activatedObject, GameObject processorObj, GameObject performerObj, HandSlot handSlot)
 	{
 		//try to look up the components on the processor that can handle this interaction
-		var processorComponents = InteractionMessageUtils.TryGetProcessors<HandActivate>(processorObj);
+		var processorComponents = InteractionMessageUtils.TryGetProcessors<HandActivate>(processorObj, TargetComponent);
 		//invoke each component that can handle this interaction
 		var activate = HandActivate.ByClient(performerObj, activatedObject, handSlot);
 		foreach (var processorComponent in processorComponents)
@@ -62,11 +63,12 @@ public class RequestHandActivateMessage : ClientMessage
 	/// of this component on the object. For organization, we suggest that the component which is sending this message
 	/// should be on the processorObject, as such this parameter should almost always be passed using "this.gameObject", and
 	/// should almost always be either a component on the target object or a component on the used object</param>
-	public static void Send(HandActivate handActivate, GameObject processorObject)
+	public static void Send(HandActivate handActivate, GameObject processorObject, string specificComponent = null)
 	{
 		var msg = new RequestHandActivateMessage
 		{
-			ProcessorObject = processorObject.GetComponent<NetworkIdentity>().netId
+			ProcessorObject = processorObject.GetComponent<NetworkIdentity>().netId,
+			TargetComponent = specificComponent
 		};
 		msg.Send();
 	}
@@ -76,12 +78,14 @@ public class RequestHandActivateMessage : ClientMessage
 	{
 		base.Deserialize(reader);
 		ProcessorObject = reader.ReadUInt32();
+		TargetComponent = reader.ReadString();
 	}
 
 	public override void Serialize(NetworkWriter writer)
 	{
 		base.Serialize(writer);
 		writer.WriteUInt32(ProcessorObject);
+		writer.WriteString(TargetComponent);
 	}
 
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -660,6 +660,17 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		}
 	}
 
+	[Command]
+	public void CmdRequestRename(GameObject target, string customName)
+	{
+		var rename = target.GetComponent<Renameable>();
+
+		if (rename != null)
+		{
+			rename.SetCustomName(customName);
+		}
+	}
+
 	/// <summary>
 	/// Performs a hug from one player to another.
 	/// </summary>

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -676,7 +676,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 			customName = customName.Substring(0, 42);
 		}
 
-		customName = Regex.Replace(customName, "<size=\"(.*)\">", "");
+		customName = Regex.Replace(customName, "<size=\"(.*)\">", "", RegexOptions.IgnoreCase);
 		customName = customName.Replace("</size>", "");
 
 		rename.SetCustomName(customName);

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using UnityEngine;
 using Mirror;
 
@@ -665,10 +666,20 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	{
 		var rename = target.GetComponent<Renameable>();
 
-		if (rename != null)
+		if (rename == null)
 		{
-			rename.SetCustomName(customName);
+			return;
 		}
+
+		if (customName.Length > 42)
+		{
+			customName = customName.Substring(0, 42);
+		}
+
+		customName = Regex.Replace(customName, "<size=\"(.*)\">", "");
+		customName = customName.Replace("</size>", "");
+
+		rename.SetCustomName(customName);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -679,7 +679,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		customName = Regex.Replace(customName, "<size=\"(.*)\">", "", RegexOptions.IgnoreCase);
 		customName = customName.Replace("</size>", "");
 
-		rename.SetCustomName(customName, rename.originalName);
+		rename.SetCustomName(customName);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -679,7 +679,7 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		customName = Regex.Replace(customName, "<size=\"(.*)\">", "", RegexOptions.IgnoreCase);
 		customName = customName.Replace("</size>", "");
 
-		rename.SetCustomName(customName);
+		rename.SetCustomName(customName, rename.originalName);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/UI/Net/Elements/NetFilledInputField.cs
+++ b/UnityProject/Assets/Scripts/UI/Net/Elements/NetFilledInputField.cs
@@ -1,0 +1,45 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Lets server set initial text for input field.
+/// Don't use it to enforce some text:
+/// It's intended for suggestions or existing values
+/// </summary>
+[RequireComponent(typeof(InputField))]
+[Serializable]
+public class NetFilledInputField : NetUIElement
+{
+	public override ElementMode InteractionMode => ElementMode.ServerWrite;
+
+	public override string Value
+	{
+		get { return Element.text; }
+		set
+		{
+			externalChange = true;
+			Element.text = value;
+			externalChange = false;
+		}
+	}
+
+	private InputField element;
+
+	public InputField Element
+	{
+		get
+		{
+			if ( !element )
+			{
+				element = GetComponent<InputField>();
+			}
+
+			return element;
+		}
+	}
+
+	public override void ExecuteServer()
+	{
+	}
+}

--- a/UnityProject/Assets/Scripts/UI/Net/Elements/NetFilledInputField.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/Net/Elements/NetFilledInputField.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ac8f82ad7ed44f94843fbafd1cf5606c
+timeCreated: 1570901269

--- a/UnityProject/Assets/Scripts/UI/Net/NetTab.cs
+++ b/UnityProject/Assets/Scripts/UI/Net/NetTab.cs
@@ -18,6 +18,7 @@ public enum NetTabType {
 	Canister = 10,
 	Comms = 11,
 	IdConsole = 12,
+	Rename = 13,
 	//add your tabs here
 }
 /// Descriptor for unique Net UI Tab

--- a/UnityProject/Assets/Scripts/UI/Net/NetTab.cs
+++ b/UnityProject/Assets/Scripts/UI/Net/NetTab.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using UnityEngine;
+using UnityEngine.Events;
 
 public enum NetTabType {
 	None = -1,
@@ -40,6 +41,11 @@ public class NetTab : Tab {
 	public HashSet<ConnectedPlayer> Peepers => peepers;
 	private HashSet<ConnectedPlayer> peepers = new HashSet<ConnectedPlayer>();
 	public bool IsUnobserved => Peepers.Count == 0;
+	
+	/// <summary>
+	/// Invoked when there is a new peeper to this tab
+	/// </summary>
+	public ConnectedPlayerEvent OnTabOpened = new ConnectedPlayerEvent();
 
 	public ElementValue[] ElementValues => CachedElements.Values.Select( element => element.ElementValue ).ToArray(); //likely expensive
 
@@ -72,8 +78,11 @@ public class NetTab : Tab {
 	public NetUIElement this[ string elementId ] => CachedElements.ContainsKey(elementId) ? CachedElements[elementId] : null;
 
 	//for server
-	public void AddPlayer( GameObject player ) {
-		Peepers.Add( PlayerList.Instance.Get( player ) );
+	public void AddPlayer( GameObject player )
+	{
+		ConnectedPlayer newPeeper = PlayerList.Instance.Get( player );
+		Peepers.Add( newPeeper );
+		OnTabOpened.Invoke( newPeeper );
 	}
 	public void RemovePlayer( GameObject player ) {
 		Peepers.Remove( PlayerList.Instance.Get( player ) );
@@ -190,3 +199,4 @@ public class NetTab : Tab {
         }
 	}
 }
+public class ConnectedPlayerEvent : UnityEvent<ConnectedPlayer> { }

--- a/UnityProject/Assets/Scripts/UI/PopUps/GUI_Rename.cs
+++ b/UnityProject/Assets/Scripts/UI/PopUps/GUI_Rename.cs
@@ -25,23 +25,8 @@ public class GUI_Rename : NetTab
 		{
 			yield return WaitFor.EndOfFrame;
 		}
-		RefreshText();
 	}
-
-	public override void RefreshTab()
-	{
-		RefreshText();
-		base.RefreshTab();
-	}
-
-	public void RefreshText()
-	{
-		if (Provider != null)
-		{
-			textField.text = Provider.GetComponent<Renameable>().GetCustomName();
-		}
-	}
-
+	
 	public void CloseDialog()
 	{
 		ControlTabs.CloseTab(Type, Provider);

--- a/UnityProject/Assets/Scripts/UI/PopUps/GUI_Rename.cs
+++ b/UnityProject/Assets/Scripts/UI/PopUps/GUI_Rename.cs
@@ -1,0 +1,104 @@
+using System.Collections;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class GUI_Rename : NetTab
+{
+
+	public InputField textField;
+	public ContentSizeFitter contentSizeFitter;
+
+	private const int MAX_NAME_LENGTH = 42;
+
+	public override void OnEnable()
+	{
+		base.OnEnable();
+		StartCoroutine(WaitForProvider());
+		textField.interactable = false;
+	}
+
+	IEnumerator WaitForProvider()
+	{
+		while (Provider == null)
+		{
+			yield return WaitFor.EndOfFrame;
+		}
+		RefreshText();
+	}
+
+	public override void RefreshTab()
+	{
+		RefreshText();
+		base.RefreshTab();
+	}
+
+	public void RefreshText()
+	{
+		if (Provider != null)
+		{
+			textField.text = Provider.GetComponent<Renameable>().GetCustomName();
+		}
+	}
+
+	public void CloseDialog()
+	{
+		ControlTabs.CloseTab(Type, Provider);
+	}
+
+	public void OnEditStart()
+	{
+		textField.interactable = true;
+		textField.ActivateInputField();
+
+		UIManager.IsInputFocus = true;
+		CheckForInput();
+	}
+
+	//Safety measure:
+	private async void CheckForInput()
+	{
+		await Task.Delay(500);
+		if (!textField.isFocused)
+		{
+			UIManager.IsInputFocus = false;
+		}
+	}
+
+	//Request an edit from server:
+	public void OnTextEditEnd()
+	{
+		var customName = textField.text;
+		if (customName.Length > MAX_NAME_LENGTH)
+		{
+			customName = customName.Substring(0, MAX_NAME_LENGTH);
+		}
+
+		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRequestRename(Provider.gameObject, customName);
+		UIManager.IsInputFocus = false;
+	}
+
+	public void OnTextValueChange()
+	{
+		//Only way to refresh it to get it to do its job (unity bug):
+		contentSizeFitter.enabled = false;
+		contentSizeFitter.enabled = true;
+		if (!textField.placeholder.enabled)
+		{
+			CheckLine();
+		}
+	}
+
+	private void CheckLine()
+	{
+		Canvas.ForceUpdateCanvases();
+		if (textField.text.Length > MAX_NAME_LENGTH)
+		{
+			var sub = textField.text.Substring(0, MAX_NAME_LENGTH);
+			textField.text = sub;
+		}
+
+		textField.text = Regex.Replace(textField.text, @"\r\n?|\n", "");
+	}
+}

--- a/UnityProject/Assets/Scripts/UI/PopUps/GUI_Rename.cs
+++ b/UnityProject/Assets/Scripts/UI/PopUps/GUI_Rename.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -6,11 +7,35 @@ using UnityEngine.UI;
 
 public class GUI_Rename : NetTab
 {
+	[SerializeField]
+	private InputField textField;
+	[SerializeField]
+	private NetFilledInputField networkedInputField;
+	[SerializeField]
+	private ContentSizeFitter contentSizeFitter;
 
-	public InputField textField;
-	public ContentSizeFitter contentSizeFitter;
+	private Renameable renameable;
 
 	private const int MAX_NAME_LENGTH = 42;
+
+	private void Awake()
+	{
+		if ( IsServer )
+		{
+			OnTabOpened.AddListener( newPeeper =>
+			{
+				if ( renameable == null )
+				{
+					return;
+				}
+
+				if ( renameable.CustomName.Length > 0 )
+				{
+					networkedInputField.SetValue = renameable.CustomName;
+				}
+			} );
+		}
+	}
 
 	public override void OnEnable()
 	{
@@ -25,6 +50,8 @@ public class GUI_Rename : NetTab
 		{
 			yield return WaitFor.EndOfFrame;
 		}
+
+		renameable = Provider.GetComponent<Renameable>();
 	}
 	
 	public void CloseDialog()

--- a/UnityProject/Assets/Scripts/UI/PopUps/GUI_Rename.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/PopUps/GUI_Rename.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ba01c3d6c2a1439a861404617bfd7cba
+timeCreated: 1570285638


### PR DESCRIPTION
### Purpose
Add Renameable component. Attached Renameable to paper. Objects can be renamed by right clicking and hitting "Rename". Dialog pops up, it's a squashed down paper background (I'm not an artist).

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

