### PR TITLE
Adds hand torches and extinguishers to fire cabinets

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Fire_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Unlockable/Closet_Fire_Red.prefab
@@ -203,7 +203,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  DefaultContents:
+  - {fileID: 1907679543779350, guid: 7920a824df456044381e381e90277a5d, type: 3}
+  - {fileID: 1907679543779350, guid: 7920a824df456044381e381e90277a5d, type: 3}
+  - {fileID: 1869747887731904, guid: 9c91a985c48aef648b219b1d267a9cab, type: 3}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -226,7 +229,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  parentContainer: {fileID: 0}
   isNotPushable: 0
 --- !u!114 &114440515152274470
 MonoBehaviour:
@@ -320,8 +322,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3724488775
+  m_AssetId: 4fdae0bf999fe4d8e9df1b81aecffa66
+  m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Items/Mining/Resources/Handheld Torch.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Items/Mining/Resources/Handheld Torch.prefab
@@ -280,7 +280,7 @@ MonoBehaviour:
   itemName: Lamp
   itemDescription: A Lamp
   itemType: 0
-  size: 2
+  size: 1
   spriteType: 0
   CanConnectToTank: 0
   hitDamage: 0
@@ -340,7 +340,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   LightEmission: {fileID: 0}
-  Intensity: 0.8
+  Intensity: 0.9
   Colour: {r: 0.990566, g: 0.96984947, b: 0.88309896, a: 1}
   EnumSprite: 0
   Size: 8


### PR DESCRIPTION
### Purpose
So you can see where you're going in the dark and put out fires
### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [n/a]  I correctly commented my code
- [ n/a]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
