### PR TITLE
#2209 Allow adding solid plasma to plasma canisters

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/BaseCanister.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/BaseCanister.prefab
@@ -343,6 +343,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 1000
+  initialIntegrity: 100
 --- !u!114 &114835659847540804
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -357,8 +358,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: e9620f26b24f33c4cbe56a85ae95865d
-  m_SceneId: 0
+  m_AssetId: 
+  m_SceneId: 3771512773
 --- !u!1 &3261001144065486905
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/BaseCanister.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/BaseCanister.prefab
@@ -91,6 +91,7 @@ GameObject:
   - component: {fileID: 4854478120677698}
   - component: {fileID: 61143840767580364}
   - component: {fileID: 61645807559194036}
+  - component: {fileID: 4239973459482825917}
   - component: {fileID: 114271548548165924}
   - component: {fileID: 6725492196284391236}
   - component: {fileID: 114623103168110180}
@@ -176,6 +177,22 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &4239973459482825917
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1513316462072450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 931d5444a5bf4c9aa3be62ecbf046740, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  gasContainer: {fileID: 114104253718565984}
+  molesAdded: 15000
 --- !u!114 &114271548548165924
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -358,8 +375,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3771512773
+  m_AssetId: e9620f26b24f33c4cbe56a85ae95865d
+  m_SceneId: 0
 --- !u!1 &3261001144065486905
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/PlasmaCanister.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/PlasmaCanister.prefab
@@ -1,21 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &8439127588548344762
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8375170143500002732}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 931d5444a5bf4c9aa3be62ecbf046740, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  gasContainer: {fileID: 8478753847137821518}
-  molesAdded: 15000
 --- !u!1001 &8376682685256562478
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -254,21 +238,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e9620f26b24f33c4cbe56a85ae95865d, type: 3}
---- !u!1 &8375170143500002732 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1513316462072450, guid: e9620f26b24f33c4cbe56a85ae95865d,
-    type: 3}
-  m_PrefabInstance: {fileID: 8376682685256562478}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &8478753847137821518 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 114104253718565984, guid: e9620f26b24f33c4cbe56a85ae95865d,
-    type: 3}
-  m_PrefabInstance: {fileID: 8376682685256562478}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8375170143500002732}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cf6a312c50114272bc561c429cbb4175, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/PlasmaCanister.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/PlasmaCanister.prefab
@@ -1,5 +1,21 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &8439127588548344762
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8375170143500002732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 931d5444a5bf4c9aa3be62ecbf046740, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  gasContainer: {fileID: 8478753847137821518}
+  molesAdded: 15000
 --- !u!1001 &8376682685256562478
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -54,6 +70,16 @@ PrefabInstance:
     - target: {fileID: 4854478120677698, guid: e9620f26b24f33c4cbe56a85ae95865d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114104253718565984, guid: e9620f26b24f33c4cbe56a85ae95865d,
+        type: 3}
+      propertyPath: Gases.Array.data[0]
+      value: 60933
+      objectReference: {fileID: 0}
+    - target: {fileID: 114104253718565984, guid: e9620f26b24f33c4cbe56a85ae95865d,
+        type: 3}
+      propertyPath: ReleasePressure
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 114271548548165924, guid: e9620f26b24f33c4cbe56a85ae95865d,
         type: 3}
@@ -124,16 +150,6 @@ PrefabInstance:
         type: 3}
       propertyPath: ContentsName
       value: Plasma
-      objectReference: {fileID: 0}
-    - target: {fileID: 114104253718565984, guid: e9620f26b24f33c4cbe56a85ae95865d,
-        type: 3}
-      propertyPath: Gases.Array.data[0]
-      value: 60933
-      objectReference: {fileID: 0}
-    - target: {fileID: 114104253718565984, guid: e9620f26b24f33c4cbe56a85ae95865d,
-        type: 3}
-      propertyPath: ReleasePressure
-      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 114615155852173970, guid: e9620f26b24f33c4cbe56a85ae95865d,
         type: 3}
@@ -238,3 +254,21 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e9620f26b24f33c4cbe56a85ae95865d, type: 3}
+--- !u!1 &8375170143500002732 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1513316462072450, guid: e9620f26b24f33c4cbe56a85ae95865d,
+    type: 3}
+  m_PrefabInstance: {fileID: 8376682685256562478}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8478753847137821518 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 114104253718565984, guid: e9620f26b24f33c4cbe56a85ae95865d,
+    type: 3}
+  m_PrefabInstance: {fileID: 8376682685256562478}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8375170143500002732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf6a312c50114272bc561c429cbb4175, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Scripts/Objects/PlasmaAddable.cs
+++ b/UnityProject/Assets/Scripts/Objects/PlasmaAddable.cs
@@ -1,0 +1,64 @@
+
+/**
+ * This is a temporary component to be used while we do not have a system for converting solid plasma
+ * into liquid plasma. When this is implemented, this component is to be deleted.
+ */
+
+using Atmospherics;
+using Objects;
+using UnityEngine;
+
+public class PlasmaAddable : NBHandApplyInteractable, IRightClickable
+{
+	public GasContainer gasContainer;
+	public float molesAdded = 15000f;
+
+	protected override bool WillInteract(HandApply interaction, NetworkSide side)
+	{
+		if (!base.WillInteract(interaction, side))
+		{
+			return false;
+		}
+
+		if (interaction.TargetObject != gameObject
+		    || interaction.HandObject == null
+		    || interaction.HandObject.GetComponent<SolidPlasma>() == null)
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	protected override void ServerPerformInteraction(HandApply interaction)
+	{
+		var handObj = interaction.HandObject;
+
+		if (handObj.GetComponent<SolidPlasma>() == null)
+		{
+			return;
+		}
+
+		var slot = InventoryManager.GetSlotFromOriginatorHand(interaction.Performer, interaction.HandSlot.equipSlot);
+		handObj.GetComponent<Pickupable>().DisappearObject(slot);
+		
+		gasContainer.GasMix = gasContainer.GasMix.AddGasReturn(Gas.Plasma, molesAdded);
+	}
+
+	public RightClickableResult GenerateRightClickOptions()
+	{
+		var result = RightClickableResult.Create();
+
+		if (WillInteract(HandApply.ByLocalPlayer(gameObject), NetworkSide.Client))
+		{
+			result.AddElement("Add Solid Plasma", RightClickInteract);
+		}
+
+		return result;
+	}
+
+	private void RightClickInteract()
+	{
+		Interact(HandApply.ByLocalPlayer(gameObject), nameof(PlasmaAddable));
+	}
+}

--- a/UnityProject/Assets/Scripts/Objects/PlasmaAddable.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/PlasmaAddable.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 931d5444a5bf4c9aa3be62ecbf046740
+timeCreated: 1571615216

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -189,6 +189,15 @@ namespace Atmospherics
 			RecalculateTemperatureCache();
 		}
 
+		public GasMix AddGasReturn(Gas gas, float moles)
+		{
+			TemperatureCache = Temperature;
+			Gases[gas] += moles;
+
+			RecalculateTemperatureCache();
+			return (this);
+		}
+
 		public void RemoveGas(Gas gas, float moles)
 		{
 			TemperatureCache = Temperature;


### PR DESCRIPTION
### Purpose
Fixes #2209. Allows right clicking with plasma in hand to add to a plasma canister. 

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  Any new / changed components have been [tested using Respawn](https://github.com/unitystation/unitystation/wiki/Object-Lifecycle-Best-Practices)
- [x]  This PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
I didn't know how to balance this at all, so 1 sheet of plasma adds 15000 moles, which is about 1/4 of a tank. It's easy enough to change.
