### PR TITLE
Adds Chat feed scroll bar hiding events

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatSystem.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatSystem.prefab
@@ -1983,6 +1983,8 @@ MonoBehaviour:
   toggleChatBubbleImage: {fileID: 8272338613766088271}
   toggleOffCol: {r: 0.2735849, g: 0.2735849, b: 0.2735849, a: 1}
   toggleOnCol: {r: 0.30980393, g: 0.46274513, b: 0.6117647, a: 1}
+  scrollHandle: {fileID: 2807939661053576224}
+  scrollBackground: {fileID: 50052018069764188}
 --- !u!1 &1100739055192324531
 GameObject:
   m_ObjectHideFlags: 0
@@ -2570,7 +2572,7 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
@@ -2658,7 +2660,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.27607688, g: 0.35021952, b: 0.41509432, a: 1}
+  m_Color: {r: 0.40988785, g: 0.493755, b: 0.5754717, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatSystem.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatSystem.prefab
@@ -2613,6 +2613,7 @@ GameObject:
   - component: {fileID: 5333097039435445460}
   - component: {fileID: 2236887876137949243}
   - component: {fileID: 2807939661053576224}
+  - component: {fileID: 5187137510668436110}
   m_Layer: 5
   m_Name: Handle
   m_TagString: Untagged
@@ -2635,7 +2636,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -2675,6 +2676,46 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5187137510668436110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5476938683763610884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25d16e8ae69e73845a42e760d1ffddab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  onPointerDownEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114720228895401702}
+        m_MethodName: OnScrollBarInteract
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  onPointerUpEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 114720228895401702}
+        m_MethodName: OnScrollBarInteractEnd
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &6866044044155091702
 GameObject:
   m_ObjectHideFlags: 0
@@ -3311,15 +3352,15 @@ PrefabInstance:
       objectReference: {fileID: 1897758349740974}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a311e2bde4b0f554c980666c969a060c, type: 3}
---- !u!1 &8380570029279695647 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5590516185401122086, guid: a311e2bde4b0f554c980666c969a060c,
-    type: 3}
-  m_PrefabInstance: {fileID: 4168157131774070329}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &942134156153933411 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3804247380278558810, guid: a311e2bde4b0f554c980666c969a060c,
+    type: 3}
+  m_PrefabInstance: {fileID: 4168157131774070329}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8380570029279695647 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5590516185401122086, guid: a311e2bde4b0f554c980666c969a060c,
     type: 3}
   m_PrefabInstance: {fileID: 4168157131774070329}
   m_PrefabAsset: {fileID: 0}
@@ -3441,15 +3482,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 115e79e65ed316546aea2bf6ffdcc366, type: 3}
---- !u!224 &9021516341056411997 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 224321409555159418, guid: 115e79e65ed316546aea2bf6ffdcc366,
-    type: 3}
-  m_PrefabInstance: {fileID: 9092255765942517799}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &9091622191222137699 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1618776996635460, guid: 115e79e65ed316546aea2bf6ffdcc366,
+    type: 3}
+  m_PrefabInstance: {fileID: 9092255765942517799}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &9021516341056411997 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 224321409555159418, guid: 115e79e65ed316546aea2bf6ffdcc366,
     type: 3}
   m_PrefabInstance: {fileID: 9092255765942517799}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -106,7 +106,7 @@ public partial class Chat
 		{
 			chan = "";
 		}
-		
+
 		return AddMsgColor(channels, $"{chan}<b>{speaker}</b> {verb} " + "\"" + message + "\"");
 	}
 

--- a/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
@@ -3,97 +3,131 @@ using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class ChatEntry : MonoBehaviour {
-
-    public Text text;
-    private bool isCoolingDown = true;
+public class ChatEntry : MonoBehaviour
+{
+	public Text text;
+	private bool isCoolingDown = true;
 	public RectTransform rect;
 
 	private Coroutine coCoolDown;
 	private bool isHidden = false;
 
-    void OnEnable()
-    {
-        EventManager.AddHandler(EVENT.ChatFocused, OnChatFocused);
-        EventManager.AddHandler(EVENT.ChatUnfocused, OnChatUnfocused);
-        if (!ChatUI.Instance.chatInputWindow.gameObject.activeInHierarchy){
-            if (isCoolingDown)
-            {
+	void OnEnable()
+	{
+		EventManager.AddHandler(EVENT.ChatFocused, OnChatFocused);
+		EventManager.AddHandler(EVENT.ChatUnfocused, OnChatUnfocused);
+		ChatUI.Instance.scrollBarEvent += OnScrollInteract;
+		if (!ChatUI.Instance.chatInputWindow.gameObject.activeInHierarchy)
+		{
+			if (isCoolingDown)
+			{
 				coCoolDown = StartCoroutine(CoolDown());
-            }
-        }
-    }
+			}
+		}
+	}
 
-    void OnDisable()
-    {
-        EventManager.RemoveHandler(EVENT.ChatFocused, OnChatFocused);
-        EventManager.RemoveHandler(EVENT.ChatUnfocused, OnChatUnfocused);
-    }
+	void OnDisable()
+	{
+		EventManager.RemoveHandler(EVENT.ChatFocused, OnChatFocused);
+		EventManager.RemoveHandler(EVENT.ChatUnfocused, OnChatUnfocused);
+	}
 
-    public void OnChatFocused()
-    {
-        if (isCoolingDown)
-        {
-			if (coCoolDown != null) {
+	public void OnDestroy()
+	{
+		if (ChatUI.Instance != null)
+		{
+			ChatUI.Instance.scrollBarEvent -= OnScrollInteract;
+			if (isHidden)
+			{
+				ChatUI.Instance.ReportEntryState(false);
+			}
+		}
+	}
+
+	public void OnChatFocused()
+	{
+		if (isCoolingDown)
+		{
+			if (coCoolDown != null)
+			{
 				StopCoroutine(coCoolDown);
 				coCoolDown = null;
 			}
-        }
-        text.CrossFadeAlpha(1f, 0f, false);
-        if (isHidden)
-        {
-	        isHidden = false;
-	        ChatUI.Instance.ReportEntryState(false);
-        }
-    }
+		}
 
-    public void OnChatUnfocused()
-    {
-        if (isCoolingDown)
-        {
+		text.CrossFadeAlpha(1f, 0f, false);
+		if (isHidden)
+		{
+			isHidden = false;
+			ChatUI.Instance.ReportEntryState(false);
+		}
+	}
+
+	public void OnChatUnfocused()
+	{
+		if (isCoolingDown)
+		{
 			coCoolDown = StartCoroutine(CoolDown());
-        } else
-        {
-            text.CrossFadeAlpha(0f, 0f, false);
-            if (!isHidden)
-            {
-	            isHidden = true;
-	            ChatUI.Instance.ReportEntryState(true);
-            }
-        }
-    }
+		}
+		else
+		{
+			text.CrossFadeAlpha(0f, 0f, false);
+			if (!isHidden)
+			{
+				isHidden = true;
+				ChatUI.Instance.ReportEntryState(true);
+			}
+		}
+	}
 
-    IEnumerator CoolDown()
-    {
+	IEnumerator CoolDown()
+	{
 		Vector2 sizeDelta = rect.sizeDelta;
 		sizeDelta.x = 472f;
 		rect.sizeDelta = sizeDelta;
-        yield return WaitFor.Seconds(12f);
-        if (!ChatUI.Instance.chatInputWindow.gameObject.activeInHierarchy)
-        {
-            text.CrossFadeAlpha(0.01f, 3f, false);
-        } else
-        {
-            yield break;
-        }
-        yield return WaitFor.Seconds(3f);
-        isCoolingDown = false;
+		yield return WaitFor.Seconds(12f);
+		if (!ChatUI.Instance.chatInputWindow.gameObject.activeInHierarchy)
+		{
+			text.CrossFadeAlpha(0.01f, 3f, false);
+			if (!isHidden)
+			{
+				isHidden = true;
+				ChatUI.Instance.ReportEntryState(true, true);
+			}
+		}
+		else
+		{
+			yield break;
+		}
 
-        if (!isHidden)
-        {
-	        isHidden = true;
-	        ChatUI.Instance.ReportEntryState(true);
-        }
-    }
+		yield return WaitFor.Seconds(3f);
+		isCoolingDown = false;
+	}
 
-    public void OnDestroy()
-    {
-	    if (ChatUI.Instance != null)
-	    {
-		    if (isHidden)
-		    {
-			    ChatUI.Instance.ReportEntryState(false);
-		    }
-	    }
-    }
+	//state = is mouse button down on the scroll bar handle
+	private void OnScrollInteract(bool state)
+	{
+		if (isHidden && state)
+		{
+			text.CrossFadeAlpha(1f, 0f, false);
+			isHidden = false;
+			ChatUI.Instance.ReportEntryState(false);
+		}
+
+		if (!isHidden && !state
+		              && !ChatUI.Instance.chatInputWindow.gameObject.activeInHierarchy)
+		{
+			if (isCoolingDown)
+			{
+				if (coCoolDown != null)
+				{
+					StopCoroutine(coCoolDown);
+					coCoolDown = null;
+				}
+			}
+
+			isCoolingDown = true;
+			coCoolDown = StartCoroutine(CoolDown());
+		}
+	}
 }

--- a/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -9,6 +10,7 @@ public class ChatEntry : MonoBehaviour {
 	public RectTransform rect;
 
 	private Coroutine coCoolDown;
+	private bool isHidden = false;
 
     void OnEnable()
     {
@@ -38,6 +40,11 @@ public class ChatEntry : MonoBehaviour {
 			}
         }
         text.CrossFadeAlpha(1f, 0f, false);
+        if (isHidden)
+        {
+	        isHidden = false;
+	        ChatUI.Instance.ReportEntryState(false);
+        }
     }
 
     public void OnChatUnfocused()
@@ -48,6 +55,11 @@ public class ChatEntry : MonoBehaviour {
         } else
         {
             text.CrossFadeAlpha(0f, 0f, false);
+            if (!isHidden)
+            {
+	            isHidden = true;
+	            ChatUI.Instance.ReportEntryState(true);
+            }
         }
     }
 
@@ -66,5 +78,22 @@ public class ChatEntry : MonoBehaviour {
         }
         yield return WaitFor.Seconds(3f);
         isCoolingDown = false;
+
+        if (!isHidden)
+        {
+	        isHidden = true;
+	        ChatUI.Instance.ReportEntryState(true);
+        }
+    }
+
+    public void OnDestroy()
+    {
+	    if (ChatUI.Instance != null)
+	    {
+		    if (isHidden)
+		    {
+			    ChatUI.Instance.ReportEntryState(false);
+		    }
+	    }
     }
 }

--- a/UnityProject/Assets/Scripts/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatRelay.cs
@@ -176,11 +176,7 @@ public class ChatRelay : NetworkBehaviour
 
 		if (channels != ChatChannel.None)
 		{
-			GameObject chatEntry = Instantiate(ChatUI.Instance.chatEntryPrefab, Vector3.zero, Quaternion.identity);
-			Text text = chatEntry.GetComponent<Text>();
-			text.text = message;
-			chatEntry.transform.SetParent(ChatUI.Instance.content, false);
-			chatEntry.transform.localScale = Vector3.one;
+			ChatUI.Instance.AddChatEntry(message);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Events.meta
+++ b/UnityProject/Assets/Scripts/UI/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a8892640e17dbf54ca387577bc49221e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/Events/PointerDownUpTrigger.cs
+++ b/UnityProject/Assets/Scripts/UI/Events/PointerDownUpTrigger.cs
@@ -1,0 +1,30 @@
+﻿using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.Events;
+
+/// <summary>
+/// Use this in areas where you need to get around an Event Trigger consuming all the events
+/// (i.e. if you add an event trigger to the handle of the scroll bar, the scroll bar does not
+/// work anymore. So use custom scripts that use the IPointer interfaces instead)
+/// </summary>
+public class PointerDownUpTrigger : MonoBehaviour, IPointerDownHandler, IPointerUpHandler
+{
+	public UnityEvent onPointerDownEvent;
+	public UnityEvent onPointerUpEvent;
+
+	public void OnPointerDown(PointerEventData eventData)
+	{
+		if (onPointerDownEvent != null)
+		{
+			onPointerDownEvent.Invoke();
+		}
+	}
+
+	public void OnPointerUp(PointerEventData eventData)
+	{
+		if (onPointerUpEvent != null)
+		{
+			onPointerUpEvent.Invoke();
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/UI/Events/PointerDownUpTrigger.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/Events/PointerDownUpTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25d16e8ae69e73845a42e760d1ffddab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
- Conveniently hides the scroll bar when not needed
- Allows the ability to view the full chat stream without going into the chat prompt by clicking on the edge of the screen where the scroll bar is hidden and holding down the mouse button. This will show the scroll bar and chat feed and allow you to scroll through it. Letting go of the mouse button causes the chat feed to be shown for a few seconds before fading out again