### PR TITLE
Adds Chat Collapsing to duplicated chat messages

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatEntry.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatEntry.prefab
@@ -31,7 +31,8 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.37314814, y: 0.37314814, z: 0.37314814}
-  m_Children: []
+  m_Children:
+  - {fileID: 2000913768062860772}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -108,6 +109,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   text: {fileID: 114303381418770216}
   rect: {fileID: 224781789997769250}
+  stackTimesObj: {fileID: 4585939312796838426}
 --- !u!114 &5076524011034038868
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -123,3 +125,76 @@ MonoBehaviour:
   m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
   m_EffectDistance: {x: 2, y: -2}
   m_UseGraphicAlpha: 1
+--- !u!1 &4585939312796838426
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2000913768062860772}
+  - component: {fileID: 1769979081924563562}
+  - component: {fileID: 6621845892192530244}
+  m_Layer: 5
+  m_Name: StackObj
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2000913768062860772
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4585939312796838426}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224781789997769250}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 325.64294, y: 10.025054}
+  m_SizeDelta: {x: 31.15, y: 22.55}
+  m_Pivot: {x: -0.6, y: 0.5}
+--- !u!222 &1769979081924563562
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4585939312796838426}
+  m_CullTransparentMesh: 0
+--- !u!114 &6621845892192530244
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4585939312796838426}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.0017437935, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 71b4caebf7d1f51418e2f3b0e70d3bfd, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatEntry.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatEntry.prefab
@@ -159,11 +159,11 @@ RectTransform:
   m_Father: {fileID: 224781789997769250}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 325.64288, y: -4.485039}
-  m_SizeDelta: {x: 31.15, y: 22.55}
-  m_Pivot: {x: -0.6, y: 0.3}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 9.599976, y: 9.5}
+  m_SizeDelta: {x: 31.150024, y: 22.55}
+  m_Pivot: {x: -0.6, y: 0.5}
 --- !u!222 &1769979081924563562
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatEntry.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatEntry.prefab
@@ -110,6 +110,7 @@ MonoBehaviour:
   text: {fileID: 114303381418770216}
   rect: {fileID: 224781789997769250}
   stackTimesObj: {fileID: 4585939312796838426}
+  stackTimesText: {fileID: 4940237022917455902}
 --- !u!114 &5076524011034038868
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -142,7 +143,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2000913768062860772
 RectTransform:
   m_ObjectHideFlags: 0
@@ -153,15 +154,16 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 8409342325046921093}
   m_Father: {fileID: 224781789997769250}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 325.64294, y: 10.025054}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 325.64288, y: -4.485039}
   m_SizeDelta: {x: 31.15, y: 22.55}
-  m_Pivot: {x: -0.6, y: 0.5}
+  m_Pivot: {x: -0.6, y: 0.3}
 --- !u!222 &1769979081924563562
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -183,7 +185,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0.0017437935, b: 1, a: 1}
+  m_Color: {r: 0.8396226, g: 0.21782663, b: 0.3421857, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -198,3 +200,80 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5904897521658884244
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8409342325046921093}
+  - component: {fileID: 9073771508466571109}
+  - component: {fileID: 4940237022917455902}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8409342325046921093
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5904897521658884244}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.40936, y: 0.40936, z: 0.40936}
+  m_Children: []
+  m_Father: {fileID: 2000913768062860772}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.3600006, y: 1.05}
+  m_SizeDelta: {x: 58.59, y: 49.97}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9073771508466571109
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5904897521658884244}
+  m_CullTransparentMesh: 0
+--- !u!114 &4940237022917455902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5904897521658884244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 54
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 54
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: x4

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatSystem.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatSystem.prefab
@@ -1016,7 +1016,7 @@ MonoBehaviour:
   m_ChildAlignment: 6
   m_Spacing: 4
   m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
+  m_ChildForceExpandHeight: 0
   m_ChildControlWidth: 0
   m_ChildControlHeight: 1
   m_ChildScaleWidth: 0

--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatSystem.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Chat/ChatSystem.prefab
@@ -434,12 +434,12 @@ RectTransform:
   m_Children:
   - {fileID: 224576715969102918}
   m_Father: {fileID: 8533227384194854147}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -9.9999695, y: 3.346283}
-  m_SizeDelta: {x: -64.3, y: -41.3}
+  m_AnchoredPosition: {x: -87.3002, y: 3.3346863}
+  m_SizeDelta: {x: -219.00002, y: -41.323254}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &114372616190709386
 MonoBehaviour:
@@ -2505,17 +2505,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3727012269302036365}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4549032093832692454}
   m_Father: {fileID: 8533227384194854147}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -239, y: 12.5}
+  m_AnchoredPosition: {x: -316.2998, y: 12.488341}
   m_SizeDelta: {x: 20, y: 590.7}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8808882025034335762
@@ -2596,7 +2596,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2807939661053576224}
   m_HandleRect: {fileID: 5333097039435445460}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -2636,7 +2636,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -3081,15 +3081,15 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 224798581258123564}
   - {fileID: 9207531746528235545}
+  - {fileID: 224798581258123564}
   m_Father: {fileID: 224450798116547786}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.000012218952}
-  m_SizeDelta: {x: 0.0000022053719, y: -0.2232542}
+  m_AnchoredPosition: {x: 77.3, y: -0.000012218952}
+  m_SizeDelta: {x: 154.7, y: -0.2}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &2579559975836504402
 CanvasRenderer:

--- a/UnityProject/Assets/Scripts/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.cs
@@ -67,13 +67,13 @@ public partial class Chat : MonoBehaviour
 			return;
 		}
 
+		//Check if the player is allowed to talk:
 		if (player.playerHealth != null)
 		{
 			if (player.playerHealth.IsCrit || player.playerHealth.IsCardiacArrest)
 			{
 				if (!player.playerHealth.IsDead)
 				{
-
 					return;
 				}
 				else
@@ -81,308 +81,318 @@ public partial class Chat : MonoBehaviour
 					channels = ChatChannel.Ghost;
 				}
 			}
+			else
+			{
+				if (!player.playerHealth.IsDead && !player.IsGhost)
+				{
+					{
+						//Control the chat bubble
+						player.playerNetworkActions.CmdToggleChatIcon(true, message, channels);
+					}
+				}
+			}
 		}
 
 		// There could be multiple channels we need to send a message for each.
-		// We do this on the server side that local chans can be determined correctly
-		foreach (Enum value in Enum.GetValues(channels.GetType()))
-		{
-			if (channels.HasFlag((ChatChannel) value))
+			// We do this on the server side that local chans can be determined correctly
+			foreach (Enum value in Enum.GetValues(channels.GetType()))
 			{
-				//Using HasFlag will always return true for flag at value 0 so skip it
-				if ((ChatChannel) value == ChatChannel.None) continue;
+				if (channels.HasFlag((ChatChannel) value))
+				{
+					//Using HasFlag will always return true for flag at value 0 so skip it
+					if ((ChatChannel) value == ChatChannel.None) continue;
 
-				if (IsNamelessChan((ChatChannel) value)) continue;
+					if (IsNamelessChan((ChatChannel) value)) continue;
 
-				chatEvent.channels = (ChatChannel) value;
-				Instance.addChatLogServer.Invoke(chatEvent);
+					chatEvent.channels = (ChatChannel) value;
+					Instance.addChatLogServer.Invoke(chatEvent);
+				}
 			}
 		}
-	}
 
-	/// <summary>
-	/// Adds a system message to all players on the given matrix
-	/// You must color your own system messages as they are not done automatically!
-	/// Server side only
-	/// </summary>
-	/// <param name="message"> message to add to each clients chat stream</param>
-	/// <param name="stationMatrix"> the matrix to broadcast the message too</param>
-	public static void AddSystemMsgToChat(string message, MatrixInfo stationMatrix)
-	{
-		if (!IsServer()) return;
-
-		Instance.addChatLogServer.Invoke(new ChatEvent
+		/// <summary>
+		/// Adds a system message to all players on the given matrix
+		/// You must color your own system messages as they are not done automatically!
+		/// Server side only
+		/// </summary>
+		/// <param name="message"> message to add to each clients chat stream</param>
+		/// <param name="stationMatrix"> the matrix to broadcast the message too</param>
+		public static void AddSystemMsgToChat(string message, MatrixInfo stationMatrix)
 		{
-			message = message,
-			channels = ChatChannel.System,
-			matrix = stationMatrix
-		});
-	}
+			if (!IsServer()) return;
 
-	/// <summary>
-	/// For game wide system messages like admin messages or
-	/// messages related to the round itself.
-	/// You must color your own system messages as they are not done automatically!
-	/// </summary>
-	public static void AddGameWideSystemMsgToChat(string message)
-	{
-		if (!IsServer()) return;
-
-		Instance.addChatLogServer.Invoke(new ChatEvent
-		{
-			message = message,
-			channels = ChatChannel.System
-		});
-	}
-
-	/// <summary>
-	/// For all general action based messages (i.e. The clown hugged runtime)
-	/// Do not use this method for combat messages
-	/// Remember to only use this server side
-	/// </summary>
-	/// <param name="originator"> The player who caused the action</param>
-	/// <param name="originatorMessage"> The message that should be given to the originator only (i.e you hugged ian) </param>
-	/// <param name="othersMessage"> The message that will be shown to other players (i.e. Cuban Pete hugged ian)</param>
-	public static void AddActionMsgToChat(GameObject originator, string originatorMessage,
-		string othersMessage)
-	{
-		if (!IsServer()) return;
-
-		Instance.addChatLogServer.Invoke(new ChatEvent
-		{
-			channels = ChatChannel.Action,
-			speaker = originator.name,
-			message = originatorMessage,
-			messageOthers = othersMessage,
-			position = originator.transform.position,
-			originator = originator
-		});
-	}
-
-	/// <summary>
-	/// Use this for general combat messages
-	/// </summary>
-	/// <param name="originator"> Who is doing the attacking</param>
-	/// <param name="originatorMsg"> The message to be shown to the originator</param>
-	/// <param name="othersMsg"> The message to be shown to everyone else</param>
-	/// <param name="hitZone"> Hitzone of the attack on the victim</param>
-	public static void AddCombatMsgToChat(GameObject originator, string originatorMsg,
-		string othersMsg, BodyPartType hitZone = BodyPartType.None)
-	{
-		if (!IsServer()) return;
-
-		Instance.addChatLogServer.Invoke(new ChatEvent
-		{
-			channels = ChatChannel.Combat,
-			message = originatorMsg,
-			messageOthers = othersMsg,
-			speaker = originator.name,
-			position = originator.transform.position,
-			originator = originator
-		});
-	}
-
-	/// <summary>
-	/// Sends a message to all players about an attack that took place
-	/// </summary>
-	/// <param name="attacker">GameObject of the player that attacked</param>
-	/// <param name="victim">GameObject of the player hat was the victim</param>
-	/// <param name="damage">damage done</param>
-	/// <param name="hitZone">zone that was damaged</param>
-	/// <param name="item">optional gameobject with an itemattributes, representing the item the attack was made with</param>
-	/// <param name="customAttackVerb">If you want to override the attack verb then pass the verb here</param>
-	public static void AddAttackMsgToChat(GameObject attacker, GameObject victim,
-		BodyPartType hitZone = BodyPartType.None, GameObject item = null, string customAttackVerb = "")
-	{
-		string attackVerb;
-		string attack;
-
-		if (item)
-		{
-			var itemAttributes = item.GetComponent<ItemAttributes>();
-			attackVerb = itemAttributes.attackVerb.GetRandom() ?? "attacked";
-			attack = $" with {itemAttributes.itemName}";
-		}
-		else
-		{
-			// Punch attack as there is no item.
-			attackVerb = "punched";
-			attack = "";
-		}
-
-		if (!string.IsNullOrEmpty(customAttackVerb))
-		{
-			attackVerb = customAttackVerb;
-		}
-
-		var player = victim.Player();
-		if (player == null)
-		{
-			hitZone = BodyPartType.None;
-		}
-
-		string victimName;
-		string victimNameOthers = "";
-		if (attacker == victim)
-		{
-			victimName = "yourself";
-			if (player != null)
+			Instance.addChatLogServer.Invoke(new ChatEvent
 			{
-				if (player.Script.characterSettings.Gender == Gender.Female)
-				{
-					victimNameOthers = "herself";
-				}
+				message = message,
+				channels = ChatChannel.System,
+				matrix = stationMatrix
+			});
+		}
 
-				if (player.Script.characterSettings.Gender == Gender.Male)
-				{
-					victimNameOthers = "himself";
-				}
+		/// <summary>
+		/// For game wide system messages like admin messages or
+		/// messages related to the round itself.
+		/// You must color your own system messages as they are not done automatically!
+		/// </summary>
+		public static void AddGameWideSystemMsgToChat(string message)
+		{
+			if (!IsServer()) return;
 
-				if (player.Script.characterSettings.Gender == Gender.Neuter)
+			Instance.addChatLogServer.Invoke(new ChatEvent
+			{
+				message = message,
+				channels = ChatChannel.System
+			});
+		}
+
+		/// <summary>
+		/// For all general action based messages (i.e. The clown hugged runtime)
+		/// Do not use this method for combat messages
+		/// Remember to only use this server side
+		/// </summary>
+		/// <param name="originator"> The player who caused the action</param>
+		/// <param name="originatorMessage"> The message that should be given to the originator only (i.e you hugged ian) </param>
+		/// <param name="othersMessage"> The message that will be shown to other players (i.e. Cuban Pete hugged ian)</param>
+		public static void AddActionMsgToChat(GameObject originator, string originatorMessage,
+			string othersMessage)
+		{
+			if (!IsServer()) return;
+
+			Instance.addChatLogServer.Invoke(new ChatEvent
+			{
+				channels = ChatChannel.Action,
+				speaker = originator.name,
+				message = originatorMessage,
+				messageOthers = othersMessage,
+				position = originator.transform.position,
+				originator = originator
+			});
+		}
+
+		/// <summary>
+		/// Use this for general combat messages
+		/// </summary>
+		/// <param name="originator"> Who is doing the attacking</param>
+		/// <param name="originatorMsg"> The message to be shown to the originator</param>
+		/// <param name="othersMsg"> The message to be shown to everyone else</param>
+		/// <param name="hitZone"> Hitzone of the attack on the victim</param>
+		public static void AddCombatMsgToChat(GameObject originator, string originatorMsg,
+			string othersMsg, BodyPartType hitZone = BodyPartType.None)
+		{
+			if (!IsServer()) return;
+
+			Instance.addChatLogServer.Invoke(new ChatEvent
+			{
+				channels = ChatChannel.Combat,
+				message = originatorMsg,
+				messageOthers = othersMsg,
+				speaker = originator.name,
+				position = originator.transform.position,
+				originator = originator
+			});
+		}
+
+		/// <summary>
+		/// Sends a message to all players about an attack that took place
+		/// </summary>
+		/// <param name="attacker">GameObject of the player that attacked</param>
+		/// <param name="victim">GameObject of the player hat was the victim</param>
+		/// <param name="damage">damage done</param>
+		/// <param name="hitZone">zone that was damaged</param>
+		/// <param name="item">optional gameobject with an itemattributes, representing the item the attack was made with</param>
+		/// <param name="customAttackVerb">If you want to override the attack verb then pass the verb here</param>
+		public static void AddAttackMsgToChat(GameObject attacker, GameObject victim,
+			BodyPartType hitZone = BodyPartType.None, GameObject item = null, string customAttackVerb = "")
+		{
+			string attackVerb;
+			string attack;
+
+			if (item)
+			{
+				var itemAttributes = item.GetComponent<ItemAttributes>();
+				attackVerb = itemAttributes.attackVerb.GetRandom() ?? "attacked";
+				attack = $" with {itemAttributes.itemName}";
+			}
+			else
+			{
+				// Punch attack as there is no item.
+				attackVerb = "punched";
+				attack = "";
+			}
+
+			if (!string.IsNullOrEmpty(customAttackVerb))
+			{
+				attackVerb = customAttackVerb;
+			}
+
+			var player = victim.Player();
+			if (player == null)
+			{
+				hitZone = BodyPartType.None;
+			}
+
+			string victimName;
+			string victimNameOthers = "";
+			if (attacker == victim)
+			{
+				victimName = "yourself";
+				if (player != null)
+				{
+					if (player.Script.characterSettings.Gender == Gender.Female)
+					{
+						victimNameOthers = "herself";
+					}
+
+					if (player.Script.characterSettings.Gender == Gender.Male)
+					{
+						victimNameOthers = "himself";
+					}
+
+					if (player.Script.characterSettings.Gender == Gender.Neuter)
+					{
+						victimNameOthers = "itself";
+					}
+				}
+				else
 				{
 					victimNameOthers = "itself";
 				}
 			}
 			else
 			{
-				victimNameOthers = "itself";
+				victimName = victim.ExpensiveName();
+				victimNameOthers = victimName;
 			}
-		}
-		else
-		{
-			victimName = victim.ExpensiveName();
-			victimNameOthers = victimName;
-		}
 
-		var attackerName = attacker.Player()?.Name;
-		if (string.IsNullOrEmpty(attackerName))
-		{
-			var mobAi = attacker.GetComponent<MobAI>();
-			if (mobAi != null)
+			var attackerName = attacker.Player()?.Name;
+			if (string.IsNullOrEmpty(attackerName))
 			{
-				attackerName = mobAi.mobName;
+				var mobAi = attacker.GetComponent<MobAI>();
+				if (mobAi != null)
+				{
+					attackerName = mobAi.mobName;
+				}
+				else
+				{
+					attackerName = "Unknown";
+				}
 			}
-			else
+
+			var messageOthers = $"{attackerName} has {attackVerb} {victimNameOthers}{InTheZone(hitZone)}{attack}!";
+			var message = $"You {attackVerb} {victimName}{InTheZone(hitZone)}{attack}!";
+
+			Instance.addChatLogServer.Invoke(new ChatEvent
 			{
-				attackerName = "Unknown";
-			}
+				channels = ChatChannel.Combat,
+				message = message,
+				messageOthers = messageOthers,
+				position = attacker.transform.position,
+				speaker = attacker.name,
+				originator = attacker
+			});
 		}
 
-		var messageOthers = $"{attackerName} has {attackVerb} {victimNameOthers}{InTheZone(hitZone)}{attack}!";
-		var message = $"You {attackVerb} {victimName}{InTheZone(hitZone)}{attack}!";
-
-		Instance.addChatLogServer.Invoke(new ChatEvent
+		/// <summary>
+		/// Adds a hit msg from a thrown item to all nearby players chat stream
+		/// Serverside only
+		/// </summary>
+		public static void AddThrowHitMsgToChat(GameObject item, GameObject victim,
+			BodyPartType hitZone = BodyPartType.None)
 		{
-			channels = ChatChannel.Combat,
-			message = message,
-			messageOthers = messageOthers,
-			position = attacker.transform.position,
-			speaker = attacker.name,
-			originator = attacker
-		});
-	}
+			if (!IsServer()) return;
 
-	/// <summary>
-	/// Adds a hit msg from a thrown item to all nearby players chat stream
-	/// Serverside only
-	/// </summary>
-	public static void AddThrowHitMsgToChat(GameObject item, GameObject victim,
-		BodyPartType hitZone = BodyPartType.None)
-	{
-		if (!IsServer()) return;
-
-		var player = victim.Player();
-		if (player == null)
-		{
-			hitZone = BodyPartType.None;
-		}
-
-		var message =
-			$"{victim.ExpensiveName()} has been hit by {item.Item()?.itemName ?? item.name}{InTheZone(hitZone)}";
-		Instance.addChatLogServer.Invoke(new ChatEvent
-		{
-			channels = ChatChannel.Combat,
-			message = message,
-			position = victim.transform.position
-		});
-	}
-
-	/// <summary>
-	/// For any other local messages that are not an Action or a Combat Action.
-	/// I.E for machines
-	/// Server side only
-	/// </summary>
-	/// <param name="message">The message to show in the chat stream</param>
-	/// <param name="worldPos">The position of the local message</param>
-	public static void AddLocalMsgToChat(string message, Vector2 worldPos)
-	{
-		if (!IsServer()) return;
-
-		Instance.addChatLogServer.Invoke(new ChatEvent
-		{
-			channels = ChatChannel.Local,
-			message = message,
-			position = worldPos
-		});
-	}
-
-	/// <summary>
-	/// Used on the server to send examine messages to a player
-	/// Server only
-	/// </summary>
-	/// <param name="recipient">The player object to send the message too</param>
-	/// <param name="msg">The examine message</param>
-	public static void AddExamineMsgFromServer(GameObject recipient, string msg)
-	{
-		if (!IsServer()) return;
-		UpdateChatMessage.Send(recipient, ChatChannel.Examine, ChatModifier.None, msg);
-	}
-
-	/// <summary>
-	/// Used on the client for examine messages.
-	/// Use client side only!
-	/// </summary>
-	/// <param name="message"> The message to add to the client chat stream</param>
-	public static void AddExamineMsgToClient(string message)
-	{
-		Instance.addChatLogClient.Invoke(message, ChatChannel.Examine);
-	}
-
-	/// <summary>
-	/// This should only be called via UpdateChatMessage
-	/// on the client. Do not use for anything else!
-	/// </summary>
-	public static void ProcessUpdateChatMessage(uint recipient, uint originator, string message,
-		string messageOthers, ChatChannel channels, ChatModifier modifiers, string speaker)
-	{
-		//If there is a message in MessageOthers then determine
-		//if it should be the main message or not.
-		if (!string.IsNullOrEmpty(messageOthers))
-		{
-			//This is not the originator so use the messageOthers
-			if (recipient != originator)
+			var player = victim.Player();
+			if (player == null)
 			{
-				message = messageOthers;
+				hitZone = BodyPartType.None;
 			}
+
+			var message =
+				$"{victim.ExpensiveName()} has been hit by {item.Item()?.itemName ?? item.name}{InTheZone(hitZone)}";
+			Instance.addChatLogServer.Invoke(new ChatEvent
+			{
+				channels = ChatChannel.Combat,
+				message = message,
+				position = victim.transform.position
+			});
 		}
 
-		var msg = ProcessMessageFurther(message, speaker, channels, modifiers);
-		Instance.addChatLogClient.Invoke(msg, channels);
-	}
-
-	private static string InTheZone(BodyPartType hitZone)
-	{
-		return hitZone == BodyPartType.None ? "" : $" in the {hitZone.ToString().ToLower().Replace("_", " ")}";
-	}
-
-	private static bool IsServer()
-	{
-		if (!CustomNetworkManager.Instance._isServer)
+		/// <summary>
+		/// For any other local messages that are not an Action or a Combat Action.
+		/// I.E for machines
+		/// Server side only
+		/// </summary>
+		/// <param name="message">The message to show in the chat stream</param>
+		/// <param name="worldPos">The position of the local message</param>
+		public static void AddLocalMsgToChat(string message, Vector2 worldPos)
 		{
-			Logger.LogError("A server only method was called on a client in chat.cs", Category.Chat);
-			return false;
+			if (!IsServer()) return;
+
+			Instance.addChatLogServer.Invoke(new ChatEvent
+			{
+				channels = ChatChannel.Local,
+				message = message,
+				position = worldPos
+			});
 		}
 
-		return true;
+		/// <summary>
+		/// Used on the server to send examine messages to a player
+		/// Server only
+		/// </summary>
+		/// <param name="recipient">The player object to send the message too</param>
+		/// <param name="msg">The examine message</param>
+		public static void AddExamineMsgFromServer(GameObject recipient, string msg)
+		{
+			if (!IsServer()) return;
+			UpdateChatMessage.Send(recipient, ChatChannel.Examine, ChatModifier.None, msg);
+		}
+
+		/// <summary>
+		/// Used on the client for examine messages.
+		/// Use client side only!
+		/// </summary>
+		/// <param name="message"> The message to add to the client chat stream</param>
+		public static void AddExamineMsgToClient(string message)
+		{
+			Instance.addChatLogClient.Invoke(message, ChatChannel.Examine);
+		}
+
+		/// <summary>
+		/// This should only be called via UpdateChatMessage
+		/// on the client. Do not use for anything else!
+		/// </summary>
+		public static void ProcessUpdateChatMessage(uint recipient, uint originator, string message,
+			string messageOthers, ChatChannel channels, ChatModifier modifiers, string speaker)
+		{
+			//If there is a message in MessageOthers then determine
+			//if it should be the main message or not.
+			if (!string.IsNullOrEmpty(messageOthers))
+			{
+				//This is not the originator so use the messageOthers
+				if (recipient != originator)
+				{
+					message = messageOthers;
+				}
+			}
+
+			var msg = ProcessMessageFurther(message, speaker, channels, modifiers);
+			Instance.addChatLogClient.Invoke(msg, channels);
+		}
+
+		private static string InTheZone(BodyPartType hitZone)
+		{
+			return hitZone == BodyPartType.None ? "" : $" in the {hitZone.ToString().ToLower().Replace("_", " ")}";
+		}
+
+		private static bool IsServer()
+		{
+			if (!CustomNetworkManager.Instance._isServer)
+			{
+				Logger.LogError("A server only method was called on a client in chat.cs", Category.Chat);
+				return false;
+			}
+
+			return true;
+		}
 	}
-}

--- a/UnityProject/Assets/Scripts/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.cs
@@ -49,6 +49,7 @@ public partial class Chat : MonoBehaviour
 	{
 		var player = sentByPlayer.Script;
 
+
 		var chatEvent = new ChatEvent
 		{
 			message = message,
@@ -66,11 +67,27 @@ public partial class Chat : MonoBehaviour
 			return;
 		}
 
+		if (player.playerHealth != null)
+		{
+			if (player.playerHealth.IsCrit || player.playerHealth.IsCardiacArrest)
+			{
+				if (!player.playerHealth.IsDead)
+				{
+
+					return;
+				}
+				else
+				{
+					channels = ChatChannel.Ghost;
+				}
+			}
+		}
+
 		// There could be multiple channels we need to send a message for each.
 		// We do this on the server side that local chans can be determined correctly
 		foreach (Enum value in Enum.GetValues(channels.GetType()))
 		{
-			if (channels.HasFlag((ChatChannel)value))
+			if (channels.HasFlag((ChatChannel) value))
 			{
 				//Using HasFlag will always return true for flag at value 0 so skip it
 				if ((ChatChannel) value == ChatChannel.None) continue;
@@ -230,7 +247,6 @@ public partial class Chat : MonoBehaviour
 			{
 				victimNameOthers = "itself";
 			}
-
 		}
 		else
 		{
@@ -251,6 +267,7 @@ public partial class Chat : MonoBehaviour
 				attackerName = "Unknown";
 			}
 		}
+
 		var messageOthers = $"{attackerName} has {attackVerb} {victimNameOthers}{InTheZone(hitZone)}{attack}!";
 		var message = $"You {attackVerb} {victimName}{InTheZone(hitZone)}{attack}!";
 

--- a/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
@@ -171,8 +171,12 @@ public class ChatEntry : MonoBehaviour
 		}
 	}
 
+	private bool stackPosSet = false;
 	void SetStackPos()
 	{
+		if (stackPosSet) return;
+		stackPosSet = true;
+
 		string _text = text.text;
 
 		TextGenerator textGen = new TextGenerator(_text.Length);
@@ -182,8 +186,17 @@ public class ChatEntry : MonoBehaviour
 		{
 			return;
 		}
-		stackTimesObj.transform.localPosition =
-			textGen.verts[textGen.vertexCount - 1].position / text.canvas.scaleFactor;
+
+		var newPos = stackTimesObj.transform.localPosition;
+		newPos.x = (textGen.verts[textGen.vertexCount - 1].position / text.canvas.scaleFactor).x;
+
+
+		if (rect.rect.height < 30f)
+		{
+			newPos.y += 3.5f * rect.localScale.y;
+		}
+
+		stackTimesObj.transform.localPosition = newPos;
 	}
 
 	void SetCrossFadeAlpha(float amt, float time)

--- a/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using IngameDebugConsole;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -11,6 +12,7 @@ public class ChatEntry : MonoBehaviour
 
 	private Coroutine coCoolDown;
 	private bool isHidden = false;
+	public GameObject stackTimesObj;
 
 	void OnEnable()
 	{
@@ -85,6 +87,8 @@ public class ChatEntry : MonoBehaviour
 		Vector2 sizeDelta = rect.sizeDelta;
 		sizeDelta.x = 472f;
 		rect.sizeDelta = sizeDelta;
+		yield return WaitFor.EndOfFrame;
+		SetStackPos();
 		yield return WaitFor.Seconds(12f);
 		if (!ChatUI.Instance.chatInputWindow.gameObject.activeInHierarchy)
 		{
@@ -129,5 +133,18 @@ public class ChatEntry : MonoBehaviour
 			isCoolingDown = true;
 			coCoolDown = StartCoroutine(CoolDown());
 		}
+	}
+
+	[ContextMenu("Force Stack Position")]
+	void SetStackPos()
+	{
+		string _text = text.text;
+
+		TextGenerator textGen = new TextGenerator(_text.Length);
+		Vector2 extents = text.gameObject.GetComponent<RectTransform>().rect.size;
+		textGen.Populate(_text, text.GetGenerationSettings(extents));
+
+		stackTimesObj.transform.localPosition =
+			textGen.verts[textGen.vertexCount - 1].position / text.canvas.scaleFactor;
 	}
 }

--- a/UnityProject/Assets/Scripts/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatRelay.cs
@@ -156,6 +156,8 @@ public class ChatRelay : NetworkBehaviour
 	[Client]
 	private void UpdateClientChat(string message, ChatChannel channels)
 	{
+		if (string.IsNullOrEmpty(message)) return;
+		
 		if (UIManager.Instance.ttsToggle)
 		{
 			//Text to Speech:

--- a/UnityProject/Assets/Scripts/Chat/ChatUI.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatUI.cs
@@ -47,9 +47,8 @@ public class ChatUI : MonoBehaviour
 	/// </summary>
 	private Dictionary<ChatChannel, GameObject> ActiveChannels = new Dictionary<ChatChannel, GameObject>();
 
-	//All the current chat entries in the chat feed. It's a queue so they are easier to trim
-	//if needed in the future
-	private Queue<ChatEntry> allEntries = new Queue<ChatEntry>();
+	//All the current chat entries in the chat feed
+	private List<ChatEntry> allEntries = new List<ChatEntry>();
 	private int hiddenEntries = 0;
 	private bool scrollBarInteract = false;
 	public event Action<bool> scrollBarEvent;
@@ -179,12 +178,22 @@ public class ChatUI : MonoBehaviour
 	/// </summary>
 	public void AddChatEntry(string message)
 	{
+		//Check for chat entry dupes:
+		if (allEntries.Count != 0)
+		{
+			if (message.Equals(allEntries[allEntries.Count - 1].text.text))
+			{
+				allEntries[allEntries.Count - 1].AddChatDuplication();
+				return;
+			}
+		}
+
 		GameObject entry = Instantiate(chatEntryPrefab, Vector3.zero, Quaternion.identity);
 		var chatEntry = entry.GetComponent<ChatEntry>();
 		chatEntry.text.text = message;
 		entry.transform.SetParent(content, false);
 		entry.transform.localScale = Vector3.one;
-		allEntries.Enqueue(chatEntry);
+		allEntries.Add(chatEntry);
 		hiddenEntries++;
 		ReportEntryState(false);
 	}

--- a/UnityProject/Assets/Scripts/Chat/ChatUI.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatUI.cs
@@ -285,31 +285,7 @@ public class ChatUI : MonoBehaviour
 	{
 		// Selected channels already masks all unavailable channels in it's get method
 		PostToChatMessage.Send(InputFieldChat.text, SelectedChannels);
-
-		if (PlayerChatShown())
-		{
-			PlayerManager.LocalPlayerScript.playerNetworkActions.CmdToggleChatIcon(true, InputFieldChat.text,
-				SelectedChannels);
-		}
-
 		InputFieldChat.text = "";
-	}
-
-	/// <summary>
-	/// Check if player should show a speech balloon
-	/// </summary>
-	private bool PlayerChatShown()
-	{
-		// Don't show if player is talking in OOC, dead, crit, or sent an empty message
-		if (SelectedChannels.Equals(ChatChannel.OOC) ||
-		    PlayerManager.LocalPlayerScript.IsGhost ||
-		    PlayerManager.LocalPlayerScript.playerHealth.IsCrit ||
-		    InputFieldChat.text == "")
-		{
-			return false;
-		}
-
-		return true;
 	}
 
 	public void OnChatCancel()

--- a/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs
@@ -15,13 +15,11 @@ public class PostToChatMessage : ClientMessage
 	{
 		if (SentByPlayer != ConnectedPlayer.Invalid)
 		{
-			if (ValidRequest(SentByPlayer)) {
-				Chat.AddChatMsgToChat(SentByPlayer, ChatMessageText, Channels);
-			}
+			Chat.AddChatMsgToChat(SentByPlayer, ChatMessageText, Channels);
 		}
 		yield return null;
 	}
-	
+
 	//This is only used to send the chat input on the client to the server
 	public static PostToChatMessage Send(string message, ChatChannel channels)
 	{
@@ -33,26 +31,6 @@ public class PostToChatMessage : ClientMessage
 		msg.Send();
 
 		return msg;
-	}
-
-	public bool ValidRequest(ConnectedPlayer player)
-	{
-		//Need to add system channel here so player can transmit system level events but not select it in the UI
-		ChatChannel availableChannels = ChatChannel.System;
-		if (player.Script == null)
-		{
-			availableChannels |= ChatChannel.OOC;
-		}
-		else
-		{
-			availableChannels |= player.Script.GetAvailableChannelsMask();
-		}
-
-		if ((availableChannels & Channels) == Channels)
-		{
-			return true;
-		}
-		return false;
 	}
 
 	public override void Deserialize(NetworkReader reader)

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -480,8 +480,9 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	[Command]
 	public void CmdToggleChatIcon(bool turnOn, string message, ChatChannel chatChannel)
 	{
-		if (!playerScript.pushPull.VisibleState || (playerScript.mind.jobType == JobType.NULL)
-		                                        || playerScript.playerHealth.IsDead || playerScript.playerHealth.IsCrit)
+		if (!playerScript.pushPull.VisibleState || (playerScript.mind.jobType == JobType.NULL) ||
+		    playerScript.playerHealth.IsDead || playerScript.playerHealth.IsCrit ||
+		    playerScript.playerHealth.IsCardiacArrest)
 		{
 			//Don't do anything with chat icon if player is invisible or not spawned in
 			//This will also prevent clients from snooping other players local chat messages that aren't visible to them

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -226,7 +226,13 @@ public class PlayerScript : ManagedNetworkBehaviour
 
 	public ChatChannel GetAvailableChannelsMask(bool transmitOnly = true)
 	{
-		if (IsGhost)
+		var isDeadOrGhost = IsGhost;
+		if (playerHealth != null)
+		{
+			isDeadOrGhost = playerHealth.IsDead;
+		}
+
+		if (isDeadOrGhost)
 		{
 			ChatChannel ghostTransmitChannels = ChatChannel.Ghost | ChatChannel.OOC;
 			ChatChannel ghostReceiveChannels = ChatChannel.Examine | ChatChannel.System | ChatChannel.Combat;


### PR DESCRIPTION
### Purpose
- Messages now collapse if there is two identical ones in a row: 
![image](https://user-images.githubusercontent.com/20813925/68367701-00dbc300-0182-11ea-841c-ca2ecb3b63c0.png)


### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  Any new / changed components have been [tested using Respawn](https://github.com/unitystation/unitystation/wiki/Object-Lifecycle-Best-Practices)
- [x]  This PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
