### PR TITLE
2031 Remove Gravity from Taser Shot

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_EnergyShot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_EnergyShot.prefab
@@ -215,8 +215,8 @@ Rigidbody2D:
   m_UseAutoMass: 0
   m_Mass: 1
   m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
+  m_AngularDrag: 0
+  m_GravityScale: 0
   m_Material: {fileID: 0}
   m_Interpolate: 2
   m_SleepingMode: 1


### PR DESCRIPTION
### Purpose
Fixes #2031. Removes angular drag and gravity from the taser shot prefab.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
