### PR TITLE
Fix for #1859 - Added belt trait to emergency oxygen tank

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Prefabs/Items/Other/Resources/Emergency Oxygen Tank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Prefabs/Items/Other/Resources/Emergency Oxygen Tank.prefab
@@ -199,7 +199,8 @@ MonoBehaviour:
   itemName: Emergency Oxygen Tank
   itemDescription: Used for emergencies. Contains very little oxygen, so try to conserve
     it until you actually need it.
-  initialTraits: []
+  initialTraits:
+  - {fileID: 11400000, guid: 5eafba0d7388d428c8e08ed1b5d5d260, type: 2}
   size: 1
   spriteType: 0
   CanConnectToTank: 0


### PR DESCRIPTION
### Purpose
Fixes #1859 by adding belt trait to the emergency oxygen tank prefab

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  Any new / changed components have been [tested using Respawn](https://github.com/unitystation/unitystation/wiki/Proper-Spawning-and-Despawning-%28Object-Lifecycle%29)
- [ ]  This PR has been tested with round restarts.
- [ ]  This PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
