### PR TITLE
Add names to Grown plants

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Botany/food.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Botany/food.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4645335817288720}
   - component: {fileID: 61202592083071704}
-  - component: {fileID: 114828422824226692}
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
@@ -23,6 +22,7 @@ GameObject:
   - component: {fileID: 1920082862656044705}
   - component: {fileID: 5215751682783047895}
   - component: {fileID: 5113648241220904242}
+  - component: {fileID: 7992913776653634697}
   m_Layer: 10
   m_Name: food
   m_TagString: Untagged
@@ -71,35 +71,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!114 &114828422824226692
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  spriteDataHandler: {fileID: 7175800046361583346}
-  InventoryIcon: {fileID: 0}
-  itemName: bike horn
-  itemDescription: A horn off of a bicycle.
-  initialTraits: []
-  size: 1
-  spriteType: 0
-  CanConnectToTank: 0
-  hitDamage: 0
-  damageType: 0
-  throwDamage: 0
-  throwSpeed: 2
-  throwRange: 7
-  hitSound: GenericHit
-  attackVerb: []
 --- !u!114 &114931546224579044
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -132,9 +103,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114208883059431984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -292,12 +260,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Temperature: 293.15
+  temperatureKelvin: 293.15
   MaxCapacity: 100
-  MoveAmount: 0
   InSolidForm: 0
   Reagents: []
   Amounts: []
+  TraitWhitelist: []
+  ReagentWhitelist: []
+  TransferMode: 0
+  InitialTransferAmount: 20
+  PossibleTransferAmounts: []
 --- !u!114 &5113648241220904242
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -348,8 +320,36 @@ MonoBehaviour:
     ReagentProduction: []
     MutatesInTo: []
   reagentContainer: {fileID: 5215751682783047895}
+  ItemAttributesV2: {fileID: 0}
   PlantSyncString: 
   SizeScale: 0
+--- !u!114 &7992913776653634697
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99794c150ee14b21a829d6ed54d27a60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  initialName: 
+  initialDescription: 
+  initialTraits: []
+  initialSize: 0
+  hitDamage: 0
+  damageType: 0
+  throwDamage: 0
+  throwSpeed: 2
+  throwRange: 7
+  hitSound: GenericHit
+  canConnectToTank: 0
+  isEVACapable: 0
+  attackVerbs: []
 --- !u!1 &1469747287601084
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Botany/GrownFood.cs
+++ b/UnityProject/Assets/Scripts/Botany/GrownFood.cs
@@ -15,7 +15,7 @@ public class GrownFood : NetworkBehaviour, IInteractable<HandActivate>
 	public SpriteHandler SpriteHandler;
 	public PlantData plantData;
 	public ReagentContainer reagentContainer;
-
+	public ItemAttributesV2 ItemAttributesV2;
 
 	[SyncVar(hook = nameof(SyncPlant))]
 	public string PlantSyncString;
@@ -25,7 +25,7 @@ public class GrownFood : NetworkBehaviour, IInteractable<HandActivate>
 		PlantSyncString = _PlantSyncString;
 		if (!isServer)
 		{
-			
+
 			if (DefaultPlantData.PlantDictionary.ContainsKey(PlantSyncString))
 			{
 				plantData = DefaultPlantData.PlantDictionary[PlantSyncString].plantData;
@@ -33,6 +33,15 @@ public class GrownFood : NetworkBehaviour, IInteractable<HandActivate>
 		}
 		SpriteHandler.Infos = StaticSpriteHandler.SetupSingleSprite(plantData.ProduceSprite);
 		SpriteHandler.PushTexture();
+		if (ItemAttributesV2 == null) {
+			ItemAttributesV2 = this.GetComponent<ItemAttributesV2>();
+		}
+		if (isServer && ItemAttributesV2 != null) { 
+			ItemAttributesV2.ServerSetItemDescription(plantData.Description);
+			ItemAttributesV2.ServerSetItemName(plantData.Plantname);
+		}
+		this.name = plantData.Plantname;
+			
 	}
 
 
@@ -63,9 +72,12 @@ public class GrownFood : NetworkBehaviour, IInteractable<HandActivate>
 	}
 
 
-	public void SetupChemicalContents() {
-		if (plantData.ReagentProduction.Count > 0) {			var ChemicalDictionary = new Dictionary<string, float>();
-			foreach (var Chemical in plantData.ReagentProduction) {
+	public void SetupChemicalContents()
+	{
+		if (plantData.ReagentProduction.Count > 0)
+		{			var ChemicalDictionary = new Dictionary<string, float>();
+			foreach (var Chemical in plantData.ReagentProduction)
+			{
 				ChemicalDictionary[Chemical.String] = (Chemical.Int * (plantData.Potency / 100f));
 			}
 			reagentContainer.AddReagents(ChemicalDictionary);
@@ -73,16 +85,12 @@ public class GrownFood : NetworkBehaviour, IInteractable<HandActivate>
 		}
 	}
 
-    // Start is called before the first frame update
+	// Start is called before the first frame update
 	public void ServerPerformInteraction(HandActivate interaction)
 	{
-		Logger.Log("HEY!!!!!");
 		if (plantData != null)
 		{
-			if (SeedPacket == null) {
-				Logger.LogError("help!!");
-			}
-			var _Object = Spawn.ServerPrefab(SeedPacket, interaction.Performer.transform.position, parent: interaction.Performer.transform.parent).GameObject; 
+			var _Object = Spawn.ServerPrefab(SeedPacket, interaction.Performer.transform.position, parent: interaction.Performer.transform.parent).GameObject;
 			var seedPacket = _Object.GetComponent<SeedPacket>();
 			seedPacket.plantData = plantData;
 
@@ -92,13 +100,13 @@ public class GrownFood : NetworkBehaviour, IInteractable<HandActivate>
 			Inventory.ServerAdd(_Object, interaction.HandSlot, ReplacementStrategy.DespawnOther);
 		}
 
-	
+
 	}
 
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
+	// Update is called once per frame
+	void Update()
+	{
+
+	}
 }
 

--- a/UnityProject/Assets/Scripts/Botany/PlantData.cs
+++ b/UnityProject/Assets/Scripts/Botany/PlantData.cs
@@ -30,6 +30,8 @@ public class PlantData
 
 	public void MutateTo(DefaultPlantData _DefaultPlantData)
 	{
+		Plantname = _DefaultPlantData.plantData.Plantname;
+		Description = _DefaultPlantData.plantData.Description;
 		Name = _DefaultPlantData.plantData.Name;
 		ProduceObject = _DefaultPlantData.plantData.ProduceObject;
 		PacketsSprite = _DefaultPlantData.plantData.PacketsSprite;
@@ -55,6 +57,8 @@ public class PlantData
 
 	public void SetValues(PlantData _PlantData)
 	{
+		Plantname = _PlantData.Plantname;
+		Description = _PlantData.Description;
 		Name = _PlantData.Name;
 		ProduceObject = _PlantData.ProduceObject;
 		PacketsSprite = _PlantData.PacketsSprite;
@@ -79,7 +83,8 @@ public class PlantData
 	{
 		var _PlantData = DefaultPlantData.plantData;
 		Name = _PlantData.Name;
-
+		Plantname = _PlantData.Plantname;
+		Description = _PlantData.Description;
 		if (ProduceObject == null)
 		{
 			ProduceObject = _PlantData.ProduceObject;
@@ -113,6 +118,8 @@ public class PlantData
 		Endurance = _PlantData.Endurance;
 		Yield = _PlantData.Yield;
 		Lifespan = _PlantData.Lifespan;
+
+
 
 		PlantTrays = (_PlantData.PlantTrays.Union(PlantTrays)).ToList();
 		MutatesInTo = (_PlantData.MutatesInTo.Union(MutatesInTo)).ToList();


### PR DESCRIPTION
### Purpose
Due to an storage database error, the Station received the wrong Food Seed Package, Sadly This also resulted in Clown station Collapsing due to the lack of Bike horns
### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  Any new / changed components have been [tested using Respawn](https://github.com/unitystation/unitystation/wiki/Proper-Spawning-and-Despawning-%28Object-Lifecycle%29)
- [ ]  This PR has been tested with round restarts.
- [ ]  This PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

### Notes: 
Still can't work out how to do the onstar client Thing