### PR TITLE
Add racks and rack parts

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/Rack Parts.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/Rack Parts.prefab
@@ -1,0 +1,428 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6034371561869202664
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4381113110606243709}
+  - component: {fileID: 5335341827054386356}
+  - component: {fileID: 8267928415466736549}
+  - component: {fileID: 2959146656708143528}
+  - component: {fileID: 132348641917229106}
+  - component: {fileID: 8301933286516629790}
+  - component: {fileID: 7887144931197074431}
+  - component: {fileID: 4664957552587279702}
+  - component: {fileID: -1445245493585989624}
+  - component: {fileID: 2010458303386780433}
+  - component: {fileID: 490726123092147132}
+  - component: {fileID: 3118628355925246483}
+  - component: {fileID: 925564419828475077}
+  m_Layer: 10
+  m_Name: Rack Parts
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4381113110606243709
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2852747728811166626}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &5335341827054386356
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.047329515, y: -0.07709029}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.7853411, y: 0.4768201}
+  m_EdgeRadius: 0
+--- !u!114 &8267928415466736549
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &2959146656708143528
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  registerTile: {fileID: 0}
+  isNotPushable: 0
+--- !u!114 &132348641917229106
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteDataHandler: {fileID: 925564419828475077}
+  InventoryIcon: {fileID: 0}
+  itemName: Rack Parts
+  itemDescription: Parts of a rack.
+  itemType: 0
+  size: 3
+  spriteType: 0
+  CanConnectToTank: 0
+  hitDamage: 0
+  damageType: 0
+  throwDamage: 0
+  throwSpeed: 2
+  throwRange: 7
+  hitSound: GenericHit
+  attackVerb: []
+--- !u!114 &8301933286516629790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  layer: {fileID: 0}
+  ObjectType: 0
+  crossed:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &7887144931197074431
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteMatrixRotationBehavior: 1
+--- !u!114 &4664957552587279702
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  OnDropServer:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &-1445245493585989624
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 97fdf482368144449ed763bc3854f584, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rackPrefab: {fileID: 7144248469089430455, guid: f9d3bcbd125054bb4a8d60e18d3fcf34,
+    type: 3}
+--- !u!114 &2010458303386780433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &490726123092147132
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24590037b6b486082fc874d1bfd9d95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  Armor:
+    Melee: 0
+    Bullet: 0
+    Laser: 0
+    Energy: 0
+    Bomb: 0
+    Rad: 0
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+  initialIntegrity: 100
+--- !u!114 &3118628355925246483
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  serverOnly: 0
+  localPlayerAuthority: 0
+  m_AssetId: 5c6173d6c15c149ff82f936c14acb687
+  m_SceneId: 0
+--- !u!114 &925564419828475077
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Infos:
+    spriteIndex: 0
+    VariantIndex: 0
+    AID: 19
+    Serialized:
+    - inlistID: 2
+      listID: 3
+      sprite: {fileID: 21300000, guid: 72e2469af48db1a4d9bcde31113fbc5f, type: 3}
+      waitTime: 0
+    - inlistID: 1
+      listID: 2
+      sprite: {fileID: 0}
+      waitTime: 0
+    - inlistID: 4
+      listID: 5
+      sprite: {fileID: 21300002, guid: 72e2469af48db1a4d9bcde31113fbc5f, type: 3}
+      waitTime: 0
+    - inlistID: 1
+      listID: 4
+      sprite: {fileID: 0}
+      waitTime: 0
+    - inlistID: 6
+      listID: 7
+      sprite: {fileID: 21300004, guid: 72e2469af48db1a4d9bcde31113fbc5f, type: 3}
+      waitTime: 0
+    - inlistID: 1
+      listID: 6
+      sprite: {fileID: 0}
+      waitTime: 0
+    - inlistID: 8
+      listID: 9
+      sprite: {fileID: 21300006, guid: 72e2469af48db1a4d9bcde31113fbc5f, type: 3}
+      waitTime: 0
+    - inlistID: 1
+      listID: 8
+      sprite: {fileID: 0}
+      waitTime: 0
+    - inlistID: 0
+      listID: 1
+      sprite: {fileID: 0}
+      waitTime: 0
+    - inlistID: 11
+      listID: 12
+      sprite: {fileID: 21300000, guid: 322c32785aded4c4d93edb1591a2ef79, type: 3}
+      waitTime: 0
+    - inlistID: 10
+      listID: 11
+      sprite: {fileID: 0}
+      waitTime: 0
+    - inlistID: 13
+      listID: 14
+      sprite: {fileID: 21300002, guid: 322c32785aded4c4d93edb1591a2ef79, type: 3}
+      waitTime: 0
+    - inlistID: 10
+      listID: 13
+      sprite: {fileID: 0}
+      waitTime: 0
+    - inlistID: 15
+      listID: 16
+      sprite: {fileID: 21300004, guid: 322c32785aded4c4d93edb1591a2ef79, type: 3}
+      waitTime: 0
+    - inlistID: 10
+      listID: 15
+      sprite: {fileID: 0}
+      waitTime: 0
+    - inlistID: 17
+      listID: 18
+      sprite: {fileID: 21300006, guid: 322c32785aded4c4d93edb1591a2ef79, type: 3}
+      waitTime: 0
+    - inlistID: 10
+      listID: 17
+      sprite: {fileID: 0}
+      waitTime: 0
+    - inlistID: 0
+      listID: 10
+      sprite: {fileID: 0}
+      waitTime: 0
+  spriteList:
+  - {fileID: 21300000, guid: 72e2469af48db1a4d9bcde31113fbc5f, type: 3}
+  - {fileID: 21300000, guid: 322c32785aded4c4d93edb1591a2ef79, type: 3}
+--- !u!1 &9210611658135231461
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2852747728811166626}
+  - component: {fileID: 1708533548773404995}
+  m_Layer: 10
+  m_Name: BaseSprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2852747728811166626
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9210611658135231461}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4381113110606243709}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1708533548773404995
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9210611658135231461}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1463207863
+  m_SortingLayer: 11
+  m_SortingOrder: 660
+  m_Sprite: {fileID: 21300000, guid: 06cfdc9d61abc804f9b2b5806c13154f, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/Rack Parts.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/Rack Parts.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5c6173d6c15c149ff82f936c14acb687
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/Rack.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/Rack.prefab
@@ -1,0 +1,307 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2239508276124512771
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4963249456697642776}
+  - component: {fileID: 9179395053284328901}
+  m_Layer: 0
+  m_Name: BaseSprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4963249456697642776
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2239508276124512771}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1925386106379506438}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &9179395053284328901
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2239508276124512771}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -391668011
+  m_SortingLayer: 9
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: cc4288219ec7de0449099a04c31f2b07, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &7144248469089430455
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1925386106379506438}
+  - component: {fileID: 8819730959757270550}
+  - component: {fileID: 799095722577257379}
+  - component: {fileID: 4436606494572318361}
+  - component: {fileID: 74958767906644875}
+  - component: {fileID: 4216241947996897747}
+  - component: {fileID: 243253553239203302}
+  - component: {fileID: 2611605342679031968}
+  - component: {fileID: 1835757013911865864}
+  - component: {fileID: 3348285834374005981}
+  - component: {fileID: 8662366804555004195}
+  m_Layer: 11
+  m_Name: Rack
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1925386106379506438
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7144248469089430455}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4963249456697642776}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &8819730959757270550
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7144248469089430455}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.015, y: -0.06}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.91, y: 0.7}
+  m_EdgeRadius: 0
+--- !u!114 &799095722577257379
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7144248469089430455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &4436606494572318361
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7144248469089430455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  registerTile: {fileID: 0}
+  isNotPushable: 1
+--- !u!114 &74958767906644875
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7144248469089430455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a459a0316cc4d5b87d046f28dc136c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  layer: {fileID: 0}
+  ObjectType: 1
+  AtmosPassable: 1
+  Passable: 0
+--- !u!114 &4216241947996897747
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7144248469089430455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteMatrixRotationBehavior: 1
+--- !u!114 &243253553239203302
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7144248469089430455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 06cd60fceaba43eaac0fbddda1e4219d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  rackParts: {fileID: 6034371561869202664, guid: 5c6173d6c15c149ff82f936c14acb687,
+    type: 3}
+--- !u!114 &2611605342679031968
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7144248469089430455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1835757013911865864
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7144248469089430455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24590037b6b486082fc874d1bfd9d95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  Armor:
+    Melee: 0
+    Bullet: 0
+    Laser: 0
+    Energy: 0
+    Bomb: 0
+    Rad: 0
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+  initialIntegrity: 20
+--- !u!114 &3348285834374005981
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7144248469089430455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  serverOnly: 0
+  localPlayerAuthority: 0
+  m_AssetId: f9d3bcbd125054bb4a8d60e18d3fcf34
+  m_SceneId: 0
+--- !u!114 &8662366804555004195
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7144248469089430455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Infos:
+    spriteIndex: 0
+    VariantIndex: 0
+    AID: 0
+    Serialized: []
+  spriteList: []

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/Rack.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/Rack.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f9d3bcbd125054bb4a8d60e18d3fcf34
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -58,6 +58,8 @@ public class Integrity : NetworkBehaviour, IFireExposable, IRightClickable, IOnS
 	         " won't ignite.")]
 	public float HeatResistance = 100;
 
+	public float initialIntegrity = 100f;
+
 	[SyncVar(hook = nameof(SyncOnFire))]
 	private bool onFire = false;
 	private BurningOverlay burningObjectOverlay;
@@ -118,7 +120,7 @@ public class Integrity : NetworkBehaviour, IFireExposable, IRightClickable, IOnS
 		else
 		{
 			//spawned
-			integrity = 100f;
+			integrity = initialIntegrity;
 			timeSinceLastBurn = 0;
 			destroyed = false;
 			if (burningObjectOverlay != null)

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/Interactions/InventoryApply.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/Interactions/InventoryApply.cs
@@ -31,8 +31,8 @@ public class InventoryApply : TargetedInteraction
 	/// </summary>
 	/// <param name="performer">The gameobject of the player performing the InventoryApply</param>
 	/// <param name="handObject">Object in the player's active hand. Null if player's hand is empty.</param>
+	/// <param name="targetSlot">object that the player applying the used object to</param>
 	/// <param name="handSlot">hand slot of handObject</param>
-	/// <param name="targetObject">object that the player applying the used object to</param>
 	private InventoryApply(GameObject performer, GameObject handObject, InventorySlot targetSlot, HandSlot handSlot) :
 		base(performer, handObject, targetSlot.Item)
 	{

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/InteractionMessageUtils.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/InteractionMessageUtils.cs
@@ -40,7 +40,8 @@ public static class InteractionMessageUtils
 
 		if (!(processor is Component))
 		{
-			Logger.LogError("processor must be a component, but isn't. The message will not be sent.", Category.NetMessage);
+			Logger.LogError("processor must be a component, but isn't. The message will not be sent.",
+				Category.NetMessage);
 			return;
 		}
 
@@ -69,6 +70,11 @@ public static class InteractionMessageUtils
 		else if (typeof(T) == typeof(HandActivate))
 		{
 			RequestHandActivateMessage.Send(info as HandActivate, processorObject);
+			return;
+		}
+		else if (typeof(T) == typeof(InventoryApply))
+		{
+			RequestInventoryApplyMessage.Send(info as InventoryApply, processorObject);
 			return;
 		}
 

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInventoryApplyMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInventoryApplyMessage.cs
@@ -1,0 +1,77 @@
+using System.Collections;
+using Mirror;
+using UnityEngine;
+
+public class RequestInventoryApplyMessage : ClientMessage
+{
+	public static short MessageType = (short) MessageTypes.RequestInventoryApplyMessage;
+
+	//object that will process the interaction
+	public uint ProcessorObject;
+
+	public override IEnumerator Process()
+	{
+		yield return WaitFor(ProcessorObject);
+		var processorObj = NetworkObject;
+		var performerObj = SentByPlayer.GameObject;
+		var pna = SentByPlayer.Script.playerNetworkActions;
+		var handSlot = HandSlot.ForName(pna.activeHand);
+		var handObject = pna.Inventory[handSlot.equipSlot].Item;
+
+		ProcessActivate(processorObj, performerObj, pna.GetInventorySlot(processorObj), handObject, handSlot);
+	}
+
+	private void ProcessActivate(GameObject processorObj, GameObject performerObj, InventorySlot targetSlot,
+		GameObject handObject, HandSlot handSlot)
+	{
+		//try to look up the components on the processor that can handle this interaction
+		var processorComponents = InteractionMessageUtils.TryGetProcessors<InventoryApply>(processorObj);
+
+		//invoke each component that can handle this interaction
+		// GameObject clientPlayer, InventorySlot targetObjectSlot, GameObject handObject, HandSlot handSlot
+		var activate = InventoryApply.ByClient(performerObj, targetSlot, handObject, handSlot);
+		foreach (var processorComponent in processorComponents)
+		{
+			if (processorComponent.ServerProcessInteraction(activate))
+			{
+				//something happened, don't check further components
+				return;
+			}
+		}
+	}
+
+	/// <summary>
+	/// For most cases you should use InteractionMessageUtils.SendRequest() instead of this.
+	///
+	/// Sends a request to the server to validate + perform the interaction.
+	/// </summary>
+	/// <param name="inventoryApply">info on the interaction being performed. Each object involved in the interaction
+	/// must have a networkidentity.</param>
+	/// <param name="processorObject">object who has a component implementing IInteractionProcessor<Activate> which
+	/// will process the interaction on the server-side. This object must have a NetworkIdentity and there must only be one instance
+	/// of this component on the object. For organization, we suggest that the component which is sending this message
+	/// should be on the processorObject, as such this parameter should almost always be passed using "this.gameObject", and
+	/// should almost always be either a component on the target object or a component on the used object</param>
+	public static void Send(InventoryApply inventoryApply, GameObject processorObject)
+	{
+		var msg = new RequestInventoryApplyMessage
+		{
+			ProcessorObject = processorObject.GetComponent<NetworkIdentity>().netId
+		};
+		msg.Send();
+	}
+
+
+	public override void Deserialize(NetworkReader reader)
+	{
+		base.Deserialize(reader);
+		ProcessorObject = reader.ReadUInt32();
+	}
+
+	public override void Serialize(NetworkWriter writer)
+	{
+		base.Serialize(writer);
+		writer.WriteUInt32(ProcessorObject);
+	}
+
+}

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInventoryApplyMessage.cs.meta
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInventoryApplyMessage.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 48a0ad90080841dd9221c7c62bbe787f
+timeCreated: 1570921564

--- a/UnityProject/Assets/Scripts/Messages/MessageTypes.cs
+++ b/UnityProject/Assets/Scripts/Messages/MessageTypes.cs
@@ -70,7 +70,7 @@ internal enum MessageTypes : short
 	RequestHandApplyMessage = 2019,
 	RequestAimApplyMessage = 2020,
 	RequestHandActivateMessage = 2021,
-	// = 2022, unused, replace at will
+	RequestInventoryApplyMessage = 2022,
 	RequestPositionalHandApplyMessage = 2023,
 	RequestActivateMessage = 2024,
 	RequestToViewObjectsAtTile = 2026,

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -165,6 +165,21 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 		return false;
 	}
 
+	// If the player has item in an inventory slot, get it
+	[Server]
+	public InventorySlot GetInventorySlot(GameObject item)
+	{
+		foreach (var slot in Inventory)
+		{
+			if (item == slot.Value.Item)
+			{
+				return slot.Value;
+			}
+		}
+
+		return null;
+	}
+
 	private bool IsEquipSpriteSlot(InventorySlot slot)
 	{
 		return slot.IsUISlot;

--- a/UnityProject/Assets/Scripts/Storage/Rack.cs
+++ b/UnityProject/Assets/Scripts/Storage/Rack.cs
@@ -1,0 +1,60 @@
+using System;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+public class Rack : NBPositionalHandApplyInteractable
+{
+	public GameObject rackParts;
+
+	private Integrity integrity;
+
+	private void Start()
+	{
+		integrity = gameObject.GetComponent<Integrity>();
+		integrity.OnWillDestroyServer.AddListener(OnWillDestroyServer);
+	}
+
+	private void OnWillDestroyServer(DestructionInfo arg0)
+	{
+		PoolManager.PoolNetworkInstantiate(rackParts, gameObject.TileWorldPosition().To3Int(), transform.parent);
+	}
+
+	protected override bool WillInteract(PositionalHandApply interaction, NetworkSide side)
+	{
+		if (!base.WillInteract(interaction, side)) return false;
+
+		if (!DefaultWillInteract.PositionalHandApply(interaction, NetworkSide.Client)) return false;
+
+		return true;
+	}
+
+	protected override void ServerPerformInteraction(PositionalHandApply interaction)
+	{
+		PlayerNetworkActions pna = interaction.Performer.GetComponent<PlayerNetworkActions>();
+
+		if (interaction.HandObject == null)
+		{ // No item in hand, so let's TEACH THIS RACK A LESSON
+			UpdateChatMessage.Send(interaction.Performer, ChatChannel.Combat,
+				 interaction.Performer.ExpensiveName() + " kicks the rack.");
+			integrity.ApplyDamage(Random.Range(4, 8), AttackType.Melee, DamageType.Brute);
+			return;
+		}
+
+		// If the player is using a wrench on the rack, deconstruct it
+		if (Validations.IsTool(interaction.HandObject, ToolType.Wrench)
+		    && !interaction.Performer.Player().Script.playerMove.IsHelpIntent)
+		{
+			SoundManager.PlayNetworkedAtPos("Wrench", interaction.WorldPositionTarget, 1f);
+			PoolManager.PoolNetworkInstantiate(rackParts, interaction.WorldPositionTarget.RoundToInt(),
+				interaction.TargetObject.transform.parent);
+			PoolManager.PoolNetworkDestroy(gameObject);
+
+			return;
+		}
+
+		// Like a table, but everything is neatly stacked.
+		Vector3 targetPosition = interaction.WorldPositionTarget.RoundToInt();
+		targetPosition.z = -0.2f;
+		pna.CmdPlaceItem(interaction.HandSlot.equipSlot, targetPosition, interaction.Performer, true);
+	}
+}

--- a/UnityProject/Assets/Scripts/Storage/Rack.cs.meta
+++ b/UnityProject/Assets/Scripts/Storage/Rack.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 06cd60fceaba43eaac0fbddda1e4219d
+timeCreated: 1570841917

--- a/UnityProject/Assets/Scripts/Storage/RackParts.cs
+++ b/UnityProject/Assets/Scripts/Storage/RackParts.cs
@@ -1,0 +1,103 @@
+using UnityEngine;
+
+public class RackParts : Interactable<PositionalHandApply, InventoryApply>
+{
+
+	public GameObject rackPrefab;
+	private bool isBuilding;
+
+	protected override bool WillInteract(PositionalHandApply interaction, NetworkSide side)
+	{
+		if (!base.WillInteract(interaction, side))
+		{
+			return false;
+		}
+
+		if (Validations.IsTool(interaction.HandObject, ToolType.Wrench))
+		{
+			return true;
+		}
+
+		// Must be constructing the rack somewhere empty
+		var vector = interaction.WorldPositionTarget.RoundToInt();
+		if (!MatrixManager.IsPassableAt(vector, vector, false))
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	protected override bool WillInteractT2(InventoryApply interaction, NetworkSide side)
+	{
+		if (!base.WillInteractT2(interaction, side))
+		{
+			return false;
+		}
+
+		if (interaction.TargetObject != gameObject
+		    || !Validations.IsTool(interaction.HandObject, ToolType.Wrench))
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	protected override void ServerPerformInteraction(PositionalHandApply interaction)
+	{
+		if (Validations.IsTool(interaction.HandObject, ToolType.Wrench))
+		{
+			SoundManager.PlayNetworkedAtPos("Wrench", interaction.WorldPositionTarget, 1f);
+			ObjectFactory.SpawnMetal(1, interaction.WorldPositionTarget.To2Int(), parent: transform.parent);
+			PoolManager.PoolNetworkDestroy(gameObject);
+
+			return;
+		}
+
+		if (isBuilding)
+		{
+			return;
+		}
+
+		UpdateChatMessage.Send(interaction.Performer, ChatChannel.Examine,
+			"You start constructing a rack...");
+
+		var progressFinishAction = new FinishProgressAction(
+			reason =>
+			{
+				if (reason == FinishProgressAction.FinishReason.INTERRUPTED)
+				{
+					isBuilding = false;
+				}
+				else if (reason == FinishProgressAction.FinishReason.COMPLETED)
+				{
+					UpdateChatMessage.Send(interaction.Performer, ChatChannel.Examine,
+						"You assemble a rack.");
+
+					PoolManager.PoolNetworkInstantiate(rackPrefab, interaction.WorldPositionTarget.RoundToInt(), interaction.Performer.transform.parent);
+
+					var handObj = interaction.HandObject;
+					var slot = InventoryManager.GetSlotFromOriginatorHand(interaction.Performer, interaction.HandSlot.equipSlot);
+					handObj.GetComponent<Pickupable>().DisappearObject(slot);
+
+					isBuilding = false;
+				}
+			}
+		);
+		isBuilding = true;
+
+		UIManager.ProgressBar.StartProgress(interaction.WorldPositionTarget.RoundToInt(),
+			5f, progressFinishAction, interaction.Performer);
+	}
+
+	protected override void ServerPerformInteraction(InventoryApply interaction)
+	{
+		SoundManager.PlayNetworkedAtPos("Wrench", interaction.Performer.WorldPosServer(), 1f);
+		ObjectFactory.SpawnMetal(1, interaction.Performer.WorldPosServer().To2Int(), parent: transform.parent);
+
+		var rack = interaction.TargetObject;
+		var slot = InventoryManager.GetSlotFromOriginatorHand(interaction.Performer, interaction.TargetSlot.equipSlot);
+		rack.GetComponent<Pickupable>().DisappearObject(slot);
+	}
+}

--- a/UnityProject/Assets/Scripts/Storage/RackParts.cs.meta
+++ b/UnityProject/Assets/Scripts/Storage/RackParts.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 97fdf482368144449ed763bc3854f584
+timeCreated: 1570907743


### PR DESCRIPTION
### Purpose
Adds racks. Racks function similarly to tables, but all items placed go into the center. They can be deconstructed by using a wrench in a non-help intent, then deconstructed again into a piece of metal. Clicking the ground while holding rack parts will build a new rack at that spot.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)


