### PR TITLE
Fixed grenade animation with new inventory system

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Weapons/Explosive/Grenade.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Weapons/Explosive/Grenade.prefab
@@ -253,6 +253,7 @@ MonoBehaviour:
   maxEffectDuration: 0.25
   minEffectDuration: 0.05
   spriteHandler: {fileID: 13680737134351771}
+  pickupable: {fileID: 114110293052994112}
 --- !u!114 &114110293052994112
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Purpose
Fixed grenade animation with new inventory system (#1755 again)
Fixed bug when destroyed grenade explodes in (0, 0, -100)
Validate, that grenade now destroys correctly (#2231)

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  Any new / changed components have been [tested using Respawn](https://github.com/unitystation/unitystation/wiki/Proper-Spawning-and-Despawning-%28Object-Lifecycle%29)
- [x]  This PR has been tested with round restarts.
- [ ]  This PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
