### PR TITLE
2030 Push Progress bars one tile up

### DIFF
--- a/UnityProject/Assets/Scripts/UI/ProgressBar/ProgressBar.cs
+++ b/UnityProject/Assets/Scripts/UI/ProgressBar/ProgressBar.cs
@@ -35,6 +35,7 @@ public class ProgressBar : NetworkBehaviour
 		string _additionalSfx = "", float _additionalSfxPitch = 1f, bool _allowTurning = true)
 	{
 		var _playerDirectional = _player.GetComponent<Directional>();
+		pos.y += 1;
 		playerProgress.Add(new PlayerProgressEntry
 		{
 			player = _player,


### PR DESCRIPTION
### Purpose
Fixes #2030.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
i have no idea if this is dumb or not
