### PR TITLE
#1748 Add in hands for clothing item

### DIFF
--- a/UnityProject/Assets/Resources/textures/clothing/back/Gray backpack/grey backpack.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/back/Gray backpack/grey backpack.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: grey backpack
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 11
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: e56068607c4ca6e4598963f8e42236de, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: e56068607c4ca6e4598963f8e42236de, type: 3}
       EquippedData: {fileID: 4900000, guid: 05739b9db6411b441a496f356199d793, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 34f40c1b80830724ebd33fa86a7df9c8, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 34f40c1b80830724ebd33fa86a7df9c8, type: 3}
+      - {fileID: 21300002, guid: 34f40c1b80830724ebd33fa86a7df9c8, type: 3}
+      - {fileID: 21300004, guid: 34f40c1b80830724ebd33fa86a7df9c8, type: 3}
+      - {fileID: 21300006, guid: 34f40c1b80830724ebd33fa86a7df9c8, type: 3}
+      EquippedData: {fileID: 4900000, guid: 0218b36ba5efdd8489729b4540ccf0ff, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 55cf6a4d1d1f9874794c147837009ffd, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 55cf6a4d1d1f9874794c147837009ffd, type: 3}
+      - {fileID: 21300002, guid: 55cf6a4d1d1f9874794c147837009ffd, type: 3}
+      - {fileID: 21300004, guid: 55cf6a4d1d1f9874794c147837009ffd, type: 3}
+      - {fileID: 21300006, guid: 55cf6a4d1d1f9874794c147837009ffd, type: 3}
+      EquippedData: {fileID: 4900000, guid: fbf4dd5cb95b77440848285812761829, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 298efc3197e5fd34f87f478691d47745, type: 3}
       Sprites:
@@ -38,17 +61,3 @@ MonoBehaviour:
   StorageData:
     maxSlots: 7
     maxItemSize: 4
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 11
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/ears/Captains  headset/Captains headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/Captains  headset/Captains headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: Captains headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 1224f878e95088747b42c2130b414f0f, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 1224f878e95088747b42c2130b414f0f, type: 3}
       EquippedData: {fileID: 4900000, guid: a0bdad2b9ed7e3f41aba0816f0057e55, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 332b742ace1420744af658a2c9161e33, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 332b742ace1420744af658a2c9161e33, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 10

--- a/UnityProject/Assets/Resources/textures/clothing/ears/Chief engineer headset/Chief engineer headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/Chief engineer headset/Chief engineer headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: Chief engineer headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: fc16b10aa17b4874d98cc5c67955a5e1, type: 3}
       Sprites:
       - {fileID: 21300000, guid: fc16b10aa17b4874d98cc5c67955a5e1, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 13

--- a/UnityProject/Assets/Resources/textures/clothing/ears/Chief medical officers headset/Chief medical officers headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/Chief medical officers headset/Chief medical officers headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: Chief medical officers headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 67df9eae07e22574a8abaedc639678ca, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 67df9eae07e22574a8abaedc639678ca, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 14

--- a/UnityProject/Assets/Resources/textures/clothing/ears/Robotics headset/Robotics headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/Robotics headset/Robotics headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: Robotics headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 4aabc6e139d5d7b4082254e7adce1738, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 4aabc6e139d5d7b4082254e7adce1738, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 3

--- a/UnityProject/Assets/Resources/textures/clothing/ears/cargo headset/cargo headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/cargo headset/cargo headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: cargo headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 92f4436825a9515489971311f25595c2, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 92f4436825a9515489971311f25595c2, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 6

--- a/UnityProject/Assets/Resources/textures/clothing/ears/engineering headset/engineering headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/engineering headset/engineering headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: engineering headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 33a8f162cc734e84b9055ffcbbf1f972, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 33a8f162cc734e84b9055ffcbbf1f972, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 8

--- a/UnityProject/Assets/Resources/textures/clothing/ears/genetics headset/genetics headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/genetics headset/genetics headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: genetics headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 9d9c3a7ea1a06ed4b95898a260593bb9, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 9d9c3a7ea1a06ed4b95898a260593bb9, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 19

--- a/UnityProject/Assets/Resources/textures/clothing/ears/head of personnel headset/head of personnel headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/head of personnel headset/head of personnel headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: head of personnel headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 1224f878e95088747b42c2130b414f0f, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 1224f878e95088747b42c2130b414f0f, type: 3}
       EquippedData: {fileID: 4900000, guid: a0bdad2b9ed7e3f41aba0816f0057e55, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: fc16b10aa17b4874d98cc5c67955a5e1, type: 3}
       Sprites:
       - {fileID: 21300000, guid: fc16b10aa17b4874d98cc5c67955a5e1, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 9

--- a/UnityProject/Assets/Resources/textures/clothing/ears/head of security headset/head of security headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/head of security headset/head of security headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: head of security headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 73a1018684ba7ca4795c75f9e3201ae5, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 73a1018684ba7ca4795c75f9e3201ae5, type: 3}
       EquippedData: {fileID: 4900000, guid: 89c5fb94a5a6fd44f9a0b5f6a4376d6e, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 2276e5afac687c643ac37823a5744d1b, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 2276e5afac687c643ac37823a5744d1b, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 12

--- a/UnityProject/Assets/Resources/textures/clothing/ears/headset common/headset common.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/headset common/headset common.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: headset common
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 70f387a63a6b45d47b7417b73f4a2352, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 70f387a63a6b45d47b7417b73f4a2352, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 1

--- a/UnityProject/Assets/Resources/textures/clothing/ears/medical headset/medical headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/medical headset/medical headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: medical headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 614b8ef7bdfe13349b78ad1bc612d9fc, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 614b8ef7bdfe13349b78ad1bc612d9fc, type: 3}
       EquippedData: {fileID: 4900000, guid: 1876eb1ea4e034244acca94015f79b35, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: c5cd272e9a7e126469152ee0a0e71fd4, type: 3}
       Sprites:
       - {fileID: 21300000, guid: c5cd272e9a7e126469152ee0a0e71fd4, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 2

--- a/UnityProject/Assets/Resources/textures/clothing/ears/mining headset/mining headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/mining headset/mining headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: mining headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 1128d570ea0833f47985676631daddc9, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 1128d570ea0833f47985676631daddc9, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 18

--- a/UnityProject/Assets/Resources/textures/clothing/ears/quartermaster headset/quartermaster headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/quartermaster headset/quartermaster headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: quartermaster headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 92f4436825a9515489971311f25595c2, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 92f4436825a9515489971311f25595c2, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 7

--- a/UnityProject/Assets/Resources/textures/clothing/ears/research directors headset/research director headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/research directors headset/research director headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: research director headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: fc16b10aa17b4874d98cc5c67955a5e1, type: 3}
       Sprites:
       - {fileID: 21300000, guid: fc16b10aa17b4874d98cc5c67955a5e1, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 11

--- a/UnityProject/Assets/Resources/textures/clothing/ears/science headset/science headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/science headset/science headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: science headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: e894679f856187a41949044dcdf2bdfc, type: 3}
       Sprites:
       - {fileID: 21300000, guid: e894679f856187a41949044dcdf2bdfc, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 3

--- a/UnityProject/Assets/Resources/textures/clothing/ears/security earpiece/security earpiece.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/security earpiece/security earpiece.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: security earpiece
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: d058976f9b5009344a3866f21cdceb03, type: 3}
       Sprites:
       - {fileID: 21300000, guid: d058976f9b5009344a3866f21cdceb03, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 5

--- a/UnityProject/Assets/Resources/textures/clothing/ears/security headset/Security headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/security headset/Security headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: Security headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 73a1018684ba7ca4795c75f9e3201ae5, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 73a1018684ba7ca4795c75f9e3201ae5, type: 3}
       EquippedData: {fileID: 4900000, guid: 89c5fb94a5a6fd44f9a0b5f6a4376d6e, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 2276e5afac687c643ac37823a5744d1b, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 2276e5afac687c643ac37823a5744d1b, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 5

--- a/UnityProject/Assets/Resources/textures/clothing/ears/service headset/service headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/service headset/service headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: service headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0953f57898a569e4081071c90d7885e6, type: 3}
       EquippedData: {fileID: 4900000, guid: 853a81d81cb4c0e4cab3a286a21f7291, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 3a8cfab7629eaea41bc0637023c3576a, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 3a8cfab7629eaea41bc0637023c3576a, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 4

--- a/UnityProject/Assets/Resources/textures/clothing/ears/syndicate headset/syndicate headset.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/ears/syndicate headset/syndicate headset.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: syndicate headset
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 5
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Sprites:
     Equipped:
       Texture: {fileID: 2800000, guid: c33abe003ef10ef41bd55df9515d893a, type: 3}
@@ -23,31 +38,25 @@ MonoBehaviour:
       - {fileID: 21300006, guid: c33abe003ef10ef41bd55df9515d893a, type: 3}
       EquippedData: {fileID: 4900000, guid: 9190834b0fbba8a4982cb3eca5bfed55, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300002, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300004, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      - {fileID: 21300006, guid: 70ba8e0352dd81544849989e4abacff5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 147e5145073b5f44b9df5fcbc08146b0, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300002, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300004, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      - {fileID: 21300006, guid: a4baffe7b0bee7a4286c05ed53b0310d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 34cf85f5368714b489f878dd7831f68a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 10cbc8985f71cce4f816b9d139f5829a, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 10cbc8985f71cce4f816b9d139f5829a, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 5
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []
   Key:
     EncryptionKey: 16

--- a/UnityProject/Assets/Resources/textures/clothing/eyes/sunglasses/sunglasses eyes.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/eyes/sunglasses/sunglasses eyes.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: sunglasses eyes
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 1
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 1376f18af8a58524196ba5cc67ca01d9, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 1376f18af8a58524196ba5cc67ca01d9, type: 3}
       EquippedData: {fileID: 4900000, guid: 0e61948dcd928ee4687f348035b38950, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 471d376ca74793341937d1b9110474e0, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 471d376ca74793341937d1b9110474e0, type: 3}
+      - {fileID: 21300002, guid: 471d376ca74793341937d1b9110474e0, type: 3}
+      - {fileID: 21300004, guid: 471d376ca74793341937d1b9110474e0, type: 3}
+      - {fileID: 21300006, guid: 471d376ca74793341937d1b9110474e0, type: 3}
+      EquippedData: {fileID: 4900000, guid: 1feca02fed8e5a74abcbe4bceda43c96, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 73e03e69f60366c48874e8d2b826ad77, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 73e03e69f60366c48874e8d2b826ad77, type: 3}
+      - {fileID: 21300002, guid: 73e03e69f60366c48874e8d2b826ad77, type: 3}
+      - {fileID: 21300004, guid: 73e03e69f60366c48874e8d2b826ad77, type: 3}
+      - {fileID: 21300006, guid: 73e03e69f60366c48874e8d2b826ad77, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2c44ab6a2171c31498f24eb7211bd40f, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: e8a6d8afa09aeac44a2797d2d2f2ac84, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 1
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/hands/black gloves/black gloves.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/hands/black gloves/black gloves.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: black gloves
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 8
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: fd0fe20b567bc11409d7fe35aa8b3824, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: fd0fe20b567bc11409d7fe35aa8b3824, type: 3}
       EquippedData: {fileID: 4900000, guid: fc21e78b351f298459390a204f5dd37a, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 0af721053f3a14343abb2a161869497e, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 0af721053f3a14343abb2a161869497e, type: 3}
+      - {fileID: 21300002, guid: 0af721053f3a14343abb2a161869497e, type: 3}
+      - {fileID: 21300004, guid: 0af721053f3a14343abb2a161869497e, type: 3}
+      - {fileID: 21300006, guid: 0af721053f3a14343abb2a161869497e, type: 3}
+      EquippedData: {fileID: 4900000, guid: f9a1438746d46464e815a0bb7232a3ed, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 5993f28f791aa914f8b00b9adc46d049, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 5993f28f791aa914f8b00b9adc46d049, type: 3}
+      - {fileID: 21300002, guid: 5993f28f791aa914f8b00b9adc46d049, type: 3}
+      - {fileID: 21300004, guid: 5993f28f791aa914f8b00b9adc46d049, type: 3}
+      - {fileID: 21300006, guid: 5993f28f791aa914f8b00b9adc46d049, type: 3}
+      EquippedData: {fileID: 4900000, guid: 15b90fc7928e0c449bb8f206f93a8443, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 9ee96f0c40b490342aec9b3eb4b93489, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 8
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/head/beret/beret.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/head/beret/beret.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: beret
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 2
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 12f8309869b71ac469b3bdb8c50f973d, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 12f8309869b71ac469b3bdb8c50f973d, type: 3}
       EquippedData: {fileID: 4900000, guid: 575660d0ddbfc9648857b1333fcd235c, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300002, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300004, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300006, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2b75533fe2f42e0418862cca0371f8f3, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300002, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300004, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300006, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      EquippedData: {fileID: 4900000, guid: 12fdd422b0613e94aab3646ae5c49dc9, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 1246ed038ba02f64eaa9a62d93547559, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 2
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/head/captain's hat/captain's hat.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/head/captain's hat/captain's hat.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: captain's hat
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 2
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: ebb60957608d8df4b9622fa03629703c, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: ebb60957608d8df4b9622fa03629703c, type: 3}
       EquippedData: {fileID: 4900000, guid: dfb1f393dff431045bc34d1cdd95f61a, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300002, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300004, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300006, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2b75533fe2f42e0418862cca0371f8f3, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300002, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300004, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300006, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      EquippedData: {fileID: 4900000, guid: 12fdd422b0613e94aab3646ae5c49dc9, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 25a0a5f690e78154099d631411d1f19c, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 2
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/head/cat ears/Cat ears.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/head/cat ears/Cat ears.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: Cat ears
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 2
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: bce563184c34e354b80a4633136797fb, type: 3}
@@ -39,13 +54,21 @@ MonoBehaviour:
       - {fileID: 21300038, guid: bce563184c34e354b80a4633136797fb, type: 3}
       EquippedData: {fileID: 4900000, guid: e7b933c8f18c4d343a03c0f6bdf1cebf, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300002, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300004, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300006, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2b75533fe2f42e0418862cca0371f8f3, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300002, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300004, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300006, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      EquippedData: {fileID: 4900000, guid: 12fdd422b0613e94aab3646ae5c49dc9, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 39c16004eecd4d840909485ca0d0c402, type: 3}
       Sprites:
@@ -86,17 +109,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 2
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/head/chef hat/chefs hat.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/head/chef hat/chefs hat.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: chefs hat
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 2
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 6b0711c9d3cb23a4d9fa0845cddbe10d, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 6b0711c9d3cb23a4d9fa0845cddbe10d, type: 3}
       EquippedData: {fileID: 4900000, guid: d2e4f0c6a0061294abde21f2beef9f7a, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 3e618aa9ed65f10409b036373dd704aa, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 3e618aa9ed65f10409b036373dd704aa, type: 3}
+      - {fileID: 21300002, guid: 3e618aa9ed65f10409b036373dd704aa, type: 3}
+      - {fileID: 21300004, guid: 3e618aa9ed65f10409b036373dd704aa, type: 3}
+      - {fileID: 21300006, guid: 3e618aa9ed65f10409b036373dd704aa, type: 3}
+      EquippedData: {fileID: 4900000, guid: 490ef4325060aba4f8aa70a3465e7ade, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 903f024d12a63d44aaaaab7b234d47ea, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 903f024d12a63d44aaaaab7b234d47ea, type: 3}
+      - {fileID: 21300002, guid: 903f024d12a63d44aaaaab7b234d47ea, type: 3}
+      - {fileID: 21300004, guid: 903f024d12a63d44aaaaab7b234d47ea, type: 3}
+      - {fileID: 21300006, guid: 903f024d12a63d44aaaaab7b234d47ea, type: 3}
+      EquippedData: {fileID: 4900000, guid: 51949e8745efafa4292cf2360d3b78c7, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 71e9f7e00950ee4479f60d92399a6eb0, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 2
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/head/curator hat/curators had.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/head/curator hat/curators had.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: curators had
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 2
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 3be94f79299374240a2cc23e6d052abb, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 3be94f79299374240a2cc23e6d052abb, type: 3}
       EquippedData: {fileID: 4900000, guid: 2caa48d9f0b30b54b84de66b8388179d, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300002, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300004, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300006, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2b75533fe2f42e0418862cca0371f8f3, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300002, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300004, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300006, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      EquippedData: {fileID: 4900000, guid: 12fdd422b0613e94aab3646ae5c49dc9, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 4190d9b72062b0849bc2025112a6bff5, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 2
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/head/detectives hat/detective hat.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/head/detectives hat/detective hat.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: detective hat
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 2
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: f51047bef96cf134f882a82595a7a347, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: f51047bef96cf134f882a82595a7a347, type: 3}
       EquippedData: {fileID: 4900000, guid: 0cce027e86ad9dc42acc8e2414f3cc27, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: bb112b27d64a030448f7555d3fa7da8b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: bb112b27d64a030448f7555d3fa7da8b, type: 3}
+      - {fileID: 21300002, guid: bb112b27d64a030448f7555d3fa7da8b, type: 3}
+      - {fileID: 21300004, guid: bb112b27d64a030448f7555d3fa7da8b, type: 3}
+      - {fileID: 21300006, guid: bb112b27d64a030448f7555d3fa7da8b, type: 3}
+      EquippedData: {fileID: 4900000, guid: 4b813ef9a606d344ab08dcc748a79c08, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 52121a5743c8dfe4989416ef9f2e69e0, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 52121a5743c8dfe4989416ef9f2e69e0, type: 3}
+      - {fileID: 21300002, guid: 52121a5743c8dfe4989416ef9f2e69e0, type: 3}
+      - {fileID: 21300004, guid: 52121a5743c8dfe4989416ef9f2e69e0, type: 3}
+      - {fileID: 21300006, guid: 52121a5743c8dfe4989416ef9f2e69e0, type: 3}
+      EquippedData: {fileID: 4900000, guid: 19342c602dcc67f4c835db8a7540bd05, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: d495e202f2c15944385052c259cbaff2, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 2
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/head/head of personnel hat/head of personnel cap.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/head/head of personnel hat/head of personnel cap.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: head of personnel cap
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 2
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 9f97ac349a2541a40aa38115c8917efe, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 9f97ac349a2541a40aa38115c8917efe, type: 3}
       EquippedData: {fileID: 4900000, guid: 5e6d9def407601e499924b20797b194f, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300002, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300004, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300006, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2b75533fe2f42e0418862cca0371f8f3, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300002, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300004, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300006, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      EquippedData: {fileID: 4900000, guid: 12fdd422b0613e94aab3646ae5c49dc9, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: e995cdcc8926ea24f954d5c381bad2f9, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 2
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/head/head of securitie cap/head of securitie beret.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/head/head of securitie cap/head of securitie beret.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: head of securitie beret
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 2
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 0d331e923f79b3c4496bae60071c52f3, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0d331e923f79b3c4496bae60071c52f3, type: 3}
       EquippedData: {fileID: 4900000, guid: 5f69bc80261bed04881bc7427b9d432d, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300002, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300004, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300006, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2b75533fe2f42e0418862cca0371f8f3, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300002, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300004, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300006, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      EquippedData: {fileID: 4900000, guid: 12fdd422b0613e94aab3646ae5c49dc9, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 5abfe83af5141d74a88a40262641ff65, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 2
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/head/syndicate hard suit head/syndicate hard suit  head.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/head/syndicate hard suit head/syndicate hard suit  head.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: syndicate hard suit  head
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 2
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: f771d3960809136459a9adbc19cc15b3, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: f771d3960809136459a9adbc19cc15b3, type: 3}
       EquippedData: {fileID: 4900000, guid: f06c2ce0d57cbc34d9953c3374a0530c, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300002, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300004, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300006, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2b75533fe2f42e0418862cca0371f8f3, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300002, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300004, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300006, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      EquippedData: {fileID: 4900000, guid: 12fdd422b0613e94aab3646ae5c49dc9, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: c2d7fbb23c69cf343bf5684618664593, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 2
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/head/warden hat/Dooblys Hat.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/head/warden hat/Dooblys Hat.asset
@@ -13,6 +13,22 @@ MonoBehaviour:
   m_Name: Dooblys Hat
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: Doobly's hat
+    itemDescription: yeah it's Doobly's hat
+    itemType: 2
+    size: 2
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 100
+    throwSpeed: 9
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb:
+    - smighted
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 82acbecaab844e947b8fac479dd60b4f, type: 3}
@@ -23,13 +39,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 82acbecaab844e947b8fac479dd60b4f, type: 3}
       EquippedData: {fileID: 4900000, guid: d0d6aa8e6db886448bbe5dcc68d09935, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300002, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300004, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300006, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2b75533fe2f42e0418862cca0371f8f3, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300002, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300004, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300006, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      EquippedData: {fileID: 4900000, guid: 12fdd422b0613e94aab3646ae5c49dc9, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 5f55f117a5d47e44498cd69c26167e8a, type: 3}
       Sprites:
@@ -70,18 +94,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: Doobly's hat
-    itemDescription: yeah it's Doobly's hat
-    itemType: 2
-    size: 2
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 100
-    throwSpeed: 9
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb:
-    - smighted

--- a/UnityProject/Assets/Resources/textures/clothing/mask/clown mask/clown mask.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/mask/clown mask/clown mask.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: clown mask
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 4
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 5cb8d84b7d7867541a253b41548b64a4, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 5cb8d84b7d7867541a253b41548b64a4, type: 3}
       EquippedData: {fileID: 4900000, guid: d967f96c3d199084f85f4c7a53a248b8, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: baf4a6efc45e8a74fb40c70853bd8dea, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: baf4a6efc45e8a74fb40c70853bd8dea, type: 3}
+      - {fileID: 21300002, guid: baf4a6efc45e8a74fb40c70853bd8dea, type: 3}
+      - {fileID: 21300004, guid: baf4a6efc45e8a74fb40c70853bd8dea, type: 3}
+      - {fileID: 21300006, guid: baf4a6efc45e8a74fb40c70853bd8dea, type: 3}
+      EquippedData: {fileID: 4900000, guid: ed542bc915af56f43815c6c345401c02, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 3e16329ffa60b4542a6c749b325e7105, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 3e16329ffa60b4542a6c749b325e7105, type: 3}
+      - {fileID: 21300002, guid: 3e16329ffa60b4542a6c749b325e7105, type: 3}
+      - {fileID: 21300004, guid: 3e16329ffa60b4542a6c749b325e7105, type: 3}
+      - {fileID: 21300006, guid: 3e16329ffa60b4542a6c749b325e7105, type: 3}
+      EquippedData: {fileID: 4900000, guid: ec5b504f19f68474d88cdabf1179beab, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 1d6f3709e44daf346b10135e2372d1fd, type: 3}
       Sprites:
@@ -75,17 +98,3 @@ MonoBehaviour:
       - {fileID: 21300000, guid: 941c2ac08cf0186438c2d2a96d641971, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 4
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/mask/mime mask/mime musk.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/mask/mime mask/mime musk.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: mime musk
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 4
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: aff2146b5eae70748ae4a698f7fa5ee6, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: aff2146b5eae70748ae4a698f7fa5ee6, type: 3}
       EquippedData: {fileID: 4900000, guid: 6fc67ae5ba3e7c84a8b27cfe4109298a, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300002, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300004, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      - {fileID: 21300006, guid: fa5946686cd0b1541a1366e85ea2c40b, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2b75533fe2f42e0418862cca0371f8f3, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300002, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300004, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      - {fileID: 21300006, guid: b24c446f587994e4cad70c25534bf2a6, type: 3}
+      EquippedData: {fileID: 4900000, guid: 12fdd422b0613e94aab3646ae5c49dc9, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 4bf4ed780ba111442b14747c272ac81f, type: 3}
       Sprites:
@@ -133,17 +156,3 @@ MonoBehaviour:
       Sprites:
       - {fileID: 21300000, guid: 25a6be825dc91bf4fbcfcc28e2686c9f, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 4
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/shoes/Black shoes/black shoes.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/shoes/Black shoes/black shoes.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: black shoes
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 9
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: ecc2cbba4d404fd408884708ed5fb32f, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: ecc2cbba4d404fd408884708ed5fb32f, type: 3}
       EquippedData: {fileID: 4900000, guid: b01806e2aee66d442ba357aaca60f1e5, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: f21c513f3d1ef9c42bc0de8f788c13b2, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: f21c513f3d1ef9c42bc0de8f788c13b2, type: 3}
+      - {fileID: 21300002, guid: f21c513f3d1ef9c42bc0de8f788c13b2, type: 3}
+      - {fileID: 21300004, guid: f21c513f3d1ef9c42bc0de8f788c13b2, type: 3}
+      - {fileID: 21300006, guid: f21c513f3d1ef9c42bc0de8f788c13b2, type: 3}
+      EquippedData: {fileID: 4900000, guid: 6cad2d19bca0df34e95119eac0aa47f9, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: ea1c33e7fe6bc29428e2dd3c56c993d2, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: ea1c33e7fe6bc29428e2dd3c56c993d2, type: 3}
+      - {fileID: 21300002, guid: ea1c33e7fe6bc29428e2dd3c56c993d2, type: 3}
+      - {fileID: 21300004, guid: ea1c33e7fe6bc29428e2dd3c56c993d2, type: 3}
+      - {fileID: 21300006, guid: ea1c33e7fe6bc29428e2dd3c56c993d2, type: 3}
+      EquippedData: {fileID: 4900000, guid: 5e80323c7c2c88d4aaafe2d1f17ce277, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 78d4bcdd667178e44bc865a5796eaad4, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 9
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/shoes/Explorer boots/explores boots.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/shoes/Explorer boots/explores boots.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: explores boots
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 9
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 06cbcdb6d55ed0747b120b41bcd87e02, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 06cbcdb6d55ed0747b120b41bcd87e02, type: 3}
       EquippedData: {fileID: 4900000, guid: d71a7dbffcb06a84e9474cd99452781a, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 35c83ab6fa02a2549aa7e461ba1c14cf, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 35c83ab6fa02a2549aa7e461ba1c14cf, type: 3}
+      - {fileID: 21300002, guid: 35c83ab6fa02a2549aa7e461ba1c14cf, type: 3}
+      - {fileID: 21300004, guid: 35c83ab6fa02a2549aa7e461ba1c14cf, type: 3}
+      - {fileID: 21300006, guid: 35c83ab6fa02a2549aa7e461ba1c14cf, type: 3}
+      EquippedData: {fileID: 4900000, guid: b2c3b774fd50be04d85319c2c7512493, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 68ad7690c84729a439a6176aa765f38c, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 68ad7690c84729a439a6176aa765f38c, type: 3}
+      - {fileID: 21300002, guid: 68ad7690c84729a439a6176aa765f38c, type: 3}
+      - {fileID: 21300004, guid: 68ad7690c84729a439a6176aa765f38c, type: 3}
+      - {fileID: 21300006, guid: 68ad7690c84729a439a6176aa765f38c, type: 3}
+      EquippedData: {fileID: 4900000, guid: cf8ee2c74da4e4b4489409087f19ab0b, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 891f566fc38e08443b8286cca6c0425a, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 9
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/shoes/brown shoes/shoes_brown.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/shoes/brown shoes/shoes_brown.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: shoes_brown
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 9
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 9a4a35ed7fb225940bdb946bbcca3105, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 9a4a35ed7fb225940bdb946bbcca3105, type: 3}
       EquippedData: {fileID: 4900000, guid: 07c09fa58b237324d9dfa909db50bf30, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: fc597b65af8e4f9438997d1489f85873, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: fc597b65af8e4f9438997d1489f85873, type: 3}
+      - {fileID: 21300002, guid: fc597b65af8e4f9438997d1489f85873, type: 3}
+      - {fileID: 21300004, guid: fc597b65af8e4f9438997d1489f85873, type: 3}
+      - {fileID: 21300006, guid: fc597b65af8e4f9438997d1489f85873, type: 3}
+      EquippedData: {fileID: 4900000, guid: 72bb2fec49180504d8c857e01bd93b67, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 46a828882699e534f92505a337360f80, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 46a828882699e534f92505a337360f80, type: 3}
+      - {fileID: 21300002, guid: 46a828882699e534f92505a337360f80, type: 3}
+      - {fileID: 21300004, guid: 46a828882699e534f92505a337360f80, type: 3}
+      - {fileID: 21300006, guid: 46a828882699e534f92505a337360f80, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2c9e2c27e815b7b478198faeefca41ab, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 576b70ebdbe57cc488b64c71ad360657, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 9
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/shoes/clown shoes/clown shoes.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/shoes/clown shoes/clown shoes.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: clown shoes
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 9
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: e5fc0f02275e87746aeb36828ffdad1c, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: e5fc0f02275e87746aeb36828ffdad1c, type: 3}
       EquippedData: {fileID: 4900000, guid: 897e69ec186b55f4ebf8b74378eb5de8, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 31e854dda1146884c830a7d22f19db40, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 31e854dda1146884c830a7d22f19db40, type: 3}
+      - {fileID: 21300002, guid: 31e854dda1146884c830a7d22f19db40, type: 3}
+      - {fileID: 21300004, guid: 31e854dda1146884c830a7d22f19db40, type: 3}
+      - {fileID: 21300006, guid: 31e854dda1146884c830a7d22f19db40, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2cd8e65d96282ba4082a04605feec7ac, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b39f68c0df450374cbd768304207a0e7, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b39f68c0df450374cbd768304207a0e7, type: 3}
+      - {fileID: 21300002, guid: b39f68c0df450374cbd768304207a0e7, type: 3}
+      - {fileID: 21300004, guid: b39f68c0df450374cbd768304207a0e7, type: 3}
+      - {fileID: 21300006, guid: b39f68c0df450374cbd768304207a0e7, type: 3}
+      EquippedData: {fileID: 4900000, guid: f6be9aa9631ac16418b1b9984e4b2f21, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: c9971e3bcaf77174e8222687f685734d, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 9
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/shoes/white shoes/white shoes.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/shoes/white shoes/white shoes.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: white shoes
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 9
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 7a665d88269053b4489a4d41d5b9f7c4, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 7a665d88269053b4489a4d41d5b9f7c4, type: 3}
       EquippedData: {fileID: 4900000, guid: d82e7c957fb5704479e0433ce44361ac, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: ca2513a13dc5ea34d984d91face14036, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: ca2513a13dc5ea34d984d91face14036, type: 3}
+      - {fileID: 21300002, guid: ca2513a13dc5ea34d984d91face14036, type: 3}
+      - {fileID: 21300004, guid: ca2513a13dc5ea34d984d91face14036, type: 3}
+      - {fileID: 21300006, guid: ca2513a13dc5ea34d984d91face14036, type: 3}
+      EquippedData: {fileID: 4900000, guid: 14eeea5cac6fe154eb3b07dbd7b4f122, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a12aae169e9b17346a06fe4603e7d3ac, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a12aae169e9b17346a06fe4603e7d3ac, type: 3}
+      - {fileID: 21300002, guid: a12aae169e9b17346a06fe4603e7d3ac, type: 3}
+      - {fileID: 21300004, guid: a12aae169e9b17346a06fe4603e7d3ac, type: 3}
+      - {fileID: 21300006, guid: a12aae169e9b17346a06fe4603e7d3ac, type: 3}
+      EquippedData: {fileID: 4900000, guid: 42a8f6bcd0d3c06478c58754d752982b, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 76ea565ed12575144bb80d234170857d, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 9
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/shoes/work boots/work boots.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/shoes/work boots/work boots.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: work boots
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 9
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 51532684b831ed545adc84e32815e29f, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 51532684b831ed545adc84e32815e29f, type: 3}
       EquippedData: {fileID: 4900000, guid: 40c2818d246c05448aa828ca6961523b, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 35c83ab6fa02a2549aa7e461ba1c14cf, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 35c83ab6fa02a2549aa7e461ba1c14cf, type: 3}
+      - {fileID: 21300002, guid: 35c83ab6fa02a2549aa7e461ba1c14cf, type: 3}
+      - {fileID: 21300004, guid: 35c83ab6fa02a2549aa7e461ba1c14cf, type: 3}
+      - {fileID: 21300006, guid: 35c83ab6fa02a2549aa7e461ba1c14cf, type: 3}
+      EquippedData: {fileID: 4900000, guid: b2c3b774fd50be04d85319c2c7512493, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 68ad7690c84729a439a6176aa765f38c, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 68ad7690c84729a439a6176aa765f38c, type: 3}
+      - {fileID: 21300002, guid: 68ad7690c84729a439a6176aa765f38c, type: 3}
+      - {fileID: 21300004, guid: 68ad7690c84729a439a6176aa765f38c, type: 3}
+      - {fileID: 21300006, guid: 68ad7690c84729a439a6176aa765f38c, type: 3}
+      EquippedData: {fileID: 4900000, guid: cf8ee2c74da4e4b4489409087f19ab0b, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 546d8cee5883e3840bcfaef02ae68097, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 9
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/suits/Chief medical officers lab coat/Chief medical officers lab coat.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/suits/Chief medical officers lab coat/Chief medical officers lab coat.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: Chief medical officers lab coat
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 6
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 9a2084aa5be9dfe4494dc2826d9f9a56, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 9a2084aa5be9dfe4494dc2826d9f9a56, type: 3}
       EquippedData: {fileID: 4900000, guid: a5ed69b347487d4428e65fdda4aa42f5, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300002, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300004, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300006, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      EquippedData: {fileID: 4900000, guid: fee2788b370ec6b4c948f0892dd2cafe, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300002, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300004, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300006, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      EquippedData: {fileID: 4900000, guid: c97c7c60767b5c84ab05b9362b9e5127, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 5e36c75d2221e57478dde90550e52b99, type: 3}
       Sprites:
@@ -75,17 +98,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 6
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/suits/Medic lab coat/medical lab coat.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/suits/Medic lab coat/medical lab coat.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: medical lab coat
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 6
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 6b21e86472dfaae4cbcd25365ee99ad7, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 6b21e86472dfaae4cbcd25365ee99ad7, type: 3}
       EquippedData: {fileID: 4900000, guid: 340e1a6234577584abb6c29fbecff22b, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300002, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300004, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300006, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      EquippedData: {fileID: 4900000, guid: fee2788b370ec6b4c948f0892dd2cafe, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300002, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300004, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300006, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      EquippedData: {fileID: 4900000, guid: c97c7c60767b5c84ab05b9362b9e5127, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 8f46c1b4c71acd14fabb877b0f488395, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 6
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/suits/chemist lab coat/chemist lab coat.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/suits/chemist lab coat/chemist lab coat.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: chemist lab coat
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 6
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 2144ced4d672fcb489e87fc343f9c996, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 2144ced4d672fcb489e87fc343f9c996, type: 3}
       EquippedData: {fileID: 4900000, guid: c9cef4fc99a5fa34fae3ec73f46ac516, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300002, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300004, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300006, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      EquippedData: {fileID: 4900000, guid: fee2788b370ec6b4c948f0892dd2cafe, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300002, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300004, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300006, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      EquippedData: {fileID: 4900000, guid: c97c7c60767b5c84ab05b9362b9e5127, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 969b18701876a6e4484800733b7b72d2, type: 3}
       Sprites:
@@ -75,17 +98,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 6
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/suits/curator/curators jacket.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/suits/curator/curators jacket.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: curators jacket
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 6
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 29100d482b5ad704b8f412f2a13458e8, type: 3}
@@ -70,17 +85,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 6
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/suits/geneticist lab coat/geneticist lab coat.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/suits/geneticist lab coat/geneticist lab coat.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: geneticist lab coat
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 6
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: fa4ac39c9f290054ba96b00e5d9cd9e1, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: fa4ac39c9f290054ba96b00e5d9cd9e1, type: 3}
       EquippedData: {fileID: 4900000, guid: 6b992f16f18251944805cc33759098f3, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300002, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300004, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300006, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      EquippedData: {fileID: 4900000, guid: fee2788b370ec6b4c948f0892dd2cafe, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300002, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300004, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300006, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      EquippedData: {fileID: 4900000, guid: c97c7c60767b5c84ab05b9362b9e5127, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 5ca87254656343448b3cc2f2f1d0f31f, type: 3}
       Sprites:
@@ -75,17 +98,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 6
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/suits/virology white lab coat/virology lab coat.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/suits/virology white lab coat/virology lab coat.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: virology lab coat
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 6
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 24f280b18dcd49a4a9906225312904e0, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 24f280b18dcd49a4a9906225312904e0, type: 3}
       EquippedData: {fileID: 4900000, guid: 5296e5062bb303147a581116aac635d9, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300002, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300004, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      - {fileID: 21300006, guid: 7551adbe6cdcb854a977913b433e6f07, type: 3}
+      EquippedData: {fileID: 4900000, guid: fee2788b370ec6b4c948f0892dd2cafe, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300002, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300004, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      - {fileID: 21300006, guid: 73b889d1c7e4a7c4ca697e133e05d2d1, type: 3}
+      EquippedData: {fileID: 4900000, guid: c97c7c60767b5c84ab05b9362b9e5127, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 5ca87254656343448b3cc2f2f1d0f31f, type: 3}
       Sprites:
@@ -75,17 +98,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 6
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Botany/botanists uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Botany/botanists uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: botanists uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 49bb3394945cf7845a3fb4aa12842af5, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 49bb3394945cf7845a3fb4aa12842af5, type: 3}
       EquippedData: {fileID: 4900000, guid: 1199cffa45685b44f8ca40ed5a1a1bb2, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 5e22c3dc0500ec0449123df69bfcfb85, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 5e22c3dc0500ec0449123df69bfcfb85, type: 3}
+      - {fileID: 21300002, guid: 5e22c3dc0500ec0449123df69bfcfb85, type: 3}
+      - {fileID: 21300004, guid: 5e22c3dc0500ec0449123df69bfcfb85, type: 3}
+      - {fileID: 21300006, guid: 5e22c3dc0500ec0449123df69bfcfb85, type: 3}
+      EquippedData: {fileID: 4900000, guid: 86df4e4519a19fd49ad23d2a111a7f94, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 0516c91851501d44ca77806f1f8fcfcd, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 0516c91851501d44ca77806f1f8fcfcd, type: 3}
+      - {fileID: 21300002, guid: 0516c91851501d44ca77806f1f8fcfcd, type: 3}
+      - {fileID: 21300004, guid: 0516c91851501d44ca77806f1f8fcfcd, type: 3}
+      - {fileID: 21300006, guid: 0516c91851501d44ca77806f1f8fcfcd, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2747bc7fee05fce45852a92008b07d7b, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 0c57228ff628b4a498056a6f06aad03a, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 0f254fc3ed5e38746acc0dc658975346, type: 3}
       EquippedData: {fileID: 4900000, guid: 094d24e74e8ee6d469714fd0a2ce4dd0, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 5e22c3dc0500ec0449123df69bfcfb85, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 5e22c3dc0500ec0449123df69bfcfb85, type: 3}
+      - {fileID: 21300002, guid: 5e22c3dc0500ec0449123df69bfcfb85, type: 3}
+      - {fileID: 21300004, guid: 5e22c3dc0500ec0449123df69bfcfb85, type: 3}
+      - {fileID: 21300006, guid: 5e22c3dc0500ec0449123df69bfcfb85, type: 3}
+      EquippedData: {fileID: 4900000, guid: 86df4e4519a19fd49ad23d2a111a7f94, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 0516c91851501d44ca77806f1f8fcfcd, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 0516c91851501d44ca77806f1f8fcfcd, type: 3}
+      - {fileID: 21300002, guid: 0516c91851501d44ca77806f1f8fcfcd, type: 3}
+      - {fileID: 21300004, guid: 0516c91851501d44ca77806f1f8fcfcd, type: 3}
+      - {fileID: 21300006, guid: 0516c91851501d44ca77806f1f8fcfcd, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2747bc7fee05fce45852a92008b07d7b, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 4e41956d58fb59c4c9162240c590cf62, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 4e41956d58fb59c4c9162240c590cf62, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Chaplin/Chapman's uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Chaplin/Chapman's uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: Chapman's uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 576b03cb83cfbf1448bc31a26e5ea47d, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 576b03cb83cfbf1448bc31a26e5ea47d, type: 3}
       EquippedData: {fileID: 4900000, guid: d34176781eacf18469ac205b004a0347, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      - {fileID: 21300002, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      - {fileID: 21300004, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      - {fileID: 21300006, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      EquippedData: {fileID: 4900000, guid: c248bbea60f8d0241bff0ef9dda51765, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      - {fileID: 21300002, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      - {fileID: 21300004, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      - {fileID: 21300006, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      EquippedData: {fileID: 4900000, guid: 9389cc5f6f7acc2479eaa8df115b1dfb, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: bb9c3779e82710a469a8660f61fa35a0, type: 3}
       Sprites:
@@ -62,30 +85,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: c492d10684b630b4e9c355dc43345ced, type: 3}
       EquippedData: {fileID: 4900000, guid: fe4d4963f76c5e6429b3566892ff05a1, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      - {fileID: 21300002, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      - {fileID: 21300004, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      - {fileID: 21300006, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      EquippedData: {fileID: 4900000, guid: c248bbea60f8d0241bff0ef9dda51765, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      - {fileID: 21300002, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      - {fileID: 21300004, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      - {fileID: 21300006, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      EquippedData: {fileID: 4900000, guid: 9389cc5f6f7acc2479eaa8df115b1dfb, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: b90523758a431f34c90d06c0a284d058, type: 3}
       Sprites:
       - {fileID: 21300000, guid: b90523758a431f34c90d06c0a284d058, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Chef/chef's uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Chef/chef's uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: chef's uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 27a5ead404a66c948817d570eaa13bae, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 27a5ead404a66c948817d570eaa13bae, type: 3}
       EquippedData: {fileID: 4900000, guid: 16d98ba596c3995459248ea9a2338ae1, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: da8ef7ad856c7754c856e891034c1bfc, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: da8ef7ad856c7754c856e891034c1bfc, type: 3}
+      - {fileID: 21300002, guid: da8ef7ad856c7754c856e891034c1bfc, type: 3}
+      - {fileID: 21300004, guid: da8ef7ad856c7754c856e891034c1bfc, type: 3}
+      - {fileID: 21300006, guid: da8ef7ad856c7754c856e891034c1bfc, type: 3}
+      EquippedData: {fileID: 4900000, guid: 0de6430c6936d9642bb83611e420e8d7, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: bc087b7ff7ec6b84d923a7747f7286c9, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: bc087b7ff7ec6b84d923a7747f7286c9, type: 3}
+      - {fileID: 21300002, guid: bc087b7ff7ec6b84d923a7747f7286c9, type: 3}
+      - {fileID: 21300004, guid: bc087b7ff7ec6b84d923a7747f7286c9, type: 3}
+      - {fileID: 21300006, guid: bc087b7ff7ec6b84d923a7747f7286c9, type: 3}
+      EquippedData: {fileID: 4900000, guid: 5d7b990a64215544290f6a3d1d24ef55, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: aea7ada13df471c409a41f1cb41993a4, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 6863bfc974640fb4ca4157a12cbedabd, type: 3}
       EquippedData: {fileID: 4900000, guid: 5b4b032dc0a8c69479a425e28512bc6e, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: da8ef7ad856c7754c856e891034c1bfc, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: da8ef7ad856c7754c856e891034c1bfc, type: 3}
+      - {fileID: 21300002, guid: da8ef7ad856c7754c856e891034c1bfc, type: 3}
+      - {fileID: 21300004, guid: da8ef7ad856c7754c856e891034c1bfc, type: 3}
+      - {fileID: 21300006, guid: da8ef7ad856c7754c856e891034c1bfc, type: 3}
+      EquippedData: {fileID: 4900000, guid: 0de6430c6936d9642bb83611e420e8d7, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: bc087b7ff7ec6b84d923a7747f7286c9, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: bc087b7ff7ec6b84d923a7747f7286c9, type: 3}
+      - {fileID: 21300002, guid: bc087b7ff7ec6b84d923a7747f7286c9, type: 3}
+      - {fileID: 21300004, guid: bc087b7ff7ec6b84d923a7747f7286c9, type: 3}
+      - {fileID: 21300006, guid: bc087b7ff7ec6b84d923a7747f7286c9, type: 3}
+      EquippedData: {fileID: 4900000, guid: 5d7b990a64215544290f6a3d1d24ef55, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 6ac604b8c67e724408a6e5189cbe1f96, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 6ac604b8c67e724408a6e5189cbe1f96, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Chemist/cchemist uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Chemist/cchemist uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: cchemist uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 1f1c407b399063345b1a8dd720a35067, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 1f1c407b399063345b1a8dd720a35067, type: 3}
       EquippedData: {fileID: 4900000, guid: 397ba0fd417c97c48b296f459a7792cd, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300002, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300004, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300006, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      EquippedData: {fileID: 4900000, guid: dc26195dccfb7ae40845517ca6ddb5ae, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300002, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300004, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300006, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 4311d86bae7c9b242bd1756f817f2c68, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: cf46245b3aa14664ebdef9de3aff5a0f, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: a242befbef58c5342a7b39c487ed1e35, type: 3}
       EquippedData: {fileID: 4900000, guid: 68ed6116d0acc2947a09313dc940f401, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300002, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300004, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300006, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      EquippedData: {fileID: 4900000, guid: dc26195dccfb7ae40845517ca6ddb5ae, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300002, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300004, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300006, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 4311d86bae7c9b242bd1756f817f2c68, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: e871e454d4a365445b3ad6bf4ba67ef9, type: 3}
       Sprites:
       - {fileID: 21300000, guid: e871e454d4a365445b3ad6bf4ba67ef9, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Chief engineer/Chief engineer uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Chief engineer/Chief engineer uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: Chief engineer uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: c5783c96ad16c1d4c82d5242a77503fe, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: c5783c96ad16c1d4c82d5242a77503fe, type: 3}
       EquippedData: {fileID: 4900000, guid: 9a3150d1225efe847ad05cd70a0a773d, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      - {fileID: 21300002, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      - {fileID: 21300004, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      - {fileID: 21300006, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      EquippedData: {fileID: 4900000, guid: 372376dd5cdbeee42922f290071e8415, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      - {fileID: 21300002, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      - {fileID: 21300004, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      - {fileID: 21300006, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      EquippedData: {fileID: 4900000, guid: 6066566e5f2356344b64a22d288eda81, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 0e074f7cfd26af447acf914aa04939f1, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 8e113c83858429f46a1d8bc27a03e21a, type: 3}
       EquippedData: {fileID: 4900000, guid: 892ef02a1c691f74abbb41c8cf796a61, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      - {fileID: 21300002, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      - {fileID: 21300004, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      - {fileID: 21300006, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      EquippedData: {fileID: 4900000, guid: 372376dd5cdbeee42922f290071e8415, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      - {fileID: 21300002, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      - {fileID: 21300004, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      - {fileID: 21300006, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      EquippedData: {fileID: 4900000, guid: 6066566e5f2356344b64a22d288eda81, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: f9647c98720a1f94ebe993c38cc2302d, type: 3}
       Sprites:
       - {fileID: 21300000, guid: f9647c98720a1f94ebe993c38cc2302d, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Chief medical Officer/Chief medical officer uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Chief medical Officer/Chief medical officer uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: Chief medical officer uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 5826b8b2fc9f57c4ba2b39a7955d7ea8, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 5826b8b2fc9f57c4ba2b39a7955d7ea8, type: 3}
       EquippedData: {fileID: 4900000, guid: 6bac19fbcb8655647a8703f2a5d269c8, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300002, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300004, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300006, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      EquippedData: {fileID: 4900000, guid: dc26195dccfb7ae40845517ca6ddb5ae, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300002, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300004, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300006, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 4311d86bae7c9b242bd1756f817f2c68, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 9c83d081f4299604e8dc77908c802e0a, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 9fe0adbbbc5f40c40bb94aff9f9e0a07, type: 3}
       EquippedData: {fileID: 4900000, guid: e597395fd26f11140afbcbba343946d8, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300002, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300004, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300006, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      EquippedData: {fileID: 4900000, guid: dc26195dccfb7ae40845517ca6ddb5ae, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300002, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300004, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300006, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 4311d86bae7c9b242bd1756f817f2c68, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 560f121e0aa993943b252d0f74004b1a, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 560f121e0aa993943b252d0f74004b1a, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Clown/clown uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Clown/clown uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: clown uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 21021aa77dcf50f41bdfef6470086c53, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 21021aa77dcf50f41bdfef6470086c53, type: 3}
       EquippedData: {fileID: 4900000, guid: 3b053e697a69e444c8fd1e9f9efebcb4, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 67db629d918654649ad0c536d0acc0ee, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 67db629d918654649ad0c536d0acc0ee, type: 3}
+      - {fileID: 21300002, guid: 67db629d918654649ad0c536d0acc0ee, type: 3}
+      - {fileID: 21300004, guid: 67db629d918654649ad0c536d0acc0ee, type: 3}
+      - {fileID: 21300006, guid: 67db629d918654649ad0c536d0acc0ee, type: 3}
+      EquippedData: {fileID: 4900000, guid: 980b349b478f33e49b8e594f47be5f1d, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: fc256fab2164cca4b8b3532abce78458, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: fc256fab2164cca4b8b3532abce78458, type: 3}
+      - {fileID: 21300002, guid: fc256fab2164cca4b8b3532abce78458, type: 3}
+      - {fileID: 21300004, guid: fc256fab2164cca4b8b3532abce78458, type: 3}
+      - {fileID: 21300006, guid: fc256fab2164cca4b8b3532abce78458, type: 3}
+      EquippedData: {fileID: 4900000, guid: 4c70632b26dbc95408527ae765628b3d, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: abc6ec23d6bf16646866d3e7a4afdc47, type: 3}
       Sprites:
@@ -79,13 +102,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 4ca026f4d8d005446abb71bb5a81ea27, type: 3}
       EquippedData: {fileID: 4900000, guid: aaf9d950b051aa943869ae944c482d7b, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a8ad373bba5d0884f9736b45c7bc0fbe, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a8ad373bba5d0884f9736b45c7bc0fbe, type: 3}
+      - {fileID: 21300002, guid: a8ad373bba5d0884f9736b45c7bc0fbe, type: 3}
+      - {fileID: 21300004, guid: a8ad373bba5d0884f9736b45c7bc0fbe, type: 3}
+      - {fileID: 21300006, guid: a8ad373bba5d0884f9736b45c7bc0fbe, type: 3}
+      EquippedData: {fileID: 4900000, guid: 336465001a3d8054c927e306ae420fd2, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 0f855e30f2aacff48be9434f27c14eac, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 0f855e30f2aacff48be9434f27c14eac, type: 3}
+      - {fileID: 21300002, guid: 0f855e30f2aacff48be9434f27c14eac, type: 3}
+      - {fileID: 21300004, guid: 0f855e30f2aacff48be9434f27c14eac, type: 3}
+      - {fileID: 21300006, guid: 0f855e30f2aacff48be9434f27c14eac, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2bb779f799f97c34c9ecce84439b24e7, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: b45dc710f0991ec42b5b6ab4572c548f, type: 3}
       Sprites:
@@ -100,13 +131,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 809316159747b274f9854539bc3078ac, type: 3}
       EquippedData: {fileID: 4900000, guid: 2ade867d65a3ece4782e3a5ba133f45d, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: f3e24e0422cc2f7468ed96209bd71add, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: f3e24e0422cc2f7468ed96209bd71add, type: 3}
+      - {fileID: 21300002, guid: f3e24e0422cc2f7468ed96209bd71add, type: 3}
+      - {fileID: 21300004, guid: f3e24e0422cc2f7468ed96209bd71add, type: 3}
+      - {fileID: 21300006, guid: f3e24e0422cc2f7468ed96209bd71add, type: 3}
+      EquippedData: {fileID: 4900000, guid: 931f51cf0e7e728469d425e9f6399e0c, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: a969ba36574117c49aebdc193f831c61, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a969ba36574117c49aebdc193f831c61, type: 3}
+      - {fileID: 21300002, guid: a969ba36574117c49aebdc193f831c61, type: 3}
+      - {fileID: 21300004, guid: a969ba36574117c49aebdc193f831c61, type: 3}
+      - {fileID: 21300006, guid: a969ba36574117c49aebdc193f831c61, type: 3}
+      EquippedData: {fileID: 4900000, guid: 0466fc2c2b2270e4e93948ae3445bea8, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 3f7228df6b3b12248bf720a230b96c29, type: 3}
       Sprites:
@@ -121,13 +160,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 210ec685708415a43b51f9876fd590dc, type: 3}
       EquippedData: {fileID: 4900000, guid: 161397e327d5ac547976f544c8d8a58a, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 5a37b4760e00c96448a4d1ebe5c33726, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 5a37b4760e00c96448a4d1ebe5c33726, type: 3}
+      - {fileID: 21300002, guid: 5a37b4760e00c96448a4d1ebe5c33726, type: 3}
+      - {fileID: 21300004, guid: 5a37b4760e00c96448a4d1ebe5c33726, type: 3}
+      - {fileID: 21300006, guid: 5a37b4760e00c96448a4d1ebe5c33726, type: 3}
+      EquippedData: {fileID: 4900000, guid: 98d8331022167464ebf52c12d3a9e97c, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 841e4fad2ce3ea341baef97c52b7b01e, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 841e4fad2ce3ea341baef97c52b7b01e, type: 3}
+      - {fileID: 21300002, guid: 841e4fad2ce3ea341baef97c52b7b01e, type: 3}
+      - {fileID: 21300004, guid: 841e4fad2ce3ea341baef97c52b7b01e, type: 3}
+      - {fileID: 21300006, guid: 841e4fad2ce3ea341baef97c52b7b01e, type: 3}
+      EquippedData: {fileID: 4900000, guid: ef741d667a125644fb973f352f245248, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: a52b3c7add4683444a7f04dea1bd361b, type: 3}
       Sprites:
@@ -142,13 +189,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 904a26a383a72684ab3c2e587ed0d73e, type: 3}
       EquippedData: {fileID: 4900000, guid: f0cb0fa6a822e88469ea01e4df3b0a28, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: cf4b8d226096dd64ab058e7d83ed809f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: cf4b8d226096dd64ab058e7d83ed809f, type: 3}
+      - {fileID: 21300002, guid: cf4b8d226096dd64ab058e7d83ed809f, type: 3}
+      - {fileID: 21300004, guid: cf4b8d226096dd64ab058e7d83ed809f, type: 3}
+      - {fileID: 21300006, guid: cf4b8d226096dd64ab058e7d83ed809f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 824b50ab5b04ca049b69f8ca741c3b21, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c309f261617cfd843b3b02a785dbcbe9, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c309f261617cfd843b3b02a785dbcbe9, type: 3}
+      - {fileID: 21300002, guid: c309f261617cfd843b3b02a785dbcbe9, type: 3}
+      - {fileID: 21300004, guid: c309f261617cfd843b3b02a785dbcbe9, type: 3}
+      - {fileID: 21300006, guid: c309f261617cfd843b3b02a785dbcbe9, type: 3}
+      EquippedData: {fileID: 4900000, guid: 325ed6c99afdcf54cb20479be2a40d78, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: e750174f5987ae047b46d0c6a15dc6f1, type: 3}
       Sprites:
@@ -163,13 +218,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 1c76996cdf9506d458709ab34970f0c6, type: 3}
       EquippedData: {fileID: 4900000, guid: ee82acb91e6e27e44a7aba9e54978cd4, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 815c9a79a7d2bb54282b7551fd2b5bf0, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 815c9a79a7d2bb54282b7551fd2b5bf0, type: 3}
+      - {fileID: 21300002, guid: 815c9a79a7d2bb54282b7551fd2b5bf0, type: 3}
+      - {fileID: 21300004, guid: 815c9a79a7d2bb54282b7551fd2b5bf0, type: 3}
+      - {fileID: 21300006, guid: 815c9a79a7d2bb54282b7551fd2b5bf0, type: 3}
+      EquippedData: {fileID: 4900000, guid: 261a894f52c0ce64fb3dacb3e1ac3497, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 8e7c659c2c9c8c443a527fcdcc5aa04a, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 8e7c659c2c9c8c443a527fcdcc5aa04a, type: 3}
+      - {fileID: 21300002, guid: 8e7c659c2c9c8c443a527fcdcc5aa04a, type: 3}
+      - {fileID: 21300004, guid: 8e7c659c2c9c8c443a527fcdcc5aa04a, type: 3}
+      - {fileID: 21300006, guid: 8e7c659c2c9c8c443a527fcdcc5aa04a, type: 3}
+      EquippedData: {fileID: 4900000, guid: 8ec618a5cd5624e4a9f573792513d21b, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 999cfc11e03e7c846b38556bcd7e5cd5, type: 3}
       Sprites:
@@ -184,29 +247,23 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 600bcdb8300869c40ad52221459abb42, type: 3}
       EquippedData: {fileID: 4900000, guid: 53a40d88db0bf194eae0bcde6eecdaa9, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: f1860e19adfc4b24c8a7058d5688ea5d, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: f1860e19adfc4b24c8a7058d5688ea5d, type: 3}
+      - {fileID: 21300002, guid: f1860e19adfc4b24c8a7058d5688ea5d, type: 3}
+      - {fileID: 21300004, guid: f1860e19adfc4b24c8a7058d5688ea5d, type: 3}
+      - {fileID: 21300006, guid: f1860e19adfc4b24c8a7058d5688ea5d, type: 3}
+      EquippedData: {fileID: 4900000, guid: 5979e547fd4fc56489e8ad9ded99fc33, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 58ba23158ebf0ff418f62303e2ed4f96, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 58ba23158ebf0ff418f62303e2ed4f96, type: 3}
+      - {fileID: 21300002, guid: 58ba23158ebf0ff418f62303e2ed4f96, type: 3}
+      - {fileID: 21300004, guid: 58ba23158ebf0ff418f62303e2ed4f96, type: 3}
+      - {fileID: 21300006, guid: 58ba23158ebf0ff418f62303e2ed4f96, type: 3}
+      EquippedData: {fileID: 4900000, guid: ac60284964c07744bb5e61a27ec4e492, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 2f1b72d9d1860c740887c14ee6fb60ad, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 2f1b72d9d1860c740887c14ee6fb60ad, type: 3}
       EquippedData: {fileID: 0}
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Detective/Detective uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Detective/Detective uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: Detective uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 8cd0e4e70c5dc95439c4a8cf44238f02, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 8cd0e4e70c5dc95439c4a8cf44238f02, type: 3}
       EquippedData: {fileID: 4900000, guid: c4349dc7e3df68543b4068b75830711b, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 262db39f04628e549a87eb6e0ee529b1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 262db39f04628e549a87eb6e0ee529b1, type: 3}
+      - {fileID: 21300002, guid: 262db39f04628e549a87eb6e0ee529b1, type: 3}
+      - {fileID: 21300004, guid: 262db39f04628e549a87eb6e0ee529b1, type: 3}
+      - {fileID: 21300006, guid: 262db39f04628e549a87eb6e0ee529b1, type: 3}
+      EquippedData: {fileID: 4900000, guid: f0ab40db19e2f9f4fb4752917c436093, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 737937692c90a23419f66e7bb09e64b7, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 737937692c90a23419f66e7bb09e64b7, type: 3}
+      - {fileID: 21300002, guid: 737937692c90a23419f66e7bb09e64b7, type: 3}
+      - {fileID: 21300004, guid: 737937692c90a23419f66e7bb09e64b7, type: 3}
+      - {fileID: 21300006, guid: 737937692c90a23419f66e7bb09e64b7, type: 3}
+      EquippedData: {fileID: 4900000, guid: 79974b8238ea60f40a7015415c418a7a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 0588df996bd78384c8db1779bff7ab65, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 51264878333d5c249bbcf3637c41aedb, type: 3}
       EquippedData: {fileID: 4900000, guid: 729ce14352141894d93a14c74ee64a20, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 262db39f04628e549a87eb6e0ee529b1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 262db39f04628e549a87eb6e0ee529b1, type: 3}
+      - {fileID: 21300002, guid: 262db39f04628e549a87eb6e0ee529b1, type: 3}
+      - {fileID: 21300004, guid: 262db39f04628e549a87eb6e0ee529b1, type: 3}
+      - {fileID: 21300006, guid: 262db39f04628e549a87eb6e0ee529b1, type: 3}
+      EquippedData: {fileID: 4900000, guid: f0ab40db19e2f9f4fb4752917c436093, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 737937692c90a23419f66e7bb09e64b7, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 737937692c90a23419f66e7bb09e64b7, type: 3}
+      - {fileID: 21300002, guid: 737937692c90a23419f66e7bb09e64b7, type: 3}
+      - {fileID: 21300004, guid: 737937692c90a23419f66e7bb09e64b7, type: 3}
+      - {fileID: 21300006, guid: 737937692c90a23419f66e7bb09e64b7, type: 3}
+      EquippedData: {fileID: 4900000, guid: 79974b8238ea60f40a7015415c418a7a, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: a67cce218d1ecd94aa35db5eaced25b4, type: 3}
       Sprites:
       - {fileID: 21300000, guid: a67cce218d1ecd94aa35db5eaced25b4, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Engineering/engineering uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Engineering/engineering uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: engineering uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 9b7ea14674591224794f5114c45628c3, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 9b7ea14674591224794f5114c45628c3, type: 3}
       EquippedData: {fileID: 4900000, guid: df220d31fe0ed2544b34652bb01a2975, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c7a6a569ef0d3e04397d660369ca4de7, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c7a6a569ef0d3e04397d660369ca4de7, type: 3}
+      - {fileID: 21300002, guid: c7a6a569ef0d3e04397d660369ca4de7, type: 3}
+      - {fileID: 21300004, guid: c7a6a569ef0d3e04397d660369ca4de7, type: 3}
+      - {fileID: 21300006, guid: c7a6a569ef0d3e04397d660369ca4de7, type: 3}
+      EquippedData: {fileID: 4900000, guid: 715cf3ead6c4ed445a1d5925eceea66e, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 64d0f992770475244884ff07cbf4e3d6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 64d0f992770475244884ff07cbf4e3d6, type: 3}
+      - {fileID: 21300002, guid: 64d0f992770475244884ff07cbf4e3d6, type: 3}
+      - {fileID: 21300004, guid: 64d0f992770475244884ff07cbf4e3d6, type: 3}
+      - {fileID: 21300006, guid: 64d0f992770475244884ff07cbf4e3d6, type: 3}
+      EquippedData: {fileID: 4900000, guid: f58bc0c0b207d60429e9620d3420b58b, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 1e59e63ed62c87b4fa06ded5d4e6f35e, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 9045bc9d4ff53be4b9dce1ec8ae5e6c9, type: 3}
       EquippedData: {fileID: 4900000, guid: 29065255d7698ba4b80bf2f21ceed9d6, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c7a6a569ef0d3e04397d660369ca4de7, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c7a6a569ef0d3e04397d660369ca4de7, type: 3}
+      - {fileID: 21300002, guid: c7a6a569ef0d3e04397d660369ca4de7, type: 3}
+      - {fileID: 21300004, guid: c7a6a569ef0d3e04397d660369ca4de7, type: 3}
+      - {fileID: 21300006, guid: c7a6a569ef0d3e04397d660369ca4de7, type: 3}
+      EquippedData: {fileID: 4900000, guid: 715cf3ead6c4ed445a1d5925eceea66e, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 64d0f992770475244884ff07cbf4e3d6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 64d0f992770475244884ff07cbf4e3d6, type: 3}
+      - {fileID: 21300002, guid: 64d0f992770475244884ff07cbf4e3d6, type: 3}
+      - {fileID: 21300004, guid: 64d0f992770475244884ff07cbf4e3d6, type: 3}
+      - {fileID: 21300006, guid: 64d0f992770475244884ff07cbf4e3d6, type: 3}
+      EquippedData: {fileID: 4900000, guid: f58bc0c0b207d60429e9620d3420b58b, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 7d2eceaafc81c7c4fa6e64e46974160e, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 7d2eceaafc81c7c4fa6e64e46974160e, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Genetics/geneticists uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Genetics/geneticists uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: geneticists uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 767984166bda74043938fa7c11440a7f, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 767984166bda74043938fa7c11440a7f, type: 3}
       EquippedData: {fileID: 4900000, guid: dd00414f214442445828b38429ecf3f2, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300002, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300004, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300006, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      EquippedData: {fileID: 4900000, guid: dc26195dccfb7ae40845517ca6ddb5ae, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300002, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300004, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300006, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 4311d86bae7c9b242bd1756f817f2c68, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 859336e98027ce64cb55af9b31236ccd, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: e0c439ad381fda249a9361fba1f629b2, type: 3}
       EquippedData: {fileID: 4900000, guid: cce3c374c48d8d6498766dadc9680f0b, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300002, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300004, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300006, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      EquippedData: {fileID: 4900000, guid: dc26195dccfb7ae40845517ca6ddb5ae, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300002, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300004, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300006, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 4311d86bae7c9b242bd1756f817f2c68, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: dd822e7d6c24bd249ba582d68186bb72, type: 3}
       Sprites:
       - {fileID: 21300000, guid: dd822e7d6c24bd249ba582d68186bb72, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Head of security/head of securitie uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Head of security/head of securitie uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: head of securitie uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 6cd3f0ad8ace5f04094f3314aafd2628, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 6cd3f0ad8ace5f04094f3314aafd2628, type: 3}
       EquippedData: {fileID: 4900000, guid: 7aac3933244add6459e0fbb7e2854694, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      - {fileID: 21300002, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      - {fileID: 21300004, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      - {fileID: 21300006, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      EquippedData: {fileID: 4900000, guid: 621214d035653434f8270910130b66af, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      - {fileID: 21300002, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      - {fileID: 21300004, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      - {fileID: 21300006, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      EquippedData: {fileID: 4900000, guid: 6b6780dd824122a4dbe120ccd15520c2, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 0f1d9b1df45c36045a1ae0156b37c95e, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 69b4890e57afed344863af4b39104a53, type: 3}
       EquippedData: {fileID: 4900000, guid: a1f58268c9a622142b4de9eccd638a2a, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      - {fileID: 21300002, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      - {fileID: 21300004, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      - {fileID: 21300006, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      EquippedData: {fileID: 4900000, guid: 621214d035653434f8270910130b66af, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      - {fileID: 21300002, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      - {fileID: 21300004, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      - {fileID: 21300006, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      EquippedData: {fileID: 4900000, guid: 6b6780dd824122a4dbe120ccd15520c2, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: c63bc9c36530fe244a05e8d3b66f2606, type: 3}
       Sprites:
       - {fileID: 21300000, guid: c63bc9c36530fe244a05e8d3b66f2606, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Medical/medical uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Medical/medical uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: medical uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: defc7501568da024389da3befba07314, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: defc7501568da024389da3befba07314, type: 3}
       EquippedData: {fileID: 4900000, guid: 429b2d0589d37134ab903291e94dd013, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300002, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300004, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300006, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      EquippedData: {fileID: 4900000, guid: dc26195dccfb7ae40845517ca6ddb5ae, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300002, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300004, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300006, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 4311d86bae7c9b242bd1756f817f2c68, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: aff166b908c2b5b45848f9ca5e1448c0, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: ffc1af38d2ea7984da775c7459d886a8, type: 3}
       EquippedData: {fileID: 4900000, guid: 96728005116cd394caf0d36c9efa53e5, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300002, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300004, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300006, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      EquippedData: {fileID: 4900000, guid: dc26195dccfb7ae40845517ca6ddb5ae, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300002, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300004, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300006, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 4311d86bae7c9b242bd1756f817f2c68, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 05c96ade544b80c4dbc28b6cf63cb138, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 05c96ade544b80c4dbc28b6cf63cb138, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Quartermaster/quartermaster uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Quartermaster/quartermaster uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: quartermaster uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 8e57cd2f5f4f6214a837444502f2ef75, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 8e57cd2f5f4f6214a837444502f2ef75, type: 3}
       EquippedData: {fileID: 4900000, guid: 9e68722240ebd784d8b78fcd18879c4d, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300002, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300004, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300006, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      EquippedData: {fileID: 4900000, guid: 8e7b4048eddae5f4389ef4539936b60e, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300002, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300004, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300006, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      EquippedData: {fileID: 4900000, guid: 36b7d802013986346bc4494196acfbed, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: dc98f269408ae644e9e5330978e48a4a, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: cb463dbe3ec4d334c81c28cd9ec4ceb6, type: 3}
       EquippedData: {fileID: 4900000, guid: d29cae1676ea7134498135117e8b798b, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300002, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300004, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300006, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      EquippedData: {fileID: 4900000, guid: 8e7b4048eddae5f4389ef4539936b60e, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300002, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300004, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300006, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      EquippedData: {fileID: 4900000, guid: 36b7d802013986346bc4494196acfbed, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: f075ad108ca5f0a4085a6047227b036e, type: 3}
       Sprites:
       - {fileID: 21300000, guid: f075ad108ca5f0a4085a6047227b036e, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Research director/research director uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Research director/research director uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: research director uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 6a052511104d05e4685f53336f966f9b, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 6a052511104d05e4685f53336f966f9b, type: 3}
       EquippedData: {fileID: 4900000, guid: 321cf6705b73b7040ab4d04242a4a2c3, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300002, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300004, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300006, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      EquippedData: {fileID: 4900000, guid: 8e7b4048eddae5f4389ef4539936b60e, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300002, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300004, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300006, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      EquippedData: {fileID: 4900000, guid: 36b7d802013986346bc4494196acfbed, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 817d330896fe8d64eb2ad37e43e791c0, type: 3}
       Sprites:
@@ -62,30 +85,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: df9202c69d818024a8f0b38155f22164, type: 3}
       EquippedData: {fileID: 4900000, guid: 0b34744bef831f242822e3cf27ec14da, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300002, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300004, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300006, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      EquippedData: {fileID: 4900000, guid: 8e7b4048eddae5f4389ef4539936b60e, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300002, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300004, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300006, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      EquippedData: {fileID: 4900000, guid: 36b7d802013986346bc4494196acfbed, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 439a50f8d1d4cf64aad27aeefb8961f6, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 439a50f8d1d4cf64aad27aeefb8961f6, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Science/science uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Science/science uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: science uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 262d25bf1c5905040bc41169b8b896f6, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 262d25bf1c5905040bc41169b8b896f6, type: 3}
       EquippedData: {fileID: 4900000, guid: 85fb414385e08af42ad8cb9f47d2c14d, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300002, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300004, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300006, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      EquippedData: {fileID: 4900000, guid: dc26195dccfb7ae40845517ca6ddb5ae, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300002, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300004, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300006, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 4311d86bae7c9b242bd1756f817f2c68, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 31e94c5845ae39041b0aa015419829ad, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: c2ab8da54aea5184d8b7abed712db397, type: 3}
       EquippedData: {fileID: 4900000, guid: fef1c868786dd6d40854b5200c5945bf, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300002, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300004, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      - {fileID: 21300006, guid: c2a523b6623947748b924d02e3da0fd1, type: 3}
+      EquippedData: {fileID: 4900000, guid: dc26195dccfb7ae40845517ca6ddb5ae, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300002, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300004, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      - {fileID: 21300006, guid: 7b88b74fe9e4594488d1dca5c992214f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 4311d86bae7c9b242bd1756f817f2c68, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: f5535b9a9aa63ed49b62ab94dff14590, type: 3}
       Sprites:
       - {fileID: 21300000, guid: f5535b9a9aa63ed49b62ab94dff14590, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/Syndicate combat/syndicate combat uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/Syndicate combat/syndicate combat uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: syndicate combat uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 60a6b91a5894b6e48a3debb8f723625a, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 60a6b91a5894b6e48a3debb8f723625a, type: 3}
       EquippedData: {fileID: 4900000, guid: 85b964f0d08c81a47a0f226f83ffb0ae, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      - {fileID: 21300002, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      - {fileID: 21300004, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      - {fileID: 21300006, guid: ee1d6cf773e547d40b9282a9f619fae3, type: 3}
+      EquippedData: {fileID: 4900000, guid: c248bbea60f8d0241bff0ef9dda51765, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      - {fileID: 21300002, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      - {fileID: 21300004, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      - {fileID: 21300006, guid: 6764ecff60852524290196e8e8f09438, type: 3}
+      EquippedData: {fileID: 4900000, guid: 9389cc5f6f7acc2479eaa8df115b1dfb, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: b2d5dbe80228ab54f9f281c923f3ded7, type: 3}
       Sprites:
@@ -70,17 +93,3 @@ MonoBehaviour:
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/atmos/atmospheric tech.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/atmos/atmospheric tech.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: atmospheric tech
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 679584f69c87dd944b629c24468c29fb, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 679584f69c87dd944b629c24468c29fb, type: 3}
       EquippedData: {fileID: 4900000, guid: e04005dc71938be4da1f5feca4a17759, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 3eab0660a3a5d3b43bf29519a4bad892, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 3eab0660a3a5d3b43bf29519a4bad892, type: 3}
+      - {fileID: 21300002, guid: 3eab0660a3a5d3b43bf29519a4bad892, type: 3}
+      - {fileID: 21300004, guid: 3eab0660a3a5d3b43bf29519a4bad892, type: 3}
+      - {fileID: 21300006, guid: 3eab0660a3a5d3b43bf29519a4bad892, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2c90ce23a6784ec49a3c5c6f414bb295, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: d525f540548d7ad4b9f873dbe6f80c68, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: d525f540548d7ad4b9f873dbe6f80c68, type: 3}
+      - {fileID: 21300002, guid: d525f540548d7ad4b9f873dbe6f80c68, type: 3}
+      - {fileID: 21300004, guid: d525f540548d7ad4b9f873dbe6f80c68, type: 3}
+      - {fileID: 21300006, guid: d525f540548d7ad4b9f873dbe6f80c68, type: 3}
+      EquippedData: {fileID: 4900000, guid: fcf0eccc74f6cb64a8c3e4eab29560cd, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 9b6d51c0ac82a564e8c449be9bf6448d, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 3e9586097f894ff47ba952a05de2be6c, type: 3}
       EquippedData: {fileID: 4900000, guid: ec4f48288f90fc447ad3b36670b3fd94, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 3eab0660a3a5d3b43bf29519a4bad892, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 3eab0660a3a5d3b43bf29519a4bad892, type: 3}
+      - {fileID: 21300002, guid: 3eab0660a3a5d3b43bf29519a4bad892, type: 3}
+      - {fileID: 21300004, guid: 3eab0660a3a5d3b43bf29519a4bad892, type: 3}
+      - {fileID: 21300006, guid: 3eab0660a3a5d3b43bf29519a4bad892, type: 3}
+      EquippedData: {fileID: 4900000, guid: 2c90ce23a6784ec49a3c5c6f414bb295, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: d525f540548d7ad4b9f873dbe6f80c68, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: d525f540548d7ad4b9f873dbe6f80c68, type: 3}
+      - {fileID: 21300002, guid: d525f540548d7ad4b9f873dbe6f80c68, type: 3}
+      - {fileID: 21300004, guid: d525f540548d7ad4b9f873dbe6f80c68, type: 3}
+      - {fileID: 21300006, guid: d525f540548d7ad4b9f873dbe6f80c68, type: 3}
+      EquippedData: {fileID: 4900000, guid: fcf0eccc74f6cb64a8c3e4eab29560cd, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 6e345bd64f0e0734b8bf5e559784e4ff, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 6e345bd64f0e0734b8bf5e559784e4ff, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/barman/bartender uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/barman/bartender uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: bartender uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 473a193609dfb7f42a9f980570752f17, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 473a193609dfb7f42a9f980570752f17, type: 3}
       EquippedData: {fileID: 4900000, guid: 3432f04a6a3783541b23f7d641ac7b55, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 2f58e3e01e753534ca7097fd552c2fe8, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 2f58e3e01e753534ca7097fd552c2fe8, type: 3}
+      - {fileID: 21300002, guid: 2f58e3e01e753534ca7097fd552c2fe8, type: 3}
+      - {fileID: 21300004, guid: 2f58e3e01e753534ca7097fd552c2fe8, type: 3}
+      - {fileID: 21300006, guid: 2f58e3e01e753534ca7097fd552c2fe8, type: 3}
+      EquippedData: {fileID: 4900000, guid: a4d4a9035b66e214cba6ab9a2f13761c, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: e9e47ca139fc8f54c997aa2f00ca2cb1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: e9e47ca139fc8f54c997aa2f00ca2cb1, type: 3}
+      - {fileID: 21300002, guid: e9e47ca139fc8f54c997aa2f00ca2cb1, type: 3}
+      - {fileID: 21300004, guid: e9e47ca139fc8f54c997aa2f00ca2cb1, type: 3}
+      - {fileID: 21300006, guid: e9e47ca139fc8f54c997aa2f00ca2cb1, type: 3}
+      EquippedData: {fileID: 4900000, guid: cb226a9eb59bf9e4cb3ce45f78bd344c, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 31f732b7d5a73cf42b58f7eb9590ac89, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: ba2734f6f1ae19941ac1ef46a3209066, type: 3}
       EquippedData: {fileID: 4900000, guid: 4368ce9735bbd4a4a9cf6f9634891bf0, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 2f58e3e01e753534ca7097fd552c2fe8, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 2f58e3e01e753534ca7097fd552c2fe8, type: 3}
+      - {fileID: 21300002, guid: 2f58e3e01e753534ca7097fd552c2fe8, type: 3}
+      - {fileID: 21300004, guid: 2f58e3e01e753534ca7097fd552c2fe8, type: 3}
+      - {fileID: 21300006, guid: 2f58e3e01e753534ca7097fd552c2fe8, type: 3}
+      EquippedData: {fileID: 4900000, guid: a4d4a9035b66e214cba6ab9a2f13761c, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: e9e47ca139fc8f54c997aa2f00ca2cb1, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: e9e47ca139fc8f54c997aa2f00ca2cb1, type: 3}
+      - {fileID: 21300002, guid: e9e47ca139fc8f54c997aa2f00ca2cb1, type: 3}
+      - {fileID: 21300004, guid: e9e47ca139fc8f54c997aa2f00ca2cb1, type: 3}
+      - {fileID: 21300006, guid: e9e47ca139fc8f54c997aa2f00ca2cb1, type: 3}
+      EquippedData: {fileID: 4900000, guid: cb226a9eb59bf9e4cb3ce45f78bd344c, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 51a877753e4a27d40a21afedb96639c2, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 51a877753e4a27d40a21afedb96639c2, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/captain/captain uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/captain/captain uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: captain uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 49a75ce21f71243498138079a77102e4, type: 3}
@@ -74,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 994aeea3c5522c245a0475cb3f624991, type: 3}
       EquippedData: {fileID: 4900000, guid: 21ab2e935cfc6d84a9ae9d3ca8215611, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      - {fileID: 21300002, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      - {fileID: 21300004, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      - {fileID: 21300006, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 178a0d13de5ec624f840e772bd007126, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      - {fileID: 21300002, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      - {fileID: 21300004, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      - {fileID: 21300006, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 98b909c4790302343915053b7b844bb5, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 8133de4c61868d84eaacbfb1bbe55908, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 8133de4c61868d84eaacbfb1bbe55908, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/cargo/cargo uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/cargo/cargo uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: cargo uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: ad01a44ef8cba9c4d9cb122898c5a811, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: ad01a44ef8cba9c4d9cb122898c5a811, type: 3}
       EquippedData: {fileID: 4900000, guid: bd98701a873fa6746bc2cc86284d8348, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300002, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300004, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300006, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      EquippedData: {fileID: 4900000, guid: 8e7b4048eddae5f4389ef4539936b60e, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300002, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300004, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300006, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      EquippedData: {fileID: 4900000, guid: 36b7d802013986346bc4494196acfbed, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: c1b4f37c3c7913348b0c0c8b3f9e6624, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 52e2793f9914bb243914c0da3b33de39, type: 3}
       EquippedData: {fileID: 4900000, guid: aa1ac945020480b48979dcee1f80139b, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300002, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300004, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      - {fileID: 21300006, guid: 9f2d784350c4e6d4fb8c6a63469cbea9, type: 3}
+      EquippedData: {fileID: 4900000, guid: 8e7b4048eddae5f4389ef4539936b60e, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300002, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300004, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      - {fileID: 21300006, guid: d1e05aa8be0d5d843a12d13be34d4bbb, type: 3}
+      EquippedData: {fileID: 4900000, guid: 36b7d802013986346bc4494196acfbed, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: ce849ea0dfce4c4459c475503361a51a, type: 3}
       Sprites:
       - {fileID: 21300000, guid: ce849ea0dfce4c4459c475503361a51a, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/curator/Curator uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/curator/Curator uniform.asset
@@ -13,23 +13,46 @@ MonoBehaviour:
   m_Name: Curator uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
-      Texture: {fileID: 2800000, guid: 8cd4fcd8fa14f9a449331566cdea3515, type: 3}
+      Texture: {fileID: 2800000, guid: 4ad44f146f501c642a9048cfa0778b20, type: 3}
       Sprites:
-      - {fileID: 21300000, guid: 8cd4fcd8fa14f9a449331566cdea3515, type: 3}
-      - {fileID: 21300002, guid: 8cd4fcd8fa14f9a449331566cdea3515, type: 3}
-      - {fileID: 21300004, guid: 8cd4fcd8fa14f9a449331566cdea3515, type: 3}
-      - {fileID: 21300006, guid: 8cd4fcd8fa14f9a449331566cdea3515, type: 3}
-      EquippedData: {fileID: 4900000, guid: 7b500e5a760d64d40883b95329ac0714, type: 3}
+      - {fileID: 21300000, guid: 4ad44f146f501c642a9048cfa0778b20, type: 3}
+      - {fileID: 21300002, guid: 4ad44f146f501c642a9048cfa0778b20, type: 3}
+      - {fileID: 21300004, guid: 4ad44f146f501c642a9048cfa0778b20, type: 3}
+      - {fileID: 21300006, guid: 4ad44f146f501c642a9048cfa0778b20, type: 3}
+      EquippedData: {fileID: 4900000, guid: 0702fbe92dad97244b6c6b931ee8251b, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      - {fileID: 21300002, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      - {fileID: 21300004, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      - {fileID: 21300006, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      EquippedData: {fileID: 4900000, guid: 621214d035653434f8270910130b66af, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      - {fileID: 21300002, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      - {fileID: 21300004, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      - {fileID: 21300006, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      EquippedData: {fileID: 4900000, guid: 6b6780dd824122a4dbe120ccd15520c2, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 14dea9d2a86c8104aa111acec66c577a, type: 3}
       Sprites:
@@ -54,33 +77,31 @@ MonoBehaviour:
       EquippedData: {fileID: 0}
   DressVariant:
     Equipped:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 34ad32af6ae0d5e46a2be36cd4188a8e, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 34ad32af6ae0d5e46a2be36cd4188a8e, type: 3}
+      - {fileID: 21300002, guid: 34ad32af6ae0d5e46a2be36cd4188a8e, type: 3}
+      - {fileID: 21300004, guid: 34ad32af6ae0d5e46a2be36cd4188a8e, type: 3}
+      - {fileID: 21300006, guid: 34ad32af6ae0d5e46a2be36cd4188a8e, type: 3}
+      EquippedData: {fileID: 4900000, guid: 804cd542a54b68f4ba623aa9dfa2dd0a, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      - {fileID: 21300002, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      - {fileID: 21300004, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      - {fileID: 21300006, guid: 41bacba10cd9c244a94d400b6983d0d3, type: 3}
+      EquippedData: {fileID: 4900000, guid: 621214d035653434f8270910130b66af, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      - {fileID: 21300002, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      - {fileID: 21300004, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      - {fileID: 21300006, guid: 1cf1c4e45bc190b499419530e8a10187, type: 3}
+      EquippedData: {fileID: 4900000, guid: 6b6780dd824122a4dbe120ccd15520c2, type: 3}
     ItemIcon:
       Texture: {fileID: 0}
       Sprites: []
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/grey/Gray suit.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/grey/Gray suit.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: Gray suit
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 3d8b966737376684984d3d0691b072f2, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 3d8b966737376684984d3d0691b072f2, type: 3}
       EquippedData: {fileID: 4900000, guid: 1a67abaf3caeee547933fb7c3989e028, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      - {fileID: 21300002, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      - {fileID: 21300004, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      - {fileID: 21300006, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      EquippedData: {fileID: 4900000, guid: 372376dd5cdbeee42922f290071e8415, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      - {fileID: 21300002, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      - {fileID: 21300004, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      - {fileID: 21300006, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      EquippedData: {fileID: 4900000, guid: 6066566e5f2356344b64a22d288eda81, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 1ed9e3c02b5c65445b8fa457b0aa0cc8, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: dad5dc881f46fd547a58f4f1316ad734, type: 3}
       EquippedData: {fileID: 4900000, guid: 86ff9e2e7061ada41a55bfbead4a75cc, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      - {fileID: 21300002, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      - {fileID: 21300004, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      - {fileID: 21300006, guid: 42bd1873404a0da45afc254aa4d7c263, type: 3}
+      EquippedData: {fileID: 4900000, guid: 372376dd5cdbeee42922f290071e8415, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      - {fileID: 21300002, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      - {fileID: 21300004, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      - {fileID: 21300006, guid: f7c07cecd4ee26e49b49195a1a4831f7, type: 3}
+      EquippedData: {fileID: 4900000, guid: 6066566e5f2356344b64a22d288eda81, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 6b84627caa6e85546868837a60b01081, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 6b84627caa6e85546868837a60b01081, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/head of personal/head of personnel uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/head of personal/head of personnel uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: head of personnel uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 10994f019fa6f274aa3bd4e6c7379691, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 10994f019fa6f274aa3bd4e6c7379691, type: 3}
       EquippedData: {fileID: 4900000, guid: 90900f3c44e120d40b2317a6da20dbd6, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      - {fileID: 21300002, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      - {fileID: 21300004, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      - {fileID: 21300006, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 178a0d13de5ec624f840e772bd007126, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      - {fileID: 21300002, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      - {fileID: 21300004, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      - {fileID: 21300006, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 98b909c4790302343915053b7b844bb5, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: fd7639c93aef4b54dbaa6926672c0dfa, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 7edf79e5d7c3ce84b95bf9d7fba1fbae, type: 3}
       EquippedData: {fileID: 4900000, guid: 8a8ff3b78d0d2ff46bcd97de4592a573, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      - {fileID: 21300002, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      - {fileID: 21300004, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      - {fileID: 21300006, guid: cd89ba02395f43745bc816a306b2100f, type: 3}
+      EquippedData: {fileID: 4900000, guid: 178a0d13de5ec624f840e772bd007126, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      - {fileID: 21300002, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      - {fileID: 21300004, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      - {fileID: 21300006, guid: b0a06614fb9a796468ac389d0b7944a5, type: 3}
+      EquippedData: {fileID: 4900000, guid: 98b909c4790302343915053b7b844bb5, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: d33d48a2c80e96344b3ad0d637751c9c, type: 3}
       Sprites:
       - {fileID: 21300000, guid: d33d48a2c80e96344b3ad0d637751c9c, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/janitor/janitor uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/janitor/janitor uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: janitor uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: fbfcee5e769362f4a93006f5228426e7, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: fbfcee5e769362f4a93006f5228426e7, type: 3}
       EquippedData: {fileID: 4900000, guid: f7275bd0c86ab4143a7953e487d64932, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 9eef550a5fa9d884eb4abba9372fc7b6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 9eef550a5fa9d884eb4abba9372fc7b6, type: 3}
+      - {fileID: 21300002, guid: 9eef550a5fa9d884eb4abba9372fc7b6, type: 3}
+      - {fileID: 21300004, guid: 9eef550a5fa9d884eb4abba9372fc7b6, type: 3}
+      - {fileID: 21300006, guid: 9eef550a5fa9d884eb4abba9372fc7b6, type: 3}
+      EquippedData: {fileID: 4900000, guid: a241d2236f626654bbb99f54a2579ec4, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c344d4caa49fe284d8845060425e33a5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c344d4caa49fe284d8845060425e33a5, type: 3}
+      - {fileID: 21300002, guid: c344d4caa49fe284d8845060425e33a5, type: 3}
+      - {fileID: 21300004, guid: c344d4caa49fe284d8845060425e33a5, type: 3}
+      - {fileID: 21300006, guid: c344d4caa49fe284d8845060425e33a5, type: 3}
+      EquippedData: {fileID: 4900000, guid: ca191a3c4adb1ce43bf46c4a6ced23e0, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 1435830f4d7db65439fdc0012cc823b9, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 40b328e7942c67443935f58a8a0108aa, type: 3}
       EquippedData: {fileID: 4900000, guid: a2b9b085b1770374a9317a7655526cc1, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 9eef550a5fa9d884eb4abba9372fc7b6, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 9eef550a5fa9d884eb4abba9372fc7b6, type: 3}
+      - {fileID: 21300002, guid: 9eef550a5fa9d884eb4abba9372fc7b6, type: 3}
+      - {fileID: 21300004, guid: 9eef550a5fa9d884eb4abba9372fc7b6, type: 3}
+      - {fileID: 21300006, guid: 9eef550a5fa9d884eb4abba9372fc7b6, type: 3}
+      EquippedData: {fileID: 4900000, guid: a241d2236f626654bbb99f54a2579ec4, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: c344d4caa49fe284d8845060425e33a5, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c344d4caa49fe284d8845060425e33a5, type: 3}
+      - {fileID: 21300002, guid: c344d4caa49fe284d8845060425e33a5, type: 3}
+      - {fileID: 21300004, guid: c344d4caa49fe284d8845060425e33a5, type: 3}
+      - {fileID: 21300006, guid: c344d4caa49fe284d8845060425e33a5, type: 3}
+      EquippedData: {fileID: 4900000, guid: ca191a3c4adb1ce43bf46c4a6ced23e0, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 084c12f956d22c2409bfb8c2a92ceef5, type: 3}
       Sprites:
       - {fileID: 21300000, guid: 084c12f956d22c2409bfb8c2a92ceef5, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/lawyer_black/lawyer black uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/lawyer_black/lawyer black uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: lawyer black uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: 8119bdbdd36b8814b952db32b0b3a153, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 8119bdbdd36b8814b952db32b0b3a153, type: 3}
       EquippedData: {fileID: 4900000, guid: 2c9b9702561ee9348977c8a4e2b0f523, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 708d9f32f63e537469ac8ef8a2517b28, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 708d9f32f63e537469ac8ef8a2517b28, type: 3}
+      - {fileID: 21300002, guid: 708d9f32f63e537469ac8ef8a2517b28, type: 3}
+      - {fileID: 21300004, guid: 708d9f32f63e537469ac8ef8a2517b28, type: 3}
+      - {fileID: 21300006, guid: 708d9f32f63e537469ac8ef8a2517b28, type: 3}
+      EquippedData: {fileID: 4900000, guid: cfd98752bc21190469d01c56c30fee58, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 29e59b0f9955b42419f99bd9cd7adaa8, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 29e59b0f9955b42419f99bd9cd7adaa8, type: 3}
+      - {fileID: 21300002, guid: 29e59b0f9955b42419f99bd9cd7adaa8, type: 3}
+      - {fileID: 21300004, guid: 29e59b0f9955b42419f99bd9cd7adaa8, type: 3}
+      - {fileID: 21300006, guid: 29e59b0f9955b42419f99bd9cd7adaa8, type: 3}
+      EquippedData: {fileID: 4900000, guid: f7351865c8a5b444991db26831557582, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: 5d8369dde84877e43ad0aab6d5dce74f, type: 3}
       Sprites:
@@ -62,30 +85,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: c9f48f8146cd7424fbd01c5b1487f61b, type: 3}
       EquippedData: {fileID: 4900000, guid: 96fc34b5515e1e847a4e15f59689ad0e, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 708d9f32f63e537469ac8ef8a2517b28, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 708d9f32f63e537469ac8ef8a2517b28, type: 3}
+      - {fileID: 21300002, guid: 708d9f32f63e537469ac8ef8a2517b28, type: 3}
+      - {fileID: 21300004, guid: 708d9f32f63e537469ac8ef8a2517b28, type: 3}
+      - {fileID: 21300006, guid: 708d9f32f63e537469ac8ef8a2517b28, type: 3}
+      EquippedData: {fileID: 4900000, guid: cfd98752bc21190469d01c56c30fee58, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 29e59b0f9955b42419f99bd9cd7adaa8, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 29e59b0f9955b42419f99bd9cd7adaa8, type: 3}
+      - {fileID: 21300002, guid: 29e59b0f9955b42419f99bd9cd7adaa8, type: 3}
+      - {fileID: 21300004, guid: 29e59b0f9955b42419f99bd9cd7adaa8, type: 3}
+      - {fileID: 21300006, guid: 29e59b0f9955b42419f99bd9cd7adaa8, type: 3}
+      EquippedData: {fileID: 4900000, guid: f7351865c8a5b444991db26831557582, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: a5592e7f7b1477440922905a0302ce93, type: 3}
       Sprites:
       - {fileID: 21300000, guid: a5592e7f7b1477440922905a0302ce93, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []

--- a/UnityProject/Assets/Resources/textures/clothing/uniform/mime/mime uniform.asset
+++ b/UnityProject/Assets/Resources/textures/clothing/uniform/mime/mime uniform.asset
@@ -13,6 +13,21 @@ MonoBehaviour:
   m_Name: mime uniform
   m_EditorClassIdentifier: 
   PrefabVariant: {fileID: 0}
+  ItemAttributes:
+    itemName: 
+    itemDescription: 
+    itemType: 7
+    size: 0
+    spriteType: 0
+    CanConnectToTank: 0
+    IsEVACapable: 0
+    hitDamage: 0
+    damageType: 0
+    throwDamage: 0
+    throwSpeed: 2
+    throwRange: 7
+    hitSound: GenericHit
+    attackVerb: []
   Base:
     Equipped:
       Texture: {fileID: 2800000, guid: a006da631f9f14849b0bbb818b400148, type: 3}
@@ -23,13 +38,21 @@ MonoBehaviour:
       - {fileID: 21300006, guid: a006da631f9f14849b0bbb818b400148, type: 3}
       EquippedData: {fileID: 4900000, guid: 72c3051ce69efbd44b25586402e794ec, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: dc7cc83b9c5a00f4687495d46bd79f5b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: dc7cc83b9c5a00f4687495d46bd79f5b, type: 3}
+      - {fileID: 21300002, guid: dc7cc83b9c5a00f4687495d46bd79f5b, type: 3}
+      - {fileID: 21300004, guid: dc7cc83b9c5a00f4687495d46bd79f5b, type: 3}
+      - {fileID: 21300006, guid: dc7cc83b9c5a00f4687495d46bd79f5b, type: 3}
+      EquippedData: {fileID: 4900000, guid: 54691a7f4c4740a4da02d96323f5fd01, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 767bcb1c05cbeb949a71c1a293b65a62, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 767bcb1c05cbeb949a71c1a293b65a62, type: 3}
+      - {fileID: 21300002, guid: 767bcb1c05cbeb949a71c1a293b65a62, type: 3}
+      - {fileID: 21300004, guid: 767bcb1c05cbeb949a71c1a293b65a62, type: 3}
+      - {fileID: 21300006, guid: 767bcb1c05cbeb949a71c1a293b65a62, type: 3}
+      EquippedData: {fileID: 4900000, guid: 78354b9ab0937a84ba8a829aa9ce4d38, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: d26e2e29f3d1cf4418949762a40a0436, type: 3}
       Sprites:
@@ -66,30 +89,24 @@ MonoBehaviour:
       - {fileID: 21300006, guid: 7869142cc258fe54fa83e39cef6762b3, type: 3}
       EquippedData: {fileID: 4900000, guid: f9f87d99d2e74a841896d7a272507a43, type: 3}
     InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: dc7cc83b9c5a00f4687495d46bd79f5b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: dc7cc83b9c5a00f4687495d46bd79f5b, type: 3}
+      - {fileID: 21300002, guid: dc7cc83b9c5a00f4687495d46bd79f5b, type: 3}
+      - {fileID: 21300004, guid: dc7cc83b9c5a00f4687495d46bd79f5b, type: 3}
+      - {fileID: 21300006, guid: dc7cc83b9c5a00f4687495d46bd79f5b, type: 3}
+      EquippedData: {fileID: 4900000, guid: 54691a7f4c4740a4da02d96323f5fd01, type: 3}
     InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
+      Texture: {fileID: 2800000, guid: 767bcb1c05cbeb949a71c1a293b65a62, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 767bcb1c05cbeb949a71c1a293b65a62, type: 3}
+      - {fileID: 21300002, guid: 767bcb1c05cbeb949a71c1a293b65a62, type: 3}
+      - {fileID: 21300004, guid: 767bcb1c05cbeb949a71c1a293b65a62, type: 3}
+      - {fileID: 21300006, guid: 767bcb1c05cbeb949a71c1a293b65a62, type: 3}
+      EquippedData: {fileID: 4900000, guid: 78354b9ab0937a84ba8a829aa9ce4d38, type: 3}
     ItemIcon:
       Texture: {fileID: 2800000, guid: ee1c5ffa02dca834caa2a5172ab20b55, type: 3}
       Sprites:
       - {fileID: 21300000, guid: ee1c5ffa02dca834caa2a5172ab20b55, type: 3}
       EquippedData: {fileID: 0}
   Variants: []
-  ItemAttributes:
-    itemName: 
-    itemDescription: 
-    itemType: 7
-    size: 0
-    spriteType: 0
-    CanConnectToTank: 0
-    hitDamage: 0
-    damageType: 0
-    throwDamage: 0
-    throwSpeed: 2
-    throwRange: 7
-    hitSound: GenericHit
-    attackVerb: []


### PR DESCRIPTION
### Purpose
Fixes #1748. 
I added inhand sprites for everything I could under textures/clothing.

### Open Questions and Pre-Merge TODOs

- [ ]  This fix is tested on the same branch it is PR'ed to.
- [ ]  I correctly commented my code
- [ ]  My code is indented with tabs and not spaces
- [ ]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [ ]  This PR does not bring up any new compile errors
- [ ]  This PR has been tested in editor
- [ ]  Any new / changed components have been [tested using Respawn](https://github.com/unitystation/unitystation/wiki/Proper-Spawning-and-Despawning-%28Object-Lifecycle%29)
- [ ]  This PR has been tested with round restarts.
- [ ]  This PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes:
Gonna be honest.. I didn't test this super thoroughly, since this was just prefab edits and adding in hands. If I missed something or there's an inconsistency, we can always fix when we find them since it's fairly trivial. This will at least get the bulk of the work done
