### PR TITLE
Adds experimental WaitForNetworkManager method, fixes Stackables

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using Mirror;
 using UnityEngine;
 
@@ -39,10 +40,14 @@ public class Stackable : NetworkBehaviour, IServerSpawn, ICheckedInteractable<In
 		amount = initialAmount;
 		pushPull = GetComponent<PushPull>();
 		registerTile = GetComponent<RegisterTile>();
-		if (CustomNetworkManager.IsServer)
+
+		this.WaitForNetworkManager(() =>
 		{
-			registerTile.OnLocalPositionChangedServer.AddListener(OnLocalPositionChangedServer);
-		}
+			if (CustomNetworkManager.IsServer)
+			{
+				registerTile.OnLocalPositionChangedServer.AddListener(OnLocalPositionChangedServer);
+			}
+		});
 	}
 
 	private void OnLocalPositionChangedServer(Vector3Int newLocalPos)

--- a/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
@@ -267,7 +267,7 @@ public static class PlayerSpawn
 
 			//fire all hooks
 			var info = SpawnInfo.Player(OccupationList.Instance.Get(JobType.ASSISTANT), new CharacterSettings(), CustomNetworkManager.Instance.humanPlayerPrefab,
-				spawnTransform.position.RoundToInt());
+				SpawnDestination.At(spawnTransform.gameObject));
 			Spawn._ServerFireClientServerSpawnHooks(SpawnResult.Single(info, dummy));
 		}
 	}

--- a/UnityProject/Assets/Scripts/Spawners/NPCSpawner.cs
+++ b/UnityProject/Assets/Scripts/Spawners/NPCSpawner.cs
@@ -27,22 +27,7 @@ public class NPCSpawner : MonoBehaviour
 	void Start()
 	{
 		transform.localPosition = Vector3Int.RoundToInt(transform.localPosition);
-		StartCoroutine(WaitForLoad());
-	}
-
-	IEnumerator WaitForLoad()
-	{
-		while (CustomNetworkManager.Instance == null)
-		{
-			yield return WaitFor.Seconds(1f);
-		}
-
-		yield return WaitFor.EndOfFrame;
-
-		if (CustomNetworkManager.Instance._isServer)
-		{
-			OnStartServer();
-		}
+		this.WaitForNetworkManager(OnStartServer);
 	}
 
 	//Is ready on the server:

--- a/UnityProject/Assets/Scripts/Util/CoroutineExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/CoroutineExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using UnityEngine;
 
@@ -22,7 +23,7 @@ public static class CoroutineExtensions {
 	public static MonoBehaviour StartCoroutine( this MonoBehaviour script, IEnumerator routine, ref Coroutine handle ) {
 		if ( !script ) {
 #if UNITY_EDITOR
-			Logger.LogWarning( "A coroutine cannot run while it is null or being destroyed", Category.Threading ); 
+			Logger.LogWarning( "A coroutine cannot run while it is null or being destroyed", Category.Threading );
 #endif
 			return null;
 		}
@@ -48,4 +49,28 @@ public static class CoroutineExtensions {
 		return script.TryStopCoroutine( ref handle )
 			.StartCoroutine( routine, ref handle );
 	}
+
+	/// <summary>
+	/// Ensures CustomNetworkManager.Instance is not null, then executes your action
+	/// </summary>
+	public static void WaitForNetworkManager(this MonoBehaviour script, Action action)
+	{
+		if (CustomNetworkManager.Instance != null)
+		{ //Don't even start a coroutine if Instance exists
+			action.Invoke();
+		}
+
+		IEnumerator WaitForNetworkManager(Action a)
+		{
+			while (CustomNetworkManager.Instance == null)
+			{
+				yield return WaitFor.EndOfFrame;
+			}
+
+			a.Invoke();
+		}
+
+		script.StartCoroutine(WaitForNetworkManager(action));
+	}
+
 }


### PR DESCRIPTION
### Purpose
Fixes #2329 
Introduces a convenient extension method in case you have to wait for CustomNetworkManager instance to initialise

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  Any new / changed components have been [tested using Respawn](https://github.com/unitystation/unitystation/wiki/Proper-Spawning-and-Despawning-%28Object-Lifecycle%29)
- [ ]  This PR has been tested with round restarts.
- [ ]  This PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)