### PR TITLE
Attempt 3 - Fix large tab updates exceeding max packet size

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/Client/TabInteractMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/TabInteractMessage.cs
@@ -68,10 +68,10 @@ public class TabInteractMessage : ClientMessage
 		}
 	}
 
-	private TabUpdateMessage FailValidation( ConnectedPlayer player, GameObject tabProvider, string reason="" ) {
+	private void FailValidation( ConnectedPlayer player, GameObject tabProvider, string reason="" ) {
 
 		Logger.LogWarning( $"{player.Name}: Tab interaction w/{tabProvider} denied: {reason}",Category.NetUI );
-		return TabUpdateMessage.Send( player.GameObject, tabProvider, NetTabType, TabAction.Close );
+		TabUpdateMessage.Send( player.GameObject, tabProvider, NetTabType, TabAction.Close );
 	}
 
 	public static TabInteractMessage Send( GameObject tabProvider, NetTabType netTabType, string elementId, string elementValue = "-1" )

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Mirror;
 using UnityEngine;
 using Random = UnityEngine.Random;
@@ -255,5 +256,28 @@ public static class SweetExtensions
 			return output.ToArray();
 
 		return null;
+	}
+
+	/// <summary>
+	/// Splits an enumerable into chunks of a specified size
+	/// Credit to: https://extensionmethod.net/csharp/ienumerable/ienumerable-chunk
+	/// </summary>
+	/// <param name="list"></param>
+	/// <param name="chunkSize"></param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	/// <exception cref="ArgumentException"></exception>
+	public static IEnumerable<IEnumerable<T>> Chunk<T>(this IEnumerable<T> list, int chunkSize)
+	{
+		if (chunkSize <= 0)
+		{
+			throw new ArgumentException("chunkSize must be greater than 0.");
+		}
+
+		while (list.Any())
+		{
+			yield return list.Take(chunkSize);
+			list = list.Skip(chunkSize);
+		}
 	}
 }


### PR DESCRIPTION
### Purpose
Fixes #2251 

Note- also includes #2275 so please merge that first.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  Any new / changed components have been [tested using Respawn](https://github.com/unitystation/unitystation/wiki/Proper-Spawning-and-Despawning-%28Object-Lifecycle%29)
- [x]  This PR has been tested with round restarts.
- [x]  This PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
@fomalsd may want to see this since I think he was the main person working on tabs.