### PR TITLE
Fixed ghost chat, added verbs and styled chat messages to be more like TG station

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatSystem.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatSystem.prefab
@@ -1942,7 +1942,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   oocColor: {r: 0.378471, g: 0.6692517, b: 0.990566, a: 1}
-  ghostColor: {r: 0.21960784, g: 0.41568628, b: 1, a: 1}
+  ghostColor: {r: 0.7208526, g: 0.76941305, b: 0.9150943, a: 1}
   binaryColor: {r: 1, g: 0, b: 1, a: 1}
   supplyColor: {r: 1, g: 0.8051446, b: 0.3066038, a: 1}
   centComColor: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 public partial class Chat
 {
@@ -67,14 +66,14 @@ public partial class Chat
 		//Check for OOC. If selected, remove all other channels and modifiers (could happen if UI fucks up or someone tampers with it)
 		if (channels.HasFlag(ChatChannel.OOC))
 		{
-			message = AddMsgColor(channels, $"<b>{speaker}: {message}</b>");
+			message = AddMsgColor(channels, $"[ooc] <b>{speaker}: {message}</b>");
 			return message;
 		}
 
 		//Ghosts don't get modifiers
 		if (channels.HasFlag(ChatChannel.Ghost))
 		{
-			return AddMsgColor(channels, $"<b>{speaker}: ") + $"<color=white>{message}</b></color>";
+			return AddMsgColor(channels, $"[dead] <b>{speaker}</b>: {message}");
 		}
 
 		message = ApplyModifiers(message, modifiers);
@@ -83,7 +82,32 @@ public partial class Chat
 			return "";
 		}
 
-		return AddMsgColor(channels, $"<b>{speaker}</b> says:") + "<color=white> \"" + message + "\"</color>";
+		var verb = "says:";
+		var toUpperCheck = message.ToUpper(CultureInfo.InvariantCulture);
+
+		if (message.Contains("!") && toUpperCheck != message){
+			verb = "exclaims,";
+		}
+
+		if (toUpperCheck == message)
+		{
+			verb = "yells,";
+			message = $"<b>{message}</b>";
+		}
+
+		var chan = $"[{channels.ToString().ToLower().Substring(0, 3)}] ";
+
+		if (channels.HasFlag(ChatChannel.Command))
+		{
+			chan = "[cmd] ";
+		}
+
+		if (channels.HasFlag(ChatChannel.Local))
+		{
+			chan = "";
+		}
+		
+		return AddMsgColor(channels, $"{chan}<b>{speaker}</b> {verb} " + "\"" + message + "\"");
 	}
 
 	private static string StripTags(string input)


### PR DESCRIPTION
### Purpose
- Extended channel colors to the whole entry and adjusted format to be more like tg chat
- Added 'exclaims' and 'yells' verbs
- Added channel tags to the front of messages
![image](https://user-images.githubusercontent.com/20813925/67348199-81e26a00-f587-11e9-9674-35c9ab1b31e4.png)

- fixed ghost chat:
![image](https://user-images.githubusercontent.com/20813925/67348292-c241e800-f587-11e9-8216-c3e6adc88403.png)

