### PR TITLE
2165 Allow cables to be placed on tables

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Others/CableCoil.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/CableCoil.cs
@@ -45,6 +45,13 @@ public class CableCoil : NBPositionalHandApplyInteractable
 		if (!base.WillInteract(interaction, side)) return false;
 		//can only be used on tiles
 		if (!Validations.HasComponent<InteractableTiles>(interaction.TargetObject)) return false;
+
+		// If there's a table, we should drop there
+		if (MatrixManager.IsTableAt(interaction.WorldPositionTarget.RoundToInt(), side == NetworkSide.Server))
+		{
+			return false;
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
### Purpose
Fixes #2165. Return false if a table is at the position so that cables can be placed on tables.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

