### PR TITLE
Reverse IF2 Component Precedence

### DIFF
--- a/UnityProject/Assets/ClothKiller/Item.prefab
+++ b/UnityProject/Assets/ClothKiller/Item.prefab
@@ -12,11 +12,11 @@ GameObject:
   - component: {fileID: 61728060443877980}
   - component: {fileID: 114341119007412586}
   - component: {fileID: 499351249353511896}
+  - component: {fileID: 114326413956932616}
   - component: {fileID: 114734890905785284}
   - component: {fileID: 114182420558184634}
   - component: {fileID: 114776788309089574}
   - component: {fileID: 114577415631634126}
-  - component: {fileID: 114326413956932616}
   - component: {fileID: 114883521337486670}
   - component: {fileID: 114077084986960180}
   - component: {fileID: 114738972662350094}
@@ -110,6 +110,18 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+--- !u!114 &114326413956932616
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1011433845357754}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114734890905785284
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -156,9 +168,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114577415631634126
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -172,18 +181,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114326413956932616
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1011433845357754}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114883521337486670
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -232,6 +229,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -251,7 +252,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: a7abba22164ce49f0bf9b9b219f39298
+  m_AssetId: 15adb8ff4b5062d41a3738e0a52ea01c
   m_SceneId: 0
 --- !u!1 &1344926539164060
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Accessories/Pepper Shaker.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Accessories/Pepper Shaker.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4579856977360442}
   - component: {fileID: 61541833423010570}
   - component: {fileID: 114785202808129786}
+  - component: {fileID: 114460698645349856}
   - component: {fileID: 114671199612239122}
   - component: {fileID: 114550632238722826}
   - component: {fileID: 114967777731387712}
   - component: {fileID: 114591536286367976}
   - component: {fileID: 114303077026890814}
-  - component: {fileID: 114460698645349856}
   - component: {fileID: 114236039428710784}
   - component: {fileID: 114642636968297428}
   - component: {fileID: 114993261486505718}
@@ -99,6 +99,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114460698645349856
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1651733465195328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114671199612239122
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -173,18 +185,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114460698645349856
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1651733465195328}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114236039428710784
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -256,7 +256,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 1a54efe7f51314f4eb3da3e5917c99b2
   m_SceneId: 0
 --- !u!114 &-8225494683323972620
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Accessories/Salt Shaker.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Accessories/Salt Shaker.prefab
@@ -12,11 +12,11 @@ GameObject:
   - component: {fileID: 61874701466316104}
   - component: {fileID: 114983458888184870}
   - component: {fileID: 114217803941579194}
+  - component: {fileID: 114033844433843342}
   - component: {fileID: 114811898791686074}
   - component: {fileID: 114200006776994880}
   - component: {fileID: 114960262104882700}
   - component: {fileID: 114116176735104048}
-  - component: {fileID: 114033844433843342}
   - component: {fileID: 114710030649419254}
   - component: {fileID: 114005261357320888}
   - component: {fileID: 114000507018836526}
@@ -114,6 +114,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114033844433843342
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036141445992816}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114811898791686074
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -173,18 +185,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114033844433843342
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1036141445992816}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114710030649419254
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -256,7 +256,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: dd31a44e0061599419dba34dd9e7fff7
   m_SceneId: 0
 --- !u!114 &8573282411850685554
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Accessories/Space Cigarettes.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Accessories/Space Cigarettes.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61321219257688126}
   - component: {fileID: 114675370128025870}
   - component: {fileID: 114836435796936700}
+  - component: {fileID: 114901905018068164}
   - component: {fileID: 114007797438959630}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
   - component: {fileID: 114225454510358118}
-  - component: {fileID: 114901905018068164}
   - component: {fileID: 114659316457670264}
   - component: {fileID: 114343285557601882}
   - component: {fileID: 114207939444575574}
@@ -193,6 +193,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114901905018068164
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114007797438959630
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -252,18 +264,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114901905018068164
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114659316457670264
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -335,5 +335,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 29d17c6e33a25434ca93edfb29f82cb7
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Botany/Trowel.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Botany/Trowel.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114909773131868738}
   - component: {fileID: 114998062039538404}
   - component: {fileID: 114484434474911270}
+  - component: {fileID: 114850502447124420}
   - component: {fileID: 114079509811454882}
   - component: {fileID: 2107020011812829422}
   - component: {fileID: 114943451087304478}
-  - component: {fileID: 114850502447124420}
   - component: {fileID: 114596150240161284}
   - component: {fileID: 114976959642827926}
   - component: {fileID: 114877070699459104}
@@ -186,7 +186,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6f1dc4e7ed40b8841958f8a373261742, type: 2}
   size: 1
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 5
   damageType: 0
   throwDamage: 7
@@ -226,9 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
+--- !u!114 &114850502447124420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114079509811454882
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -271,18 +280,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114850502447124420
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114596150240161284
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Botany/cultivator.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Botany/cultivator.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114909773131868738}
   - component: {fileID: 114998062039538404}
   - component: {fileID: 114484434474911270}
+  - component: {fileID: 114850502447124420}
   - component: {fileID: 114079509811454882}
   - component: {fileID: 2107020011812829422}
   - component: {fileID: 114943451087304478}
-  - component: {fileID: 114850502447124420}
   - component: {fileID: 114596150240161284}
   - component: {fileID: 114976959642827926}
   - component: {fileID: 114877070699459104}
@@ -186,7 +186,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6f1dc4e7ed40b8841958f8a373261742, type: 2}
   size: 1
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 5
   damageType: 0
   throwDamage: 7
@@ -226,9 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
+--- !u!114 &114850502447124420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114079509811454882
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -271,18 +280,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114850502447124420
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114596150240161284
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Botany/food.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Botany/food.prefab
@@ -13,12 +13,12 @@ GameObject:
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
+  - component: {fileID: 114499026947524380}
   - component: {fileID: 114556432234894168}
   - component: {fileID: 114417366729828038}
   - component: {fileID: -1256564506844683021}
   - component: {fileID: 7175800046361583346}
   - component: {fileID: 114273922828647914}
-  - component: {fileID: 114499026947524380}
   - component: {fileID: 1920082862656044705}
   - component: {fileID: 5215751682783047895}
   - component: {fileID: 5113648241220904242}
@@ -118,6 +118,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114499026947524380
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114556432234894168
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -220,18 +232,6 @@ MonoBehaviour:
     FreezeProof: 0
   HeatResistance: 100
   initialIntegrity: 100
---- !u!114 &114499026947524380
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1920082862656044705
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Botany/seed packet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Botany/seed packet.prefab
@@ -107,6 +107,7 @@ MonoBehaviour:
   spriteIndex: 0
   VariantIndex: 0
   SynchroniseVariant: 1
+  test: 0
 --- !u!1 &1519710982558066
 GameObject:
   m_ObjectHideFlags: 0
@@ -121,10 +122,10 @@ GameObject:
   - component: {fileID: 114998062039538404}
   - component: {fileID: 114484434474911270}
   - component: {fileID: 114287030664492144}
+  - component: {fileID: 114850502447124420}
   - component: {fileID: 114079509811454882}
   - component: {fileID: 1012120877556218973}
   - component: {fileID: 114943451087304478}
-  - component: {fileID: 114850502447124420}
   - component: {fileID: 114596150240161284}
   - component: {fileID: 114171556259583268}
   - component: {fileID: 7775367136764396337}
@@ -195,10 +196,10 @@ MonoBehaviour:
   InventoryIcon: {fileID: 6508592049166286711}
   itemName: seed packet
   itemDescription: a packet of seeds
-  itemType: 0
+  initialTraits: []
   size: 1
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -238,9 +239,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114287030664492144
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -255,6 +253,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114850502447124420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114079509811454882
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,9 +280,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  OnDropServer:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &1012120877556218973
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -307,18 +315,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114850502447124420
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114596150240161284
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -353,6 +349,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114171556259583268
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -367,7 +364,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 1efec61511b50c844868cb49d1a711a1
+  m_AssetId: 61fbb88e43b8b4f48a44b030453bdedc
   m_SceneId: 0
 --- !u!114 &7775367136764396337
 MonoBehaviour:
@@ -381,10 +378,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: db8e8b7b55bea56498ef51fca8eaec51, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
   Sprite: {fileID: 6508592049166286711}
   plantData:
     ProduceObject: {fileID: 0}
-    plantType: 0
     Name: 
     Plantname: 
     Description: 
@@ -416,6 +414,7 @@ MonoBehaviour:
     ReagentProduction: []
     MutatesInTo: []
   defaultPlantData: {fileID: 0}
+  PlantSyncString: 
 --- !u!114 &1635926354344122938
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Bureaucracy/Resources/Paper Bin.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Bureaucracy/Resources/Paper Bin.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 1829736207480276922}
   - component: {fileID: 6441605053452467712}
   - component: {fileID: 2677451350077854373}
-  - component: {fileID: 4089351644393261817}
+  - component: {fileID: 4321281566600050422}
   - component: {fileID: 146779046979709823}
+  - component: {fileID: 4089351644393261817}
   - component: {fileID: 4149125379476819137}
   - component: {fileID: 2818992286365646655}
-  - component: {fileID: 4321281566600050422}
   - component: {fileID: 781523606564751371}
   - component: {fileID: 8918271915433250682}
   - component: {fileID: 5600470873996663622}
@@ -165,6 +165,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &6441605053452467712
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -199,10 +200,10 @@ MonoBehaviour:
   InventoryIcon: {fileID: 0}
   itemName: Paper Bin
   itemDescription: Contains all the paper you'll never need.
-  InitialTraits: []
+  initialTraits: []
   size: 3
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -210,6 +211,32 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &4321281566600050422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &146779046979709823
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6258242089137662919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &4089351644393261817
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -226,20 +253,6 @@ MonoBehaviour:
   syncInterval: 0.1
   initialPaperCount: 20
   blankPaper: {fileID: 1320386684021000, guid: 4ad202d5ed2ef44f0b3363b5fd90a066, type: 3}
---- !u!114 &146779046979709823
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6258242089137662919}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &4149125379476819137
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,21 +282,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &4321281566600050422
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6258242089137662919}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &781523606564751371
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -332,6 +330,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -365,11 +367,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdce8a163088453ca593c0e98f2c5f07, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ItemStorageStructure: {fileID: 11400000, guid: 27a302783a0494da280ad36e91b8752d,
+  itemStorageStructure: {fileID: 11400000, guid: 27a302783a0494da280ad36e91b8752d,
     type: 2}
-  ItemStorageCapacity: {fileID: 11400000, guid: f0cf26da94f1b4520a902840eebe5eb8,
+  itemStorageCapacity: {fileID: 11400000, guid: f0cf26da94f1b4520a902840eebe5eb8,
     type: 2}
-  ItemStoragePopulator: {fileID: 0}
+  itemStoragePopulator: {fileID: 0}
 --- !u!1 &6541166396586915311
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Bureaucracy/Resources/Paper.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Bureaucracy/Resources/Paper.prefab
@@ -13,13 +13,13 @@ GameObject:
   - component: {fileID: 114680268422892540}
   - component: {fileID: 114646101893439272}
   - component: {fileID: 114741019056190926}
+  - component: {fileID: 1551927132294530552}
+  - component: {fileID: 114930140412175382}
+  - component: {fileID: 7616435447516161641}
   - component: {fileID: 114843876647253344}
   - component: {fileID: 114559639511531318}
-  - component: {fileID: 7616435447516161641}
-  - component: {fileID: 114930140412175382}
   - component: {fileID: 114414318728299190}
   - component: {fileID: 114455083295167806}
-  - component: {fileID: 1551927132294530552}
   - component: {fileID: 9141838167646105436}
   - component: {fileID: 114689926834821060}
   - component: {fileID: 114831345842512288}
@@ -85,6 +85,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114646101893439272
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -119,11 +120,11 @@ MonoBehaviour:
   InventoryIcon: {fileID: 0}
   itemName: Paper
   itemDescription: A piece of paper
-  InitialTraits:
+  initialTraits:
   - {fileID: 11400000, guid: 24632eaec5a984a9f95155bf676a95bc, type: 2}
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -131,6 +132,49 @@ MonoBehaviour:
   throwRange: 1
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &1551927132294530552
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1320386684021000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114930140412175382
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1320386684021000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &7616435447516161641
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1320386684021000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c41af2d53114e99b2142b2b126717c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  NetTabType: 13
+  originalName: 
+  customName: 
 --- !u!114 &114843876647253344
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -164,37 +208,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   NetTabType: 4
   paper: {fileID: 114843876647253344}
---- !u!114 &7616435447516161641
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1320386684021000}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6c41af2d53114e99b2142b2b126717c0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  NetTabType: 13
-  originalName: 
-  customName: 
---- !u!114 &114930140412175382
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1320386684021000}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114414318728299190
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -224,21 +237,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &1551927132294530552
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1320386684021000}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &9141838167646105436
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -287,6 +285,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -306,7 +308,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 4ad202d5ed2ef44f0b3363b5fd90a066
+  m_AssetId: 549f7d7203498874bafc385496a54fb5
   m_SceneId: 0
 --- !u!1 &1731708282254700
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Bureaucracy/Resources/Pen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Bureaucracy/Resources/Pen.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 114342755618585978}
   - component: {fileID: 114288380597099474}
   - component: {fileID: 114267664904661214}
+  - component: {fileID: 8298614166764621146}
   - component: {fileID: 114330809230976920}
   - component: {fileID: 114779724774409168}
   - component: {fileID: 114694305165720408}
   - component: {fileID: 114561525083604656}
-  - component: {fileID: 8298614166764621146}
   - component: {fileID: 2600937791088103195}
   - component: {fileID: 114824716978287404}
   - component: {fileID: 114397617349825898}
@@ -163,6 +163,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114288380597099474
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -197,11 +198,11 @@ MonoBehaviour:
   InventoryIcon: {fileID: 0}
   itemName: Pen
   itemDescription: It's a normal black ink pen.
-  InitialTraits:
+  initialTraits:
   - {fileID: 11400000, guid: c2d02e56a0e4245d895e44a45323cf8b, type: 2}
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -209,6 +210,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &8298614166764621146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1277678737481138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114330809230976920
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -264,21 +277,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &8298614166764621146
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1277678737481138}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &2600937791088103195
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -327,6 +325,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Resources/BreathMask.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Resources/BreathMask.prefab
@@ -92,12 +92,12 @@ GameObject:
   - component: {fileID: 61473308885118922}
   - component: {fileID: 114383778497471820}
   - component: {fileID: 114546555560900714}
+  - component: {fileID: 114368999798544118}
   - component: {fileID: 114974857860112182}
   - component: {fileID: 114335198416293264}
   - component: {fileID: 114189084348342176}
   - component: {fileID: 114763204956872164}
   - component: {fileID: 114075693290465856}
-  - component: {fileID: 114368999798544118}
   - component: {fileID: 114550609802161842}
   - component: {fileID: 114492480403723588}
   - component: {fileID: 114498949933275300}
@@ -194,6 +194,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114368999798544118
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1639223380925416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114974857860112182
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -268,18 +280,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114368999798544118
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1639223380925416}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114550609802161842
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -425,5 +425,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 611c366b2d389b94193a817e11987cdc
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Absinthe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Absinthe.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114880268731048502}
-  - component: {fileID: 1462617622284384570}
-  - component: {fileID: 114271146238386550}
-  - component: {fileID: 114251893900744954}
   - component: {fileID: 114686747450333148}
+  - component: {fileID: 114271146238386550}
+  - component: {fileID: 1462617622284384570}
+  - component: {fileID: 114880268731048502}
+  - component: {fileID: 114251893900744954}
   - component: {fileID: 114900682771988638}
   - component: {fileID: 114084572243032196}
   - component: {fileID: 114561163148389116}
@@ -88,12 +88,10 @@ MonoBehaviour:
   InventoryIcon: {fileID: 0}
   itemName: Absinthe
   itemDescription: 
-  Traits:
-  - {fileID: 11400000, guid: fe7314825ebf744c3b651ca76d282adc, type: 2}
-  itemType: 14
+  initialTraits: []
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -133,9 +131,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114208883059431984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -150,6 +145,57 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114686747450333148
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114271146238386550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &1462617622284384570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  temperatureKelvin: 293.15
+  MaxCapacity: 50
+  InSolidForm: 0
+  Reagents:
+  - absinthe
+  Amounts:
+  - 50
+  TraitWhitelist: []
+  ReagentWhitelist: []
+  TransferMode: 0
+  InitialTransferAmount: 20
+  PossibleTransferAmounts: []
 --- !u!114 &114880268731048502
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,38 +213,6 @@ MonoBehaviour:
   leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
   healAmount: 5
   healHungerAmount: 5
---- !u!114 &1462617622284384570
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Temperature: 20
-  MaxCapacity: 50
-  Reagents:
-  - absinthe
-  Amounts:
-  - 50
---- !u!114 &114271146238386550
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114251893900744954
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,18 +226,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114686747450333148
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114900682771988638
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,6 +274,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -291,7 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 63c9a0ba448fa47b7aebb5e45f4b1167
+  m_AssetId: 9239699cf83d84f49abbede461e91717
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Ale.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Ale.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114880268731048502}
-  - component: {fileID: 7960554100023644818}
-  - component: {fileID: 114501696772707070}
-  - component: {fileID: 114141988413488586}
   - component: {fileID: 114193209175139966}
+  - component: {fileID: 114501696772707070}
+  - component: {fileID: 7960554100023644818}
+  - component: {fileID: 114880268731048502}
+  - component: {fileID: 114141988413488586}
   - component: {fileID: 114557376978054538}
   - component: {fileID: 114329078442854132}
   - component: {fileID: 114583203288483382}
@@ -88,12 +88,10 @@ MonoBehaviour:
   InventoryIcon: {fileID: 0}
   itemName: Ale
   itemDescription: 
-  Traits:
-  - {fileID: 11400000, guid: fe7314825ebf744c3b651ca76d282adc, type: 2}
-  itemType: 14
+  initialTraits: []
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 5
   damageType: 0
   throwDamage: 5
@@ -133,9 +131,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114208883059431984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -150,6 +145,57 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114193209175139966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114501696772707070
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &7960554100023644818
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  temperatureKelvin: 293.15
+  MaxCapacity: 50
+  InSolidForm: 0
+  Reagents:
+  - ale
+  Amounts:
+  - 50
+  TraitWhitelist: []
+  ReagentWhitelist: []
+  TransferMode: 0
+  InitialTransferAmount: 20
+  PossibleTransferAmounts: []
 --- !u!114 &114880268731048502
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,38 +213,6 @@ MonoBehaviour:
   leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
   healAmount: 5
   healHungerAmount: 5
---- !u!114 &7960554100023644818
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Temperature: 20
-  MaxCapacity: 50
-  Reagents:
-  - ale
-  Amounts:
-  - 50
---- !u!114 &114501696772707070
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114141988413488586
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,18 +226,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114193209175139966
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114557376978054538
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,6 +274,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -291,7 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: b22b8a1b805c44b77a8d1759a6d4e119
+  m_AssetId: 1f48cda522ed84155af5b395a1b3e957
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Banana Juice.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Banana Juice.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114880268731048502}
-  - component: {fileID: 2969234088347854461}
-  - component: {fileID: 114567038090822720}
-  - component: {fileID: 114187370657520952}
   - component: {fileID: 114830314903324832}
+  - component: {fileID: 114567038090822720}
+  - component: {fileID: 2969234088347854461}
+  - component: {fileID: 114880268731048502}
+  - component: {fileID: 114187370657520952}
   - component: {fileID: 114358443761560514}
   - component: {fileID: 114955569417628938}
   - component: {fileID: 114888360131834536}
@@ -146,7 +146,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &114880268731048502
+--- !u!114 &114830314903324832
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -155,14 +155,23 @@ MonoBehaviour:
   m_GameObject: {fileID: 1110193000772614}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a522f189bd3d44f9b962f977bec7a0a8, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114567038090822720
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
-  healAmount: 5
-  healHungerAmount: 5
 --- !u!114 &2969234088347854461
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -187,7 +196,7 @@ MonoBehaviour:
   TransferMode: 0
   InitialTransferAmount: 20
   PossibleTransferAmounts: []
---- !u!114 &114567038090822720
+--- !u!114 &114880268731048502
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -196,11 +205,14 @@ MonoBehaviour:
   m_GameObject: {fileID: 1110193000772614}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Script: {fileID: 11500000, guid: a522f189bd3d44f9b962f977bec7a0a8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
+  healAmount: 5
+  healHungerAmount: 5
 --- !u!114 &114187370657520952
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -214,18 +226,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114830314903324832
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114358443761560514
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -297,7 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: c2b2938c3617748ab9fa565d6338f68b
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Beer.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Beer.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114880268731048502}
-  - component: {fileID: 605743259192835951}
-  - component: {fileID: 114177210049336486}
-  - component: {fileID: 114560757977240184}
   - component: {fileID: 114880976887082778}
+  - component: {fileID: 114177210049336486}
+  - component: {fileID: 605743259192835951}
+  - component: {fileID: 114880268731048502}
+  - component: {fileID: 114560757977240184}
   - component: {fileID: 114742744090657670}
   - component: {fileID: 114060245427783958}
   - component: {fileID: 114005881571553808}
@@ -146,7 +146,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &114880268731048502
+--- !u!114 &114880976887082778
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -155,14 +155,23 @@ MonoBehaviour:
   m_GameObject: {fileID: 1110193000772614}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a522f189bd3d44f9b962f977bec7a0a8, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114177210049336486
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
-  healAmount: 5
-  healHungerAmount: 5
 --- !u!114 &605743259192835951
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -187,7 +196,7 @@ MonoBehaviour:
   TransferMode: 0
   InitialTransferAmount: 20
   PossibleTransferAmounts: []
---- !u!114 &114177210049336486
+--- !u!114 &114880268731048502
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -196,11 +205,14 @@ MonoBehaviour:
   m_GameObject: {fileID: 1110193000772614}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Script: {fileID: 11500000, guid: a522f189bd3d44f9b962f977bec7a0a8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
+  healAmount: 5
+  healHungerAmount: 5
 --- !u!114 &114560757977240184
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -214,18 +226,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114880976887082778
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114742744090657670
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -297,7 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 0a444092780864964b48a63b1a16cd34
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Berry Juice.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Berry Juice.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114880268731048502}
-  - component: {fileID: 5496045716309107960}
-  - component: {fileID: 114541546419594748}
-  - component: {fileID: 114796218501938598}
   - component: {fileID: 114734639477423404}
+  - component: {fileID: 114541546419594748}
+  - component: {fileID: 5496045716309107960}
+  - component: {fileID: 114880268731048502}
+  - component: {fileID: 114796218501938598}
   - component: {fileID: 114180265932455436}
   - component: {fileID: 114369601868213198}
   - component: {fileID: 114676679701662594}
@@ -88,12 +88,10 @@ MonoBehaviour:
   InventoryIcon: {fileID: 0}
   itemName: Berry Juice
   itemDescription: 
-  Traits:
-  - {fileID: 11400000, guid: fe7314825ebf744c3b651ca76d282adc, type: 2}
-  itemType: 14
+  initialTraits: []
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -133,9 +131,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114208883059431984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -150,6 +145,57 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114734639477423404
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114541546419594748
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &5496045716309107960
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  temperatureKelvin: 293.15
+  MaxCapacity: 50
+  InSolidForm: 0
+  Reagents:
+  - berryjuice
+  Amounts:
+  - 50
+  TraitWhitelist: []
+  ReagentWhitelist: []
+  TransferMode: 0
+  InitialTransferAmount: 20
+  PossibleTransferAmounts: []
 --- !u!114 &114880268731048502
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,38 +213,6 @@ MonoBehaviour:
   leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
   healAmount: 5
   healHungerAmount: 5
---- !u!114 &5496045716309107960
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Temperature: 20
-  MaxCapacity: 50
-  Reagents:
-  - berryjuice
-  Amounts:
-  - 50
---- !u!114 &114541546419594748
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114796218501938598
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,18 +226,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114734639477423404
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114180265932455436
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,6 +274,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -291,7 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 63c9a0ba448fa47b7aebb5e45f4b1167
+  m_AssetId: b71376b114dbb4fafa7973ff7f9f1861
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Cappuccino.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Cappuccino.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114880268731048502}
-  - component: {fileID: 32985149106417025}
-  - component: {fileID: 114939607469885962}
-  - component: {fileID: 114489376111717858}
   - component: {fileID: 114841374748085900}
+  - component: {fileID: 114939607469885962}
+  - component: {fileID: 32985149106417025}
+  - component: {fileID: 114880268731048502}
+  - component: {fileID: 114489376111717858}
   - component: {fileID: 114184226298934880}
   - component: {fileID: 114217141058855336}
   - component: {fileID: 114551520272498954}
@@ -146,7 +146,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &114880268731048502
+--- !u!114 &114841374748085900
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -155,14 +155,23 @@ MonoBehaviour:
   m_GameObject: {fileID: 1110193000772614}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a522f189bd3d44f9b962f977bec7a0a8, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114939607469885962
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  leavings: {fileID: 0}
-  healAmount: 5
-  healHungerAmount: 5
 --- !u!114 &32985149106417025
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -187,7 +196,7 @@ MonoBehaviour:
   TransferMode: 0
   InitialTransferAmount: 20
   PossibleTransferAmounts: []
---- !u!114 &114939607469885962
+--- !u!114 &114880268731048502
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -196,11 +205,14 @@ MonoBehaviour:
   m_GameObject: {fileID: 1110193000772614}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Script: {fileID: 11500000, guid: a522f189bd3d44f9b962f977bec7a0a8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  leavings: {fileID: 0}
+  healAmount: 5
+  healHungerAmount: 5
 --- !u!114 &114489376111717858
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -214,18 +226,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114841374748085900
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114184226298934880
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -297,7 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: d4b80359e4f4b40868cfc0bd10b94ae1
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Carrot Juice.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Carrot Juice.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114880268731048502}
-  - component: {fileID: 6970357092594888893}
-  - component: {fileID: 114245314523635918}
-  - component: {fileID: 114521655599694430}
   - component: {fileID: 114469331623966694}
+  - component: {fileID: 114245314523635918}
+  - component: {fileID: 6970357092594888893}
+  - component: {fileID: 114880268731048502}
+  - component: {fileID: 114521655599694430}
   - component: {fileID: 114981563787714684}
   - component: {fileID: 114935820698282902}
   - component: {fileID: 114252924516057578}
@@ -88,12 +88,10 @@ MonoBehaviour:
   InventoryIcon: {fileID: 0}
   itemName: Carrot Juice
   itemDescription: 
-  Traits:
-  - {fileID: 11400000, guid: fe7314825ebf744c3b651ca76d282adc, type: 2}
-  itemType: 14
+  initialTraits: []
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -133,9 +131,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114208883059431984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -150,6 +145,57 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114469331623966694
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114245314523635918
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &6970357092594888893
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  temperatureKelvin: 293.15
+  MaxCapacity: 50
+  InSolidForm: 0
+  Reagents:
+  - carrot_juice
+  Amounts:
+  - 50
+  TraitWhitelist: []
+  ReagentWhitelist: []
+  TransferMode: 0
+  InitialTransferAmount: 20
+  PossibleTransferAmounts: []
 --- !u!114 &114880268731048502
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,38 +213,6 @@ MonoBehaviour:
   leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
   healAmount: 5
   healHungerAmount: 5
---- !u!114 &6970357092594888893
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Temperature: 20
-  MaxCapacity: 50
-  Reagents:
-  - carrot_juice
-  Amounts:
-  - 50
---- !u!114 &114245314523635918
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114521655599694430
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,18 +226,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114469331623966694
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114981563787714684
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,6 +274,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -291,7 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: b22b8a1b805c44b77a8d1759a6d4e119
+  m_AssetId: ea3aced27602b4327bcbd90af271bba2
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Clowns Tears.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Clowns Tears.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114880268731048502}
-  - component: {fileID: 4687294820448930692}
-  - component: {fileID: 114062940496879486}
-  - component: {fileID: 114723923594695084}
   - component: {fileID: 114502775186044806}
+  - component: {fileID: 114062940496879486}
+  - component: {fileID: 4687294820448930692}
+  - component: {fileID: 114880268731048502}
+  - component: {fileID: 114723923594695084}
   - component: {fileID: 114701331756403066}
   - component: {fileID: 114875846473893238}
   - component: {fileID: 114298002486922380}
@@ -88,12 +88,10 @@ MonoBehaviour:
   InventoryIcon: {fileID: 0}
   itemName: Clown's Tears
   itemDescription: 
-  Traits:
-  - {fileID: 11400000, guid: fe7314825ebf744c3b651ca76d282adc, type: 2}
-  itemType: 14
+  initialTraits: []
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -133,9 +131,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114208883059431984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -150,6 +145,57 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114502775186044806
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114062940496879486
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &4687294820448930692
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  temperatureKelvin: 293.15
+  MaxCapacity: 50
+  InSolidForm: 0
+  Reagents:
+  - clown_tears
+  Amounts:
+  - 0
+  TraitWhitelist: []
+  ReagentWhitelist: []
+  TransferMode: 0
+  InitialTransferAmount: 20
+  PossibleTransferAmounts: []
 --- !u!114 &114880268731048502
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,38 +213,6 @@ MonoBehaviour:
   leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
   healAmount: 5
   healHungerAmount: 5
---- !u!114 &4687294820448930692
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Temperature: 20
-  MaxCapacity: 50
-  Reagents:
-  - clown_tears
-  Amounts:
-  - 0
---- !u!114 &114062940496879486
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114723923594695084
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,18 +226,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114502775186044806
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114701331756403066
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,6 +274,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -291,7 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: b22b8a1b805c44b77a8d1759a6d4e119
+  m_AssetId: d1da6c61a5caf46239177ab9d0b96c03
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Coffee.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Coffee.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114880268731048502}
-  - component: {fileID: 6861194358892837349}
-  - component: {fileID: 114513499398574372}
-  - component: {fileID: 114813423943035560}
   - component: {fileID: 114770388636431432}
+  - component: {fileID: 114513499398574372}
+  - component: {fileID: 6861194358892837349}
+  - component: {fileID: 114880268731048502}
+  - component: {fileID: 114813423943035560}
   - component: {fileID: 114412861693516188}
   - component: {fileID: 114661758593884598}
   - component: {fileID: 114487368033724368}
@@ -146,7 +146,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &114880268731048502
+--- !u!114 &114770388636431432
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -155,14 +155,23 @@ MonoBehaviour:
   m_GameObject: {fileID: 1110193000772614}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a522f189bd3d44f9b962f977bec7a0a8, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114513499398574372
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  leavings: {fileID: 0}
-  healAmount: 5
-  healHungerAmount: 5
 --- !u!114 &6861194358892837349
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -187,7 +196,7 @@ MonoBehaviour:
   TransferMode: 0
   InitialTransferAmount: 20
   PossibleTransferAmounts: []
---- !u!114 &114513499398574372
+--- !u!114 &114880268731048502
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -196,11 +205,14 @@ MonoBehaviour:
   m_GameObject: {fileID: 1110193000772614}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Script: {fileID: 11500000, guid: a522f189bd3d44f9b962f977bec7a0a8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  leavings: {fileID: 0}
+  healAmount: 5
+  healHungerAmount: 5
 --- !u!114 &114813423943035560
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -214,18 +226,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114770388636431432
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114412861693516188
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -297,7 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 22bc59024142b461aa3cf4ec2174f50e
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Cognac.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Cognac.prefab
@@ -11,14 +11,14 @@ GameObject:
   - component: {fileID: 4645335817288720}
   - component: {fileID: 61202592083071704}
   - component: {fileID: 114828422824226692}
-  - component: {fileID: 114608524725813366}
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114880268731048502}
-  - component: {fileID: 5408483101378986739}
-  - component: {fileID: 114959382772847396}
   - component: {fileID: 114135657224187114}
+  - component: {fileID: 114608524725813366}
+  - component: {fileID: 5408483101378986739}
+  - component: {fileID: 114880268731048502}
+  - component: {fileID: 114959382772847396}
   - component: {fileID: 114406621646408856}
   - component: {fileID: 114770518125375876}
   - component: {fileID: 114482170566687750}
@@ -88,12 +88,10 @@ MonoBehaviour:
   InventoryIcon: {fileID: 0}
   itemName: Cognac
   itemDescription: 
-  Traits:
-  - {fileID: 11400000, guid: fe7314825ebf744c3b651ca76d282adc, type: 2}
-  itemType: 14
+  initialTraits: []
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -101,20 +99,6 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
---- !u!114 &114608524725813366
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114931546224579044
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -147,9 +131,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114208883059431984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -164,6 +145,57 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114135657224187114
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114608524725813366
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &5408483101378986739
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  temperatureKelvin: 293.15
+  MaxCapacity: 50
+  InSolidForm: 0
+  Reagents:
+  - cognac
+  Amounts:
+  - 50
+  TraitWhitelist: []
+  ReagentWhitelist: []
+  TransferMode: 0
+  InitialTransferAmount: 20
+  PossibleTransferAmounts: []
 --- !u!114 &114880268731048502
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -181,24 +213,6 @@ MonoBehaviour:
   leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
   healAmount: 5
   healHungerAmount: 5
---- !u!114 &5408483101378986739
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Temperature: 20
-  MaxCapacity: 50
-  Reagents:
-  - cognac
-  Amounts:
-  - 50
 --- !u!114 &114959382772847396
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,18 +226,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114135657224187114
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114406621646408856
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,6 +274,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -291,7 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: b22b8a1b805c44b77a8d1759a6d4e119
+  m_AssetId: 2d98ab918aea74e3ca23df635c73fe63
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Creme De Menthe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Creme De Menthe.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114880268731048502}
-  - component: {fileID: 3761935791046012833}
-  - component: {fileID: 114914861136872870}
-  - component: {fileID: 114296471340327064}
   - component: {fileID: 114586852916690064}
+  - component: {fileID: 114914861136872870}
+  - component: {fileID: 3761935791046012833}
+  - component: {fileID: 114880268731048502}
+  - component: {fileID: 114296471340327064}
   - component: {fileID: 114909108030203478}
   - component: {fileID: 114022772385763622}
   - component: {fileID: 114075698181172284}
@@ -88,12 +88,10 @@ MonoBehaviour:
   InventoryIcon: {fileID: 0}
   itemName: Creme De Menthe
   itemDescription: 
-  Traits:
-  - {fileID: 11400000, guid: fe7314825ebf744c3b651ca76d282adc, type: 2}
-  itemType: 14
+  initialTraits: []
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -133,9 +131,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114208883059431984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -150,6 +145,57 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114586852916690064
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114914861136872870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &3761935791046012833
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  temperatureKelvin: 293.15
+  MaxCapacity: 50
+  InSolidForm: 0
+  Reagents:
+  - creme_de_menthe
+  Amounts:
+  - 50
+  TraitWhitelist: []
+  ReagentWhitelist: []
+  TransferMode: 0
+  InitialTransferAmount: 20
+  PossibleTransferAmounts: []
 --- !u!114 &114880268731048502
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,38 +213,6 @@ MonoBehaviour:
   leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
   healAmount: 5
   healHungerAmount: 5
---- !u!114 &3761935791046012833
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Temperature: 20
-  MaxCapacity: 50
-  Reagents:
-  - creme_de_menthe
-  Amounts:
-  - 50
---- !u!114 &114914861136872870
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114296471340327064
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,18 +226,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114586852916690064
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114909108030203478
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,6 +274,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -291,7 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 63c9a0ba448fa47b7aebb5e45f4b1167
+  m_AssetId: 873af421eddf6428b97a510eacda743e
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Icy Soda.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Icy Soda.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114410907878908488}
-  - component: {fileID: 6480922922007804596}
-  - component: {fileID: 114877294083488978}
-  - component: {fileID: 114010301858744464}
   - component: {fileID: 114679402658866878}
+  - component: {fileID: 114877294083488978}
+  - component: {fileID: 6480922922007804596}
+  - component: {fileID: 114410907878908488}
+  - component: {fileID: 114010301858744464}
   - component: {fileID: 114790101117956084}
   - component: {fileID: 114352943751652020}
   - component: {fileID: 114400684349831818}
@@ -146,7 +146,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &114410907878908488
+--- !u!114 &114679402658866878
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -155,14 +155,23 @@ MonoBehaviour:
   m_GameObject: {fileID: 1110193000772614}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a522f189bd3d44f9b962f977bec7a0a8, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114877294083488978
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
-  healAmount: 5
-  healHungerAmount: 5
 --- !u!114 &6480922922007804596
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -187,7 +196,7 @@ MonoBehaviour:
   TransferMode: 0
   InitialTransferAmount: 20
   PossibleTransferAmounts: []
---- !u!114 &114877294083488978
+--- !u!114 &114410907878908488
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -196,11 +205,14 @@ MonoBehaviour:
   m_GameObject: {fileID: 1110193000772614}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Script: {fileID: 11500000, guid: a522f189bd3d44f9b962f977bec7a0a8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  leavings: {fileID: 1110193000772614, guid: 50334239d541e7643a2b9d5c8cb43430, type: 3}
+  healAmount: 5
+  healHungerAmount: 5
 --- !u!114 &114010301858744464
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -214,18 +226,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114679402658866878
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114790101117956084
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -297,7 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: b42d2d26201dd1c4287e24202bdf3aa4
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/4no raisins.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/4no raisins.prefab
@@ -13,11 +13,11 @@ GameObject:
   - component: {fileID: 114828422824226692}
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
-  - component: {fileID: 114298061437451200}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114556432234894168}
-  - component: {fileID: 114417366729828038}
   - component: {fileID: 114375257364619298}
+  - component: {fileID: 114556432234894168}
+  - component: {fileID: 114298061437451200}
+  - component: {fileID: 114417366729828038}
   - component: {fileID: 114619782298203830}
   - component: {fileID: 114551020561031558}
   - component: {fileID: 114110746493297532}
@@ -130,6 +130,47 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114208883059431984
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114375257364619298
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114556432234894168
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &114298061437451200
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -147,35 +188,6 @@ MonoBehaviour:
   leavings: {fileID: 1110193000772614, guid: a249802e33c293c479d8008bdcbe480d, type: 3}
   healAmount: 8
   healHungerAmount: 8
---- !u!114 &114208883059431984
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  IsFixedMatrix: 0
---- !u!114 &114556432234894168
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114417366729828038
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,18 +201,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114375257364619298
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114619782298203830
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,7 +272,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 37525b624e2b1134fb3d2efdc22f2f0a
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Beef Jerky.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Beef Jerky.prefab
@@ -13,11 +13,11 @@ GameObject:
   - component: {fileID: 114828422824226692}
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
-  - component: {fileID: 114298061437451200}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114394843888639426}
-  - component: {fileID: 114823943790196644}
   - component: {fileID: 114750539260315378}
+  - component: {fileID: 114394843888639426}
+  - component: {fileID: 114298061437451200}
+  - component: {fileID: 114823943790196644}
   - component: {fileID: 114648182061133120}
   - component: {fileID: 114003728713013522}
   - component: {fileID: 114153296920932032}
@@ -130,6 +130,47 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114208883059431984
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114750539260315378
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114394843888639426
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &114298061437451200
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -147,35 +188,6 @@ MonoBehaviour:
   leavings: {fileID: 1110193000772614, guid: 90aa1645ffac72c47a059d49ae38efc2, type: 3}
   healAmount: 8
   healHungerAmount: 8
---- !u!114 &114208883059431984
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  IsFixedMatrix: 0
---- !u!114 &114394843888639426
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114823943790196644
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,18 +201,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114750539260315378
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114648182061133120
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,7 +272,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 8af5096e4df03fd42a23efb157a94bf3
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Cookie.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Cookie.prefab
@@ -13,11 +13,11 @@ GameObject:
   - component: {fileID: 114828422824226692}
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
-  - component: {fileID: 114298061437451200}
   - component: {fileID: 114208883059431984}
-  - component: {fileID: 114267865915288146}
-  - component: {fileID: 114325994199222478}
   - component: {fileID: 114189527465492128}
+  - component: {fileID: 114267865915288146}
+  - component: {fileID: 114298061437451200}
+  - component: {fileID: 114325994199222478}
   - component: {fileID: 114959027103590028}
   - component: {fileID: 114152895328573920}
   - component: {fileID: 114604942423611598}
@@ -130,6 +130,47 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114208883059431984
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114189527465492128
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114267865915288146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &114298061437451200
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -147,35 +188,6 @@ MonoBehaviour:
   leavings: {fileID: 0}
   healAmount: 4
   healHungerAmount: 4
---- !u!114 &114208883059431984
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  IsFixedMatrix: 0
---- !u!114 &114267865915288146
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114325994199222478
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,18 +201,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114189527465492128
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114959027103590028
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,7 +272,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 1a54efe7f51314f4eb3da3e5917c99b2
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Donut.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Donut.prefab
@@ -13,12 +13,12 @@ GameObject:
   - component: {fileID: 114828422824226692}
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
-  - component: {fileID: -6646073547375968554}
   - component: {fileID: 114208883059431984}
   - component: {fileID: 114464710893759880}
-  - component: {fileID: 114033023355979274}
-  - component: {fileID: 114964577068235472}
   - component: {fileID: 114499026947524380}
+  - component: {fileID: 114033023355979274}
+  - component: {fileID: -6646073547375968554}
+  - component: {fileID: 114964577068235472}
   - component: {fileID: 114273922828647914}
   - component: {fileID: 114908400867966552}
   - component: {fileID: 114110571503085058}
@@ -92,7 +92,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 7b9f470d9aa5545ce87447d3cd3d61ce, type: 2}
   size: 1
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -132,26 +132,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &-6646073547375968554
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 45e06ddb12acf47158b8cccf9289fd75, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  leavings: {fileID: 0}
-  healAmount: 30
-  healHungerAmount: 10
 --- !u!114 &114208883059431984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -179,6 +159,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e0036bd5aae14571835232bc33ddaf2e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &114499026947524380
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114033023355979274
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -193,6 +185,23 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &-6646073547375968554
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e06ddb12acf47158b8cccf9289fd75, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  leavings: {fileID: 0}
+  healAmount: 30
+  healHungerAmount: 10
 --- !u!114 &114964577068235472
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -206,18 +215,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114499026947524380
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114273922828647914
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -266,6 +263,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 19
@@ -359,7 +360,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 29d17c6e33a25434ca93edfb29f82cb7
+  m_AssetId: 6c6ba17bac93976419230baf6df34bed
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Meat Steak.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Meat Steak.prefab
@@ -13,12 +13,12 @@ GameObject:
   - component: {fileID: 114828422824226692}
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
-  - component: {fileID: 114298061437451200}
   - component: {fileID: 114208883059431984}
   - component: {fileID: 114464710893759880}
-  - component: {fileID: 114033023355979274}
-  - component: {fileID: 114964577068235472}
   - component: {fileID: 114499026947524380}
+  - component: {fileID: 114033023355979274}
+  - component: {fileID: 114298061437451200}
+  - component: {fileID: 114964577068235472}
   - component: {fileID: 114273922828647914}
   - component: {fileID: 114908400867966552}
   - component: {fileID: 114110571503085058}
@@ -131,23 +131,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
---- !u!114 &114298061437451200
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 51c0c3fdf2ebd41beb789f2d99f818ba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  leavings: {fileID: 1110193000772614, guid: 252b1325bc181714a9aaadbaf3c8147d, type: 3}
-  healAmount: 30
-  healHungerAmount: 10
 --- !u!114 &114208883059431984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -175,6 +158,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e0036bd5aae14571835232bc33ddaf2e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &114499026947524380
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114033023355979274
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,6 +184,23 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &114298061437451200
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 51c0c3fdf2ebd41beb789f2d99f818ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  leavings: {fileID: 1110193000772614, guid: 252b1325bc181714a9aaadbaf3c8147d, type: 3}
+  healAmount: 30
+  healHungerAmount: 10
 --- !u!114 &114964577068235472
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -202,18 +214,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114499026947524380
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114273922828647914
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -285,7 +285,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 6bee1f6e9832bf940a50f7cfe3788b0f
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Meat.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Meat.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61651950962559600}
   - component: {fileID: 114883841231317482}
   - component: {fileID: 114158584351897270}
-  - component: {fileID: 114267346831729768}
   - component: {fileID: 114106687397898684}
   - component: {fileID: 114855893071353060}
   - component: {fileID: 114718106824527472}
   - component: {fileID: 114040197112063446}
+  - component: {fileID: 114267346831729768}
   - component: {fileID: 114408040987671802}
   - component: {fileID: 8646462409530508651}
   - component: {fileID: 114288716083204952}
@@ -193,20 +193,6 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
---- !u!114 &114267346831729768
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1970759932574268}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114106687397898684
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -264,6 +250,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &114267346831729768
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1970759932574268}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &114408040987671802
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -349,5 +349,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: d2b4e713064f80441ac594b6a99399dd
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/IDs/Resources/Emag.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/IDs/Resources/Emag.prefab
@@ -92,12 +92,12 @@ GameObject:
   - component: {fileID: 61854855548246012}
   - component: {fileID: 114664589915332152}
   - component: {fileID: 114593161572524446}
+  - component: {fileID: 114624031663187154}
   - component: {fileID: 114716302871911692}
   - component: {fileID: 114922150393857528}
   - component: {fileID: 114065903958209818}
   - component: {fileID: 2672431944032583097}
   - component: {fileID: 114020482039318460}
-  - component: {fileID: 114624031663187154}
   - component: {fileID: 114120840063401562}
   - component: {fileID: 114011298045296396}
   m_Layer: 10
@@ -162,6 +162,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114593161572524446
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -184,7 +185,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 8ddc1bf1d79674344b6b5c7cf6b3f1ee, type: 2}
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -192,6 +193,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114624031663187154
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1748120534729806}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114716302871911692
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -238,9 +251,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &2672431944032583097
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -253,7 +263,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d441a849270a4a818e3af39cdef5ea69, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ToolType: 6
   SuccessChance: 100
   IsSyndicateVariant: 0
   SpeedMultiplier: 1
@@ -270,18 +279,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114624031663187154
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1748120534729806}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114120840063401562
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -330,6 +327,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/IDs/Resources/ID.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/IDs/Resources/ID.prefab
@@ -92,13 +92,13 @@ GameObject:
   - component: {fileID: 61854855548246012}
   - component: {fileID: 114664589915332152}
   - component: {fileID: 114593161572524446}
+  - component: {fileID: 114905964018138316}
   - component: {fileID: 114716302871911692}
   - component: {fileID: 114959086465697646}
   - component: {fileID: 114922150393857528}
   - component: {fileID: 114065903958209818}
   - component: {fileID: 114634705318122656}
   - component: {fileID: 114901070251412040}
-  - component: {fileID: 114905964018138316}
   - component: {fileID: 114767665931269096}
   - component: {fileID: 114526822079318106}
   - component: {fileID: 114669015140344374}
@@ -195,6 +195,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114905964018138316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1748120534729806}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114716302871911692
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -285,18 +297,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114905964018138316
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1748120534729806}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114767665931269096
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -442,5 +442,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 4c73033e5f8ab734eb2e85e6ae54de73
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Mop.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Mop.prefab
@@ -92,17 +92,17 @@ GameObject:
   - component: {fileID: 61847643870235902}
   - component: {fileID: 114894155089857320}
   - component: {fileID: 114364506355654784}
-  - component: {fileID: 114694404974510270}
   - component: {fileID: 114284267982980302}
   - component: {fileID: 114098538090098490}
-  - component: {fileID: 114657433043358150}
-  - component: {fileID: 114062470574361688}
+  - component: {fileID: 5199146694513484801}
   - component: {fileID: 114788874549882356}
+  - component: {fileID: 114657433043358150}
+  - component: {fileID: 114694404974510270}
+  - component: {fileID: 114062470574361688}
   - component: {fileID: 114567163244394598}
   - component: {fileID: 114441573294268492}
   - component: {fileID: 114321264871015286}
   - component: {fileID: -4141852985515784285}
-  - component: {fileID: 5199146694513484801}
   m_Layer: 10
   m_Name: Mop
   m_TagString: Untagged
@@ -199,20 +199,6 @@ MonoBehaviour:
   - bashed
   - bludgeoned
   - whacked
---- !u!114 &114694404974510270
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1801347380884054}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b87744c775a7b0469420b69b02cfc24, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  reagentsPerUse: 5
-  useTime: 5
 --- !u!114 &114284267982980302
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -245,6 +231,41 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &5199146694513484801
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1801347380884054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  temperatureKelvin: 293.15
+  MaxCapacity: 25
+  InSolidForm: 0
+  Reagents: []
+  Amounts: []
+  TraitWhitelist:
+  - {fileID: 11400000, guid: 40bbe2f167fff41efb1c05e17fb43e88, type: 2}
+  ReagentWhitelist: []
+  TransferMode: 3
+  InitialTransferAmount: 25
+  PossibleTransferAmounts: []
+--- !u!114 &114788874549882356
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1801347380884054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114657433043358150
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -259,6 +280,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &114694404974510270
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1801347380884054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b87744c775a7b0469420b69b02cfc24, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  reagentsPerUse: 5
+  useTime: 5
 --- !u!114 &114062470574361688
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,18 +307,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114788874549882356
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1801347380884054}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114567163244394598
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -429,7 +452,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 882710f093d1c5f4c9f1dbd99b8dd790
   m_SceneId: 0
 --- !u!114 &-4141852985515784285
 MonoBehaviour:
@@ -447,26 +470,3 @@ MonoBehaviour:
   backgroundColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   iconOverride: {fileID: 0}
   backgroundSprite: {fileID: 0}
---- !u!114 &5199146694513484801
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1801347380884054}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  temperatureKelvin: 293.15
-  MaxCapacity: 25
-  InSolidForm: 0
-  Reagents: []
-  Amounts: []
-  TraitWhitelist:
-  - {fileID: 11400000, guid: 40bbe2f167fff41efb1c05e17fb43e88, type: 2}
-  ReagentWhitelist: []
-  TransferMode: 3
-  InitialTransferAmount: 25
-  PossibleTransferAmounts: []

--- a/UnityProject/Assets/Resources/Prefabs/Items/Janitor/SpaceCleaner.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Janitor/SpaceCleaner.prefab
@@ -90,16 +90,16 @@ GameObject:
   m_Component:
   - component: {fileID: 4827893193398430}
   - component: {fileID: 61818042941755762}
-  - component: {fileID: 7075596509325728911}
-  - component: {fileID: 4953889069794681373}
   - component: {fileID: 114875290499615288}
   - component: {fileID: 114567485071167784}
+  - component: {fileID: 114147643764008260}
   - component: {fileID: 7891530486730515463}
+  - component: {fileID: 4953889069794681373}
+  - component: {fileID: 7075596509325728911}
   - component: {fileID: 114335573703485954}
   - component: {fileID: 114690376875817604}
   - component: {fileID: 114503468551468690}
   - component: {fileID: 114941767276165962}
-  - component: {fileID: 114147643764008260}
   - component: {fileID: 114229085023085202}
   - component: {fileID: 2076902986949784288}
   - component: {fileID: 5672786685678995422}
@@ -153,47 +153,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!114 &7075596509325728911
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1907679543779350}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 96edd14bb3cb38c4fac108e8865c1afd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  travelDistance: 3
-  reagentContainer: {fileID: 4953889069794681373}
-  reagentsPerUse: 5
---- !u!114 &4953889069794681373
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1907679543779350}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  temperatureKelvin: 293.15
-  MaxCapacity: 100
-  InSolidForm: 0
-  Reagents:
-  - cleaner
-  Amounts:
-  - 100
-  TraitWhitelist: []
-  ReagentWhitelist: []
-  TransferMode: 0
-  InitialTransferAmount: 20
-  PossibleTransferAmounts: []
 --- !u!114 &114875290499615288
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -238,6 +197,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114147643764008260
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1907679543779350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &7891530486730515463
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -252,6 +223,47 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &4953889069794681373
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1907679543779350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  temperatureKelvin: 293.15
+  MaxCapacity: 100
+  InSolidForm: 0
+  Reagents:
+  - cleaner
+  Amounts:
+  - 100
+  TraitWhitelist: []
+  ReagentWhitelist: []
+  TransferMode: 0
+  InitialTransferAmount: 20
+  PossibleTransferAmounts: []
+--- !u!114 &7075596509325728911
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1907679543779350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96edd14bb3cb38c4fac108e8865c1afd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  travelDistance: 3
+  reagentContainer: {fileID: 4953889069794681373}
+  reagentsPerUse: 5
 --- !u!114 &114335573703485954
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -309,18 +321,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114147643764008260
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1907679543779350}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114229085023085202
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -482,7 +482,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 95adc0cf36af55d46baf1b7d4ef71eef
   m_SceneId: 0
 --- !u!1 &7396984611411425534
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Ammo_Boxes/Magazine_10mmbox.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Ammo_Boxes/Magazine_10mmbox.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114430572169083370}
   - component: {fileID: 114513551998188914}
   - component: {fileID: 114025015166426706}
+  - component: {fileID: 114875793717811474}
   - component: {fileID: 114411233989225362}
   - component: {fileID: 114713364932282284}
   - component: {fileID: 114574426026239680}
   - component: {fileID: 114271337220239718}
-  - component: {fileID: 114875793717811474}
   - component: {fileID: 114005969231585682}
   - component: {fileID: 114539844613875522}
   - component: {fileID: 114752513315490410}
@@ -146,6 +146,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: 
   magazineSize: 20
+--- !u!114 &114875793717811474
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1299393041543980}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114411233989225362
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,18 +217,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114875793717811474
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1299393041543980}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114005969231585682
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -288,7 +288,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: a4779946f30fe4608ad9a8a35f2c26be
   m_SceneId: 0
 --- !u!1 &1829793713612658
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Ammo_Boxes/Magazine_357OLD.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Ammo_Boxes/Magazine_357OLD.prefab
@@ -94,11 +94,11 @@ GameObject:
   - component: {fileID: 114749409107849832}
   - component: {fileID: 114919215243523672}
   - component: {fileID: 114933170858745182}
+  - component: {fileID: 114055890188450444}
   - component: {fileID: 114197780640237474}
   - component: {fileID: 114665503198049966}
   - component: {fileID: 114388677773522352}
   - component: {fileID: 114797854197893634}
-  - component: {fileID: 114055890188450444}
   - component: {fileID: 114024121986903966}
   - component: {fileID: 114337143236557310}
   - component: {fileID: 114885097552061688}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: 
   magazineSize: 20
+--- !u!114 &114055890188450444
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1429462959919188}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114197780640237474
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -285,18 +297,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114055890188450444
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1429462959919188}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114024121986903966
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -368,5 +368,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 9acbf9ee75d57456e9ab453c6b80bca9
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Ammo_Boxes/Magazine_40mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Ammo_Boxes/Magazine_40mm.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114381276020981326}
   - component: {fileID: 114695018772429564}
   - component: {fileID: 114609473813204842}
+  - component: {fileID: 114261091352670792}
   - component: {fileID: 114582122828152908}
   - component: {fileID: 114178848517747998}
   - component: {fileID: 114309909979161082}
   - component: {fileID: 114056740142764996}
-  - component: {fileID: 114261091352670792}
   - component: {fileID: 114443175538857792}
   - component: {fileID: 114239018152342732}
   - component: {fileID: 114792611259062594}
@@ -146,6 +146,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: 
   magazineSize: 20
+--- !u!114 &114261091352670792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1175051805306024}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114582122828152908
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,18 +217,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114261091352670792
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1175051805306024}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114443175538857792
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -288,7 +288,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 9904676822848465f8b5e4ee8b7866d6
   m_SceneId: 0
 --- !u!1 &1192710714776008
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Ammo_Boxes/Magazine_45box.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Ammo_Boxes/Magazine_45box.prefab
@@ -94,11 +94,11 @@ GameObject:
   - component: {fileID: 114335115196712388}
   - component: {fileID: 114052034557952448}
   - component: {fileID: 114422278818924348}
+  - component: {fileID: 114043931460028796}
   - component: {fileID: 114215399390566468}
   - component: {fileID: 114702582014628360}
   - component: {fileID: 114716844319816192}
   - component: {fileID: 114142302363446106}
-  - component: {fileID: 114043931460028796}
   - component: {fileID: 114596301395325058}
   - component: {fileID: 114580224784839718}
   - component: {fileID: 114783956437314708}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: 
   magazineSize: 20
+--- !u!114 &114043931460028796
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1616410262931330}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114215399390566468
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -285,18 +297,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114043931460028796
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1616410262931330}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114596301395325058
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -368,5 +368,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 18ae06db10e294ddc9b1798c53309545
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Ammo_Boxes/Magazine_9mmbox.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Ammo_Boxes/Magazine_9mmbox.prefab
@@ -14,11 +14,11 @@ GameObject:
   - component: {fileID: 114492990539247866}
   - component: {fileID: 114794292802765300}
   - component: {fileID: 114146626210667084}
+  - component: {fileID: 114342228585848910}
   - component: {fileID: 114638287545981178}
   - component: {fileID: 114296565302227844}
   - component: {fileID: 114899964990969106}
   - component: {fileID: 114652620239279170}
-  - component: {fileID: 114342228585848910}
   - component: {fileID: 114004731384629482}
   - component: {fileID: 114867709943950750}
   - component: {fileID: 114874732498739832}
@@ -146,6 +146,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: 
   magazineSize: 20
+--- !u!114 &114342228585848910
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1095991925134970}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114638287545981178
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,18 +217,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114342228585848910
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1095991925134970}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114004731384629482
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -288,7 +288,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 8c2952660a46d90479f70105bc1cbab8
   m_SceneId: 0
 --- !u!1 &1679512666166504
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_12mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_12mm.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114944961118809770}
   - component: {fileID: 114604252264824848}
   - component: {fileID: 114477551015379840}
+  - component: {fileID: 114191295505836602}
   - component: {fileID: 114401754672532888}
   - component: {fileID: 114151640759957448}
   - component: {fileID: 114217086723951782}
-  - component: {fileID: 114191295505836602}
   - component: {fileID: 114796177124949924}
   - component: {fileID: 114550561066821966}
   - component: {fileID: 114826462912299504}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: 12mm
   magazineSize: 20
+--- !u!114 &114191295505836602
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1837689547681116}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114401754672532888
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,18 +281,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114191295505836602
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1837689547681116}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114796177124949924
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -352,5 +352,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 5c6f9e9e80c8a4b5a84d0376fb69f876
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_357.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_357.prefab
@@ -13,11 +13,11 @@ GameObject:
   - component: {fileID: 114978996244486278}
   - component: {fileID: 114924791543060820}
   - component: {fileID: 114772652558381996}
+  - component: {fileID: 114585774385155144}
   - component: {fileID: 114826983953154742}
   - component: {fileID: 114563500087236606}
   - component: {fileID: 114632442228932846}
   - component: {fileID: 114765861677154220}
-  - component: {fileID: 114585774385155144}
   - component: {fileID: 114083583662208312}
   - component: {fileID: 114651201226394076}
   - component: {fileID: 114641587775406066}
@@ -130,6 +130,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: 357mm
   magazineSize: 7
+--- !u!114 &114585774385155144
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1427151582832622}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114826983953154742
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,18 +201,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114585774385155144
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1427151582832622}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114083583662208312
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,7 +272,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 5d777f4b7c82a4b1eba964db405a1a46
   m_SceneId: 0
 --- !u!1 &1993948941500644
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_38.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_38.prefab
@@ -14,10 +14,10 @@ GameObject:
   - component: {fileID: 114891067180309740}
   - component: {fileID: 114462994006981904}
   - component: {fileID: 114673342454476188}
+  - component: {fileID: 114785033454628290}
   - component: {fileID: 114726631009728650}
   - component: {fileID: 114595661855791112}
   - component: {fileID: 114918708786196496}
-  - component: {fileID: 114785033454628290}
   - component: {fileID: 114995817909710720}
   - component: {fileID: 114264518890959482}
   - component: {fileID: 114741458441318312}
@@ -146,6 +146,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: 38
   magazineSize: 6
+--- !u!114 &114785033454628290
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1887694972930660}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114726631009728650
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,18 +201,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114785033454628290
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1887694972930660}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114995817909710720
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,7 +272,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 43b82868fea5e4d8b931c85860de40c6
   m_SceneId: 0
 --- !u!1 &1960548086557526
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_46x30mmtT.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_46x30mmtT.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114802394935135262}
   - component: {fileID: 114788448572266270}
   - component: {fileID: 114831615385714540}
+  - component: {fileID: 114050879831496896}
   - component: {fileID: 114851554163762622}
   - component: {fileID: 114905923286005146}
   - component: {fileID: 114391569944684062}
-  - component: {fileID: 114050879831496896}
   - component: {fileID: 114734624565663374}
   - component: {fileID: 114937405476664458}
   - component: {fileID: 114840722703133820}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: 46x30mmtT
   magazineSize: 35
+--- !u!114 &114050879831496896
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1976442409144630}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114851554163762622
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,18 +281,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114050879831496896
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1976442409144630}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114734624565663374
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -352,5 +352,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 9f7dff7070ba74fe8a7a56096104813b
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_5.56m.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_5.56m.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114117670336802206}
   - component: {fileID: 114201985098492696}
   - component: {fileID: 114692482863562414}
+  - component: {fileID: 114970850997829600}
   - component: {fileID: 114469684380555384}
   - component: {fileID: 114030497333023434}
   - component: {fileID: 114245010010922384}
-  - component: {fileID: 114970850997829600}
   - component: {fileID: 114823010984263538}
   - component: {fileID: 114878057850997212}
   - component: {fileID: 114680233419999430}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: 5.56m
   magazineSize: 35
+--- !u!114 &114970850997829600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1777791374362824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114469684380555384
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,18 +281,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114970850997829600
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1777791374362824}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114823010984263538
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -352,5 +352,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 9acbf9ee75d57456e9ab453c6b80bca9
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_50mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_50mm.prefab
@@ -14,10 +14,10 @@ GameObject:
   - component: {fileID: 114348374948258066}
   - component: {fileID: 114360322155976810}
   - component: {fileID: 114154442812104440}
+  - component: {fileID: 114929083312884540}
   - component: {fileID: 114953782875578298}
   - component: {fileID: 114017665477135202}
   - component: {fileID: 114084069852725698}
-  - component: {fileID: 114929083312884540}
   - component: {fileID: 114686440541429356}
   - component: {fileID: 114319784830858234}
   - component: {fileID: 114676585852266870}
@@ -146,6 +146,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: 50mm
   magazineSize: 4
+--- !u!114 &114929083312884540
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1141452593325796}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114953782875578298
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,18 +201,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114929083312884540
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1141452593325796}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114686440541429356
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,7 +272,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: cee540cc53ff74143bf9b39dbdd23445
   m_SceneId: 0
 --- !u!1 &1544275669418164
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_9mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_9mm.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114321033702020154}
   - component: {fileID: 114319963738854120}
   - component: {fileID: 114797802676123676}
+  - component: {fileID: 114169624292315252}
   - component: {fileID: 114656900756177718}
   - component: {fileID: 114541784541101990}
   - component: {fileID: 114068372718147972}
-  - component: {fileID: 114169624292315252}
   - component: {fileID: 114615302155291378}
   - component: {fileID: 114273266946783572}
   - component: {fileID: 114093359783869618}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: 9mm
   magazineSize: 12
+--- !u!114 &114169624292315252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1570589854574774}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114656900756177718
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,18 +281,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114169624292315252
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1570589854574774}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114615302155291378
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -352,5 +352,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: ea8c66b49b7384edaa57106fd2a385a5
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_FusionCells.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_FusionCells.prefab
@@ -12,12 +12,12 @@ GameObject:
   - component: {fileID: 61266450409097250}
   - component: {fileID: 114075639141808962}
   - component: {fileID: 114328268047279028}
+  - component: {fileID: 114681036788529772}
   - component: {fileID: 114883753794892704}
   - component: {fileID: 114093712529578112}
   - component: {fileID: 114715980748152224}
   - component: {fileID: 114527431310319946}
   - component: {fileID: 114588220176627958}
-  - component: {fileID: 114681036788529772}
   - component: {fileID: 114649564638205840}
   - component: {fileID: 114179335275894190}
   - component: {fileID: 114067592871997122}
@@ -114,6 +114,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114681036788529772
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1107561390510008}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114883753794892704
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,18 +201,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114681036788529772
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1107561390510008}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114649564638205840
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,7 +272,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: d3b90b4c0dd244a478dc3c05fe292de8
   m_SceneId: 0
 --- !u!1 &1618195301774984
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_Slug.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_Slug.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114313499704245640}
   - component: {fileID: 114106706923861624}
   - component: {fileID: 114268989769706622}
+  - component: {fileID: 114934153916549252}
   - component: {fileID: 114052493599766462}
   - component: {fileID: 114112538034184592}
   - component: {fileID: 114273380234753642}
-  - component: {fileID: 114934153916549252}
   - component: {fileID: 114902066457782140}
   - component: {fileID: 114839477089038664}
   - component: {fileID: 114711689750648596}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: Slug
   magazineSize: 2
+--- !u!114 &114934153916549252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1560639281521250}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114052493599766462
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,18 +281,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114934153916549252
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1560639281521250}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114902066457782140
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -352,5 +352,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: afa5cc272972d406eac7e8e62bcb5e4b
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_Syringe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_Syringe.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114321033702020154}
   - component: {fileID: 114319963738854120}
   - component: {fileID: 114797802676123676}
+  - component: {fileID: 114680659831034650}
   - component: {fileID: 114656900756177718}
   - component: {fileID: 114541784541101990}
   - component: {fileID: 114855648352423478}
-  - component: {fileID: 114680659831034650}
   - component: {fileID: 114011475389698314}
   - component: {fileID: 114483982261721994}
   - component: {fileID: 114625575897845998}
@@ -205,7 +205,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 8f46f13d516624e6883db235a840f575, type: 2}
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -229,6 +229,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: Syringe
   magazineSize: 1
+--- !u!114 &114680659831034650
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1570589854574774}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114656900756177718
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,18 +284,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114680659831034650
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1570589854574774}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114011475389698314
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -332,6 +332,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 19
@@ -425,8 +429,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3263003343
+  m_AssetId: 4f70cbcabed4746aea197770f764551d
+  m_SceneId: 0
 --- !u!114 &8673378308319568878
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -455,13 +459,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Temperature: 20
+  temperatureKelvin: 293.15
   MaxCapacity: 15
+  InSolidForm: 0
   Reagents: []
   Amounts: []
-  AcceptedReagents: []
+  TraitWhitelist: []
+  ReagentWhitelist: []
   TransferMode: 1
-  TransferAmount: 5
+  InitialTransferAmount: 5
   PossibleTransferAmounts:
   - 5
   - 10
@@ -484,4 +490,4 @@ MonoBehaviour:
   FullSprite: {fileID: 21300000, guid: f1299495679e8f3439d3c0f467d18ea2, type: 3}
   EmptyName: 
   FullName: 
-  spriteSync: 0
+  initialState: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_a762.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_a762.prefab
@@ -14,10 +14,10 @@ GameObject:
   - component: {fileID: 114631740818005732}
   - component: {fileID: 114110166021715606}
   - component: {fileID: 114496109277905418}
+  - component: {fileID: 114378085277235960}
   - component: {fileID: 114129525222004082}
   - component: {fileID: 114045955017882788}
   - component: {fileID: 114893899263400770}
-  - component: {fileID: 114378085277235960}
   - component: {fileID: 114167938732693570}
   - component: {fileID: 114216756564057812}
   - component: {fileID: 114004966505690078}
@@ -146,6 +146,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: A762
   magazineSize: 100
+--- !u!114 &114378085277235960
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1505511589050458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114129525222004082
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,18 +201,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114378085277235960
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1505511589050458}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114167938732693570
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,7 +272,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 5d777f4b7c82a4b1eba964db405a1a46
   m_SceneId: 0
 --- !u!1 &1645393414742414
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_smg9mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_smg9mm.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114588700412026578}
   - component: {fileID: 114704218100228718}
   - component: {fileID: 114589406112588394}
+  - component: {fileID: 114906147849428578}
   - component: {fileID: 114479092072498442}
   - component: {fileID: 114942314213274562}
   - component: {fileID: 114383225506961288}
-  - component: {fileID: 114906147849428578}
   - component: {fileID: 114771056977144756}
   - component: {fileID: 114980756005099596}
   - component: {fileID: 114601046145284994}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: smg9mm
   magazineSize: 25
+--- !u!114 &114906147849428578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1549444462283266}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114479092072498442
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,18 +281,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114906147849428578
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1549444462283266}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114771056977144756
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -352,5 +352,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 5dc72fc6825e44e5abb5a8b44d0aa649
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_uzi9mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_uzi9mm.prefab
@@ -14,10 +14,10 @@ GameObject:
   - component: {fileID: 114714776944677938}
   - component: {fileID: 114162752830568772}
   - component: {fileID: 114015820852929730}
+  - component: {fileID: 114983735344319786}
   - component: {fileID: 114607729733656858}
   - component: {fileID: 114908791848257368}
   - component: {fileID: 114762599762878714}
-  - component: {fileID: 114983735344319786}
   - component: {fileID: 114013561274049868}
   - component: {fileID: 114347820311685896}
   - component: {fileID: 114144884219838670}
@@ -146,6 +146,18 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoType: uzi9mm
   magazineSize: 30
+--- !u!114 &114983735344319786
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1249881654656566}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114607729733656858
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,18 +201,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114983735344319786
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1249881654656566}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114013561274049868
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -272,7 +272,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: ca0c28c82506949999fe11c86b5ae740
   m_SceneId: 0
 --- !u!1 &1997933536368992
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Medical/Basic Treatments/Bruise Pack.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Medical/Basic Treatments/Bruise Pack.prefab
@@ -92,13 +92,13 @@ GameObject:
   - component: {fileID: 61823647137541954}
   - component: {fileID: 114012578210888208}
   - component: {fileID: 8010059544309744433}
-  - component: {fileID: 6200346118780942845}
   - component: {fileID: 114509519296518920}
   - component: {fileID: 114250079265950594}
   - component: {fileID: 114537529964992312}
-  - component: {fileID: 1218954987858715778}
-  - component: {fileID: 114674451166709276}
   - component: {fileID: 114426671417458994}
+  - component: {fileID: 1218954987858715778}
+  - component: {fileID: 6200346118780942845}
+  - component: {fileID: 114674451166709276}
   - component: {fileID: 114077547693365806}
   - component: {fileID: 114504877800374682}
   - component: {fileID: 114143379017786812}
@@ -181,19 +181,6 @@ MonoBehaviour:
   syncInterval: 0.1
   initialAmount: 6
   maxAmount: 6
---- !u!114 &6200346118780942845
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1862150311813888}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 19988dde784f6ae4f874dcb496f6115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  healType: 0
 --- !u!114 &114509519296518920
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -255,6 +242,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114426671417458994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1862150311813888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1218954987858715778
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,6 +268,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &6200346118780942845
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1862150311813888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 19988dde784f6ae4f874dcb496f6115d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healType: 0
 --- !u!114 &114674451166709276
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -282,18 +294,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114426671417458994
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1862150311813888}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114077547693365806
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -365,5 +365,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 269d6c8129e05ee4396165bb84083f19
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Medical/Basic Treatments/Ointment.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Medical/Basic Treatments/Ointment.prefab
@@ -13,12 +13,12 @@ GameObject:
   - component: {fileID: 114005167837307954}
   - component: {fileID: 3072383976012457327}
   - component: {fileID: 114212368612829520}
-  - component: {fileID: 8494677652202687255}
   - component: {fileID: 114012095212642768}
   - component: {fileID: 114424771078077746}
-  - component: {fileID: 5839909430975384722}
-  - component: {fileID: 114667273347380272}
   - component: {fileID: 114903920813708458}
+  - component: {fileID: 5839909430975384722}
+  - component: {fileID: 8494677652202687255}
+  - component: {fileID: 114667273347380272}
   - component: {fileID: 114274718917655540}
   - component: {fileID: 114449365742732602}
   - component: {fileID: 114965978575096838}
@@ -130,19 +130,6 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
---- !u!114 &8494677652202687255
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1408536760214900}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 19988dde784f6ae4f874dcb496f6115d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  healType: 1
 --- !u!114 &114012095212642768
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -175,6 +162,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114903920813708458
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1408536760214900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &5839909430975384722
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -189,6 +188,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &8494677652202687255
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1408536760214900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 19988dde784f6ae4f874dcb496f6115d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  healType: 1
 --- !u!114 &114667273347380272
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -202,18 +214,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114903920813708458
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1408536760214900}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114274718917655540
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -285,7 +285,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: f181c8eb8ce8b8949b1ab571c8318f6f
   m_SceneId: 0
 --- !u!1 &1581002665316100
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Medical/Devices/Health Scanner.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Medical/Devices/Health Scanner.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114509519296518920}
   - component: {fileID: 114250079265950594}
   - component: {fileID: 114537529964992312}
-  - component: {fileID: 5004646865096198730}
-  - component: {fileID: 8947076166887268501}
-  - component: {fileID: 114021437303216186}
   - component: {fileID: 114025370655937082}
+  - component: {fileID: 8947076166887268501}
+  - component: {fileID: 5004646865096198730}
+  - component: {fileID: 114021437303216186}
   - component: {fileID: 114642887816301950}
   - component: {fileID: 114997751103220020}
   - component: {fileID: 114348424157646214}
@@ -226,7 +226,7 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
---- !u!114 &5004646865096198730
+--- !u!114 &114025370655937082
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -235,7 +235,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1862150311813888}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ede96e91fa456f549b8d8bf8ac9aace5, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &8947076166887268501
@@ -252,6 +252,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &5004646865096198730
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1862150311813888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ede96e91fa456f549b8d8bf8ac9aace5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114021437303216186
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -265,18 +277,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114025370655937082
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1862150311813888}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114642887816301950
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -348,5 +348,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: d1b135e5a46c6f4408972d504eaebc4b
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/MiningLamp.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/MiningLamp.prefab
@@ -191,10 +191,10 @@ GameObject:
   - component: {fileID: 114086199267058162}
   - component: {fileID: 114660078625858576}
   - component: {fileID: 114546715207081156}
-  - component: {fileID: 8733151929054526228}
-  - component: {fileID: 114852817288890120}
-  - component: {fileID: 114828444551440684}
   - component: {fileID: 114189442814561830}
+  - component: {fileID: 114852817288890120}
+  - component: {fileID: 8733151929054526228}
+  - component: {fileID: 114828444551440684}
   - component: {fileID: 114651961981478966}
   - component: {fileID: 114500040489965280}
   - component: {fileID: 114400107952342984}
@@ -283,7 +283,7 @@ MonoBehaviour:
   initialTraits: []
   size: 2
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -323,9 +323,32 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
+--- !u!114 &114189442814561830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869747887731904}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114852817288890120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869747887731904}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &8733151929054526228
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -350,20 +373,6 @@ MonoBehaviour:
     Colour: {r: 0, g: 0, b: 0, a: 0}
     EnumSprite: 0
     Size: 12
---- !u!114 &114852817288890120
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1869747887731904}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114828444551440684
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -377,18 +386,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114189442814561830
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1869747887731904}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114651961981478966
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -437,6 +434,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 19

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickAxe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PickAxe.prefab
@@ -92,12 +92,12 @@ GameObject:
   - component: {fileID: 61215679020341872}
   - component: {fileID: 114709039961508458}
   - component: {fileID: 114223419874660916}
-  - component: {fileID: 5433213316047674959}
   - component: {fileID: 114013105849664284}
   - component: {fileID: 114769722923569294}
-  - component: {fileID: 114439255724700438}
-  - component: {fileID: 114701328760886642}
   - component: {fileID: 114167832024690198}
+  - component: {fileID: 114439255724700438}
+  - component: {fileID: 5433213316047674959}
+  - component: {fileID: 114701328760886642}
   - component: {fileID: 114550329151915670}
   - component: {fileID: 114575120587847374}
   - component: {fileID: 114187735373465402}
@@ -193,18 +193,6 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
---- !u!114 &5433213316047674959
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1789684726173154}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 462d967aee8e4662964d700de16a6740, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114013105849664284
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -237,6 +225,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114167832024690198
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1789684726173154}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114439255724700438
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -251,6 +251,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &5433213316047674959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1789684726173154}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 462d967aee8e4662964d700de16a6740, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114701328760886642
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -264,18 +276,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114167832024690198
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1789684726173154}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114550329151915670
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -421,5 +421,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 410abe86fc48d40bb9ad25ad581a52fc
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/SolidPlasma.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/SolidPlasma.prefab
@@ -11,14 +11,14 @@ GameObject:
   - component: {fileID: 4127467066464624}
   - component: {fileID: 61646209752006920}
   - component: {fileID: 114074125265494850}
-  - component: {fileID: 321358772312136153}
   - component: {fileID: 114743560058134576}
   - component: {fileID: 114770869045182236}
   - component: {fileID: 114349735982439280}
+  - component: {fileID: 114315561128172322}
   - component: {fileID: 114144031159128792}
+  - component: {fileID: 321358772312136153}
   - component: {fileID: 114089053101257560}
   - component: {fileID: 114666283742656930}
-  - component: {fileID: 114315561128172322}
   - component: {fileID: 114400642944857282}
   - component: {fileID: 114667930526401654}
   - component: {fileID: 114521006495050380}
@@ -85,22 +85,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &321358772312136153
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1042464433060550}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  initialAmount: 1
-  maxAmount: 50
 --- !u!114 &114743560058134576
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -162,6 +146,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114315561128172322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1042464433060550}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114144031159128792
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -176,6 +172,22 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &321358772312136153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1042464433060550}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  initialAmount: 1
+  maxAmount: 50
 --- !u!114 &114089053101257560
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -203,18 +215,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114315561128172322
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1042464433060550}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114400642944857282
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -286,7 +286,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 1449a7168a66e544c8929677c8ba5938
   m_SceneId: 0
 --- !u!1 &1668617562811696
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Other/Resources/Encryptionkey.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Other/Resources/Encryptionkey.prefab
@@ -92,13 +92,13 @@ GameObject:
   - component: {fileID: 61099568655720156}
   - component: {fileID: 114542940909424808}
   - component: {fileID: 114780098485158714}
-  - component: {fileID: 114239101562504668}
-  - component: {fileID: 114123234982290488}
   - component: {fileID: 114535661936412438}
   - component: {fileID: 114929202879641106}
-  - component: {fileID: 114736642641914970}
-  - component: {fileID: 114386789575497412}
   - component: {fileID: 114045246557323470}
+  - component: {fileID: 114736642641914970}
+  - component: {fileID: 114123234982290488}
+  - component: {fileID: 114239101562504668}
+  - component: {fileID: 114386789575497412}
   - component: {fileID: 114709169330096406}
   - component: {fileID: 114551482045364134}
   - component: {fileID: 114187653547998928}
@@ -194,6 +194,76 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114535661936412438
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1599349953373750}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  registerTile: {fileID: 0}
+  isNotPushable: 0
+--- !u!114 &114929202879641106
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1599349953373750}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  layer: {fileID: 0}
+  ObjectType: 0
+--- !u!114 &114045246557323470
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1599349953373750}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114736642641914970
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1599349953373750}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &114123234982290488
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1599349953373750}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5cf506c5a1f18344a80b82acaac00e23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239101562504668
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -233,64 +303,6 @@ MonoBehaviour:
   supplySprite: {fileID: 21300000, guid: 262d393c22bf6704dbd74aca6c34c5bb, type: 3}
   syndicateSprite: {fileID: 21300000, guid: 7f0a7e771115d3f4a8643ea77539c6b8, type: 3}
   type: 1
---- !u!114 &114123234982290488
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1599349953373750}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5cf506c5a1f18344a80b82acaac00e23, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &114535661936412438
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1599349953373750}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  registerTile: {fileID: 0}
-  isNotPushable: 0
---- !u!114 &114929202879641106
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1599349953373750}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  layer: {fileID: 0}
-  ObjectType: 0
---- !u!114 &114736642641914970
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1599349953373750}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114386789575497412
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -304,18 +316,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114045246557323470
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1599349953373750}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114709169330096406
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -387,5 +387,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: aea32eee58845aa4c9537e8d73ca66b9
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Other/Rolled Poster.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Other/Rolled Poster.prefab
@@ -95,9 +95,9 @@ GameObject:
   - component: {fileID: 8658991325822499239}
   - component: {fileID: 7136161543135492653}
   - component: {fileID: 3287447661704391586}
+  - component: {fileID: 6436908355588305388}
   - component: {fileID: 7492156942702919239}
   - component: {fileID: 5457341699463035650}
-  - component: {fileID: 6436908355588305388}
   - component: {fileID: 4868340152356198127}
   - component: {fileID: 325157265441756014}
   - component: {fileID: 1683984791003869720}
@@ -201,7 +201,7 @@ MonoBehaviour:
   initialTraits: []
   size: 2
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -238,6 +238,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+--- !u!114 &6436908355588305388
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5074129411573611090}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &7492156942702919239
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -270,18 +282,6 @@ MonoBehaviour:
   sprite: {fileID: 0}
   legitSprite: {fileID: 21300000, guid: e3686f4fd49b3da478b3e180a674bd37, type: 3}
   contrabandSprite: {fileID: 21300000, guid: 18ac39b3a4c2e6347bb4431b95103a1a, type: 3}
---- !u!114 &6436908355588305388
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5074129411573611090}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &4868340152356198127
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -331,7 +331,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 96145b3165f5248b78302cd49658b0b2
   m_SceneId: 0
 --- !u!114 &1683984791003869720
 MonoBehaviour:
@@ -346,6 +346,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 1

--- a/UnityProject/Assets/Resources/Prefabs/Items/Other/VendingRestock.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Other/VendingRestock.prefab
@@ -15,9 +15,9 @@ GameObject:
   - component: {fileID: 155135049708627783}
   - component: {fileID: 155258164311022585}
   - component: {fileID: 154528842100026433}
+  - component: {fileID: 114776743208705184}
   - component: {fileID: 266178104534119872}
   - component: {fileID: 114378787568583714}
-  - component: {fileID: 114776743208705184}
   - component: {fileID: 114485757560598234}
   - component: {fileID: 114212347718921996}
   m_Layer: 10
@@ -82,14 +82,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  spriteHandlerData: {fileID: 0}
+  spriteDataHandler: {fileID: 0}
   InventoryIcon: {fileID: 0}
   itemName: Vending Restock
   itemDescription: 
-  itemType: 0
+  initialTraits: []
   size: 3
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 5
   damageType: 0
   throwDamage: 5
@@ -112,7 +112,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  parentContainer: {fileID: 0}
   isNotPushable: 0
 --- !u!114 &155135049708627783
 MonoBehaviour:
@@ -130,10 +129,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 --- !u!114 &155258164311022585
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -148,6 +143,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &154528842100026433
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -158,6 +154,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e0036bd5aae14571835232bc33ddaf2e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114776743208705184
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 266178104534119887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &266178104534119872
@@ -174,11 +182,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  OnDropServer:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114378787568583714
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -192,18 +195,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114776743208705184
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 266178104534119887}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114485757560598234
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -238,6 +229,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114212347718921996
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,9 +242,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -314,6 +308,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Security/Handcuffs.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Security/Handcuffs.prefab
@@ -93,9 +93,9 @@ GameObject:
   - component: {fileID: 2664584551837523162}
   - component: {fileID: 2664584551837523603}
   - component: {fileID: 2664584551837520220}
+  - component: {fileID: 2092252848639280625}
   - component: {fileID: 2664584551837523149}
   - component: {fileID: 2664584551837519923}
-  - component: {fileID: 2092252848639280625}
   - component: {fileID: 114187339857744694}
   - component: {fileID: 114857360014702054}
   m_Layer: 10
@@ -205,6 +205,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &2092252848639280625
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2664584551837519869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 040e908e0ede8564f8fddfce81867825, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  applyTime: 3
+  removeTime: 3
+  sound: Handcuffs
 --- !u!114 &2664584551837523149
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -237,21 +252,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
---- !u!114 &2092252848639280625
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2664584551837519869}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 040e908e0ede8564f8fddfce81867825, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  applyTime: 3
-  removeTime: 3
-  sound: Handcuffs
 --- !u!114 &114187339857744694
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -288,5 +288,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 5eb99a314f588b54c8e187fccf082399
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Security/Stun Baton.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Security/Stun Baton.prefab
@@ -15,8 +15,8 @@ GameObject:
   - component: {fileID: 7616869219281013817}
   - component: {fileID: 7617698541931878523}
   - component: {fileID: 7617608173269680123}
-  - component: {fileID: 6417518545994622246}
   - component: {fileID: 3232839523659743446}
+  - component: {fileID: 6417518545994622246}
   - component: {fileID: 114857257376150830}
   - component: {fileID: 114500601568321508}
   m_Layer: 10
@@ -104,7 +104,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: c45c93fdd4d59483cbdb87a1d323bcc5, type: 2}
   size: 3
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 10
   damageType: 0
   throwDamage: 7
@@ -158,9 +158,20 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
+--- !u!114 &3232839523659743446
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7503752898315862941}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9bc379e328bc3bd44a6541cd4f3e5a57, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  stunTime: 14
+  stunSound: EGloves
 --- !u!114 &6417518545994622246
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -180,20 +191,6 @@ MonoBehaviour:
   spriteActive: {fileID: 21300000, guid: 0e5edf73e36bedf4b8b621aff4559d78, type: 3}
   spriteInactive: {fileID: 21300000, guid: d692e3351e1ae8443a57daf8b9695ddd, type: 3}
   active: 0
---- !u!114 &3232839523659743446
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7503752898315862941}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9bc379e328bc3bd44a6541cd4f3e5a57, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  stunTime: 14
-  stunSound: EGloves
 --- !u!114 &114857257376150830
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -207,6 +204,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -226,7 +227,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 29d17c6e33a25434ca93edfb29f82cb7
+  m_AssetId: fcd09c3dfb3c3954cac1623e1c37bac3
   m_SceneId: 0
 --- !u!1 &7503752899205498039
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Storage/SmallBox.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Storage/SmallBox.prefab
@@ -122,10 +122,10 @@ GameObject:
   - component: {fileID: 114768507001769714}
   - component: {fileID: 114677721502774396}
   - component: {fileID: 114120662618608678}
-  - component: {fileID: 114336348675555448}
-  - component: {fileID: 114465317721107106}
-  - component: {fileID: 114166600190300968}
   - component: {fileID: 114122756854411570}
+  - component: {fileID: 114465317721107106}
+  - component: {fileID: 114336348675555448}
+  - component: {fileID: 114166600190300968}
   - component: {fileID: 114013691186649456}
   - component: {fileID: 114144300265124736}
   - component: {fileID: 114254203349742134}
@@ -255,7 +255,7 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
---- !u!114 &114336348675555448
+--- !u!114 &114122756854411570
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -264,7 +264,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1585232330438968}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 72c43885acb654c59b452e7069cb64f8, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &114465317721107106
@@ -281,6 +281,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &114336348675555448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1585232330438968}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72c43885acb654c59b452e7069cb64f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114166600190300968
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -294,18 +306,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114122756854411570
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1585232330438968}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114013691186649456
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -377,7 +377,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: f41055628add8412baae5e935a97980c
   m_SceneId: 0
 --- !u!114 &7117549763075892957
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Storage/Toolbox.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Storage/Toolbox.prefab
@@ -14,10 +14,10 @@ GameObject:
   - component: {fileID: 2901372144461622397}
   - component: {fileID: 1614627787898670548}
   - component: {fileID: 5060467795803936097}
-  - component: {fileID: 3450189410044159233}
-  - component: {fileID: 7629511162276542851}
-  - component: {fileID: 7192021640817197183}
   - component: {fileID: 4826798589450700602}
+  - component: {fileID: 7629511162276542851}
+  - component: {fileID: 3450189410044159233}
+  - component: {fileID: 7192021640817197183}
   - component: {fileID: 3016635445816934449}
   - component: {fileID: 5355802478405648676}
   - component: {fileID: 8782089620930079623}
@@ -107,7 +107,7 @@ MonoBehaviour:
   initialTraits: []
   size: 4
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 12
   damageType: 0
   throwDamage: 12
@@ -148,10 +148,7 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &3450189410044159233
+--- !u!114 &4826798589450700602
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -160,7 +157,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 2261239356000419554}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 72c43885acb654c59b452e7069cb64f8, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &7629511162276542851
@@ -177,6 +174,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &3450189410044159233
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2261239356000419554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72c43885acb654c59b452e7069cb64f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &7192021640817197183
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -190,18 +199,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &4826798589450700602
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2261239356000419554}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &3016635445816934449
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,6 +247,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -269,8 +270,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 2956743437
+  m_AssetId: 41b3fb480b523437288fe18998445d00
+  m_SceneId: 0
 --- !u!114 &3112443706636641109
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -397,6 +398,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/Emergency Oxygen Tank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/Emergency Oxygen Tank.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 114342755618585978}
   - component: {fileID: 114288380597099474}
   - component: {fileID: 114267664904661214}
+  - component: {fileID: 2393274509765689472}
   - component: {fileID: 114330809230976920}
   - component: {fileID: 3305593915559126072}
   - component: {fileID: 114896479765772544}
   - component: {fileID: 114892250899287116}
-  - component: {fileID: 2393274509765689472}
   - component: {fileID: 2711347594170807092}
   - component: {fileID: 114136922186643814}
   - component: {fileID: 114635495288501910}
@@ -212,6 +212,18 @@ MonoBehaviour:
   throwRange: 5
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &2393274509765689472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1277678737481138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114330809230976920
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -278,18 +290,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
---- !u!114 &2393274509765689472
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1277678737481138}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &2711347594170807092
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -435,5 +435,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: f99902d04c3b1fe47b0e4e4ec36b7971
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/Oxygen Tank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/Oxygen Tank.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 114342755618585978}
   - component: {fileID: 114288380597099474}
   - component: {fileID: 114267664904661214}
+  - component: {fileID: 5842428873926595982}
   - component: {fileID: 114330809230976920}
   - component: {fileID: 3305593915559126072}
   - component: {fileID: 114892679667736192}
   - component: {fileID: 114550202335981176}
-  - component: {fileID: 5842428873926595982}
   - component: {fileID: 7044729721047615613}
   - component: {fileID: 114964623363075472}
   - component: {fileID: 114436548366995844}
@@ -209,6 +209,18 @@ MonoBehaviour:
   throwRange: 1
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &5842428873926595982
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1277678737481138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114330809230976920
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -275,18 +287,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
---- !u!114 &5842428873926595982
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1277678737481138}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &7044729721047615613
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -432,5 +432,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 4661484912df68a4192af5d6c9a8cd58
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Bucket.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Bucket.prefab
@@ -94,14 +94,14 @@ GameObject:
   - component: {fileID: 114364506355654784}
   - component: {fileID: 114284267982980302}
   - component: {fileID: 114098538090098490}
-  - component: {fileID: 114657433043358150}
-  - component: {fileID: 114062470574361688}
   - component: {fileID: 114788874549882356}
+  - component: {fileID: 114657433043358150}
+  - component: {fileID: 5199146694513484801}
+  - component: {fileID: 114062470574361688}
   - component: {fileID: 114567163244394598}
   - component: {fileID: 114441573294268492}
   - component: {fileID: 114321264871015286}
   - component: {fileID: -4141852985515784285}
-  - component: {fileID: 5199146694513484801}
   m_Layer: 10
   m_Name: Bucket
   m_TagString: Untagged
@@ -228,6 +228,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114788874549882356
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1801347380884054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114657433043358150
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -242,6 +254,35 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &5199146694513484801
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1801347380884054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  temperatureKelvin: 293.15
+  MaxCapacity: 70
+  InSolidForm: 0
+  Reagents: []
+  Amounts: []
+  TraitWhitelist: []
+  ReagentWhitelist: []
+  TransferMode: 0
+  InitialTransferAmount: 20
+  PossibleTransferAmounts:
+  - 10
+  - 15
+  - 20
+  - 25
+  - 30
+  - 50
+  - 70
 --- !u!114 &114062470574361688
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -255,18 +296,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114788874549882356
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1801347380884054}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114567163244394598
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -412,7 +441,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 2b30815126120534d823a2f2fdf0a26d
   m_SceneId: 0
 --- !u!114 &-4141852985515784285
 MonoBehaviour:
@@ -430,32 +459,3 @@ MonoBehaviour:
   backgroundColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   iconOverride: {fileID: 0}
   backgroundSprite: {fileID: 0}
---- !u!114 &5199146694513484801
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1801347380884054}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  temperatureKelvin: 293.15
-  MaxCapacity: 70
-  InSolidForm: 0
-  Reagents: []
-  Amounts: []
-  TraitWhitelist: []
-  ReagentWhitelist: []
-  TransferMode: 0
-  InitialTransferAmount: 20
-  PossibleTransferAmounts:
-  - 10
-  - 15
-  - 20
-  - 25
-  - 30
-  - 50
-  - 70

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Crowbar.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Crowbar.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114909773131868738}
   - component: {fileID: 114998062039538404}
   - component: {fileID: 114484434474911270}
+  - component: {fileID: 114850502447124420}
   - component: {fileID: 114079509811454882}
   - component: {fileID: 2107020011812829422}
   - component: {fileID: 114943451087304478}
-  - component: {fileID: 114850502447124420}
   - component: {fileID: 114596150240161284}
   - component: {fileID: 114976959642827926}
   - component: {fileID: 114877070699459104}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114850502447124420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114079509811454882
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -268,18 +280,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114850502447124420
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114596150240161284
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -425,5 +425,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: ac13474c9d8108940b75c30b2bff8a38
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Extinguisher.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Extinguisher.prefab
@@ -90,16 +90,16 @@ GameObject:
   m_Component:
   - component: {fileID: 4827893193398430}
   - component: {fileID: 61818042941755762}
-  - component: {fileID: 1769529668165702070}
-  - component: {fileID: 4953889069794681373}
   - component: {fileID: 114875290499615288}
   - component: {fileID: 114567485071167784}
+  - component: {fileID: 114147643764008260}
   - component: {fileID: 7891530486730515463}
+  - component: {fileID: 4953889069794681373}
+  - component: {fileID: 1769529668165702070}
   - component: {fileID: 114335573703485954}
   - component: {fileID: 114690376875817604}
   - component: {fileID: 114503468551468690}
   - component: {fileID: 114941767276165962}
-  - component: {fileID: 114147643764008260}
   - component: {fileID: 114229085023085202}
   - component: {fileID: 114462233250351786}
   - component: {fileID: 114923660035280294}
@@ -153,55 +153,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!114 &1769529668165702070
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1907679543779350}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: df14585efc20d2f4c9f0b66982db3b8d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  travelDistance: 6
-  reagentContainer: {fileID: 4953889069794681373}
-  registerItem: {fileID: 114690376875817604}
-  pickupable: {fileID: 7891530486730515463}
-  reagentsPerUse: 5
-  spriteRenderer: {fileID: 212125191403727516}
-  spriteSync: 0
-  spriteList:
-  - {fileID: 21300000, guid: 65bae883a79671342ba887b2c584674c, type: 3}
-  - {fileID: 21300000, guid: ea2cd872d96348440a1d6a65e802dc62, type: 3}
---- !u!114 &4953889069794681373
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1907679543779350}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  temperatureKelvin: 293.15
-  MaxCapacity: 50
-  InSolidForm: 0
-  Reagents:
-  - water
-  Amounts:
-  - 50
-  TraitWhitelist: []
-  ReagentWhitelist:
-  - water
-  TransferMode: 3
-  InitialTransferAmount: 20
-  PossibleTransferAmounts: []
 --- !u!114 &114875290499615288
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -247,6 +198,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114147643764008260
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1907679543779350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &7891530486730515463
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -261,6 +224,55 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &4953889069794681373
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1907679543779350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  temperatureKelvin: 293.15
+  MaxCapacity: 50
+  InSolidForm: 0
+  Reagents:
+  - water
+  Amounts:
+  - 50
+  TraitWhitelist: []
+  ReagentWhitelist:
+  - water
+  TransferMode: 3
+  InitialTransferAmount: 20
+  PossibleTransferAmounts: []
+--- !u!114 &1769529668165702070
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1907679543779350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: df14585efc20d2f4c9f0b66982db3b8d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  travelDistance: 6
+  reagentContainer: {fileID: 4953889069794681373}
+  registerItem: {fileID: 114690376875817604}
+  pickupable: {fileID: 7891530486730515463}
+  reagentsPerUse: 5
+  spriteRenderer: {fileID: 212125191403727516}
+  spriteSync: 0
+  spriteList:
+  - {fileID: 21300000, guid: 65bae883a79671342ba887b2c584674c, type: 3}
+  - {fileID: 21300000, guid: ea2cd872d96348440a1d6a65e802dc62, type: 3}
 --- !u!114 &114335573703485954
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -318,18 +330,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114147643764008260
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1907679543779350}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114229085023085202
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -395,7 +395,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 7920a824df456044381e381e90277a5d
   m_SceneId: 0
 --- !u!114 &5519721869088170442
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Handheld Torch.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Handheld Torch.prefab
@@ -191,10 +191,10 @@ GameObject:
   - component: {fileID: 114086199267058162}
   - component: {fileID: 114660078625858576}
   - component: {fileID: 114546715207081156}
-  - component: {fileID: 8733151929054526228}
-  - component: {fileID: 114852817288890120}
-  - component: {fileID: 114828444551440684}
   - component: {fileID: 114189442814561830}
+  - component: {fileID: 114852817288890120}
+  - component: {fileID: 8733151929054526228}
+  - component: {fileID: 114828444551440684}
   - component: {fileID: 114651961981478966}
   - component: {fileID: 114500040489965280}
   - component: {fileID: 114400107952342984}
@@ -283,7 +283,7 @@ MonoBehaviour:
   initialTraits: []
   size: 1
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -323,9 +323,32 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
+--- !u!114 &114189442814561830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869747887731904}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114852817288890120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869747887731904}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &8733151929054526228
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -350,20 +373,6 @@ MonoBehaviour:
     Colour: {r: 0, g: 0, b: 0, a: 0}
     EnumSprite: 0
     Size: 12
---- !u!114 &114852817288890120
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1869747887731904}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114828444551440684
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -377,18 +386,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114189442814561830
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1869747887731904}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114651961981478966
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -437,6 +434,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 19

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Screwdriver.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Screwdriver.prefab
@@ -93,13 +93,13 @@ GameObject:
   - component: {fileID: 114287030664492144}
   - component: {fileID: 50080775290529754}
   - component: {fileID: 114909773131868738}
-  - component: {fileID: 114072330335640904}
   - component: {fileID: 114998062039538404}
   - component: {fileID: 114484434474911270}
   - component: {fileID: 2621837288423225324}
-  - component: {fileID: 114533157868152320}
-  - component: {fileID: 114196815897616336}
   - component: {fileID: 114674513833633886}
+  - component: {fileID: 114533157868152320}
+  - component: {fileID: 114072330335640904}
+  - component: {fileID: 114196815897616336}
   - component: {fileID: 114784546776582578}
   - component: {fileID: 114013628232825724}
   - component: {fileID: 114660200964279046}
@@ -218,18 +218,6 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
---- !u!114 &114072330335640904
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9511e80319bea6e47946f97051ff2b00, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114998062039538404
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -274,6 +262,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e0036bd5aae14571835232bc33ddaf2e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &114674513833633886
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114533157868152320
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -288,6 +288,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &114072330335640904
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9511e80319bea6e47946f97051ff2b00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114196815897616336
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -301,18 +313,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114674513833633886
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114784546776582578
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -377,7 +377,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: daa925ae33eab5d4988f8182a1ce33ac
   m_SceneId: 0
 --- !u!1 &5751769075716656209
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Welder.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Welder.prefab
@@ -175,10 +175,10 @@ GameObject:
   - component: {fileID: 114909773131868738}
   - component: {fileID: 114998062039538404}
   - component: {fileID: 114484434474911270}
-  - component: {fileID: 114851684007684126}
-  - component: {fileID: 114994829710997294}
-  - component: {fileID: 114973183945482710}
   - component: {fileID: 114968630120875758}
+  - component: {fileID: 114994829710997294}
+  - component: {fileID: 114851684007684126}
+  - component: {fileID: 114973183945482710}
   - component: {fileID: 114993621397341992}
   - component: {fileID: 114112507639602968}
   - component: {fileID: 114200423442709530}
@@ -330,6 +330,32 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114968630120875758
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114994829710997294
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &114851684007684126
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -358,20 +384,6 @@ MonoBehaviour:
   clientFuelAmt: 0
   damageOn: 15
   isOn: 0
---- !u!114 &114994829710997294
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114973183945482710
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -385,18 +397,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114968630120875758
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114993621397341992
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -542,7 +542,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 698c97193d3a26f48885710aa6c90ffe
   m_SceneId: 0
 --- !u!1 &8596341256241081698
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wirecutter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wirecutter.prefab
@@ -95,10 +95,10 @@ GameObject:
   - component: {fileID: 114909773131868738}
   - component: {fileID: 114998062039538404}
   - component: {fileID: 114484434474911270}
+  - component: {fileID: 114663582793708206}
   - component: {fileID: 114098934439909434}
   - component: {fileID: 3886908202543390868}
   - component: {fileID: 114480365694120160}
-  - component: {fileID: 114663582793708206}
   - component: {fileID: 114789380910347572}
   - component: {fileID: 114225723971362842}
   - component: {fileID: 114100650871773364}
@@ -248,6 +248,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114663582793708206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114098934439909434
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -290,18 +302,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114663582793708206
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114789380910347572
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -373,5 +373,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 9198440a9fbd8684fa7906b4ede7ad02
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wrench.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wrench.prefab
@@ -96,10 +96,10 @@ GameObject:
   - component: {fileID: 114998062039538404}
   - component: {fileID: 114484434474911270}
   - component: {fileID: 1022381328221600776}
+  - component: {fileID: 114117350948527228}
   - component: {fileID: 114015390832439874}
   - component: {fileID: 1880284032232329105}
   - component: {fileID: 114899683467054628}
-  - component: {fileID: 114117350948527228}
   - component: {fileID: 114485046366911826}
   - component: {fileID: 114957533591108950}
   m_Layer: 10
@@ -344,6 +344,18 @@ MonoBehaviour:
   spriteList:
   - {fileID: 21300000, guid: b573a74bb4057a3409b70ef05e511776, type: 3}
   - {fileID: 21300000, guid: 9a162d06d8c6d4243b8ea3119a0a274c, type: 3}
+--- !u!114 &114117350948527228
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519710982558066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114015390832439874
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -386,18 +398,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114117350948527228
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1519710982558066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114485046366911826
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -447,5 +447,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 716afa9ab8df5874a8801b81b5e626be
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Trash/4no raisins wrapper.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Trash/4no raisins wrapper.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4645335817288720}
   - component: {fileID: 61202592083071704}
   - component: {fileID: 114828422824226692}
+  - component: {fileID: 114299451833772860}
   - component: {fileID: 114608524725813366}
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
   - component: {fileID: 114471841111005130}
-  - component: {fileID: 114299451833772860}
   - component: {fileID: 114978529619228034}
   - component: {fileID: 114851512614710040}
   - component: {fileID: 114911584317715002}
@@ -97,6 +97,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114299451833772860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114608524725813366
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -171,18 +183,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114299451833772860
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114978529619228034
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -254,7 +254,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: a249802e33c293c479d8008bdcbe480d
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Trash/Banana peel.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Trash/Banana peel.prefab
@@ -92,13 +92,13 @@ GameObject:
   - component: {fileID: 61818042941755762}
   - component: {fileID: 114875290499615288}
   - component: {fileID: 114567485071167784}
+  - component: {fileID: 114268903903400682}
   - component: {fileID: 114229897149472310}
   - component: {fileID: 114335573703485954}
   - component: {fileID: 114690376875817604}
   - component: {fileID: 114503468551468690}
   - component: {fileID: 114385515256601920}
   - component: {fileID: 114632274079759252}
-  - component: {fileID: 114268903903400682}
   - component: {fileID: 114269914628471680}
   - component: {fileID: 114091489206424360}
   - component: {fileID: 114858167124748228}
@@ -187,7 +187,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 63ebb1ff93c93354994ab009bc8ccf7d, type: 2}
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -195,6 +195,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: Slip
   attackVerb: []
+--- !u!114 &114268903903400682
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1907679543779350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114229897149472310
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -241,9 +253,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114503468551468690
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -286,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114268903903400682
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1907679543779350}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114269914628471680
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -346,6 +343,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -365,5 +366,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 966381198
+  m_AssetId: f55ea2147f7e49449a11c6d0063822f6
+  m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Trash/Beef Jerky wrapper.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Trash/Beef Jerky wrapper.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4645335817288720}
   - component: {fileID: 61202592083071704}
   - component: {fileID: 114828422824226692}
+  - component: {fileID: 114328416591890042}
   - component: {fileID: 114608524725813366}
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
   - component: {fileID: 114126506365098240}
-  - component: {fileID: 114328416591890042}
   - component: {fileID: 114745581219216320}
   - component: {fileID: 114860404303290038}
   - component: {fileID: 114408859831679578}
@@ -97,6 +97,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114328416591890042
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114608524725813366
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -171,18 +183,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114328416591890042
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114745581219216320
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -254,7 +254,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 90aa1645ffac72c47a059d49ae38efc2
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Trash/Container.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Trash/Container.prefab
@@ -11,13 +11,13 @@ GameObject:
   - component: {fileID: 4645335817288720}
   - component: {fileID: 61202592083071704}
   - component: {fileID: 114828422824226692}
+  - component: {fileID: 114967445978809342}
   - component: {fileID: 114608524725813366}
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
   - component: {fileID: 114517333254893718}
   - component: {fileID: 114392320129148090}
-  - component: {fileID: 114967445978809342}
   - component: {fileID: 114273104990136554}
   - component: {fileID: 114808940284313810}
   m_Layer: 10
@@ -82,14 +82,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  spriteHandlerData: {fileID: 0}
+  spriteDataHandler: {fileID: 0}
   InventoryIcon: {fileID: 0}
   itemName: Empty glass
   itemDescription: 
-  itemType: 0
+  initialTraits: []
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -97,6 +97,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114967445978809342
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114608524725813366
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -111,11 +123,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  OnDropServer:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114931546224579044
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -131,7 +138,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  parentContainer: {fileID: 0}
   isNotPushable: 0
 --- !u!114 &114121219251840654
 MonoBehaviour:
@@ -149,10 +155,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 --- !u!114 &114208883059431984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,6 +169,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114517333254893718
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -179,10 +182,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Temperature: 20
+  temperatureKelvin: 293.15
   MaxCapacity: 100
+  InSolidForm: 0
   Reagents: []
   Amounts: []
+  TraitWhitelist: []
+  ReagentWhitelist: []
+  TransferMode: 0
+  InitialTransferAmount: 20
+  PossibleTransferAmounts: []
 --- !u!114 &114392320129148090
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -196,18 +205,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114967445978809342
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114273104990136554
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -242,6 +239,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114808940284313810
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -254,9 +252,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -318,6 +318,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Trash/Dirty plate.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Trash/Dirty plate.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4645335817288720}
   - component: {fileID: 61202592083071704}
   - component: {fileID: 114828422824226692}
+  - component: {fileID: 114671282202539610}
   - component: {fileID: 114608524725813366}
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
   - component: {fileID: 114720237345187292}
-  - component: {fileID: 114671282202539610}
   - component: {fileID: 114989353219908512}
   - component: {fileID: 114662771064753992}
   - component: {fileID: 114006262795209252}
@@ -97,6 +97,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114671282202539610
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114608524725813366
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -171,18 +183,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114671282202539610
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114989353219908512
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -254,7 +254,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 252b1325bc181714a9aaadbaf3c8147d
   m_SceneId: 0
 --- !u!1 &1469747287601084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Trash/Empty glass.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Trash/Empty glass.prefab
@@ -11,13 +11,13 @@ GameObject:
   - component: {fileID: 4645335817288720}
   - component: {fileID: 61202592083071704}
   - component: {fileID: 114828422824226692}
+  - component: {fileID: 114804787366308386}
   - component: {fileID: 114608524725813366}
   - component: {fileID: 114931546224579044}
   - component: {fileID: 114121219251840654}
   - component: {fileID: 114208883059431984}
   - component: {fileID: 7129349394144089427}
   - component: {fileID: 114179647736667158}
-  - component: {fileID: 114804787366308386}
   - component: {fileID: 114296532116783838}
   - component: {fileID: 114225936998993750}
   - component: {fileID: 114675233434202750}
@@ -101,6 +101,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114804787366308386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110193000772614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114608524725813366
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -197,18 +209,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114804787366308386
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1110193000772614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114296532116783838
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -354,7 +354,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 50334239d541e7643a2b9d5c8cb43430
   m_SceneId: 0
 --- !u!114 &3266362895114989803
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/C20rSMG_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/C20rSMG_Ballistic.prefab
@@ -14,10 +14,10 @@ GameObject:
   - component: {fileID: 114132912066377716}
   - component: {fileID: 114390494628489026}
   - component: {fileID: 114811499986229406}
+  - component: {fileID: 114738722789782520}
   - component: {fileID: 114436250719765578}
   - component: {fileID: 226619930613165614}
   - component: {fileID: 114282696545295336}
-  - component: {fileID: 114738722789782520}
   - component: {fileID: 114840752522192544}
   - component: {fileID: 114905685680163770}
   - component: {fileID: 114162268071507282}
@@ -148,6 +148,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114738722789782520
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1296620499762930}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114436250719765578
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,18 +217,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114738722789782520
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1296620499762930}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114840752522192544
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -362,7 +362,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 054d4c5d3f4b74caa87d549779ef4bf0
   m_SceneId: 0
 --- !u!114 &4995470330489264669
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Cshotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Cshotgun_Ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114469284172845192}
   - component: {fileID: 114500871586828832}
   - component: {fileID: 114061577710956728}
+  - component: {fileID: 114762579623046278}
   - component: {fileID: 114780009814565468}
   - component: {fileID: 8321738442037649988}
   - component: {fileID: 114371710669471992}
-  - component: {fileID: 114762579623046278}
   - component: {fileID: 114337019426290282}
   - component: {fileID: 114078596252142752}
   - component: {fileID: 114028072277060010}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114762579623046278
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1968992119088728}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114780009814565468
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114762579623046278
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1968992119088728}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114337019426290282
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -440,7 +440,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 8aa9c1617fcf44905b26d836feca524f
   m_SceneId: 0
 --- !u!114 &1144437016424961650
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Detective_Gold_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Detective_Gold_Ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114840681176295264}
   - component: {fileID: 114859515791178996}
   - component: {fileID: 114422233424066394}
+  - component: {fileID: 114343556704672746}
   - component: {fileID: 114837800581561888}
   - component: {fileID: 2902009535563850575}
   - component: {fileID: 114501986062645872}
-  - component: {fileID: 114343556704672746}
   - component: {fileID: 114767087319713958}
   - component: {fileID: 114132764856491264}
   - component: {fileID: 114792794626882886}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114343556704672746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1946347799520078}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114837800581561888
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114343556704672746
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1946347799520078}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114767087319713958
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -368,7 +368,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: f89dd1a3681f542849c3eb187dcb751f
   m_SceneId: 0
 --- !u!114 &-4641284061545249848
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Detective_Peacemaker.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Detective_Peacemaker.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114041852335868026}
   - component: {fileID: 114516547698670092}
   - component: {fileID: 114719311183369262}
+  - component: {fileID: 114600135491147070}
   - component: {fileID: 114784145966959298}
   - component: {fileID: 8667543511224189781}
   - component: {fileID: 114148491464965948}
-  - component: {fileID: 114600135491147070}
   - component: {fileID: 114905742241202176}
   - component: {fileID: 114607166594476702}
   - component: {fileID: 114353629055838280}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114600135491147070
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1831002801606018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114784145966959298
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114600135491147070
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1831002801606018}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114905742241202176
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,7 +366,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 4d2837a88209148ba9e84a5679487672
   m_SceneId: 0
 --- !u!114 &893218852628109050
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/ERT_Gun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/ERT_Gun_Ballistic.prefab
@@ -14,10 +14,10 @@ GameObject:
   - component: {fileID: 114906344895876820}
   - component: {fileID: 114752816660759734}
   - component: {fileID: 114959013130737060}
+  - component: {fileID: 114555494551418034}
   - component: {fileID: 114027104691969066}
   - component: {fileID: 2251993831743313043}
   - component: {fileID: 114538355917789768}
-  - component: {fileID: 114555494551418034}
   - component: {fileID: 114132682535115068}
   - component: {fileID: 114364732512519582}
   - component: {fileID: 114246875284351206}
@@ -148,6 +148,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114555494551418034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1167865368234136}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114027104691969066
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,18 +217,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114555494551418034
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1167865368234136}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114132682535115068
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -288,7 +288,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: df06cbd2108704926b399a65e6ff12de
   m_SceneId: 0
 --- !u!114 &-3625424685850474357
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Handgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Handgun_Ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114775921226298872}
   - component: {fileID: 114586490647730340}
   - component: {fileID: 114437442048880876}
+  - component: {fileID: 114202327773981162}
   - component: {fileID: 114956772244555426}
   - component: {fileID: 4065799211730854973}
   - component: {fileID: 114228613109971920}
-  - component: {fileID: 114202327773981162}
   - component: {fileID: 114805120630304424}
   - component: {fileID: 114259284396461018}
   - component: {fileID: 114257687528817064}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114202327773981162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1557459482202932}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114956772244555426
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114202327773981162
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1557459482202932}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114805120630304424
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,7 +366,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 46d04753927f9454796ffdd4314a1215
   m_SceneId: 0
 --- !u!114 &6943113044825457002
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Heirloom_Handgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Heirloom_Handgun_Ballistic.prefab
@@ -14,10 +14,10 @@ GameObject:
   - component: {fileID: 114064114876883076}
   - component: {fileID: 114083348550750644}
   - component: {fileID: 114335168548285402}
+  - component: {fileID: 114716733650234370}
   - component: {fileID: 114949645437376370}
   - component: {fileID: 5019103039272272128}
   - component: {fileID: 114472039501574676}
-  - component: {fileID: 114716733650234370}
   - component: {fileID: 114824171484795394}
   - component: {fileID: 114189629465493892}
   - component: {fileID: 114408061240125186}
@@ -146,6 +146,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114716733650234370
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1269203658156660}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114949645437376370
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -203,18 +215,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114716733650234370
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1269203658156660}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114824171484795394
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -286,7 +286,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 6e5bac62a83bd4e8e9764f3f7d48beaa
   m_SceneId: 0
 --- !u!114 &5385803216511162143
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Improved_Syringegun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Improved_Syringegun_Ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114318962927732260}
   - component: {fileID: 114206490819766748}
   - component: {fileID: 114698498328760798}
+  - component: {fileID: 114504224381887778}
   - component: {fileID: 114386504637134268}
   - component: {fileID: 429402183367731222}
   - component: {fileID: 114384091546263318}
-  - component: {fileID: 114504224381887778}
   - component: {fileID: 114118644793891484}
   - component: {fileID: 114423637399040020}
   - component: {fileID: 114185279304014640}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114504224381887778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1528286794630592}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114386504637134268
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114504224381887778
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1528286794630592}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114118644793891484
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,7 +366,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e48d6436f9ee64735ab497c4b2503396
   m_SceneId: 0
 --- !u!114 &7970349661409226817
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/L6SAW_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/L6SAW_Ballistic.prefab
@@ -14,10 +14,10 @@ GameObject:
   - component: {fileID: 114661774911997286}
   - component: {fileID: 114606480918356138}
   - component: {fileID: 114594973255241380}
+  - component: {fileID: 114243777355016984}
   - component: {fileID: 114879054642918062}
   - component: {fileID: 6535025367561471029}
   - component: {fileID: 114368917881796652}
-  - component: {fileID: 114243777355016984}
   - component: {fileID: 114246698634477076}
   - component: {fileID: 114177405083156228}
   - component: {fileID: 114335367358435480}
@@ -147,6 +147,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114243777355016984
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1228446059428988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114879054642918062
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,18 +216,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114243777355016984
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1228446059428988}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114246698634477076
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -287,7 +287,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: f683b1158f7f2bb45b6f6eae97cdd6f7
   m_SceneId: 0
 --- !u!114 &-956918336823585399
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/M90_ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/M90_ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114228701505719040}
   - component: {fileID: 114841962871814582}
   - component: {fileID: 114157227028527442}
+  - component: {fileID: 114700889943355420}
   - component: {fileID: 114916393656445134}
   - component: {fileID: 1352949759129444310}
   - component: {fileID: 114365911791227426}
-  - component: {fileID: 114700889943355420}
   - component: {fileID: 114374460178807822}
   - component: {fileID: 114150278371818220}
   - component: {fileID: 114939312222920820}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114700889943355420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1860654956334788}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114916393656445134
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114700889943355420
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1860654956334788}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114374460178807822
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,7 +366,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 8538829c70c6347e88747ca6d9b0a4bd
   m_SceneId: 0
 --- !u!114 &-8146093686973242629
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/P90_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/P90_Ballistic.prefab
@@ -14,10 +14,10 @@ GameObject:
   - component: {fileID: 114746251810346300}
   - component: {fileID: 114727589024977204}
   - component: {fileID: 114398833074430000}
+  - component: {fileID: 114116063777154510}
   - component: {fileID: 114037714126238430}
   - component: {fileID: 8490843982289124231}
   - component: {fileID: 114344857399219202}
-  - component: {fileID: 114116063777154510}
   - component: {fileID: 114896405872933470}
   - component: {fileID: 114162825929509216}
   - component: {fileID: 114848791018761284}
@@ -147,6 +147,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114116063777154510
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1273261371329586}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114037714126238430
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,18 +216,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114116063777154510
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1273261371329586}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114896405872933470
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -287,7 +287,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 76c4bc1413a8e4544b10069929b1f160
   m_SceneId: 0
 --- !u!114 &-5849859655428222665
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Revolver_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Revolver_Ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114461506418144158}
   - component: {fileID: 114529648990615742}
   - component: {fileID: 114451834042202350}
+  - component: {fileID: 114117284983500122}
   - component: {fileID: 114200900872640816}
   - component: {fileID: 3377771713695131618}
   - component: {fileID: 114279976420431528}
-  - component: {fileID: 114117284983500122}
   - component: {fileID: 114844005999312400}
   - component: {fileID: 114223204492019564}
   - component: {fileID: 114486861544395548}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114117284983500122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1863058284462694}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114200900872640816
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114117284983500122
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1863058284462694}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114844005999312400
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,7 +366,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: d3a2dbd5e0f5c49e7a462e9ed90887fe
   m_SceneId: 0
 --- !u!114 &-8555182458423160289
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Revolver_Detective_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Revolver_Detective_Ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114853416549807176}
   - component: {fileID: 114355234130924692}
   - component: {fileID: 114975342974608640}
+  - component: {fileID: 114671987430861900}
   - component: {fileID: 114419866923798150}
   - component: {fileID: 2522490648275854769}
   - component: {fileID: 114823945836049686}
-  - component: {fileID: 114671987430861900}
   - component: {fileID: 114482219070415538}
   - component: {fileID: 114773453504398434}
   - component: {fileID: 114417339752912292}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114671987430861900
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1589781730870112}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114419866923798150
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114671987430861900
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1589781730870112}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114482219070415538
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,7 +366,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: aa0d300c4a5b04dfd95c5e0790207b3b
   m_SceneId: 0
 --- !u!114 &-3062290403037341712
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Saber_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Saber_Ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114973869889094088}
   - component: {fileID: 114871361044904486}
   - component: {fileID: 114970828739563012}
+  - component: {fileID: 114005371888987122}
   - component: {fileID: 114339601920278918}
   - component: {fileID: 8577708417635467964}
   - component: {fileID: 114142113250670478}
-  - component: {fileID: 114005371888987122}
   - component: {fileID: 114811899316568122}
   - component: {fileID: 114625798901129294}
   - component: {fileID: 114089431332120224}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114005371888987122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1404025141166736}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114339601920278918
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114005371888987122
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1404025141166736}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114811899316568122
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,7 +366,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 0f34b20493ec445019f248dfd446e424
   m_SceneId: 0
 --- !u!114 &-4411417169104200506
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Sawn_Shotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Sawn_Shotgun_Ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114804321137780070}
   - component: {fileID: 114416272643300644}
   - component: {fileID: 114224021230560700}
+  - component: {fileID: 114831224319266548}
   - component: {fileID: 114981415598955886}
   - component: {fileID: 7663834691133376645}
   - component: {fileID: 114018308498995044}
-  - component: {fileID: 114831224319266548}
   - component: {fileID: 114968734155845580}
   - component: {fileID: 114693612237704638}
   - component: {fileID: 114762714420297520}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114831224319266548
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869071035267636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114981415598955886
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114831224319266548
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1869071035267636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114968734155845580
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,7 +366,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 9632ab1f37744429f8c2d22f85aeb310
   m_SceneId: 0
 --- !u!114 &-8875257338599547305
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Shotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Shotgun_Ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114677960272259078}
   - component: {fileID: 114469553411307036}
   - component: {fileID: 114465474734708746}
+  - component: {fileID: 114249390010484564}
   - component: {fileID: 114923350361433254}
   - component: {fileID: 3241909802591281347}
   - component: {fileID: 114597977713190532}
-  - component: {fileID: 114249390010484564}
   - component: {fileID: 114960387729673952}
   - component: {fileID: 114740566893851918}
   - component: {fileID: 114646497524625992}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114249390010484564
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1436741001650206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114923350361433254
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114249390010484564
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1436741001650206}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114960387729673952
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,7 +366,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 17a6dff99f45f4f0e86f4df4d6818f18
   m_SceneId: 0
 --- !u!114 &-7040035911593059216
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Syringegun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Syringegun_Ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114422418503778170}
   - component: {fileID: 114968577397713170}
   - component: {fileID: 114431891858334274}
+  - component: {fileID: 114157249458066654}
   - component: {fileID: 114864437693357090}
   - component: {fileID: 7520551432458179679}
   - component: {fileID: 114927517491895814}
-  - component: {fileID: 114157249458066654}
   - component: {fileID: 114658238807482858}
   - component: {fileID: 114400617428878908}
   - component: {fileID: 114509340295563454}
@@ -226,6 +226,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114157249458066654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1858738269464528}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114864437693357090
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,18 +295,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114157249458066654
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1858738269464528}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114658238807482858
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,7 +366,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 1c3f22cd692e64fb3b8686f0a767adbe
   m_SceneId: 0
 --- !u!114 &8061477873092044181
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Tactical_Handgun_ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Tactical_Handgun_ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114700499034651752}
   - component: {fileID: 114797067235565718}
   - component: {fileID: 114700230624298448}
+  - component: {fileID: 114544937745920048}
   - component: {fileID: 114109660565828716}
   - component: {fileID: 8589644988152629232}
   - component: {fileID: 114552866698914512}
-  - component: {fileID: 114544937745920048}
   - component: {fileID: 114824361522241554}
   - component: {fileID: 114434005769023190}
   - component: {fileID: 114840319352200170}
@@ -227,6 +227,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114544937745920048
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1713052969755012}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114109660565828716
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -284,18 +296,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114544937745920048
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1713052969755012}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114824361522241554
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -367,7 +367,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: fcc504f413695462b9c698e4a1d7fafe
   m_SceneId: 0
 --- !u!114 &-8165870982048707367
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Uzi_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Uzi_Ballistic.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114729131846127588}
   - component: {fileID: 114434855127349042}
   - component: {fileID: 114914675585055498}
+  - component: {fileID: 114968110253284126}
   - component: {fileID: 114020239394751432}
   - component: {fileID: 3812013440630209488}
   - component: {fileID: 114897133661706520}
-  - component: {fileID: 114968110253284126}
   - component: {fileID: 114762976677492814}
   - component: {fileID: 114852557143829536}
   - component: {fileID: 114736763035267744}
@@ -227,6 +227,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114968110253284126
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1397937101809150}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114020239394751432
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -284,18 +296,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114968110253284126
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1397937101809150}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114762976677492814
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -367,7 +367,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 3a2d5158054c440108a809dc52c9bc04
   m_SceneId: 0
 --- !u!114 &1117949388603872857
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Energy/Resources/LaserGun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Energy/Resources/LaserGun.prefab
@@ -14,10 +14,10 @@ GameObject:
   - component: {fileID: 114006053933687790}
   - component: {fileID: 114209077955755610}
   - component: {fileID: 114633601712090256}
+  - component: {fileID: 114339187557575792}
   - component: {fileID: 114535471755320426}
   - component: {fileID: 5669145644982481501}
   - component: {fileID: 114216741964076904}
-  - component: {fileID: 114339187557575792}
   - component: {fileID: 114008280874307392}
   - component: {fileID: 114269260090842122}
   - component: {fileID: 114365705417411688}
@@ -146,6 +146,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114339187557575792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1907860461332556}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114535471755320426
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -203,18 +215,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114339187557575792
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1907860461332556}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114008280874307392
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -286,7 +286,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 7c935e73269835f438b96b96b6f4403b
   m_SceneId: 0
 --- !u!114 &2060794053325888610
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Energy/Resources/LaserPistol.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Energy/Resources/LaserPistol.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114452692074497964}
   - component: {fileID: 114222453711107380}
   - component: {fileID: 114232596724965892}
+  - component: {fileID: 114613202640146834}
   - component: {fileID: 114644531332598490}
   - component: {fileID: 9012059881719020525}
   - component: {fileID: 114005296484789580}
-  - component: {fileID: 114613202640146834}
   - component: {fileID: 114089709833932218}
   - component: {fileID: 114751323075751822}
   - component: {fileID: 114001467022758570}
@@ -227,6 +227,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114613202640146834
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1245908573886190}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114644531332598490
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -284,18 +296,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114613202640146834
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1245908573886190}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114089709833932218
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -367,7 +367,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: ed6bbc7139ce2ba44bb6264c92954de0
   m_SceneId: 0
 --- !u!114 &2723904792205394333
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Energy/Resources/Tazer.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Energy/Resources/Tazer.prefab
@@ -99,10 +99,10 @@ GameObject:
   - component: {fileID: 114374851331526312}
   - component: {fileID: 114758040345321802}
   - component: {fileID: 114155970044334132}
+  - component: {fileID: 114352723021298410}
   - component: {fileID: 114088013606370678}
   - component: {fileID: 8735810588248712643}
   - component: {fileID: 114159304376706970}
-  - component: {fileID: 114352723021298410}
   - component: {fileID: 114551840644236552}
   - component: {fileID: 114232160885882454}
   - component: {fileID: 114268956197342468}
@@ -232,6 +232,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &114352723021298410
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1392830670498528}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114088013606370678
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -289,18 +301,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114352723021298410
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1392830670498528}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114551840644236552
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -372,7 +372,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 9f44d687d51603f4f93c814a3a888239
   m_SceneId: 0
 --- !u!114 &-6090260356928792423
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Explosive/Grenade.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Explosive/Grenade.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 7226413350837652230}
   - component: {fileID: 5173015474296263790}
   - component: {fileID: 4342641648236371693}
-  - component: {fileID: 7947197821612226908}
-  - component: {fileID: 114110293052994112}
-  - component: {fileID: 114501387999760508}
   - component: {fileID: 114006909984101046}
+  - component: {fileID: 114110293052994112}
+  - component: {fileID: 7947197821612226908}
+  - component: {fileID: 114501387999760508}
   - component: {fileID: 114217806038025902}
   - component: {fileID: 13680737134351771}
   - component: {fileID: 114867601024140442}
@@ -186,7 +186,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6bbea9c4e0a1b4840bde0835b8db0b2a, type: 2}
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -226,9 +226,32 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
+--- !u!114 &114006909984101046
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5134582746904691057}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114110293052994112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5134582746904691057}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &7947197821612226908
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -254,20 +277,6 @@ MonoBehaviour:
   maxEffectDuration: 0.25
   minEffectDuration: 0.05
   spriteHandler: {fileID: 13680737134351771}
---- !u!114 &114110293052994112
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5134582746904691057}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114501387999760508
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -281,18 +290,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114006909984101046
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5134582746904691057}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114217806038025902
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -341,6 +338,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 26
@@ -469,5 +470,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 29d17c6e33a25434ca93edfb29f82cb7
+  m_AssetId: 200bde3ddfd65ea4db701f0fa1c81f6c
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/Baton.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/Baton.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61000012096311666}
   - component: {fileID: 114904595007707188}
   - component: {fileID: 114000012876358140}
+  - component: {fileID: 114128851276751572}
   - component: {fileID: 114186698601475536}
   - component: {fileID: 114457471827933586}
   - component: {fileID: 114292337180728850}
   - component: {fileID: 114947022705203854}
-  - component: {fileID: 114128851276751572}
   - component: {fileID: 114571013473895252}
   - component: {fileID: 114436229020972412}
   - component: {fileID: 114137801701363466}
@@ -193,6 +193,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114128851276751572
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011622113908}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114186698601475536
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -252,18 +264,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114128851276751572
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000011622113908}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114571013473895252
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -335,5 +335,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: b3c9185918b6a40848954ead4b67f0e4
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/ChainOfCommand.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/ChainOfCommand.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61000012096311666}
   - component: {fileID: 114904595007707188}
   - component: {fileID: 114000012876358140}
+  - component: {fileID: 114541965729379946}
   - component: {fileID: 114186698601475536}
   - component: {fileID: 114457471827933586}
   - component: {fileID: 114292337180728850}
   - component: {fileID: 114994997000342420}
-  - component: {fileID: 114541965729379946}
   - component: {fileID: 114910247208891402}
   - component: {fileID: 114720253695277612}
   - component: {fileID: 114235674755919370}
@@ -196,6 +196,18 @@ MonoBehaviour:
   - whipped
   - lashed
   - disciplined
+--- !u!114 &114541965729379946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011622113908}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114186698601475536
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -255,18 +267,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114541965729379946
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000011622113908}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114910247208891402
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -338,5 +338,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: b94d86ac9713fce4cb3b8311d44212cf
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/Knife.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/Knife.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61000012096311666}
   - component: {fileID: 114904595007707188}
   - component: {fileID: 114000012876358140}
+  - component: {fileID: 114588637435364954}
   - component: {fileID: 114186698601475536}
   - component: {fileID: 114457471827933586}
   - component: {fileID: 114292337180728850}
   - component: {fileID: 114524387658485176}
-  - component: {fileID: 114588637435364954}
   - component: {fileID: 114086148071746808}
   - component: {fileID: 114047936015034586}
   - component: {fileID: 114781972732326808}
@@ -200,6 +200,18 @@ MonoBehaviour:
   - ripped
   - diced
   - cut
+--- !u!114 &114588637435364954
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011622113908}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114186698601475536
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -259,18 +271,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114588637435364954
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000011622113908}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114086148071746808
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -342,5 +342,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: fc5783dcb3f74ab1b2187da95b6c932d
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/RollingPin.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/RollingPin.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61702131476188450}
   - component: {fileID: 114716961639846354}
   - component: {fileID: 114000011671410446}
+  - component: {fileID: 114127346376007556}
   - component: {fileID: 114935930822245516}
   - component: {fileID: 114130006931618576}
   - component: {fileID: 114065043758903462}
   - component: {fileID: 114797656863405006}
-  - component: {fileID: 114127346376007556}
   - component: {fileID: 114395634636241260}
   - component: {fileID: 114353477829979338}
   - component: {fileID: 114698266538233354}
@@ -192,6 +192,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114127346376007556
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000012939332086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114935930822245516
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -251,18 +263,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114127346376007556
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000012939332086}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114395634636241260
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -334,5 +334,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 04684ac0ef7f4d938957d3420c0d938f
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/Scalpel.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/Scalpel.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61000012096311666}
   - component: {fileID: 114904595007707188}
   - component: {fileID: 114000012876358140}
+  - component: {fileID: 114755748058443534}
   - component: {fileID: 114186698601475536}
   - component: {fileID: 114457471827933586}
   - component: {fileID: 114292337180728850}
   - component: {fileID: 114624103622778140}
-  - component: {fileID: 114755748058443534}
   - component: {fileID: 114131277222387852}
   - component: {fileID: 114490681255588058}
   - component: {fileID: 114753571382319690}
@@ -193,6 +193,18 @@ MonoBehaviour:
   throwRange: 5
   hitSound: BladeSlice
   attackVerb: []
+--- !u!114 &114755748058443534
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011622113908}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114186698601475536
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -252,18 +264,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114755748058443534
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000011622113908}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114131277222387852
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -335,5 +335,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 70e9a72b546334103b60c8b557fc6a8d
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/Cable Coil.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/Cable Coil.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114836435796936700}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 2836368675170884176}
-  - component: {fileID: 114605469870542352}
-  - component: {fileID: 114201957858517422}
   - component: {fileID: 114191117801316952}
+  - component: {fileID: 114605469870542352}
+  - component: {fileID: 2836368675170884176}
+  - component: {fileID: 114201957858517422}
   - component: {fileID: 114127749902755492}
   - component: {fileID: 114936631704074404}
   - component: {fileID: 114577166391521898}
@@ -186,7 +186,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764, type: 2}
   size: 1
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -226,9 +226,32 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
+--- !u!114 &114191117801316952
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114605469870542352
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &2836368675170884176
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -246,20 +269,6 @@ MonoBehaviour:
   CableType: 0
   CablePrefab: {fileID: 1042895037894172, guid: e76e1e2174fe48d41bf086955b459b61,
     type: 3}
---- !u!114 &114605469870542352
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114201957858517422
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -273,18 +282,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114191117801316952
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114127749902755492
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -333,6 +330,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 19
@@ -426,5 +427,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 896305490
+  m_AssetId: 02204992fb099c145843af5f85a10d7d
+  m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/GlassShard.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/GlassShard.prefab
@@ -92,12 +92,12 @@ GameObject:
   - component: {fileID: 61321219257688126}
   - component: {fileID: 114675370128025870}
   - component: {fileID: 114836435796936700}
+  - component: {fileID: 114905780200061714}
   - component: {fileID: 114007797438959630}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
   - component: {fileID: 114925156265635096}
   - component: {fileID: 114280627628033994}
-  - component: {fileID: 114905780200061714}
   - component: {fileID: 114600892923789494}
   - component: {fileID: 114423506924015470}
   - component: {fileID: 6672415699437673694}
@@ -163,6 +163,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -184,7 +185,7 @@ MonoBehaviour:
   initialTraits: []
   size: 0
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 5
   damageType: 0
   throwDamage: 10
@@ -192,6 +193,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: BladeSlice
   attackVerb: []
+--- !u!114 &114905780200061714
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114007797438959630
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -238,9 +251,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114925156265635096
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -273,18 +283,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114905780200061714
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114600892923789494
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -333,6 +331,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 19
@@ -426,5 +428,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 176771780f0044e888d03a1373c39328
+  m_AssetId: 9e2cb5f8eb2084ef3840b1f6b0214159
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/High Cable Coil.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/High Cable Coil.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114836435796936700}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 2836368675170884176}
-  - component: {fileID: 114064393611054502}
-  - component: {fileID: 114917856105707652}
   - component: {fileID: 114009139927049000}
+  - component: {fileID: 114064393611054502}
+  - component: {fileID: 2836368675170884176}
+  - component: {fileID: 114917856105707652}
   - component: {fileID: 114037237496602686}
   - component: {fileID: 114822041883968204}
   - component: {fileID: 114894823419839980}
@@ -186,7 +186,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764, type: 2}
   size: 2
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -230,9 +230,32 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
+--- !u!114 &114009139927049000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114064393611054502
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &2836368675170884176
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,20 +273,6 @@ MonoBehaviour:
   CableType: 9
   CablePrefab: {fileID: 1042895037894172, guid: e3cc6d69954ca7f44b1df783b70ee6e1,
     type: 3}
---- !u!114 &114064393611054502
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114917856105707652
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -277,18 +286,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114009139927049000
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114037237496602686
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -337,6 +334,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 19
@@ -430,5 +431,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3364299744
+  m_AssetId: 1d3e5dfa03962e34086cf1e980ca96ad
+  m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/Metal.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/Metal.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 114675370128025870}
   - component: {fileID: 4017417275112362406}
   - component: {fileID: 114836435796936700}
+  - component: {fileID: 114849399154925666}
   - component: {fileID: 114007797438959630}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
   - component: {fileID: 114383244954830430}
-  - component: {fileID: 114849399154925666}
   - component: {fileID: 114991468272272648}
   - component: {fileID: 114652567487495318}
   - component: {fileID: 114739776609663992}
@@ -211,6 +211,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114849399154925666
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114007797438959630
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -270,18 +282,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114849399154925666
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114991468272272648
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -427,7 +427,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 78d9125d50217497cbcd4a18ffe2e3e4
   m_SceneId: 0
 --- !u!114 &1418731889289770694
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/Rods.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/Rods.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 114675370128025870}
   - component: {fileID: 4885514833642172020}
   - component: {fileID: 114836435796936700}
+  - component: {fileID: 114247653532312200}
   - component: {fileID: 114007797438959630}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
   - component: {fileID: 114651328662161524}
-  - component: {fileID: 114247653532312200}
   - component: {fileID: 114556138009144462}
   - component: {fileID: 114869712063591570}
   - component: {fileID: 4401039475259105916}
@@ -209,6 +209,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114247653532312200
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114007797438959630
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -268,18 +280,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114247653532312200
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114556138009144462
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -425,5 +425,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 8012b966850884ea3bea010004dedb96
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/glass sheet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/glass sheet.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 114675370128025870}
   - component: {fileID: 3216784685289553122}
   - component: {fileID: 114836435796936700}
+  - component: {fileID: 114849399154925666}
   - component: {fileID: 114007797438959630}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
   - component: {fileID: 114383244954830430}
-  - component: {fileID: 114849399154925666}
   - component: {fileID: 114991468272272648}
   - component: {fileID: 4183575758974862930}
   m_Layer: 10
@@ -208,6 +208,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114849399154925666
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114007797438959630
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -267,18 +279,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114849399154925666
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114991468272272648
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -328,5 +328,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 3566ed51b041cfb4ebde8ac7909357de
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/low Cable Coil.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/low Cable Coil.prefab
@@ -94,10 +94,10 @@ GameObject:
   - component: {fileID: 114836435796936700}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 2836368675170884176}
-  - component: {fileID: 114069018879247916}
-  - component: {fileID: 114656750720379548}
   - component: {fileID: 114647404841554186}
+  - component: {fileID: 114069018879247916}
+  - component: {fileID: 2836368675170884176}
+  - component: {fileID: 114656750720379548}
   - component: {fileID: 114550768023107790}
   - component: {fileID: 114932264185316862}
   - component: {fileID: 114174141474445510}
@@ -186,7 +186,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764, type: 2}
   size: 1
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -230,9 +230,32 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
+--- !u!114 &114647404841554186
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114069018879247916
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &2836368675170884176
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,20 +273,6 @@ MonoBehaviour:
   CableType: 8
   CablePrefab: {fileID: 1042895037894172, guid: 9de39208d8b9b5044aab78843d0c4f34,
     type: 3}
---- !u!114 &114069018879247916
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
 --- !u!114 &114656750720379548
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -277,18 +286,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114647404841554186
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114550768023107790
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -337,6 +334,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 19
@@ -430,5 +431,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 441930152
+  m_AssetId: e3eda36c29adcda4a941c23f1f18521a
+  m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/AirVent.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/AirVent.prefab
@@ -11,13 +11,13 @@ GameObject:
   - component: {fileID: 4000012824533570}
   - component: {fileID: 61000013103678858}
   - component: {fileID: 4396274152352043513}
-  - component: {fileID: 6203799934882642808}
-  - component: {fileID: 7499999529140733009}
   - component: {fileID: 8354343867630940287}
   - component: {fileID: 966013011358701611}
   - component: {fileID: 6479037130962053368}
-  - component: {fileID: 114207068481858528}
   - component: {fileID: 3953549719403137607}
+  - component: {fileID: 114207068481858528}
+  - component: {fileID: 7499999529140733009}
+  - component: {fileID: 6203799934882642808}
   - component: {fileID: 3771872541723634421}
   - component: {fileID: 1554776711696640}
   - component: {fileID: 114798627279048580}
@@ -85,47 +85,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &6203799934882642808
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000010733523080}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 027d1f2fae780624ebb2115cfc6e78af, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &7499999529140733009
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000010733523080}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 49a3b980b33b4f6c945ab7c474875ab6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  registerTile: {fileID: 0}
-  objectBehaviour: {fileID: 0}
-  nodes: []
-  direction: 0
-  anchored: 0
-  volume: 70
-  pipeSprites:
-  - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
-  - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
-  - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
-  - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
-  - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
-  spriteRenderer: {fileID: 8418407404781841632}
-  spriteSync: 0
-  MinimumPressure: 101.325
 --- !u!114 &8354343867630940287
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -187,6 +146,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &3953549719403137607
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000010733523080}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114207068481858528
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -201,7 +172,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
---- !u!114 &3953549719403137607
+--- !u!114 &7499999529140733009
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -210,7 +181,36 @@ MonoBehaviour:
   m_GameObject: {fileID: 1000010733523080}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Script: {fileID: 11500000, guid: 49a3b980b33b4f6c945ab7c474875ab6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  registerTile: {fileID: 0}
+  objectBehaviour: {fileID: 0}
+  nodes: []
+  direction: 0
+  anchored: 0
+  volume: 70
+  pipeSprites:
+  - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
+  - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
+  - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
+  - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
+  - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
+  spriteRenderer: {fileID: 8418407404781841632}
+  spriteSync: 0
+  MinimumPressure: 101.325
+--- !u!114 &6203799934882642808
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000010733523080}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 027d1f2fae780624ebb2115cfc6e78af, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &3771872541723634421
@@ -300,7 +300,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 6123044d3e1847569dcc23e34dd3d3f5
   m_SceneId: 0
 --- !u!1 &8513106460640881890
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/BentPipe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/BentPipe.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -90,13 +91,13 @@ GameObject:
   - component: {fileID: 4199534395721968}
   - component: {fileID: 61321219257688126}
   - component: {fileID: 114675370128025870}
-  - component: {fileID: 5640039996929275955}
-  - component: {fileID: 3651137208067591222}
   - component: {fileID: 114836435796936700}
+  - component: {fileID: 114880245854591566}
   - component: {fileID: 114007797438959630}
+  - component: {fileID: 3651137208067591222}
+  - component: {fileID: 5640039996929275955}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 114880245854591566}
   - component: {fileID: 114612731264727302}
   - component: {fileID: 1739955761982081149}
   - component: {fileID: 114253643887694602}
@@ -162,7 +163,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
---- !u!114 &5640039996929275955
+  IsFixedMatrix: 0
+--- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -171,7 +173,48 @@ MonoBehaviour:
   m_GameObject: {fileID: 1645856876941636}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 027d1f2fae780624ebb2115cfc6e78af, type: 3}
+  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteDataHandler: {fileID: 0}
+  InventoryIcon: {fileID: 0}
+  itemName: Pipe
+  itemDescription: 
+  initialTraits: []
+  size: 1
+  spriteType: 0
+  canConnectToTank: 0
+  hitDamage: 0
+  damageType: 0
+  throwDamage: 0
+  throwSpeed: 2
+  throwRange: 7
+  hitSound: GenericHit
+  attackVerb: []
+--- !u!114 &114880245854591566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114007797438959630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
@@ -216,7 +259,7 @@ MonoBehaviour:
   - {fileID: 21300174, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
   spriteSync: 0
---- !u!114 &114836435796936700
+--- !u!114 &5640039996929275955
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -225,45 +268,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1645856876941636}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
+  m_Script: {fileID: 11500000, guid: 027d1f2fae780624ebb2115cfc6e78af, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  spriteHandlerData: {fileID: 0}
-  InventoryIcon: {fileID: 0}
-  itemName: Pipe
-  itemDescription: 
-  itemType: 0
-  size: 1
-  spriteType: 0
-  CanConnectToTank: 0
-  hitDamage: 0
-  damageType: 0
-  throwDamage: 0
-  throwSpeed: 2
-  throwRange: 7
-  hitSound: GenericHit
-  attackVerb: []
---- !u!114 &114007797438959630
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  OnDropServer:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114923609856049834
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -279,7 +286,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  parentContainer: {fileID: 0}
   isNotPushable: 0
 --- !u!114 &114185907784239616
 MonoBehaviour:
@@ -297,22 +303,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &114880245854591566
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114612731264727302
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -347,6 +337,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &1739955761982081149
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -375,9 +366,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Connector.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Connector.prefab
@@ -91,13 +91,13 @@ GameObject:
   - component: {fileID: 4199534395721968}
   - component: {fileID: 61321219257688126}
   - component: {fileID: 114675370128025870}
-  - component: {fileID: 1017861296826197586}
-  - component: {fileID: 9021031151912966899}
   - component: {fileID: 114836435796936700}
+  - component: {fileID: 114079759797594526}
   - component: {fileID: 114007797438959630}
+  - component: {fileID: 9021031151912966899}
+  - component: {fileID: 1017861296826197586}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 114079759797594526}
   - component: {fileID: 114643104810596728}
   - component: {fileID: 7444202956614922778}
   - component: {fileID: 114933713635356078}
@@ -164,7 +164,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
---- !u!114 &1017861296826197586
+  IsFixedMatrix: 0
+--- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -173,7 +174,48 @@ MonoBehaviour:
   m_GameObject: {fileID: 1645856876941636}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 027d1f2fae780624ebb2115cfc6e78af, type: 3}
+  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteDataHandler: {fileID: 0}
+  InventoryIcon: {fileID: 0}
+  itemName: Connector
+  itemDescription: 
+  initialTraits: []
+  size: 1
+  spriteType: 0
+  canConnectToTank: 0
+  hitDamage: 0
+  damageType: 0
+  throwDamage: 0
+  throwSpeed: 2
+  throwRange: 7
+  hitSound: GenericHit
+  attackVerb: []
+--- !u!114 &114079759797594526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114007797438959630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
@@ -206,7 +248,7 @@ MonoBehaviour:
   - {fileID: 21300078, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
   spriteSync: 0
---- !u!114 &114836435796936700
+--- !u!114 &1017861296826197586
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -215,43 +257,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1645856876941636}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
+  m_Script: {fileID: 11500000, guid: 027d1f2fae780624ebb2115cfc6e78af, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  spriteDataHandler: {fileID: 0}
-  InventoryIcon: {fileID: 0}
-  itemName: Connector
-  itemDescription: 
-  itemType: 0
-  size: 1
-  spriteType: 0
-  CanConnectToTank: 0
-  hitDamage: 0
-  damageType: 0
-  throwDamage: 0
-  throwSpeed: 2
-  throwRange: 7
-  hitSound: GenericHit
-  attackVerb: []
---- !u!114 &114007797438959630
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  OnDropServer:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &114923609856049834
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -284,21 +292,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &114079759797594526
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114643104810596728
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -333,6 +326,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &7444202956614922778
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -362,6 +356,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/FourWayManifold.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/FourWayManifold.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -90,13 +91,13 @@ GameObject:
   - component: {fileID: 4199534395721968}
   - component: {fileID: 61321219257688126}
   - component: {fileID: 114675370128025870}
-  - component: {fileID: 5640039996929275955}
-  - component: {fileID: 8770073454358235300}
   - component: {fileID: 114836435796936700}
+  - component: {fileID: 114670025683286498}
   - component: {fileID: 114007797438959630}
+  - component: {fileID: 8770073454358235300}
+  - component: {fileID: 5640039996929275955}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 114670025683286498}
   - component: {fileID: 114665036458884384}
   - component: {fileID: 8413143254154855439}
   - component: {fileID: 114629543756366832}
@@ -166,7 +167,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
---- !u!114 &5640039996929275955
+  IsFixedMatrix: 0
+--- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -175,7 +177,48 @@ MonoBehaviour:
   m_GameObject: {fileID: 1645856876941636}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 027d1f2fae780624ebb2115cfc6e78af, type: 3}
+  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteDataHandler: {fileID: 0}
+  InventoryIcon: {fileID: 0}
+  itemName: Pipe
+  itemDescription: 
+  initialTraits: []
+  size: 1
+  spriteType: 0
+  canConnectToTank: 0
+  hitDamage: 0
+  damageType: 0
+  throwDamage: 0
+  throwSpeed: 2
+  throwRange: 7
+  hitSound: GenericHit
+  attackVerb: []
+--- !u!114 &114670025683286498
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114007797438959630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
@@ -216,7 +259,7 @@ MonoBehaviour:
   - {fileID: 2369631279410760376}
   - {fileID: 4656729331413939348}
   connectionSpriteSync: 0
---- !u!114 &114836435796936700
+--- !u!114 &5640039996929275955
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -225,45 +268,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1645856876941636}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
+  m_Script: {fileID: 11500000, guid: 027d1f2fae780624ebb2115cfc6e78af, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  spriteHandlerData: {fileID: 0}
-  InventoryIcon: {fileID: 0}
-  itemName: Pipe
-  itemDescription: 
-  itemType: 0
-  size: 1
-  spriteType: 0
-  CanConnectToTank: 0
-  hitDamage: 0
-  damageType: 0
-  throwDamage: 0
-  throwSpeed: 2
-  throwRange: 7
-  hitSound: GenericHit
-  attackVerb: []
---- !u!114 &114007797438959630
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  OnDropServer:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114923609856049834
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -279,7 +286,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  parentContainer: {fileID: 0}
   isNotPushable: 0
 --- !u!114 &114185907784239616
 MonoBehaviour:
@@ -297,22 +303,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &114670025683286498
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114665036458884384
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -347,6 +337,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &8413143254154855439
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -375,9 +366,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -439,6 +432,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -518,6 +512,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -597,6 +592,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -676,6 +672,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Meter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Meter.prefab
@@ -10,13 +10,13 @@ GameObject:
   m_Component:
   - component: {fileID: 4199534395721968}
   - component: {fileID: 61321219257688126}
-  - component: {fileID: 6936071994461913645}
   - component: {fileID: 114675370128025870}
   - component: {fileID: 114836435796936700}
+  - component: {fileID: 114271167785033994}
   - component: {fileID: 3715099238728451255}
+  - component: {fileID: 6936071994461913645}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 114271167785033994}
   - component: {fileID: 114405250905390060}
   - component: {fileID: 7564706497059525126}
   - component: {fileID: 114557966116762654}
@@ -68,6 +68,76 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114675370128025870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114836435796936700
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteDataHandler: {fileID: 0}
+  InventoryIcon: {fileID: 0}
+  itemName: Meter
+  itemDescription: 
+  initialTraits: []
+  size: 1
+  spriteType: 0
+  canConnectToTank: 0
+  hitDamage: 0
+  damageType: 0
+  throwDamage: 0
+  throwSpeed: 2
+  throwRange: 7
+  hitSound: GenericHit
+  attackVerb: []
+--- !u!114 &114271167785033994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3715099238728451255
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &6936071994461913645
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -91,68 +161,6 @@ MonoBehaviour:
   - {fileID: 21300018, guid: 0492631260daf4b259fb5cbe0a919ebf, type: 3}
   - {fileID: 21300030, guid: 0492631260daf4b259fb5cbe0a919ebf, type: 3}
   spriteSync: 0
---- !u!114 &114675370128025870
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 579884b05ae74e8499329b64997147d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
---- !u!114 &114836435796936700
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  spriteHandlerData: {fileID: 0}
-  InventoryIcon: {fileID: 0}
-  itemName: Meter
-  itemDescription: 
-  itemType: 0
-  size: 1
-  spriteType: 0
-  CanConnectToTank: 0
-  hitDamage: 0
-  damageType: 0
-  throwDamage: 0
-  throwSpeed: 2
-  throwRange: 7
-  hitSound: GenericHit
-  attackVerb: []
---- !u!114 &3715099238728451255
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  OnDropServer:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114923609856049834
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,7 +176,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  parentContainer: {fileID: 0}
   isNotPushable: 0
 --- !u!114 &114185907784239616
 MonoBehaviour:
@@ -186,22 +193,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &114271167785033994
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114405250905390060
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -236,6 +227,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &7564706497059525126
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -264,9 +256,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -328,6 +322,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Pipe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Pipe.prefab
@@ -11,13 +11,13 @@ GameObject:
   - component: {fileID: 4199534395721968}
   - component: {fileID: 61321219257688126}
   - component: {fileID: 114675370128025870}
-  - component: {fileID: 5640039996929275955}
-  - component: {fileID: 3760268221926563392}
   - component: {fileID: 114836435796936700}
+  - component: {fileID: 114271167785033994}
   - component: {fileID: 114007797438959630}
+  - component: {fileID: 3760268221926563392}
+  - component: {fileID: 5640039996929275955}
   - component: {fileID: 114923609856049834}
   - component: {fileID: 114185907784239616}
-  - component: {fileID: 114271167785033994}
   - component: {fileID: 114405250905390060}
   - component: {fileID: 7564706497059525126}
   - component: {fileID: 114655540776166054}
@@ -83,7 +83,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
---- !u!114 &5640039996929275955
+  IsFixedMatrix: 0
+--- !u!114 &114836435796936700
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -92,7 +93,48 @@ MonoBehaviour:
   m_GameObject: {fileID: 1645856876941636}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 027d1f2fae780624ebb2115cfc6e78af, type: 3}
+  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteDataHandler: {fileID: 0}
+  InventoryIcon: {fileID: 0}
+  itemName: Pipe
+  itemDescription: 
+  initialTraits: []
+  size: 1
+  spriteType: 0
+  canConnectToTank: 0
+  hitDamage: 0
+  damageType: 0
+  throwDamage: 0
+  throwSpeed: 2
+  throwRange: 7
+  hitSound: GenericHit
+  attackVerb: []
+--- !u!114 &114271167785033994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114007797438959630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
@@ -129,7 +171,7 @@ MonoBehaviour:
   - {fileID: 21300164, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
   spriteRenderer: {fileID: 1047382295693061733}
   spriteSync: 0
---- !u!114 &114836435796936700
+--- !u!114 &5640039996929275955
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -138,45 +180,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1645856876941636}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0c2aa599081d4bc09565dfcb42993bf7, type: 3}
+  m_Script: {fileID: 11500000, guid: 027d1f2fae780624ebb2115cfc6e78af, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  spriteHandlerData: {fileID: 0}
-  InventoryIcon: {fileID: 0}
-  itemName: Pipe
-  itemDescription: 
-  itemType: 0
-  size: 1
-  spriteType: 0
-  CanConnectToTank: 0
-  hitDamage: 0
-  damageType: 0
-  throwDamage: 0
-  throwSpeed: 2
-  throwRange: 7
-  hitSound: GenericHit
-  attackVerb: []
---- !u!114 &114007797438959630
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  OnDropServer:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114923609856049834
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -192,7 +198,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  parentContainer: {fileID: 0}
   isNotPushable: 0
 --- !u!114 &114185907784239616
 MonoBehaviour:
@@ -210,22 +215,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: OnCrossed, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &114271167785033994
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114405250905390060
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -260,6 +249,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &7564706497059525126
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -288,9 +278,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0
@@ -352,6 +344,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Scrubber.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Scrubber.prefab
@@ -11,13 +11,13 @@ GameObject:
   - component: {fileID: 4000013194526306}
   - component: {fileID: 61000011546092986}
   - component: {fileID: 5350485644128402302}
-  - component: {fileID: 6963528815061158835}
-  - component: {fileID: 114604783434980062}
   - component: {fileID: 4696558778661555457}
+  - component: {fileID: 114172504531317518}
   - component: {fileID: 493655120697083372}
+  - component: {fileID: 114604783434980062}
+  - component: {fileID: 6963528815061158835}
   - component: {fileID: 3082018966209474044}
   - component: {fileID: 200003959481001672}
-  - component: {fileID: 114172504531317518}
   - component: {fileID: 114754654923298058}
   - component: {fileID: 5447043449243603668}
   - component: {fileID: 114519943041861588}
@@ -85,47 +85,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &6963528815061158835
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000011763452766}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 027d1f2fae780624ebb2115cfc6e78af, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &114604783434980062
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000011763452766}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 284c55ecf95c48fe9eb8073c0d662d06, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  registerTile: {fileID: 0}
-  objectBehaviour: {fileID: 0}
-  nodes: []
-  direction: 0
-  anchored: 0
-  volume: 70
-  pipeSprites:
-  - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
-  - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
-  - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
-  - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
-  - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
-  spriteRenderer: {fileID: 3335986396963275010}
-  spriteSync: 0
-  MinimumPressure: 101.325
 --- !u!114 &4696558778661555457
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -155,6 +114,18 @@ MonoBehaviour:
   throwRange: 7
   hitSound: GenericHit
   attackVerb: []
+--- !u!114 &114172504531317518
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011763452766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &493655120697083372
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -169,6 +140,47 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &114604783434980062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011763452766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 284c55ecf95c48fe9eb8073c0d662d06, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  registerTile: {fileID: 0}
+  objectBehaviour: {fileID: 0}
+  nodes: []
+  direction: 0
+  anchored: 0
+  volume: 70
+  pipeSprites:
+  - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
+  - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
+  - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
+  - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
+  - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
+  spriteRenderer: {fileID: 3335986396963275010}
+  spriteSync: 0
+  MinimumPressure: 101.325
+--- !u!114 &6963528815061158835
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011763452766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 027d1f2fae780624ebb2115cfc6e78af, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &3082018966209474044
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -201,18 +213,6 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
---- !u!114 &114172504531317518
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000011763452766}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114754654923298058
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -300,7 +300,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: f0270cf6e570475a8317f8d04139e54f
   m_SceneId: 0
 --- !u!1 &3223271260076572928
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/BaseCanister.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/BaseCanister.prefab
@@ -91,15 +91,15 @@ GameObject:
   - component: {fileID: 4854478120677698}
   - component: {fileID: 61143840767580364}
   - component: {fileID: 61645807559194036}
-  - component: {fileID: 4239973459482825917}
-  - component: {fileID: 114271548548165924}
   - component: {fileID: 6725492196284391236}
   - component: {fileID: 114623103168110180}
   - component: {fileID: 114248266581299534}
-  - component: {fileID: 114104253718565984}
   - component: {fileID: 114016289089021282}
-  - component: {fileID: 2681417881209337471}
   - component: {fileID: 114781037357294102}
+  - component: {fileID: 2681417881209337471}
+  - component: {fileID: 114104253718565984}
+  - component: {fileID: 114271548548165924}
+  - component: {fileID: 4239973459482825917}
   - component: {fileID: 114615155852173970}
   - component: {fileID: 114835659847540804}
   m_Layer: 11
@@ -177,46 +177,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!114 &4239973459482825917
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1513316462072450}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 931d5444a5bf4c9aa3be62ecbf046740, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  gasContainer: {fileID: 114104253718565984}
-  molesAdded: 15000
---- !u!114 &114271548548165924
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1513316462072450}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c9ae6b6bba5c4e3aa4780272577c9bcf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  UIBGTint: {r: 0, g: 0, b: 0, a: 0}
-  UIInnerPanelTint: {r: 0, g: 0, b: 0, a: 0}
-  ContentsName: 
-  objectBehaviour: {fileID: 0}
-  container: {fileID: 0}
-  connector: {fileID: 0}
-  isConnected: 0
-  connectorRenderer: {fileID: 2306500756203524534}
-  connectorFuel: {fileID: 0}
-  connectorSprite: {fileID: 21300000, guid: a7172f3398019e044a68e8bb2fefbb72, type: 3}
 --- !u!114 &6725492196284391236
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -265,6 +225,45 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114016289089021282
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1513316462072450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteMatrixRotationBehavior: 1
+--- !u!114 &114781037357294102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1513316462072450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2681417881209337471
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1513316462072450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d7277dcc993463cb6c7f79b663f36fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetTabType: 10
 --- !u!114 &114104253718565984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -288,7 +287,7 @@ MonoBehaviour:
   - 0
   - 0
   - 0
---- !u!114 &114016289089021282
+--- !u!114 &114271548548165924
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -297,11 +296,22 @@ MonoBehaviour:
   m_GameObject: {fileID: 1513316462072450}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Script: {fileID: 11500000, guid: c9ae6b6bba5c4e3aa4780272577c9bcf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  spriteMatrixRotationBehavior: 1
---- !u!114 &2681417881209337471
+  syncMode: 0
+  syncInterval: 0.1
+  UIBGTint: {r: 0, g: 0, b: 0, a: 0}
+  UIInnerPanelTint: {r: 0, g: 0, b: 0, a: 0}
+  ContentsName: 
+  objectBehaviour: {fileID: 0}
+  container: {fileID: 0}
+  connector: {fileID: 0}
+  isConnected: 0
+  connectorRenderer: {fileID: 2306500756203524534}
+  connectorFuel: {fileID: 0}
+  connectorSprite: {fileID: 21300000, guid: a7172f3398019e044a68e8bb2fefbb72, type: 3}
+--- !u!114 &4239973459482825917
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -310,22 +320,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 1513316462072450}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6d7277dcc993463cb6c7f79b663f36fc, type: 3}
+  m_Script: {fileID: 11500000, guid: 931d5444a5bf4c9aa3be62ecbf046740, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  NetTabType: 10
---- !u!114 &114781037357294102
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1513316462072450}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  gasContainer: {fileID: 114104253718565984}
+  molesAdded: 15000
 --- !u!114 &114615155852173970
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -375,7 +374,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: e9620f26b24f33c4cbe56a85ae95865d
+  m_AssetId: 1efec61511b50c844868cb49d1a711a1
   m_SceneId: 0
 --- !u!1 &3261001144065486905
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Chemistry/ChemDispenser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Chemistry/ChemDispenser.prefab
@@ -93,10 +93,10 @@ GameObject:
   - component: {fileID: 61290137858233110}
   - component: {fileID: 114733452049384340}
   - component: {fileID: 114495021001438090}
-  - component: {fileID: 114149925567654774}
-  - component: {fileID: 8011082951398334408}
   - component: {fileID: 114177727945230188}
   - component: {fileID: 114774467603860150}
+  - component: {fileID: 8011082951398334408}
+  - component: {fileID: 114149925567654774}
   - component: {fileID: 114306958550935130}
   - component: {fileID: 114605663917569558}
   - component: {fileID: 6148042499770104604}
@@ -206,35 +206,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
---- !u!114 &114149925567654774
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1880613391911220}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2ac94ea034f589c46b4568ffe0d4d992, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  Container: {fileID: 0}
-  objectse: {fileID: 0}
---- !u!114 &8011082951398334408
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1880613391911220}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6d7277dcc993463cb6c7f79b663f36fc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  NetTabType: 5
+  IsFixedMatrix: 0
 --- !u!114 &114177727945230188
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -260,6 +232,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &8011082951398334408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1880613391911220}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d7277dcc993463cb6c7f79b663f36fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetTabType: 5
+--- !u!114 &114149925567654774
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1880613391911220}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ac94ea034f589c46b4568ffe0d4d992, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
 --- !u!114 &114306958550935130
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -309,7 +308,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 1581b03bb13b84328a0f9fe743bb5bbf
+  m_AssetId: 1efec61511b50c844868cb49d1a711a1
   m_SceneId: 0
 --- !u!114 &6148042499770104604
 MonoBehaviour:
@@ -323,8 +322,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdce8a163088453ca593c0e98f2c5f07, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ItemStorageStructure: {fileID: 11400000, guid: 263bf834f99424f12bda19d67c3ab5fc,
+  itemStorageStructure: {fileID: 11400000, guid: 263bf834f99424f12bda19d67c3ab5fc,
     type: 2}
-  ItemStorageCapacity: {fileID: 11400000, guid: 14ba874224f65461b97794ca4c792e7f,
+  itemStorageCapacity: {fileID: 11400000, guid: 14ba874224f65461b97794ca4c792e7f,
     type: 2}
-  ItemStoragePopulator: {fileID: 0}
+  itemStoragePopulator: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114793968027197088}
+  - component: {fileID: 114366364991911690}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 8994671509918900618}
   - component: {fileID: 114332551563909192}
   - component: {fileID: 114545571075304212}
-  - component: {fileID: 114366364991911690}
   - component: {fileID: 114824208707786624}
   - component: {fileID: 114434305287704188}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114366364991911690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114366364991911690
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114824208707786624
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_BioHazard_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_BioHazard_Green.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114597010362170592}
+  - component: {fileID: 114869266564877396}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 4223211768920691601}
   - component: {fileID: 114615101260203070}
   - component: {fileID: 114519977436863984}
-  - component: {fileID: 114869266564877396}
   - component: {fileID: 114495747431520570}
   - component: {fileID: 114282200537726130}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114869266564877396
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114869266564877396
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114495747431520570
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_BioHazard_Pink.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_BioHazard_Pink.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114419139457667244}
+  - component: {fileID: 114426033591178068}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 7797393742352403905}
   - component: {fileID: 114523646684726672}
   - component: {fileID: 114511804586140830}
-  - component: {fileID: 114426033591178068}
   - component: {fileID: 114949926480072206}
   - component: {fileID: 114622348777250390}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114426033591178068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114426033591178068
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114949926480072206
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_BioHazard_Red_Plain_Stripe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_BioHazard_Red_Plain_Stripe.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114192154473191574}
+  - component: {fileID: 114003549074708886}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 3537801393806581598}
   - component: {fileID: 114170089691885322}
   - component: {fileID: 114884582897557178}
-  - component: {fileID: 114003549074708886}
   - component: {fileID: 114417805006977500}
   - component: {fileID: 114977405969616476}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114003549074708886
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114003549074708886
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114417805006977500
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Black.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Black.prefab
@@ -12,11 +12,11 @@ GameObject:
   - component: {fileID: 61530228178202146}
   - component: {fileID: 61039049282667628}
   - component: {fileID: 114334495745331238}
+  - component: {fileID: 114453459472189996}
   - component: {fileID: 114310759356319872}
   - component: {fileID: 3322568146411332710}
   - component: {fileID: 114590671685477684}
   - component: {fileID: 114485981991692948}
-  - component: {fileID: 114453459472189996}
   - component: {fileID: 114536317024912758}
   - component: {fileID: 114250652878325724}
   m_Layer: 11
@@ -109,6 +109,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114453459472189996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000522475151462}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114310759356319872
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -123,7 +135,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -181,18 +193,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114453459472189996
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000522475151462}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114536317024912758
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Blue.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114809995071011442}
+  - component: {fileID: 114198836559919480}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 3997153704080178421}
   - component: {fileID: 114480465103792078}
   - component: {fileID: 114216219414848042}
-  - component: {fileID: 114198836559919480}
   - component: {fileID: 114322933163407348}
   - component: {fileID: 114164891901555160}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114198836559919480
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114198836559919480
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114322933163407348
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Bomb.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Bomb.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114949813296282442}
+  - component: {fileID: 114548938395439192}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 8936904647621052810}
   - component: {fileID: 114559887282967898}
   - component: {fileID: 114962883098702228}
-  - component: {fileID: 114548938395439192}
   - component: {fileID: 114659969039855438}
   - component: {fileID: 114972999833880538}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114548938395439192
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114548938395439192
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114659969039855438
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Brown.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Brown.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61525002680630820}
   - component: {fileID: 61084689437042768}
   - component: {fileID: 114178227343361656}
+  - component: {fileID: 114216657320350334}
   - component: {fileID: 114226188280779116}
   - component: {fileID: 8773753914500097141}
   - component: {fileID: 114137355759862740}
   - component: {fileID: 114322818485990734}
-  - component: {fileID: 114216657320350334}
   - component: {fileID: 114680114684444950}
   - component: {fileID: 114209072084939298}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114216657320350334
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1326196951998806}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114226188280779116
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114216657320350334
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1326196951998806}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114680114684444950
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 7810af49b77d742c896054c4ca04c533
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1522744671779814
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Electricity.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Electricity.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114368139429836270}
+  - component: {fileID: 114362215054439366}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 7562707666127099412}
   - component: {fileID: 114544474243738448}
   - component: {fileID: 114658243340217052}
-  - component: {fileID: 114362215054439366}
   - component: {fileID: 114795807729836256}
   - component: {fileID: 114670724401799660}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114362215054439366
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114362215054439366
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114795807729836256
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: ef7e3df6c731a41dfaf0ef12427d8236
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Enginering.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Enginering.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114098053694904296}
+  - component: {fileID: 114002550037464120}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 1080965637159235536}
   - component: {fileID: 114235402911808258}
   - component: {fileID: 114053857859740838}
-  - component: {fileID: 114002550037464120}
   - component: {fileID: 114785418953280918}
   - component: {fileID: 114519386190484530}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114002550037464120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114002550037464120
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114785418953280918
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: f8348e86f47d84bb4935ad29269cc0b6
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Fire_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Fire_Red.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114394553509429574}
+  - component: {fileID: 114689924531840992}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 8792057519854234871}
   - component: {fileID: 114440515152274470}
   - component: {fileID: 114994280551353884}
-  - component: {fileID: 114689924531840992}
   - component: {fileID: 114953135145814492}
   - component: {fileID: 114283936535908966}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114689924531840992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,10 +216,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents:
-  - {fileID: 1907679543779350, guid: 7920a824df456044381e381e90277a5d, type: 3}
-  - {fileID: 1907679543779350, guid: 7920a824df456044381e381e90277a5d, type: 3}
-  - {fileID: 1869747887731904, guid: 9c91a985c48aef648b219b1d267a9cab, type: 3}
   initialContents: {fileID: 11400000, guid: 9f62b95e807bf4e849acaefe0649625b, type: 2}
   IsClosed: 0
   IsLocked: 0
@@ -266,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114689924531840992
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114953135145814492
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -327,8 +323,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 2831814168
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Fire_Yellow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Fire_Yellow.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114811604509801888}
+  - component: {fileID: 114589091714129470}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 5344113240821275593}
   - component: {fileID: 114817056745690750}
   - component: {fileID: 114592498458485390}
-  - component: {fileID: 114589091714129470}
   - component: {fileID: 114949438660992254}
   - component: {fileID: 114926137667740974}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114589091714129470
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114589091714129470
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114949438660992254
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 327ce0086e56842dca6294113683db5b
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Green.prefab
@@ -203,11 +203,11 @@ GameObject:
   - component: {fileID: 61504699971644330}
   - component: {fileID: 61666067858058194}
   - component: {fileID: 114501655910360080}
+  - component: {fileID: 114867587912100682}
   - component: {fileID: 114672394582474368}
   - component: {fileID: 2895454558127337523}
   - component: {fileID: 114471672769914432}
   - component: {fileID: 114237451671875158}
-  - component: {fileID: 114867587912100682}
   - component: {fileID: 114183221725790220}
   - component: {fileID: 114406694185764888}
   m_Layer: 11
@@ -300,6 +300,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114867587912100682
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1992679967695770}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114672394582474368
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -314,7 +326,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -372,18 +384,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114867587912100682
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1992679967695770}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114183221725790220
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -433,5 +433,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 3dee6075d2985471f96fc108fce9c4fc
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Grey.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Grey.prefab
@@ -123,11 +123,11 @@ GameObject:
   - component: {fileID: 61809843329405100}
   - component: {fileID: 61355010685805950}
   - component: {fileID: 114881239354733470}
+  - component: {fileID: 114123421790055112}
   - component: {fileID: 114859863419137498}
   - component: {fileID: 7776293278677718898}
   - component: {fileID: 114407287186085312}
   - component: {fileID: 114233137969556542}
-  - component: {fileID: 114123421790055112}
   - component: {fileID: 114678415081477658}
   - component: {fileID: 114706465110969542}
   m_Layer: 11
@@ -220,6 +220,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114123421790055112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1180280463732794}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114859863419137498
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -234,7 +246,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -292,18 +304,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114123421790055112
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1180280463732794}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114678415081477658
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -353,7 +353,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 52fddf9aa0dcd42ac85b86d274269aeb
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1588453877446412
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_HOS.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_HOS.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114013243339958884}
+  - component: {fileID: 114662150197785266}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 1585773974844788982}
   - component: {fileID: 114086862237097484}
   - component: {fileID: 114563700993001040}
-  - component: {fileID: 114662150197785266}
   - component: {fileID: 114591247578194088}
   - component: {fileID: 114079580530092406}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114662150197785266
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114662150197785266
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114591247578194088
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: dffae8aaf61944c3986fb4151254fa35
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Janitor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Janitor.prefab
@@ -203,11 +203,11 @@ GameObject:
   - component: {fileID: 61007529738442410}
   - component: {fileID: 61116065849539486}
   - component: {fileID: 114569148275177306}
+  - component: {fileID: 114747560364237798}
   - component: {fileID: 114835786064520692}
   - component: {fileID: 5340951544890428132}
   - component: {fileID: 114092939811341892}
   - component: {fileID: 114301095212362376}
-  - component: {fileID: 114747560364237798}
   - component: {fileID: 114211058334962584}
   - component: {fileID: 114452926348086496}
   m_Layer: 11
@@ -300,6 +300,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114747560364237798
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967120683374944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114835786064520692
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -314,12 +326,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents:
-  - {fileID: 1801347380884054, guid: 882710f093d1c5f4c9f1dbd99b8dd790, type: 3}
-  - {fileID: 1801347380884054, guid: 882710f093d1c5f4c9f1dbd99b8dd790, type: 3}
-  - {fileID: 1110193000772614, guid: 8c2952660a46d90479f70105bc1cbab8, type: 3}
-  - {fileID: 1110193000772614, guid: 8c2952660a46d90479f70105bc1cbab8, type: 3}
-  - {fileID: 1110193000772614, guid: 8c2952660a46d90479f70105bc1cbab8, type: 3}
   initialContents: {fileID: 11400000, guid: 625920d375152449caf40d27d3f220c4, type: 2}
   IsClosed: 0
   IsLocked: 0
@@ -378,18 +384,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114747560364237798
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1967120683374944}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114211058334962584
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -439,5 +433,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 625294219
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Blue.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114204169222423732}
+  - component: {fileID: 114730002614233440}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 3782995635667095493}
   - component: {fileID: 114644364860119310}
   - component: {fileID: 114679315888303910}
-  - component: {fileID: 114730002614233440}
   - component: {fileID: 114184619831133766}
   - component: {fileID: 114739185875198414}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114730002614233440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114730002614233440
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114184619831133766
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: b9bac4713758242b1adfbb9cebae2524
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_CE.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_CE.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114460486150970724}
+  - component: {fileID: 114976252067547656}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 1627890463338545184}
   - component: {fileID: 114248233175949198}
   - component: {fileID: 114580957745180896}
-  - component: {fileID: 114976252067547656}
   - component: {fileID: 114134456598108044}
   - component: {fileID: 114059616408737060}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114976252067547656
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114976252067547656
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114134456598108044
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 598cc664ae1c8471cab3685a68462d6d
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_CMO.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_CMO.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114819687656175812}
+  - component: {fileID: 114098304295291438}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 8881526303799773611}
   - component: {fileID: 114649345137454126}
   - component: {fileID: 114854720885297536}
-  - component: {fileID: 114098304295291438}
   - component: {fileID: 114467813415429724}
   - component: {fileID: 114635920524582264}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114098304295291438
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,16 +216,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents:
-  - {fileID: 1408536760214900, guid: f181c8eb8ce8b8949b1ab571c8318f6f, type: 3}
-  - {fileID: 1408536760214900, guid: f181c8eb8ce8b8949b1ab571c8318f6f, type: 3}
-  - {fileID: 1408536760214900, guid: f181c8eb8ce8b8949b1ab571c8318f6f, type: 3}
-  - {fileID: 1862150311813888, guid: 269d6c8129e05ee4396165bb84083f19, type: 3}
-  - {fileID: 1862150311813888, guid: 269d6c8129e05ee4396165bb84083f19, type: 3}
-  - {fileID: 1862150311813888, guid: 269d6c8129e05ee4396165bb84083f19, type: 3}
-  - {fileID: 1862150311813888, guid: d1b135e5a46c6f4408972d504eaebc4b, type: 3}
-  - {fileID: 5620111257449852176, guid: a21353068392d4a7298ca43e3c7f997b, type: 3}
-  - {fileID: 5620111257449852176, guid: a21353068392d4a7298ca43e3c7f997b, type: 3}
   initialContents: {fileID: 11400000, guid: 0924c7c2f344c4a38a1932e0bf0cf5ce, type: 2}
   IsClosed: 0
   IsLocked: 0
@@ -272,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114098304295291438
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114467813415429724
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -333,8 +323,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 741742991
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Captain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Captain.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114892240168144284}
+  - component: {fileID: 114598731305681276}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 5491620380268735057}
   - component: {fileID: 114935263454225050}
   - component: {fileID: 114231714007873568}
-  - component: {fileID: 114598731305681276}
   - component: {fileID: 114665286229305142}
   - component: {fileID: 114084805871065702}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114598731305681276
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114598731305681276
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114665286229305142
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 618c20f588d5b47df8586c307d149258
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Enginering.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Enginering.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114024170624231532}
+  - component: {fileID: 114344180126848958}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 5882714057584091815}
   - component: {fileID: 114812631774233812}
   - component: {fileID: 114679465133796020}
-  - component: {fileID: 114344180126848958}
   - component: {fileID: 114183283830880582}
   - component: {fileID: 114465801357544374}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114344180126848958
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114344180126848958
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114183283830880582
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 0091e778d3669438995782c382ea1e5c
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Green.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114007936688419140}
+  - component: {fileID: 114634028473111634}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 6767682041400390801}
   - component: {fileID: 114896337446882410}
   - component: {fileID: 114718002685166136}
-  - component: {fileID: 114634028473111634}
   - component: {fileID: 114433275972931140}
   - component: {fileID: 114414071828871298}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114634028473111634
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114634028473111634
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114433275972931140
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 2af33b649df3542efbd6f93fe805d443
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_HOP.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_HOP.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114065163849066438}
+  - component: {fileID: 114015206678546644}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 8815294934689948227}
   - component: {fileID: 114582121561473138}
   - component: {fileID: 114281493637463554}
-  - component: {fileID: 114015206678546644}
   - component: {fileID: 114616758355617534}
   - component: {fileID: 114102618017133598}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114015206678546644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114015206678546644
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114616758355617534
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: dd41a4785fb694a33a2e8a23f0145eb1
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_HOS2.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_HOS2.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114444741572267014}
+  - component: {fileID: 114691238717007316}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 2982773529938248515}
   - component: {fileID: 114689190573812974}
   - component: {fileID: 114418841570268954}
-  - component: {fileID: 114691238717007316}
   - component: {fileID: 114367294292188536}
   - component: {fileID: 114348464567647238}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114691238717007316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114691238717007316
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114367294292188536
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 0ccf91ad318a648d8aa457a53eb9e717
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Medical_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Medical_Blue.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114325376994497856}
+  - component: {fileID: 114155641224926020}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 6588397637707655660}
   - component: {fileID: 114731592007980676}
   - component: {fileID: 114971026841769662}
-  - component: {fileID: 114155641224926020}
   - component: {fileID: 114519330285391926}
   - component: {fileID: 114141487803868132}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114155641224926020
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,13 +216,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents:
-  - {fileID: 1408536760214900, guid: f181c8eb8ce8b8949b1ab571c8318f6f, type: 3}
-  - {fileID: 1408536760214900, guid: f181c8eb8ce8b8949b1ab571c8318f6f, type: 3}
-  - {fileID: 1408536760214900, guid: f181c8eb8ce8b8949b1ab571c8318f6f, type: 3}
-  - {fileID: 1862150311813888, guid: 269d6c8129e05ee4396165bb84083f19, type: 3}
-  - {fileID: 1862150311813888, guid: 269d6c8129e05ee4396165bb84083f19, type: 3}
-  - {fileID: 1862150311813888, guid: 269d6c8129e05ee4396165bb84083f19, type: 3}
   initialContents: {fileID: 11400000, guid: 912b2b5a6fefc4c97b6cd53506caf1ac, type: 2}
   IsClosed: 0
   IsLocked: 0
@@ -269,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114155641224926020
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114519330285391926
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -330,8 +323,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3600863957
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Medical_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Medical_Red.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114850073692931946}
+  - component: {fileID: 114626758695652662}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 1354527636327440602}
   - component: {fileID: 114693708255967736}
   - component: {fileID: 114915998634745900}
-  - component: {fileID: 114626758695652662}
   - component: {fileID: 114228522244671226}
   - component: {fileID: 114851175473603892}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114626758695652662
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114626758695652662
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114228522244671226
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: ac5d1e09aae2c4b15bd7bd685a577616
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Plain.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114380468365835130}
+  - component: {fileID: 114333108055755356}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 5476562201802546663}
   - component: {fileID: 114892200674845614}
   - component: {fileID: 114097080808669552}
-  - component: {fileID: 114333108055755356}
   - component: {fileID: 114929448901867910}
   - component: {fileID: 114086851076150106}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114333108055755356
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114333108055755356
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114929448901867910
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 951a8e1779fea4e8eab1ab3aa05089cb
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Purple.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Purple.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114297601676347656}
+  - component: {fileID: 114737612938809852}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 6399753720074431582}
   - component: {fileID: 114038549829774776}
   - component: {fileID: 114814996517245894}
-  - component: {fileID: 114737612938809852}
   - component: {fileID: 114565555807557412}
   - component: {fileID: 114793977738550174}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114737612938809852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114737612938809852
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114565555807557412
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 8cb0473f4e7bc4f34a84f3de92de9441
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_RD.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_RD.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114360195284987434}
+  - component: {fileID: 114666279363054950}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 7485403622017351907}
   - component: {fileID: 114281463853194846}
   - component: {fileID: 114570445175126256}
-  - component: {fileID: 114666279363054950}
   - component: {fileID: 114666867725769994}
   - component: {fileID: 114987683645712798}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114666279363054950
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114666279363054950
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114666867725769994
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 7769e2c52133e474ca5683c6457406c3
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Security.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Security.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114836660138393894}
+  - component: {fileID: 114919532952929156}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 3371351615256674035}
   - component: {fileID: 114605337504269064}
   - component: {fileID: 114113182609010320}
-  - component: {fileID: 114919532952929156}
   - component: {fileID: 114921955171148146}
   - component: {fileID: 114959860031397196}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114919532952929156
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,10 +216,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents:
-  - {fileID: 2664584551837519869, guid: 5eb99a314f588b54c8e187fccf082399, type: 3}
-  - {fileID: 7503752898315862941, guid: fcd09c3dfb3c3954cac1623e1c37bac3, type: 3}
-  - {fileID: 1392830670498528, guid: 9f44d687d51603f4f93c814a3a888239, type: 3}
   initialContents: {fileID: 11400000, guid: 3ba1e72f1892a4a35bbb60902077f9b9, type: 2}
   IsClosed: 0
   IsLocked: 0
@@ -266,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114919532952929156
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114921955171148146
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -327,8 +323,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3917749387
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Warden.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Warden.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114014101349316756}
+  - component: {fileID: 114732841179402168}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 460845709627303480}
   - component: {fileID: 114922293611875512}
   - component: {fileID: 114142356391403884}
-  - component: {fileID: 114732841179402168}
   - component: {fileID: 114603204766106980}
   - component: {fileID: 114659495049121970}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114732841179402168
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114732841179402168
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114603204766106980
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: e0c48d89cf4244b65bff4e257b382fbc
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Yellow_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Yellow_Blue.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114519431623713784}
+  - component: {fileID: 114997322407266526}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 8700910813481451396}
   - component: {fileID: 114002540538224682}
   - component: {fileID: 114204684251905994}
-  - component: {fileID: 114997322407266526}
   - component: {fileID: 114685661576406798}
   - component: {fileID: 114920613611409380}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114997322407266526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114997322407266526
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114685661576406798
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 3c989876a48e24f5295ba655c1c22142
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Yellow_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Yellow_Green.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114183100861501246}
+  - component: {fileID: 114098732444032164}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 7172996459588766801}
   - component: {fileID: 114934066705055290}
   - component: {fileID: 114688112107947502}
-  - component: {fileID: 114098732444032164}
   - component: {fileID: 114507594765309756}
   - component: {fileID: 114310511498173712}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114098732444032164
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114098732444032164
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114507594765309756
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 64d99c42cc47c40b5b320361c01a224b
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Yellow_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_Yellow_Red.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114167712126867458}
+  - component: {fileID: 114127902504606950}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 56515454735926037}
   - component: {fileID: 114322238352018174}
   - component: {fileID: 114676575423395924}
-  - component: {fileID: 114127902504606950}
   - component: {fileID: 114836399885807646}
   - component: {fileID: 114597594558029052}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114127902504606950
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114127902504606950
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114836399885807646
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 9f6e6691be3b24685bb87b8315e09a82
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_mining.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Locker_mining.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114026821851648828}
+  - component: {fileID: 114873780379729372}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 7968807753044366903}
   - component: {fileID: 114159567590582482}
   - component: {fileID: 114404811438738350}
-  - component: {fileID: 114873780379729372}
   - component: {fileID: 114169189415504790}
   - component: {fileID: 114920841608507116}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114873780379729372
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114873780379729372
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114169189415504790
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: a3b6cf305b4154cf181f32f37749cb6a
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Nuclear.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Nuclear.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114547321624010300}
+  - component: {fileID: 114089204106093226}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 2123884027975894421}
   - component: {fileID: 114636999251767984}
   - component: {fileID: 114255594270957750}
-  - component: {fileID: 114089204106093226}
   - component: {fileID: 114650494087732356}
   - component: {fileID: 114490479269003968}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114089204106093226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114089204106093226
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114650494087732356
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 6fa428711cfde49eca96fb52974eeb6b
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Oxygen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Oxygen.prefab
@@ -12,12 +12,12 @@ GameObject:
   - component: {fileID: 61073988275347620}
   - component: {fileID: 61187366832375296}
   - component: {fileID: 114836981699317108}
+  - component: {fileID: 114523164427909220}
   - component: {fileID: 114325905384881024}
   - component: {fileID: 3578799147172016980}
   - component: {fileID: 114195129605414080}
   - component: {fileID: 114202447134840306}
   - component: {fileID: 114689867610377938}
-  - component: {fileID: 114523164427909220}
   - component: {fileID: 114238733534567912}
   - component: {fileID: 114132597043430612}
   m_Layer: 11
@@ -110,6 +110,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114523164427909220
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1146263997293372}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114325905384881024
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -124,12 +136,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents:
-  - {fileID: 1277678737481138, guid: f99902d04c3b1fe47b0e4e4ec36b7971, type: 3}
-  - {fileID: 1639223380925416, guid: 611c366b2d389b94193a817e11987cdc, type: 3}
-  - {fileID: 1277678737481138, guid: f99902d04c3b1fe47b0e4e4ec36b7971, type: 3}
-  - {fileID: 1639223380925416, guid: 611c366b2d389b94193a817e11987cdc, type: 3}
-  - {fileID: 1277678737481138, guid: 4661484912df68a4192af5d6c9a8cd58, type: 3}
   initialContents: {fileID: 11400000, guid: 133558ddd198d490f836732ad1b9c8a2, type: 2}
   IsClosed: 0
   IsLocked: 0
@@ -200,18 +206,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114523164427909220
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1146263997293372}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114238733534567912
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -261,8 +255,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3776031325
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1324576255968780
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Pink_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Pink_Plain.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114840521567148940}
+  - component: {fileID: 114805670532339736}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 2197213693828040461}
   - component: {fileID: 114411567513637418}
   - component: {fileID: 114975304268083358}
-  - component: {fileID: 114805670532339736}
   - component: {fileID: 114295063405960238}
   - component: {fileID: 114416068328850912}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114805670532339736
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114805670532339736
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114295063405960238
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 8bb47ee8364404b398585bf71d058119
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Red.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114110721192159654}
+  - component: {fileID: 114275825723298338}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 3086966535502858973}
   - component: {fileID: 114098930696084046}
   - component: {fileID: 114652153136408314}
-  - component: {fileID: 114275825723298338}
   - component: {fileID: 114126440591903066}
   - component: {fileID: 114648249213097858}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114275825723298338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114275825723298338
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114126440591903066
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 5ec30c55d74a449339d4b4ba44bb475a
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Red_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_Red_Plain.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114181166744408970}
+  - component: {fileID: 114049400745050608}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 1317586965163005727}
   - component: {fileID: 114789322306219058}
   - component: {fileID: 114890316843556772}
-  - component: {fileID: 114049400745050608}
   - component: {fileID: 114678563790420386}
   - component: {fileID: 114260906593171520}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114049400745050608
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,12 +216,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents:
-  - {fileID: 1296620499762930, guid: 054d4c5d3f4b74caa87d549779ef4bf0, type: 3}
-  - {fileID: 1269203658156660, guid: 6e5bac62a83bd4e8e9764f3f7d48beaa, type: 3}
-  - {fileID: 1570589854574774, guid: ea8c66b49b7384edaa57106fd2a385a5, type: 3}
-  - {fileID: 1570589854574774, guid: ea8c66b49b7384edaa57106fd2a385a5, type: 3}
-  - {fileID: 1837689547681116, guid: 5c6f9e9e80c8a4b5a84d0376fb69f876, type: 3}
   initialContents: {fileID: 11400000, guid: 590f9106bfdc84a3bba3a5bcf585d06d, type: 2}
   IsClosed: 0
   IsLocked: 0
@@ -268,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114049400745050608
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114678563790420386
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -329,8 +323,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 1504822273
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_YellowBlue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Closets/Closet_YellowBlue.prefab
@@ -93,11 +93,11 @@ GameObject:
   - component: {fileID: 61442980425183844}
   - component: {fileID: 61828718115089044}
   - component: {fileID: 114300286672676254}
+  - component: {fileID: 114832056121705382}
   - component: {fileID: 114239634461430000}
   - component: {fileID: 202514586087202308}
   - component: {fileID: 114212272870360996}
   - component: {fileID: 114258542002609098}
-  - component: {fileID: 114832056121705382}
   - component: {fileID: 114751559918818782}
   - component: {fileID: 114258317497933096}
   m_Layer: 11
@@ -190,6 +190,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114832056121705382
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615565101381030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114239634461430000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -262,18 +274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114832056121705382
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615565101381030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114751559918818782
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 5ca1ac398c97e49c59e202455fcf7d66
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1660108514398418
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Consoles/Cargo_Console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Consoles/Cargo_Console.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -94,9 +95,9 @@ GameObject:
   - component: {fileID: 3397741670811314997}
   - component: {fileID: 3397319190446495777}
   - component: {fileID: 5210483117512304919}
+  - component: {fileID: 114322071421580458}
   - component: {fileID: 4352017894842036142}
   - component: {fileID: 114212155062859864}
-  - component: {fileID: 114322071421580458}
   - component: {fileID: 114711192283274066}
   - component: {fileID: 114251416167812810}
   m_Layer: 11
@@ -207,6 +208,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &3397319190446495777
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -273,6 +275,18 @@ MonoBehaviour:
   RelatedAPC: {fileID: 0}
   AdvancedControlToScript: 0
   State: 2
+--- !u!114 &114322071421580458
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3365708065215268791}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &4352017894842036142
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -299,18 +313,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114322071421580458
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3365708065215268791}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114711192283274066
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -345,6 +347,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114251416167812810
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -359,8 +362,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3582311320
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &3365832635514216189
 GameObject:
   m_ObjectHideFlags: 0
@@ -417,6 +420,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -516,6 +520,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Consoles/Cloning_Console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Consoles/Cloning_Console.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -135,6 +136,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -169,14 +171,14 @@ GameObject:
   - component: {fileID: 4397739893321814}
   - component: {fileID: 61199487226274286}
   - component: {fileID: 61206666438295416}
-  - component: {fileID: 587524036529041418}
   - component: {fileID: 114178605300182066}
   - component: {fileID: 114784912755194898}
   - component: {fileID: 114080400140570374}
   - component: {fileID: 7421829385032138288}
-  - component: {fileID: 4746695837673661153}
-  - component: {fileID: 114424193572042698}
   - component: {fileID: 114277093133318622}
+  - component: {fileID: 4746695837673661153}
+  - component: {fileID: 587524036529041418}
+  - component: {fileID: 114424193572042698}
   - component: {fileID: 114254690631665046}
   - component: {fileID: 114135642198018370}
   m_Layer: 11
@@ -255,21 +257,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!114 &587524036529041418
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1581020911112336}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 60ab2691c833e4d47acba80181e7ebd3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  scanner: {fileID: 0}
-  cloningPod: {fileID: 0}
-  consoleGUI: {fileID: 0}
 --- !u!114 &114178605300182066
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -302,6 +289,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114080400140570374
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -432,6 +420,18 @@ MonoBehaviour:
   RelatedAPC: {fileID: 0}
   AdvancedControlToScript: 0
   State: 2
+--- !u!114 &114277093133318622
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1581020911112336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &4746695837673661153
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -445,6 +445,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   NetTabType: 8
+--- !u!114 &587524036529041418
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1581020911112336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60ab2691c833e4d47acba80181e7ebd3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scanner: {fileID: 0}
+  cloningPod: {fileID: 0}
+  consoleGUI: {fileID: 0}
 --- !u!114 &114424193572042698
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -458,18 +473,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114277093133318622
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1581020911112336}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114254690631665046
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -504,6 +507,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114135642198018370
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -518,8 +522,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 2215831195
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1753008131445868
 GameObject:
   m_ObjectHideFlags: 0
@@ -596,6 +600,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Consoles/Communications_Console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Consoles/Communications_Console.prefab
@@ -175,9 +175,9 @@ GameObject:
   - component: {fileID: 114310873128946770}
   - component: {fileID: 114142617040337854}
   - component: {fileID: 2263657787625324565}
-  - component: {fileID: 3288341768066379701}
-  - component: {fileID: 6121755517172193553}
   - component: {fileID: 114077426834687316}
+  - component: {fileID: 6121755517172193553}
+  - component: {fileID: 3288341768066379701}
   - component: {fileID: 114756124129542138}
   - component: {fileID: 6354374949080783350}
   - component: {fileID: 114302809726908850}
@@ -290,6 +290,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114142617040337854
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -325,7 +326,7 @@ MonoBehaviour:
   RelatedAPC: {fileID: 0}
   AdvancedControlToScript: 0
   State: 2
---- !u!114 &3288341768066379701
+--- !u!114 &114077426834687316
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -334,7 +335,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1832449994204696}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 294d2b1b66f24ff8befbc4e71f48652f, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &6121755517172193553
@@ -350,7 +351,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   NetTabType: 11
---- !u!114 &114077426834687316
+--- !u!114 &3288341768066379701
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -359,7 +360,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1832449994204696}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Script: {fileID: 11500000, guid: 294d2b1b66f24ff8befbc4e71f48652f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &114756124129542138
@@ -439,7 +440,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!114 &8020537792279011488
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Consoles/Id_Console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Consoles/Id_Console.prefab
@@ -112,10 +112,10 @@ GameObject:
   - component: {fileID: 5554068536061526188}
   - component: {fileID: 5554772505365935032}
   - component: {fileID: 3061441890875507342}
-  - component: {fileID: 5514185242108095533}
-  - component: {fileID: 6797707358650549303}
-  - component: {fileID: 7180695751072322497}
   - component: {fileID: 7180163552371466035}
+  - component: {fileID: 6797707358650549303}
+  - component: {fileID: 5514185242108095533}
+  - component: {fileID: 7180695751072322497}
   - component: {fileID: 7180073561033371851}
   - component: {fileID: 114577545745324966}
   - component: {fileID: 8597459946000449771}
@@ -227,6 +227,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &5554772505365935032
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -277,7 +278,7 @@ MonoBehaviour:
   RelatedAPC: {fileID: 0}
   AdvancedControlToScript: 0
   State: 2
---- !u!114 &5514185242108095533
+--- !u!114 &7180163552371466035
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -286,10 +287,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 5514185242108095534}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a792564bc5bddb7da8c271b001b644cc, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  LoggedIn: 0
 --- !u!114 &6797707358650549303
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -303,6 +303,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   NetTabType: 12
+--- !u!114 &5514185242108095533
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5514185242108095534}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a792564bc5bddb7da8c271b001b644cc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LoggedIn: 0
 --- !u!114 &7180695751072322497
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -316,18 +329,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &7180163552371466035
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5514185242108095534}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &7180073561033371851
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -377,7 +378,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: fe7830029b255694f826e807700cb24f
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!114 &8597459946000449771
 MonoBehaviour:
@@ -391,11 +392,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdce8a163088453ca593c0e98f2c5f07, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ItemStorageStructure: {fileID: 11400000, guid: 74bf3e872403e488695c17ecdde194ab,
+  itemStorageStructure: {fileID: 11400000, guid: 74bf3e872403e488695c17ecdde194ab,
     type: 2}
-  ItemStorageCapacity: {fileID: 11400000, guid: 6151cf8fb4f9c4bf890b69fad47b155b,
+  itemStorageCapacity: {fileID: 11400000, guid: 6151cf8fb4f9c4bf890b69fad47b155b,
     type: 2}
-  ItemStoragePopulator: {fileID: 0}
+  itemStoragePopulator: {fileID: 0}
 --- !u!1 &5514342282601624932
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Consoles/SecurityRecords_Console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Consoles/SecurityRecords_Console.prefab
@@ -192,10 +192,10 @@ GameObject:
   - component: {fileID: 523872058597329049}
   - component: {fileID: 524578223692725133}
   - component: {fileID: 6930270276971121339}
-  - component: {fileID: 2445436616556644236}
-  - component: {fileID: 1443236447715953666}
-  - component: {fileID: 3024129255899388916}
   - component: {fileID: 3023104479544448774}
+  - component: {fileID: 1443236447715953666}
+  - component: {fileID: 2445436616556644236}
+  - component: {fileID: 3024129255899388916}
   - component: {fileID: 3023489747755219198}
   - component: {fileID: 114695737729270508}
   - component: {fileID: 4106014234681766500}
@@ -307,6 +307,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &524578223692725133
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -385,7 +386,7 @@ MonoBehaviour:
   RelatedAPC: {fileID: 0}
   AdvancedControlToScript: 0
   State: 2
---- !u!114 &2445436616556644236
+--- !u!114 &3023104479544448774
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -394,7 +395,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 492998437866873883}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 48b80d0b128d003b382b531e42c28cfa, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &1443236447715953666
@@ -410,6 +411,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   NetTabType: 9
+--- !u!114 &2445436616556644236
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 492998437866873883}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48b80d0b128d003b382b531e42c28cfa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &3024129255899388916
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -423,18 +436,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &3023104479544448774
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 492998437866873883}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &3023489747755219198
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -484,7 +485,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 8db968c27956eebd2a561f59883fd437
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!114 &4106014234681766500
 MonoBehaviour:
@@ -498,11 +499,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdce8a163088453ca593c0e98f2c5f07, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ItemStorageStructure: {fileID: 11400000, guid: 263bf834f99424f12bda19d67c3ab5fc,
+  itemStorageStructure: {fileID: 11400000, guid: 263bf834f99424f12bda19d67c3ab5fc,
     type: 2}
-  ItemStorageCapacity: {fileID: 11400000, guid: 6151cf8fb4f9c4bf890b69fad47b155b,
+  itemStorageCapacity: {fileID: 11400000, guid: 6151cf8fb4f9c4bf890b69fad47b155b,
     type: 2}
-  ItemStoragePopulator: {fileID: 0}
+  itemStoragePopulator: {fileID: 0}
 --- !u!1 &493082733683129681
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Consoles/shuttle_console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Consoles/shuttle_console.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -92,10 +93,10 @@ GameObject:
   - component: {fileID: 61687826196341392}
   - component: {fileID: 114959292841992252}
   - component: {fileID: 114489178862107254}
-  - component: {fileID: 114660502884524074}
-  - component: {fileID: 290742843891720739}
-  - component: {fileID: 5763908275250210171}
   - component: {fileID: 114779478609998338}
+  - component: {fileID: 290742843891720739}
+  - component: {fileID: 114660502884524074}
+  - component: {fileID: 5763908275250210171}
   - component: {fileID: 114671522045060476}
   - component: {fileID: 114341681926248934}
   m_Layer: 11
@@ -205,7 +206,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
---- !u!114 &114660502884524074
+  IsFixedMatrix: 0
+--- !u!114 &114779478609998338
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -214,16 +216,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1413862099450234}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 15547858c4462dc4fb5dcad7eb78f118, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  ShuttleMatrixMove: {fileID: 0}
-  OnStateChange:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: TabStateEvent, Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 --- !u!114 &290742843891720739
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -237,6 +232,22 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   NetTabType: 1
+--- !u!114 &114660502884524074
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1413862099450234}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15547858c4462dc4fb5dcad7eb78f118, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShuttleMatrixMove: {fileID: 0}
+  OnStateChange:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &5763908275250210171
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,18 +261,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114779478609998338
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1413862099450234}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114671522045060476
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -296,6 +295,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114341681926248934
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -310,8 +310,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 1510216014
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1529566477441902
 GameObject:
   m_ObjectHideFlags: 0
@@ -368,6 +368,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Girder.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Girder.prefab
@@ -92,9 +92,9 @@ GameObject:
   - component: {fileID: 7387402309273897296}
   - component: {fileID: 7479226819894283132}
   - component: {fileID: 7478891196200289026}
+  - component: {fileID: 114868527810879464}
   - component: {fileID: 5151831765998453531}
   - component: {fileID: 114475937421885612}
-  - component: {fileID: 114868527810879464}
   - component: {fileID: 114590610092742494}
   - component: {fileID: 114876689548865824}
   m_Layer: 11
@@ -178,6 +178,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 1
+--- !u!114 &114868527810879464
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7376449702682419346}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &5151831765998453531
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -207,18 +219,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114868527810879464
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7376449702682419346}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114590610092742494
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -268,5 +268,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Rack Parts.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Rack Parts.prefab
@@ -15,9 +15,9 @@ GameObject:
   - component: {fileID: 132348641917229106}
   - component: {fileID: 8301933286516629790}
   - component: {fileID: 7887144931197074431}
+  - component: {fileID: 2010458303386780433}
   - component: {fileID: 4664957552587279702}
   - component: {fileID: -1445245493585989624}
-  - component: {fileID: 2010458303386780433}
   - component: {fileID: 490726123092147132}
   - component: {fileID: 3118628355925246483}
   - component: {fileID: 925564419828475077}
@@ -158,6 +158,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+--- !u!114 &2010458303386780433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6034371561869202664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &4664957552587279702
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -186,18 +198,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rackPrefab: {fileID: 7144248469089430455, guid: f9d3bcbd125054bb4a8d60e18d3fcf34,
     type: 3}
---- !u!114 &2010458303386780433
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6034371561869202664}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &490726123092147132
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -247,7 +247,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!114 &925564419828475077
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Rack.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Rack.prefab
@@ -94,8 +94,8 @@ GameObject:
   - component: {fileID: 4436606494572318361}
   - component: {fileID: 74958767906644875}
   - component: {fileID: 4216241947996897747}
-  - component: {fileID: 243253553239203302}
   - component: {fileID: 2611605342679031968}
+  - component: {fileID: 243253553239203302}
   - component: {fileID: 1835757013911865864}
   - component: {fileID: 3348285834374005981}
   - component: {fileID: 8662366804555004195}
@@ -161,6 +161,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &4436606494572318361
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -208,6 +209,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+--- !u!114 &2611605342679031968
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7144248469089430455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &243253553239203302
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -224,18 +237,6 @@ MonoBehaviour:
   syncInterval: 0.1
   rackParts: {fileID: 6034371561869202664, guid: 5c6173d6c15c149ff82f936c14acb687,
     type: 3}
---- !u!114 &2611605342679031968
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7144248469089430455}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1835757013911865864
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -285,7 +286,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: f9d3bcbd125054bb4a8d60e18d3fcf34
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!114 &8662366804555004195
 MonoBehaviour:
@@ -300,6 +301,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/UniFloorTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/UniFloorTile.prefab
@@ -9,15 +9,15 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4391181751561356}
-  - component: {fileID: 114625618949545954}
   - component: {fileID: 114194510371795276}
   - component: {fileID: 114455019697819228}
   - component: {fileID: 114208499505719652}
   - component: {fileID: 114469368480071740}
   - component: {fileID: 61430955032025016}
-  - component: {fileID: 114624743037909254}
-  - component: {fileID: 114197504116165090}
   - component: {fileID: 114002554109735238}
+  - component: {fileID: 114624743037909254}
+  - component: {fileID: 114625618949545954}
+  - component: {fileID: 114197504116165090}
   - component: {fileID: 114018975004714514}
   - component: {fileID: 114794553342207796}
   - component: {fileID: 114563246730424860}
@@ -43,19 +43,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114625618949545954
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1417416714511440}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4aeeb3afb58744a528b5a88d40de80c7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  FloorTileType: Floor
 --- !u!114 &114194510371795276
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -159,6 +146,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114002554109735238
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417416714511440}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114624743037909254
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -173,6 +172,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &114625618949545954
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417416714511440}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4aeeb3afb58744a528b5a88d40de80c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  FloorTileType: Floor
 --- !u!114 &114197504116165090
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -186,18 +198,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114002554109735238
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1417416714511440}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114018975004714514
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,7 +269,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1485591792757996
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_25.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_25.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61586921195375732}
   - component: {fileID: 61114502559717726}
   - component: {fileID: 114312187167322552}
+  - component: {fileID: 114136419983048134}
   - component: {fileID: 114624201496929774}
   - component: {fileID: 1453939733841449103}
   - component: {fileID: 114503017526061194}
   - component: {fileID: 114675033540669420}
-  - component: {fileID: 114136419983048134}
   - component: {fileID: 114507018881518080}
   - component: {fileID: 114341358096139776}
   m_Layer: 11
@@ -189,6 +189,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114136419983048134
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1501407896951118}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114624201496929774
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -203,7 +215,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -261,18 +273,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114136419983048134
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1501407896951118}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114507018881518080
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -322,7 +322,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: f2cd419b41c964ba0a7a26218ec7a38c
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1704144015676808
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_27.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_27.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61192281597667100}
   - component: {fileID: 61806154779726060}
   - component: {fileID: 114502689129448986}
+  - component: {fileID: 114515549684986276}
   - component: {fileID: 114041722743958658}
   - component: {fileID: 1749361335863143025}
   - component: {fileID: 114712611594111156}
   - component: {fileID: 114157843574121182}
-  - component: {fileID: 114515549684986276}
   - component: {fileID: 114327552217618110}
   - component: {fileID: 114340885752221528}
   m_Layer: 11
@@ -189,6 +189,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114515549684986276
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523863081027030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114041722743958658
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -203,7 +215,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -261,18 +273,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114515549684986276
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1523863081027030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114327552217618110
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -322,7 +322,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 3e4e73ba010fe42ae85287bd445dc900
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1691532816611442
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_29.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_29.prefab
@@ -172,11 +172,11 @@ GameObject:
   - component: {fileID: 61234227494707590}
   - component: {fileID: 61385178883414074}
   - component: {fileID: 114680917774830940}
+  - component: {fileID: 114120919427970644}
   - component: {fileID: 114909173354328112}
   - component: {fileID: 4711233239866855599}
   - component: {fileID: 114472020371701898}
   - component: {fileID: 114698634746036494}
-  - component: {fileID: 114120919427970644}
   - component: {fileID: 114280047209228998}
   - component: {fileID: 114593648421149528}
   m_Layer: 11
@@ -269,6 +269,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114120919427970644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1476871417342792}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114909173354328112
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,7 +295,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -341,18 +353,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114120919427970644
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1476871417342792}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114280047209228998
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -402,7 +402,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 73581251874bf4d0dae574e6da07cd5b
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1673024211849270
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_31.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_31.prefab
@@ -173,11 +173,11 @@ GameObject:
   - component: {fileID: 61306058889527168}
   - component: {fileID: 61655575604032862}
   - component: {fileID: 114203660061737976}
+  - component: {fileID: 114947677908184196}
   - component: {fileID: 114727864889730296}
   - component: {fileID: 7162012068265166464}
   - component: {fileID: 114017635886564424}
   - component: {fileID: 114298576944570384}
-  - component: {fileID: 114947677908184196}
   - component: {fileID: 114623413063744682}
   - component: {fileID: 114012694958917392}
   m_Layer: 11
@@ -270,6 +270,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114947677908184196
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1930016640541606}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114727864889730296
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -284,7 +296,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -342,18 +354,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114947677908184196
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1930016640541606}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114623413063744682
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -403,7 +403,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 568232a9a8ae84f3890c6af3f51b278e
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1938915013109780
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_33.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_33.prefab
@@ -12,11 +12,11 @@ GameObject:
   - component: {fileID: 61096127390705098}
   - component: {fileID: 61878033155631260}
   - component: {fileID: 114451849879818634}
+  - component: {fileID: 114140607278720338}
   - component: {fileID: 114687776773198576}
   - component: {fileID: 481603465417082134}
   - component: {fileID: 114769490943460672}
   - component: {fileID: 114892361574453892}
-  - component: {fileID: 114140607278720338}
   - component: {fileID: 114053921996311286}
   - component: {fileID: 114959749493755652}
   m_Layer: 11
@@ -109,6 +109,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114140607278720338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1172562073016694}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114687776773198576
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -123,7 +135,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -181,18 +193,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114140607278720338
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1172562073016694}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114053921996311286
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -242,7 +242,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 40c7902bc54d245849fc664a9fd34c9c
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1499276632513872
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_35.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_35.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61138413513912276}
   - component: {fileID: 61295873178423188}
   - component: {fileID: 114471373235078564}
+  - component: {fileID: 114205363735940822}
   - component: {fileID: 114792840174579722}
   - component: {fileID: 2036395685959740061}
   - component: {fileID: 114770697319524486}
   - component: {fileID: 114109153953547982}
-  - component: {fileID: 114205363735940822}
   - component: {fileID: 114455171434770934}
   - component: {fileID: 114774281985442532}
   m_Layer: 11
@@ -189,6 +189,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114205363735940822
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1725541231692740}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114792840174579722
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -203,7 +215,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -261,18 +273,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114205363735940822
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1725541231692740}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114455171434770934
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -322,7 +322,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 33fd4da6c64ef473ca4b0f3647b3f6ac
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1734688042214090
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_37.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_37.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61504171790029006}
   - component: {fileID: 61720396500020216}
   - component: {fileID: 114033159393086184}
+  - component: {fileID: 114944343643340868}
   - component: {fileID: 114095274155442226}
   - component: {fileID: 2341535699890660284}
   - component: {fileID: 114789974186404946}
   - component: {fileID: 114818822793105008}
-  - component: {fileID: 114944343643340868}
   - component: {fileID: 114670156753081908}
   - component: {fileID: 114746092582152720}
   m_Layer: 11
@@ -189,6 +189,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114944343643340868
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1623680258428568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114095274155442226
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -203,7 +215,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -261,18 +273,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114944343643340868
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1623680258428568}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114670156753081908
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -322,7 +322,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: d5e2aef45df114aa39de1eae7d792aa2
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1924107092796194
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_39.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_39.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61850832509916282}
   - component: {fileID: 61138204033551586}
   - component: {fileID: 114297742929761050}
+  - component: {fileID: 114443179641081274}
   - component: {fileID: 114071782524652884}
   - component: {fileID: 7197230643576437747}
   - component: {fileID: 114228922600464636}
   - component: {fileID: 114714168694325888}
-  - component: {fileID: 114443179641081274}
   - component: {fileID: 114805644433781372}
   - component: {fileID: 114021949924643028}
   m_Layer: 11
@@ -189,6 +189,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114443179641081274
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1171324585748574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114071782524652884
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -203,7 +215,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -261,18 +273,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114443179641081274
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1171324585748574}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114805644433781372
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -322,7 +322,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: e1538e2e5a9a84e1eb1da706417d5d21
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1450320603821982
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_41.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_41.prefab
@@ -253,11 +253,11 @@ GameObject:
   - component: {fileID: 61167037230259828}
   - component: {fileID: 61040727025422938}
   - component: {fileID: 114871415670409854}
+  - component: {fileID: 114268110994210856}
   - component: {fileID: 114005325939491094}
   - component: {fileID: 3598255003094367172}
   - component: {fileID: 114249522964518044}
   - component: {fileID: 114468713582360326}
-  - component: {fileID: 114268110994210856}
   - component: {fileID: 114096449226284646}
   - component: {fileID: 114833227775017900}
   m_Layer: 11
@@ -350,6 +350,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114268110994210856
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1924829694925096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114005325939491094
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -364,7 +376,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -422,18 +434,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114268110994210856
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1924829694925096}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114096449226284646
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -483,5 +483,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 3758fca9d770d401bbed6e4a5594e198
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_43.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_43.prefab
@@ -252,11 +252,11 @@ GameObject:
   - component: {fileID: 4994202061024532}
   - component: {fileID: 61050333321013898}
   - component: {fileID: 114172041256659066}
+  - component: {fileID: 114423092868137762}
   - component: {fileID: 114997183691469382}
   - component: {fileID: 1469083798200047767}
   - component: {fileID: 114204757990214010}
   - component: {fileID: 114040774181031300}
-  - component: {fileID: 114423092868137762}
   - component: {fileID: 114740207427103198}
   - component: {fileID: 114358436539017554}
   m_Layer: 11
@@ -323,6 +323,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114423092868137762
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1969509301568012}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114997183691469382
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -337,7 +349,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -395,18 +407,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114423092868137762
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1969509301568012}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114740207427103198
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -456,5 +456,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_45.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_45.prefab
@@ -92,11 +92,11 @@ GameObject:
   - component: {fileID: 61563282651521928}
   - component: {fileID: 61358298278567270}
   - component: {fileID: 114439906662283016}
+  - component: {fileID: 114053198053435132}
   - component: {fileID: 114168612985768984}
   - component: {fileID: 3312694908317578026}
   - component: {fileID: 114602900905777840}
   - component: {fileID: 114489996226808170}
-  - component: {fileID: 114053198053435132}
   - component: {fileID: 114152464543914716}
   - component: {fileID: 114142304136326718}
   m_Layer: 11
@@ -189,6 +189,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114053198053435132
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1502243171082208}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114168612985768984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -203,7 +215,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -261,18 +273,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114053198053435132
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1502243171082208}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114152464543914716
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -322,7 +322,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 50e0c4bcff9f848a1ad1329119954556
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1657152118737778
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_47.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_47.prefab
@@ -172,11 +172,11 @@ GameObject:
   - component: {fileID: 61722482349278122}
   - component: {fileID: 61970599936095162}
   - component: {fileID: 114388335254351326}
+  - component: {fileID: 114531887164001030}
   - component: {fileID: 114294527913026106}
   - component: {fileID: 6828377580895755862}
   - component: {fileID: 114167406021928690}
   - component: {fileID: 114862946691867494}
-  - component: {fileID: 114531887164001030}
   - component: {fileID: 114531288635340852}
   - component: {fileID: 114587828367191750}
   m_Layer: 11
@@ -269,6 +269,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114531887164001030
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1478563989471078}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114294527913026106
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,7 +295,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -341,18 +353,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114531887164001030
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1478563989471078}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114531288635340852
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -402,7 +402,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 4aa73692e39fa407188ca0c6cf0f303b
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1897796544186528
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_49.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_49.prefab
@@ -253,11 +253,11 @@ GameObject:
   - component: {fileID: 61354511301467718}
   - component: {fileID: 61090429304919756}
   - component: {fileID: 114798688265202516}
+  - component: {fileID: 114226781320182858}
   - component: {fileID: 114999291194090438}
   - component: {fileID: 2330541816643088886}
   - component: {fileID: 114452331490182166}
   - component: {fileID: 114594932833701242}
-  - component: {fileID: 114226781320182858}
   - component: {fileID: 114097639001149906}
   - component: {fileID: 114669540274702640}
   m_Layer: 11
@@ -350,6 +350,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114226781320182858
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1907093438119012}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114999291194090438
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -364,7 +376,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -422,18 +434,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114226781320182858
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1907093438119012}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114097639001149906
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -483,5 +483,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: c3c698df4321844769d83ff6cd426675
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_51.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_51.prefab
@@ -12,11 +12,11 @@ GameObject:
   - component: {fileID: 61840074911869304}
   - component: {fileID: 61943151341322730}
   - component: {fileID: 114559310912600516}
+  - component: {fileID: 114247149713162176}
   - component: {fileID: 114810580295933042}
   - component: {fileID: 3621892529651158124}
   - component: {fileID: 114764355540025994}
   - component: {fileID: 114061062732988380}
-  - component: {fileID: 114247149713162176}
   - component: {fileID: 114701798964041712}
   - component: {fileID: 114905207942403198}
   m_Layer: 11
@@ -109,6 +109,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114247149713162176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1211152131464520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114810580295933042
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -123,7 +135,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -181,18 +193,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114247149713162176
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1211152131464520}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114701798964041712
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -242,7 +242,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: b54b5f971d42242d3bbb327a12ce74d2
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1425752812718570
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_55.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_55.prefab
@@ -12,11 +12,11 @@ GameObject:
   - component: {fileID: 61510480500321770}
   - component: {fileID: 61761375012810014}
   - component: {fileID: 114176581051234016}
+  - component: {fileID: 114550382447619690}
   - component: {fileID: 114111814946665734}
   - component: {fileID: 6707346723057253345}
   - component: {fileID: 114158540661954676}
   - component: {fileID: 114214447182105028}
-  - component: {fileID: 114550382447619690}
   - component: {fileID: 114132199755193898}
   - component: {fileID: 114986165515162306}
   m_Layer: 11
@@ -109,6 +109,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114550382447619690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1158274957469326}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114111814946665734
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -123,10 +135,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents:
-  - {fileID: 5134582746904691057, guid: 200bde3ddfd65ea4db701f0fa1c81f6c, type: 3}
-  - {fileID: 5134582746904691057, guid: 200bde3ddfd65ea4db701f0fa1c81f6c, type: 3}
-  - {fileID: 5134582746904691057, guid: 200bde3ddfd65ea4db701f0fa1c81f6c, type: 3}
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -184,18 +193,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114550382447619690
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1158274957469326}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114132199755193898
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -245,7 +242,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 0c90c295e1ca14b9d8891720b5d3ba64
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1382922708889030
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_59.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_59.prefab
@@ -203,11 +203,11 @@ GameObject:
   - component: {fileID: 61590744280274906}
   - component: {fileID: 61087441100130190}
   - component: {fileID: 114967653116276958}
+  - component: {fileID: 114572156223799922}
   - component: {fileID: 114077872851233106}
   - component: {fileID: 8239539641171403942}
   - component: {fileID: 114713051113849806}
   - component: {fileID: 114829380719981106}
-  - component: {fileID: 114572156223799922}
   - component: {fileID: 114286038032828750}
   - component: {fileID: 114210493713494930}
   m_Layer: 11
@@ -300,6 +300,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114572156223799922
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1716772823250544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114077872851233106
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -314,7 +326,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -372,18 +384,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114572156223799922
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1716772823250544}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114286038032828750
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -433,5 +433,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 730423d14b4d3421eb34e6d89b2a2948
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_75.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_75.prefab
@@ -253,11 +253,11 @@ GameObject:
   - component: {fileID: 61243447183557372}
   - component: {fileID: 61694457173941954}
   - component: {fileID: 114502573446041974}
+  - component: {fileID: 114065067979641996}
   - component: {fileID: 114097983808980254}
   - component: {fileID: 6890847082882444101}
   - component: {fileID: 114743391073407562}
   - component: {fileID: 114829705146086590}
-  - component: {fileID: 114065067979641996}
   - component: {fileID: 114681055770281856}
   - component: {fileID: 114108007364388938}
   m_Layer: 11
@@ -350,6 +350,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114065067979641996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1260013458057742}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114097983808980254
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -364,7 +376,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -422,18 +434,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114065067979641996
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1260013458057742}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114681055770281856
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -483,5 +483,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: f2102521882cd4ad09293a1af1f50eb7
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_77.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Crates/crates_77.prefab
@@ -173,11 +173,11 @@ GameObject:
   - component: {fileID: 61854204177053354}
   - component: {fileID: 61160135615835210}
   - component: {fileID: 114247083654374572}
+  - component: {fileID: 114082798907328428}
   - component: {fileID: 114142976522380120}
   - component: {fileID: 7457605859256951026}
   - component: {fileID: 114869123330114316}
   - component: {fileID: 114492627388576618}
-  - component: {fileID: 114082798907328428}
   - component: {fileID: 114143735093462494}
   - component: {fileID: 114274226027426436}
   m_Layer: 11
@@ -270,6 +270,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114082798907328428
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1780409705432866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114142976522380120
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -284,7 +296,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -342,18 +354,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114082798907328428
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1780409705432866}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114143735093462494
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -403,7 +403,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 0129f82261c424e77abe787f4e54c048
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1808927232221560
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/AirLock.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/AirLock.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4000012887992874}
   - component: {fileID: 61000013173726114}
+  - component: {fileID: 114247149050027938}
   - component: {fileID: 114232321497863980}
   - component: {fileID: 114990158330489740}
   - component: {fileID: 114298626141523242}
@@ -18,7 +19,6 @@ GameObject:
   - component: {fileID: 114179192191593204}
   - component: {fileID: 114811207805226602}
   - component: {fileID: 114936590258962662}
-  - component: {fileID: 114247149050027938}
   - component: {fileID: 114535589590408862}
   - component: {fileID: 114842947250423336}
   m_Layer: 18
@@ -72,6 +72,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114247149050027938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011462531918}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114232321497863980
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -388,6 +400,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114936590258962662
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -401,18 +414,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114247149050027938
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000011462531918}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114535589590408862
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -447,6 +448,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114842947250423336
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -461,8 +463,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 866313934
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1000014101652626
 GameObject:
   m_ObjectHideFlags: 0
@@ -519,6 +521,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -598,6 +601,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -677,6 +681,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/AtmosDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/AtmosDoor.prefab
@@ -466,6 +466,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4172947130070054}
   - component: {fileID: 61963350373266860}
+  - component: {fileID: 114199714939546294}
   - component: {fileID: 114201876269245600}
   - component: {fileID: 114955538477622776}
   - component: {fileID: 114796983354351306}
@@ -474,7 +475,6 @@ GameObject:
   - component: {fileID: 114044152573828612}
   - component: {fileID: 114503345661438504}
   - component: {fileID: 114678535423316900}
-  - component: {fileID: 114199714939546294}
   - component: {fileID: 114327845946784816}
   - component: {fileID: 114065811379349204}
   m_Layer: 17
@@ -528,6 +528,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114199714939546294
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1457523303891292}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114201876269245600
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -826,18 +838,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114199714939546294
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1457523303891292}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114327845946784816
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -887,7 +887,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1626320556660626
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/CommandDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/CommandDoor.prefab
@@ -43,6 +43,7 @@ GameObject:
   - component: {fileID: 4266402893207056}
   - component: {fileID: 61995305346850986}
   - component: {fileID: 114389256914724986}
+  - component: {fileID: 114096071785223306}
   - component: {fileID: 114136653046911712}
   - component: {fileID: 114134813779297148}
   - component: {fileID: 114341371726771256}
@@ -50,7 +51,6 @@ GameObject:
   - component: {fileID: 114325599141030802}
   - component: {fileID: 114993360566056090}
   - component: {fileID: 114844421098606906}
-  - component: {fileID: 114096071785223306}
   - component: {fileID: 114503660770427716}
   - component: {fileID: 114121495487176538}
   m_Layer: 17
@@ -135,6 +135,18 @@ MonoBehaviour:
   openSFX: {fileID: 82352768117769496}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114096071785223306
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1069162904971260}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114136653046911712
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -402,18 +414,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114096071785223306
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1069162904971260}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114503660770427716
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -463,7 +463,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1100598751287574
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/EngineeringDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/EngineeringDoor.prefab
@@ -455,6 +455,7 @@ GameObject:
   - component: {fileID: 4033324952160438}
   - component: {fileID: 61790059268313222}
   - component: {fileID: 114059249025983974}
+  - component: {fileID: 114054792819298036}
   - component: {fileID: 114566587194028974}
   - component: {fileID: 114030775671006844}
   - component: {fileID: 114602670746664174}
@@ -462,7 +463,6 @@ GameObject:
   - component: {fileID: 114150526163596710}
   - component: {fileID: 114403590302997272}
   - component: {fileID: 114369509130701644}
-  - component: {fileID: 114054792819298036}
   - component: {fileID: 114948840395722872}
   - component: {fileID: 114646079871242220}
   m_Layer: 17
@@ -547,6 +547,18 @@ MonoBehaviour:
   openSFX: {fileID: 82119343689486036}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114054792819298036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1636844411894304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114566587194028974
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -814,18 +826,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114054792819298036
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1636844411894304}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114948840395722872
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -875,7 +875,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1811374188611904
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/FireDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/FireDoor.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -89,12 +90,12 @@ GameObject:
   m_Component:
   - component: {fileID: 4000014115740678}
   - component: {fileID: 61000012152155796}
+  - component: {fileID: 114753548897917196}
   - component: {fileID: 114160558175690770}
   - component: {fileID: 114598344239668270}
   - component: {fileID: 114021965903796278}
   - component: {fileID: 114947599300197550}
   - component: {fileID: 114407035379192880}
-  - component: {fileID: 114753548897917196}
   - component: {fileID: 114943941073503478}
   - component: {fileID: 114056414907250730}
   m_Layer: 16
@@ -145,6 +146,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114753548897917196
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011470677956}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114160558175690770
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,6 +218,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114407035379192880
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -218,18 +232,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114753548897917196
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000011470677956}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114943941073503478
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -264,6 +266,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114056414907250730
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -278,5 +281,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 1724635217
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MaintDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MaintDoor.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 4505898709889416}
   - component: {fileID: 61947071500429418}
   - component: {fileID: 114052080359656786}
+  - component: {fileID: 114605867674204026}
   - component: {fileID: 114898495208177878}
   - component: {fileID: 114989240748267380}
   - component: {fileID: 114976444947845894}
@@ -18,7 +19,6 @@ GameObject:
   - component: {fileID: 114225837126444506}
   - component: {fileID: 114001778842025294}
   - component: {fileID: 114214113307820836}
-  - component: {fileID: 114605867674204026}
   - component: {fileID: 114087671671177448}
   - component: {fileID: 114543117907524900}
   m_Layer: 17
@@ -103,6 +103,18 @@ MonoBehaviour:
   openSFX: {fileID: 82377813942762574}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114605867674204026
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1006244272141468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114898495208177878
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -370,18 +382,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114605867674204026
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1006244272141468}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114087671671177448
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -431,7 +431,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1256603339586500
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MedBayDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MedBayDoor.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 4745867992339454}
   - component: {fileID: 61066386049267686}
   - component: {fileID: 114813765941142440}
+  - component: {fileID: 114225884042522992}
   - component: {fileID: 114203827934596338}
   - component: {fileID: 114416454276806238}
   - component: {fileID: 114244929954303746}
@@ -18,7 +19,6 @@ GameObject:
   - component: {fileID: 114052302235371846}
   - component: {fileID: 114937836975816266}
   - component: {fileID: 114437412268890836}
-  - component: {fileID: 114225884042522992}
   - component: {fileID: 114589234034436630}
   - component: {fileID: 114868604017624666}
   m_Layer: 17
@@ -103,6 +103,18 @@ MonoBehaviour:
   openSFX: {fileID: 82424364662987246}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114225884042522992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1033492078376264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114203827934596338
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -356,6 +368,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114437412268890836
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -369,18 +382,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114225884042522992
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1033492078376264}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114589234034436630
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -415,6 +416,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114868604017624666
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -429,8 +431,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 2908017026
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1231954462806972
 GameObject:
   m_ObjectHideFlags: 0
@@ -487,6 +489,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -566,6 +569,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1021,6 +1025,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MiningDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MiningDoor.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -307,6 +308,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -386,6 +388,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -420,6 +423,7 @@ GameObject:
   - component: {fileID: 4167565504569672}
   - component: {fileID: 61193192194644474}
   - component: {fileID: 114349135786929062}
+  - component: {fileID: 114364956214880162}
   - component: {fileID: 114968749450346888}
   - component: {fileID: 114996715703636540}
   - component: {fileID: 114426269936519498}
@@ -427,7 +431,6 @@ GameObject:
   - component: {fileID: 114959284593202518}
   - component: {fileID: 114428493304418258}
   - component: {fileID: 114899963005649814}
-  - component: {fileID: 114364956214880162}
   - component: {fileID: 114720590840359214}
   - component: {fileID: 114796707213592052}
   m_Layer: 17
@@ -512,6 +515,18 @@ MonoBehaviour:
   openSFX: {fileID: 82338390985291098}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114364956214880162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649904137728258}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114968749450346888
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -765,6 +780,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114899963005649814
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -778,18 +794,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114364956214880162
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1649904137728258}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114720590840359214
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -824,6 +828,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114796707213592052
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -838,8 +843,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 2042991183
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1725845316396368
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/PublicDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/PublicDoor.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -135,6 +136,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -214,6 +216,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -248,6 +251,7 @@ GameObject:
   - component: {fileID: 4000014249828276}
   - component: {fileID: 61000013105870566}
   - component: {fileID: 114000012557435128}
+  - component: {fileID: 114936201514075140}
   - component: {fileID: 114287951213915578}
   - component: {fileID: 114647979991530576}
   - component: {fileID: 114129184533949936}
@@ -255,7 +259,6 @@ GameObject:
   - component: {fileID: 114837052012237978}
   - component: {fileID: 114925179271084826}
   - component: {fileID: 114246988198392272}
-  - component: {fileID: 114936201514075140}
   - component: {fileID: 114120275764581544}
   - component: {fileID: 114852647110043552}
   m_Layer: 18
@@ -340,6 +343,18 @@ MonoBehaviour:
   openSFX: {fileID: 82241881426066012}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114936201514075140
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000013208201100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114287951213915578
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -663,6 +678,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114246988198392272
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -676,18 +692,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114936201514075140
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000013208201100}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114120275764581544
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -722,6 +726,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114852647110043552
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -736,8 +741,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3476840515
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1252112242230248
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/ResearchDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/ResearchDoor.prefab
@@ -547,6 +547,7 @@ GameObject:
   - component: {fileID: 4323373760588200}
   - component: {fileID: 61227424932192340}
   - component: {fileID: 114527851460587104}
+  - component: {fileID: 114411665271381982}
   - component: {fileID: 114071899722853512}
   - component: {fileID: 114740141523933832}
   - component: {fileID: 114513430624311320}
@@ -554,7 +555,6 @@ GameObject:
   - component: {fileID: 114262271484396110}
   - component: {fileID: 114029847589311114}
   - component: {fileID: 114499061253949106}
-  - component: {fileID: 114411665271381982}
   - component: {fileID: 114808882908742840}
   - component: {fileID: 114908063341546646}
   m_Layer: 17
@@ -639,6 +639,18 @@ MonoBehaviour:
   openSFX: {fileID: 82646497274377664}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114411665271381982
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1471265584270754}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114071899722853512
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -906,18 +918,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114411665271381982
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1471265584270754}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114808882908742840
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -967,7 +967,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1491549408370048
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/ScienceDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/ScienceDoor.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -167,6 +168,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -373,6 +375,7 @@ GameObject:
   - component: {fileID: 4748612260957174}
   - component: {fileID: 61064916821730822}
   - component: {fileID: 114116368055496416}
+  - component: {fileID: 114218133984102536}
   - component: {fileID: 114636056436692218}
   - component: {fileID: 114746668465746426}
   - component: {fileID: 114487638215291910}
@@ -380,7 +383,6 @@ GameObject:
   - component: {fileID: 114933752625763360}
   - component: {fileID: 114144917001484400}
   - component: {fileID: 114628056186747552}
-  - component: {fileID: 114218133984102536}
   - component: {fileID: 114542259333970298}
   - component: {fileID: 114505900221247960}
   m_Layer: 17
@@ -465,6 +467,18 @@ MonoBehaviour:
   openSFX: {fileID: 82585580305196082}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114218133984102536
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1703130924713270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114636056436692218
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -718,6 +732,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114628056186747552
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -731,18 +746,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114218133984102536
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1703130924713270}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114542259333970298
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -777,6 +780,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114505900221247960
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -791,8 +795,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 748884229
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1780058016609078
 GameObject:
   m_ObjectHideFlags: 0
@@ -1021,6 +1025,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/SecDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/SecDoor.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -135,6 +136,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -214,6 +216,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -280,6 +283,7 @@ GameObject:
   - component: {fileID: 4234808167028828}
   - component: {fileID: 61622627488599052}
   - component: {fileID: 114716872036012102}
+  - component: {fileID: 114337906859418372}
   - component: {fileID: 114776570776623186}
   - component: {fileID: 114063757892050276}
   - component: {fileID: 114224470283974914}
@@ -287,7 +291,6 @@ GameObject:
   - component: {fileID: 114533986054935752}
   - component: {fileID: 114294399663088630}
   - component: {fileID: 114213890963482172}
-  - component: {fileID: 114337906859418372}
   - component: {fileID: 114393521091076038}
   - component: {fileID: 114999507860870354}
   m_Layer: 17
@@ -372,6 +375,18 @@ MonoBehaviour:
   openSFX: {fileID: 82426556019595742}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114337906859418372
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1488470923909840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114776570776623186
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -625,6 +640,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114213890963482172
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -638,18 +654,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114337906859418372
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488470923909840}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114393521091076038
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -684,6 +688,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114999507860870354
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -698,8 +703,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 1385781523
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1809255076827042
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/Shutters.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/Shutters.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4000014063601880}
   - component: {fileID: 61000011364772196}
   - component: {fileID: 95341735492961758}
+  - component: {fileID: 114857803639874670}
   - component: {fileID: 114640096819736908}
   - component: {fileID: 114056072402202090}
   - component: {fileID: 114820902694638386}
   - component: {fileID: 114639175160094770}
   - component: {fileID: 114254577639162406}
-  - component: {fileID: 114857803639874670}
   - component: {fileID: 114878883059172016}
   - component: {fileID: 114072514322392988}
   m_Layer: 16
@@ -86,6 +86,18 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!114 &114857803639874670
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000010316053548}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114640096819736908
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -147,6 +159,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114254577639162406
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -160,18 +173,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114857803639874670
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000010316053548}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114878883059172016
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -206,6 +207,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114072514322392988
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -220,8 +222,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 1210603535
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1000014037698914
 GameObject:
   m_ObjectHideFlags: 0
@@ -278,6 +280,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -288,7 +291,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1825689229
-  m_SortingLayer: 18
+  m_SortingLayer: 17
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300030, guid: 9357df457aba141c5983326814664ee2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/SpaceshipDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/SpaceshipDoor.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 4891136336376908}
   - component: {fileID: 61800481816224806}
   - component: {fileID: 114459946896903996}
+  - component: {fileID: 114556128449730364}
   - component: {fileID: 114082268845705964}
   - component: {fileID: 114555128303457534}
   - component: {fileID: 114934665753762238}
@@ -18,7 +19,6 @@ GameObject:
   - component: {fileID: 114037208615598810}
   - component: {fileID: 114099541723345954}
   - component: {fileID: 114035779326436766}
-  - component: {fileID: 114556128449730364}
   - component: {fileID: 114237979692699644}
   - component: {fileID: 114236151146984836}
   m_Layer: 18
@@ -103,6 +103,18 @@ MonoBehaviour:
   openSFX: {fileID: 82121942072772510}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114556128449730364
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1067917369029206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114082268845705964
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -346,6 +358,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114035779326436766
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -359,18 +372,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114556128449730364
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1067917369029206}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114237979692699644
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -405,6 +406,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114236151146984836
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -419,8 +421,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3187052238
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1100409614402886
 GameObject:
   m_ObjectHideFlags: 0
@@ -477,6 +479,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -556,6 +559,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -635,6 +639,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/Virology.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/Virology.prefab
@@ -260,6 +260,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -294,6 +295,7 @@ GameObject:
   - component: {fileID: 4204755108866328}
   - component: {fileID: 61825246499241048}
   - component: {fileID: 114767970609396208}
+  - component: {fileID: 114402342960215008}
   - component: {fileID: 114235526540606744}
   - component: {fileID: 114072467774251574}
   - component: {fileID: 114823388259431498}
@@ -301,7 +303,6 @@ GameObject:
   - component: {fileID: 114198649978379182}
   - component: {fileID: 114730684442348350}
   - component: {fileID: 114316500856782408}
-  - component: {fileID: 114402342960215008}
   - component: {fileID: 114746686171187298}
   - component: {fileID: 114653797462880782}
   m_Layer: 17
@@ -386,6 +387,18 @@ MonoBehaviour:
   openSFX: {fileID: 82420744150140008}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114402342960215008
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807313548142900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114235526540606744
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -639,6 +652,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114316500856782408
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -652,18 +666,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114402342960215008
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1807313548142900}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114746686171187298
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -698,6 +700,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114653797462880782
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -712,8 +715,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3419818861
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1828443249856144
 GameObject:
   m_ObjectHideFlags: 0
@@ -942,6 +945,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1021,6 +1025,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/WhiteServiceDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/WhiteServiceDoor.prefab
@@ -171,6 +171,7 @@ GameObject:
   - component: {fileID: 4000011478263398}
   - component: {fileID: 61000012796496776}
   - component: {fileID: 114000011089653234}
+  - component: {fileID: 114787423019724530}
   - component: {fileID: 114672552748689518}
   - component: {fileID: 114644895939695836}
   - component: {fileID: 114937751941926332}
@@ -178,7 +179,6 @@ GameObject:
   - component: {fileID: 114416756673474986}
   - component: {fileID: 114503806518682766}
   - component: {fileID: 114400959280037558}
-  - component: {fileID: 114787423019724530}
   - component: {fileID: 114124740212131036}
   - component: {fileID: 114146222308376800}
   m_Layer: 18
@@ -263,6 +263,18 @@ MonoBehaviour:
   openSFX: {fileID: 82034696694369034}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114787423019724530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000013430947772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114672552748689518
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -566,18 +578,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114787423019724530
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000013430947772}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114124740212131036
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -627,7 +627,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1000013482044110
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/WinDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/WinDoor.prefab
@@ -434,6 +434,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4343317833518374}
   - component: {fileID: 61633824712190514}
+  - component: {fileID: 114793191091603260}
   - component: {fileID: 114424348708298150}
   - component: {fileID: 114029210237443714}
   - component: {fileID: 114719229024385200}
@@ -441,7 +442,6 @@ GameObject:
   - component: {fileID: 114531569165117964}
   - component: {fileID: 114132872333290976}
   - component: {fileID: 114743819203466024}
-  - component: {fileID: 114793191091603260}
   - component: {fileID: 114320171668943648}
   - component: {fileID: 114317237157285656}
   m_Layer: 18
@@ -493,6 +493,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114793191091603260
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1797280918088156}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114424348708298150
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -612,18 +624,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &114793191091603260
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1797280918088156}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114320171668943648
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -673,7 +673,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1811994644492090
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/APC.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/APC.prefab
@@ -10,18 +10,18 @@ GameObject:
   m_Component:
   - component: {fileID: 4205639279356858}
   - component: {fileID: 61247865679427770}
+  - component: {fileID: -3592624819478316981}
+  - component: {fileID: 3892757361480040570}
   - component: {fileID: 114538119136657758}
   - component: {fileID: 114840369580293110}
   - component: {fileID: 114809207030236184}
   - component: {fileID: 5337989651947616586}
   - component: {fileID: 7309201818092580452}
   - component: {fileID: 3643045761793170736}
-  - component: {fileID: 3892757361480040570}
   - component: {fileID: 114272396163984250}
   - component: {fileID: 114348839316776372}
   - component: {fileID: 114168478660762876}
   - component: {fileID: 114619189916669420}
-  - component: {fileID: -3592624819478316981}
   - component: {fileID: 8587603746953740326}
   m_Layer: 19
   m_Name: APC
@@ -72,6 +72,31 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &-3592624819478316981
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1638130848907210}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3892757361480040570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1638130848907210}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d7277dcc993463cb6c7f79b663f36fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetTabType: 6
 --- !u!114 &114538119136657758
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -229,19 +254,6 @@ MonoBehaviour:
   ListCanConnectTo: 09000000
   SelfDestruct: 0
   Reactions: []
---- !u!114 &3892757361480040570
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1638130848907210}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6d7277dcc993463cb6c7f79b663f36fc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  NetTabType: 6
 --- !u!114 &114272396163984250
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -285,6 +297,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114619189916669420
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -299,20 +312,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 1801627989
---- !u!114 &-3592624819478316981
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1638130848907210}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!114 &8587603746953740326
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/DepartmentBattery.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/DepartmentBattery.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 61366423541260584}
   - component: {fileID: 114038174743996046}
   - component: {fileID: 114703946515217786}
+  - component: {fileID: -8468313094457109945}
   - component: {fileID: 114500746951952046}
   - component: {fileID: 114421102744754910}
   - component: {fileID: 3451459747492305769}
@@ -21,7 +22,6 @@ GameObject:
   - component: {fileID: 8556410435183048791}
   - component: {fileID: 114325058325635246}
   - component: {fileID: 114006907476957006}
-  - component: {fileID: -8468313094457109945}
   - component: {fileID: -476175051414813368}
   m_Layer: 11
   m_Name: DepartmentBattery
@@ -132,6 +132,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &-8468313094457109945
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1575520830166772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114500746951952046
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -363,20 +376,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
---- !u!114 &-8468313094457109945
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1575520830166772}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &-476175051414813368
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/FieldGenerator.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/FieldGenerator.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4647312529661892}
+  - component: {fileID: 114722768857009208}
   - component: {fileID: 114590706900826186}
   - component: {fileID: 61697181358093446}
   - component: {fileID: 61444365541677466}
@@ -18,7 +19,6 @@ GameObject:
   - component: {fileID: 1461403780681083615}
   - component: {fileID: 1120991291872144437}
   - component: {fileID: 114258488119912856}
-  - component: {fileID: 114722768857009208}
   - component: {fileID: 114211369790186800}
   - component: {fileID: 114104876763743222}
   m_Layer: 11
@@ -43,6 +43,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114722768857009208
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1305738920282892}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114590706900826186
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -163,6 +175,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &3903394726411491279
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -259,18 +272,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114722768857009208
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1305738920282892}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114211369790186800
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -305,6 +306,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114104876763743222
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -319,8 +321,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 2659409449
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1712574560713454
 GameObject:
   m_ObjectHideFlags: 0
@@ -377,6 +379,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/SMES.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/SMES.prefab
@@ -93,6 +93,7 @@ GameObject:
   - component: {fileID: 61366423541260584}
   - component: {fileID: 114038174743996046}
   - component: {fileID: 114703946515217786}
+  - component: {fileID: -6323473989204236853}
   - component: {fileID: 114705152130084640}
   - component: {fileID: 1302529419740996430}
   - component: {fileID: 2683382063024116834}
@@ -100,7 +101,6 @@ GameObject:
   - component: {fileID: 2504760058904090374}
   - component: {fileID: 114897658894920132}
   - component: {fileID: 114429980035310924}
-  - component: {fileID: -6323473989204236853}
   - component: {fileID: 3432798136324343086}
   m_Layer: 11
   m_Name: SMES
@@ -211,6 +211,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &-6323473989204236853
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1575520830166772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114705152130084640
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -408,20 +421,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 2883979192
---- !u!114 &-6323473989204236853
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1575520830166772}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!114 &3432798136324343086
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/VIR_LowVoltageMachineConnector.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/VIR_LowVoltageMachineConnector.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4025345055859194}
   - component: {fileID: 114947796331066130}
+  - component: {fileID: 870447227101467930}
   - component: {fileID: 114217685053654352}
   - component: {fileID: 114008051345712512}
   - component: {fileID: 5437261449283511172}
@@ -17,7 +18,6 @@ GameObject:
   - component: {fileID: 61506100139303226}
   - component: {fileID: 114004853824327828}
   - component: {fileID: 114328546139034518}
-  - component: {fileID: 870447227101467930}
   - component: {fileID: -8286469531888557596}
   m_Layer: 22
   m_Name: VIR_LowVoltageMachineConnector
@@ -61,9 +61,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
+--- !u!114 &870447227101467930
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1127054139694796}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114217685053654352
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -208,20 +217,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 4218490625
---- !u!114 &870447227101467930
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1127054139694796}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!114 &-8286469531888557596
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/VIR_MediumMachine character.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/VIR_MediumMachine character.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4025345055859194}
   - component: {fileID: 114947796331066130}
+  - component: {fileID: -3181088053320797584}
   - component: {fileID: 114906788329055910}
   - component: {fileID: 114008051345712512}
   - component: {fileID: 114969823251644552}
@@ -17,7 +18,6 @@ GameObject:
   - component: {fileID: 3643008678441238377}
   - component: {fileID: 114854152648262332}
   - component: {fileID: 114828964617408344}
-  - component: {fileID: -3181088053320797584}
   - component: {fileID: -645348354636420746}
   m_Layer: 22
   m_Name: VIR_MediumMachine character
@@ -61,9 +61,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
-  crossed:
-    m_PersistentCalls:
-      m_Calls: []
+--- !u!114 &-3181088053320797584
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1127054139694796}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114906788329055910
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -208,20 +217,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 2807249486
---- !u!114 &-3181088053320797584
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1127054139694796}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!114 &-645348354636420746
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/bed.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/bed.prefab
@@ -90,11 +90,11 @@ GameObject:
   m_Component:
   - component: {fileID: 4759473417489106}
   - component: {fileID: 61542989738847636}
+  - component: {fileID: 114175700939651864}
   - component: {fileID: 8536537474672733830}
   - component: {fileID: 114728226944580436}
   - component: {fileID: 114638872430197162}
   - component: {fileID: 114498668641564784}
-  - component: {fileID: 114175700939651864}
   - component: {fileID: 114167651192437712}
   - component: {fileID: 684769290395936646}
   - component: {fileID: 114626364792080042}
@@ -146,6 +146,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114175700939651864
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1609215198608670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &8536537474672733830
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,18 +217,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114175700939651864
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1609215198608670}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114167651192437712
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -282,5 +282,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 47123d0f42584c444bdede9f29da2438
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/metal_chair.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/metal_chair.prefab
@@ -10,13 +10,13 @@ GameObject:
   m_Component:
   - component: {fileID: 4905743905385754}
   - component: {fileID: 61595398863923038}
+  - component: {fileID: 114189510743418800}
   - component: {fileID: 9048663693282033040}
   - component: {fileID: 114601193997943186}
   - component: {fileID: 114055517453558958}
   - component: {fileID: 114338334281631116}
   - component: {fileID: 8641185870989047510}
   - component: {fileID: 8992642222336011252}
-  - component: {fileID: 114189510743418800}
   - component: {fileID: 114176516835243776}
   - component: {fileID: 114383195819837994}
   m_Layer: 23
@@ -68,6 +68,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114189510743418800
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1169897606440870}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &9048663693282033040
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,18 +179,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114189510743418800
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1169897606440870}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114176516835243776
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -228,7 +228,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 281a9627782b7bd4a9ad7283af0300ce
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1581991274901662
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/DinnerWareVendor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/DinnerWareVendor.prefab
@@ -57,6 +57,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -109,10 +110,10 @@ GameObject:
   - component: {fileID: 114737298292197450}
   - component: {fileID: 61926733661208534}
   - component: {fileID: 114418060968581254}
+  - component: {fileID: 114869464615547648}
   - component: {fileID: 8473214172519441615}
   - component: {fileID: 5612805261423721810}
   - component: {fileID: 114047225924766264}
-  - component: {fileID: 114869464615547648}
   - component: {fileID: 114887499896345430}
   - component: {fileID: 114168230066825450}
   m_Layer: 11
@@ -247,6 +248,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
+--- !u!114 &114869464615547648
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000013211423706}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &8473214172519441615
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -259,8 +273,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8ed381a72f1e344bb8020dc181414b43, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   VendorContent:
   - Item: {fileID: 1000011622113908, guid: fc5783dcb3f74ab1b2187da95b6c932d, type: 3}
     Stock: 5
@@ -297,18 +309,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114869464615547648
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000013211423706}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114887499896345430
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -343,6 +343,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114168230066825450
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -357,5 +358,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 2137820972
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/FoodCart.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/FoodCart.prefab
@@ -91,12 +91,12 @@ GameObject:
   - component: {fileID: 4000013836882314}
   - component: {fileID: 61000010556243922}
   - component: {fileID: 61296298072299154}
+  - component: {fileID: 114005397856953186}
   - component: {fileID: 114585462459452276}
   - component: {fileID: 114969507595526308}
   - component: {fileID: 114101716766838300}
   - component: {fileID: 2893974677095702031}
   - component: {fileID: 114965468110209590}
-  - component: {fileID: 114005397856953186}
   - component: {fileID: 114657714564364446}
   - component: {fileID: 114994120514330062}
   m_Layer: 11
@@ -173,6 +173,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114005397856953186
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011358831344}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114585462459452276
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -252,18 +264,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114005397856953186
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000011358831344}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114657714564364446
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -313,5 +313,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/Gibber.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/Gibber.prefab
@@ -11,13 +11,13 @@ GameObject:
   - component: {fileID: 4734668451131728}
   - component: {fileID: 61352393546771900}
   - component: {fileID: 61396788385139568}
+  - component: {fileID: 114337780428805880}
   - component: {fileID: 114180727939927124}
   - component: {fileID: 114320204715381500}
   - component: {fileID: 61959303962396766}
   - component: {fileID: 114027247402343528}
   - component: {fileID: 2013712145609182859}
   - component: {fileID: 114681733432307198}
-  - component: {fileID: 114337780428805880}
   - component: {fileID: 114847357675988776}
   - component: {fileID: 114226404326177330}
   m_Layer: 11
@@ -95,6 +95,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114337780428805880
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1058895993067106}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114180727939927124
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -196,18 +208,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114337780428805880
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1058895993067106}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114847357675988776
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -257,7 +257,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1367537609961248
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/Microwave.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/Microwave.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4000011140861540}
   - component: {fileID: 61000014178328654}
   - component: {fileID: 82554502596860898}
+  - component: {fileID: 114057145851387186}
   - component: {fileID: 114226724488088840}
   - component: {fileID: 114643057465573826}
   - component: {fileID: 114977697586778270}
   - component: {fileID: 114348264163667782}
-  - component: {fileID: 114057145851387186}
   - component: {fileID: 114203140017427936}
   - component: {fileID: 114971658974239060}
   - component: {fileID: 114085600953189384}
@@ -163,6 +163,18 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
+--- !u!114 &114057145851387186
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000010765165894}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114226724488088840
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -222,18 +234,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114057145851387186
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000010765165894}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114203140017427936
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -298,7 +298,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1000010906387252
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/Refrigerator.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/Refrigerator.prefab
@@ -91,11 +91,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4000012120925626}
+  - component: {fileID: 114340165100671152}
   - component: {fileID: 114759099205373710}
   - component: {fileID: 61865588668533116}
   - component: {fileID: 114767645651203294}
   - component: {fileID: 114644010719156962}
-  - component: {fileID: 114340165100671152}
   - component: {fileID: 114687831839695146}
   - component: {fileID: 114522011428669004}
   - component: {fileID: 114887182886586962}
@@ -123,6 +123,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114340165100671152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000013052373872}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114759099205373710
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -137,7 +149,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 114522763113633208}
@@ -205,18 +217,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114340165100671152
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000013052373872}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114687831839695146
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -281,7 +281,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: a5a41da50b7c4d0db05bff38a6996260
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!114 &391860069733632804
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/SmartFridge.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/SmartFridge.prefab
@@ -13,10 +13,10 @@ GameObject:
   - component: {fileID: 61065945433850934}
   - component: {fileID: 114312756739737956}
   - component: {fileID: 114010932235653022}
-  - component: {fileID: 525738165772301342}
-  - component: {fileID: 5787332934185140899}
-  - component: {fileID: 114893308072197662}
   - component: {fileID: 114781087812551048}
+  - component: {fileID: 5787332934185140899}
+  - component: {fileID: 525738165772301342}
+  - component: {fileID: 114893308072197662}
   - component: {fileID: 114490796894361376}
   - component: {fileID: 114407379193247608}
   m_Layer: 11
@@ -126,6 +126,31 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114781087812551048
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000013344912928}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5787332934185140899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000013344912928}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d7277dcc993463cb6c7f79b663f36fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetTabType: 0
 --- !u!114 &525738165772301342
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -150,19 +175,6 @@ MonoBehaviour:
   HullColor: {r: 0.98039216, g: 0.972549, b: 0.972549, a: 1}
   EjectObjects: 0
   EjectDirection: 0
---- !u!114 &5787332934185140899
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000013344912928}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6d7277dcc993463cb6c7f79b663f36fc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  NetTabType: 0
 --- !u!114 &114893308072197662
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -176,18 +188,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114781087812551048
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000013344912928}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114490796894361376
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -237,7 +237,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 8415a5df4c61423dacd6b94592fd8e72
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1000013897877296
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/kitchen_1.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/kitchen_1.prefab
@@ -91,12 +91,12 @@ GameObject:
   - component: {fileID: 4029966181796116}
   - component: {fileID: 61803746773692450}
   - component: {fileID: 61932274647132618}
+  - component: {fileID: 114012712933916654}
   - component: {fileID: 114703331788313678}
   - component: {fileID: 114294245173373084}
   - component: {fileID: 114638907353670626}
   - component: {fileID: 4452113284100863044}
   - component: {fileID: 114036182614911014}
-  - component: {fileID: 114012712933916654}
   - component: {fileID: 114523074382699150}
   - component: {fileID: 114312522063247970}
   m_Layer: 11
@@ -173,6 +173,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114012712933916654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1539789314040182}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114703331788313678
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,18 +262,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114012712933916654
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1539789314040182}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114523074382699150
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -311,5 +311,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/kitchen_2.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/kitchen_2.prefab
@@ -91,12 +91,12 @@ GameObject:
   - component: {fileID: 4144421296827670}
   - component: {fileID: 61749927792347462}
   - component: {fileID: 61212157609306960}
+  - component: {fileID: 114823277481007850}
   - component: {fileID: 114762731618527884}
   - component: {fileID: 114392787270580666}
   - component: {fileID: 114458678934354534}
   - component: {fileID: 69478300063108000}
   - component: {fileID: 114682177732088168}
-  - component: {fileID: 114823277481007850}
   - component: {fileID: 114237837769881030}
   - component: {fileID: 114058516359569840}
   m_Layer: 11
@@ -173,6 +173,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114823277481007850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1751984553619856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114762731618527884
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,18 +262,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114823277481007850
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1751984553619856}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114237837769881030
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -311,5 +311,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/kitchen_58.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/kitchen_58.prefab
@@ -91,12 +91,12 @@ GameObject:
   - component: {fileID: 4667768644863624}
   - component: {fileID: 61547189736919662}
   - component: {fileID: 61513006529587702}
+  - component: {fileID: 114892356372757746}
   - component: {fileID: 114668526465205184}
   - component: {fileID: 114294952158468094}
   - component: {fileID: 114576026829816668}
   - component: {fileID: 9083440936198049442}
   - component: {fileID: 114212809293836738}
-  - component: {fileID: 114892356372757746}
   - component: {fileID: 114839175629978664}
   - component: {fileID: 114999509781892224}
   m_Layer: 11
@@ -173,6 +173,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114892356372757746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1867260642268590}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114668526465205184
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -248,18 +260,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114892356372757746
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1867260642268590}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114839175629978664
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -309,5 +309,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/kitchen_60.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/kitchen_60.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4466176758832028}
   - component: {fileID: 61873695731418744}
   - component: {fileID: 61068753471145350}
+  - component: {fileID: 114494880147442136}
   - component: {fileID: 114068128721699304}
   - component: {fileID: 114360944403272528}
   - component: {fileID: 114702170245798982}
   - component: {fileID: 7072840375899318138}
   - component: {fileID: 114236524552828258}
-  - component: {fileID: 114494880147442136}
   - component: {fileID: 114125262972053904}
   - component: {fileID: 114414808644966794}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114494880147442136
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883046252454388}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114068128721699304
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,18 +180,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114494880147442136
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1883046252454388}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114125262972053904
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -229,7 +229,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1884255579492132
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Library/library_1.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Library/library_1.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4565145403298492}
   - component: {fileID: 61907205426723402}
   - component: {fileID: 61828601808675306}
+  - component: {fileID: 114185696473753504}
   - component: {fileID: 114089415072229660}
   - component: {fileID: 114351494878950674}
   - component: {fileID: 114737151936151896}
   - component: {fileID: 114797502105998804}
-  - component: {fileID: 114185696473753504}
   - component: {fileID: 114631850848208250}
   - component: {fileID: 114765052790037288}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114185696473753504
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1468530452120236}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114089415072229660
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,18 +243,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114185696473753504
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1468530452120236}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114631850848208250
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -292,5 +292,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Library/library_16.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Library/library_16.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4183915456150636}
   - component: {fileID: 61411671645371586}
   - component: {fileID: 61775511274652004}
+  - component: {fileID: 114170115696704740}
   - component: {fileID: 114289210889667374}
   - component: {fileID: 114811028013375792}
   - component: {fileID: 114329835983415444}
   - component: {fileID: 114690929241432008}
-  - component: {fileID: 114170115696704740}
   - component: {fileID: 114879672812678722}
   - component: {fileID: 114916626451936824}
   m_Layer: 11
@@ -92,6 +92,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114170115696704740
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1147365206990882}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114289210889667374
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -151,18 +163,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114170115696704740
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1147365206990882}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114879672812678722
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,7 +212,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1535613627215266
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Library/library_17.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Library/library_17.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4444041875581058}
   - component: {fileID: 61567620803228916}
   - component: {fileID: 61349128036915478}
+  - component: {fileID: 114040327461295660}
   - component: {fileID: 114640577171960680}
   - component: {fileID: 114648981082683144}
   - component: {fileID: 114024347346030618}
   - component: {fileID: 114775432733148844}
-  - component: {fileID: 114040327461295660}
   - component: {fileID: 114127890465708066}
   - component: {fileID: 114828171744822874}
   m_Layer: 11
@@ -92,6 +92,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114040327461295660
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1473141577548690}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114640577171960680
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -151,18 +163,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114040327461295660
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1473141577548690}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114127890465708066
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,7 +212,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1761031683560858
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Library/library_22.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Library/library_22.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4935453910410470}
   - component: {fileID: 61318521377750894}
   - component: {fileID: 61269487335202012}
+  - component: {fileID: 114040185783655172}
   - component: {fileID: 114822711099070390}
   - component: {fileID: 114175792750307930}
   - component: {fileID: 114164894262585894}
   - component: {fileID: 114741405229011804}
-  - component: {fileID: 114040185783655172}
   - component: {fileID: 114548144553307966}
   - component: {fileID: 114526617574379078}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114040185783655172
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1333219615532306}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114822711099070390
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,18 +243,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114040185783655172
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1333219615532306}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114548144553307966
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -292,5 +292,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Library/library_29.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Library/library_29.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4378753459020184}
   - component: {fileID: 61638367490018656}
   - component: {fileID: 61311899592847206}
+  - component: {fileID: 114857230938904928}
   - component: {fileID: 114287391478463910}
   - component: {fileID: 114725628649511992}
   - component: {fileID: 114475860773099416}
   - component: {fileID: 114074672574213552}
-  - component: {fileID: 114857230938904928}
   - component: {fileID: 114377819143740478}
   - component: {fileID: 114332010292109568}
   m_Layer: 11
@@ -92,6 +92,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114857230938904928
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1794279790554174}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114287391478463910
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -151,18 +163,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114857230938904928
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1794279790554174}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114377819143740478
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,7 +212,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1906618533940164
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Medical/BluespaceBodyBag.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Medical/BluespaceBodyBag.prefab
@@ -12,12 +12,12 @@ GameObject:
   - component: {fileID: 6731728321784917618}
   - component: {fileID: 3038011448654529925}
   - component: {fileID: 8345129679702463860}
-  - component: {fileID: 2705797924642854530}
+  - component: {fileID: 8444025109147823341}
   - component: {fileID: 2074079411905809823}
+  - component: {fileID: 2705797924642854530}
   - component: {fileID: 4733810172940174988}
   - component: {fileID: 3263870368252374070}
   - component: {fileID: 2170628449131254784}
-  - component: {fileID: 8444025109147823341}
   - component: {fileID: 2790500944196246186}
   - component: {fileID: 988237533008200232}
   - component: {fileID: 8770403083761675918}
@@ -112,7 +112,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &2705797924642854530
+--- !u!114 &8444025109147823341
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -121,11 +121,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 3055497906850374734}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3d80668073924c6a819f2671001f1fe8, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  prefabVariant: {fileID: 5474488674200563466, guid: 63c9a0ba448fa47b7aebb5e45f4b1167,
-    type: 3}
 --- !u!114 &2074079411905809823
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -140,7 +138,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 0
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -150,6 +148,20 @@ MonoBehaviour:
   statusSync: 2
   doorOpened: {fileID: 21300000, guid: 48ecbee7156165642a243144273386e5, type: 3}
   spriteRenderer: {fileID: 3321031949753315050}
+--- !u!114 &2705797924642854530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3055497906850374734}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d80668073924c6a819f2671001f1fe8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prefabVariant: {fileID: 5474488674200563466, guid: 63c9a0ba448fa47b7aebb5e45f4b1167,
+    type: 3}
 --- !u!114 &4733810172940174988
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -198,18 +210,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &8444025109147823341
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3055497906850374734}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &2790500944196246186
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -259,7 +259,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!114 &8770403083761675918
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Medical/BodyBag.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Medical/BodyBag.prefab
@@ -12,12 +12,12 @@ GameObject:
   - component: {fileID: 5356096613843325042}
   - component: {fileID: 5115763253594566977}
   - component: {fileID: 7131390043218951289}
-  - component: {fileID: 3454878196567402495}
+  - component: {fileID: 6772364848836299487}
   - component: {fileID: 5190175475481606144}
+  - component: {fileID: 3454878196567402495}
   - component: {fileID: 7980705040523986758}
   - component: {fileID: 352345922348454203}
   - component: {fileID: 1469759712343314486}
-  - component: {fileID: 6772364848836299487}
   - component: {fileID: 8742827382765301170}
   - component: {fileID: 5549330274845593174}
   - component: {fileID: 7759675923938615605}
@@ -112,7 +112,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &3454878196567402495
+--- !u!114 &6772364848836299487
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -121,11 +121,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 529109779100470021}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3d80668073924c6a819f2671001f1fe8, type: 3}
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  prefabVariant: {fileID: 5620111257449852176, guid: a21353068392d4a7298ca43e3c7f997b,
-    type: 3}
 --- !u!114 &5190175475481606144
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -150,6 +148,20 @@ MonoBehaviour:
   statusSync: 2
   doorOpened: {fileID: 21300000, guid: c4c8e4f0eae328d4abb69b55a4a37752, type: 3}
   spriteRenderer: {fileID: 7293602500519226833}
+--- !u!114 &3454878196567402495
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 529109779100470021}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d80668073924c6a819f2671001f1fe8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prefabVariant: {fileID: 5620111257449852176, guid: a21353068392d4a7298ca43e3c7f997b,
+    type: 3}
 --- !u!114 &7980705040523986758
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -198,18 +210,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &6772364848836299487
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 529109779100470021}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &8742827382765301170
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -259,7 +259,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!114 &7759675923938615605
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Medical/Cryogenic2/Cryogenic2_63.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Medical/Cryogenic2/Cryogenic2_63.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4394745035888168}
   - component: {fileID: 61054170799917302}
   - component: {fileID: 61828212124744490}
+  - component: {fileID: 114956339807306816}
   - component: {fileID: 114138375094823538}
   - component: {fileID: 114635937697434958}
   - component: {fileID: 114111448524298732}
   - component: {fileID: 114642480618045628}
-  - component: {fileID: 114956339807306816}
   - component: {fileID: 114686357817313810}
   - component: {fileID: 114159545982335982}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114956339807306816
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1893643997622116}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114138375094823538
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,18 +243,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114956339807306816
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1893643997622116}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114686357817313810
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -292,5 +292,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: bcf6f9908f2814377b1071eeae042987
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Medical/Cryogenic2/Cryogenic2_98.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Medical/Cryogenic2/Cryogenic2_98.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4251723224821666}
   - component: {fileID: 61825483424478004}
   - component: {fileID: 61049774012001146}
+  - component: {fileID: 114657020474330800}
   - component: {fileID: 114944457297235808}
   - component: {fileID: 114215485290820220}
   - component: {fileID: 114322510274770602}
   - component: {fileID: 114821566562252132}
-  - component: {fileID: 114657020474330800}
   - component: {fileID: 114041748982974356}
   - component: {fileID: 114820595845249396}
   m_Layer: 11
@@ -92,6 +92,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114657020474330800
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1191112353003356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114944457297235808
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -151,18 +163,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114657020474330800
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1191112353003356}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114041748982974356
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,7 +212,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 675bc7b09d0b644c2a18ae140b4003a6
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1783734983500956
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Medical/FoldedBluespaceBodyBag.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Medical/FoldedBluespaceBodyBag.prefab
@@ -95,9 +95,9 @@ GameObject:
   - component: {fileID: 3708183737056045869}
   - component: {fileID: 8660130930388877041}
   - component: {fileID: 3608028946632254207}
+  - component: {fileID: 6131961916030040304}
   - component: {fileID: 8030091416075537494}
   - component: {fileID: 3912772081314498544}
-  - component: {fileID: 6131961916030040304}
   - component: {fileID: 232133090902815782}
   - component: {fileID: 9011093994975062449}
   - component: {fileID: 3601667555067628660}
@@ -207,7 +207,7 @@ MonoBehaviour:
   initialTraits: []
   size: 2
   spriteType: 0
-  CanConnectToTank: 0
+  canConnectToTank: 0
   hitDamage: 0
   damageType: 0
   throwDamage: 0
@@ -247,6 +247,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &6131961916030040304
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5474488674200563466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &8030091416075537494
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -274,18 +286,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &6131961916030040304
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5474488674200563466}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &232133090902815782
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -335,7 +335,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!114 &3601667555067628660
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Medical/FoldedBodyBag.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Medical/FoldedBodyBag.prefab
@@ -15,9 +15,9 @@ GameObject:
   - component: {fileID: 645373707633738118}
   - component: {fileID: 2750812223248454435}
   - component: {fileID: 8719630062288667462}
+  - component: {fileID: 6487628113956004103}
   - component: {fileID: 4668401069542360656}
   - component: {fileID: 5355423063329961544}
-  - component: {fileID: 6487628113956004103}
   - component: {fileID: 6444598946028513662}
   - component: {fileID: 8213862876224306985}
   - component: {fileID: 1687833025890641942}
@@ -166,6 +166,18 @@ MonoBehaviour:
   syncInterval: 0.1
   layer: {fileID: 0}
   ObjectType: 0
+--- !u!114 &6487628113956004103
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5620111257449852176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &4668401069542360656
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -193,18 +205,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &6487628113956004103
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5620111257449852176}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &6444598946028513662
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -254,7 +254,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!114 &1687833025890641942
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Medical/Genetics/DNA_Scanner.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Medical/Genetics/DNA_Scanner.prefab
@@ -90,13 +90,13 @@ GameObject:
   m_Component:
   - component: {fileID: 4715117052207926}
   - component: {fileID: 61404138305600890}
+  - component: {fileID: 114529692711081598}
   - component: {fileID: 9128197607768152992}
   - component: {fileID: 114657711786529776}
   - component: {fileID: 5322609074420117545}
   - component: {fileID: 2464575245303528366}
   - component: {fileID: 5293454678208234974}
   - component: {fileID: 114532654656294352}
-  - component: {fileID: 114529692711081598}
   - component: {fileID: 114039584032850022}
   - component: {fileID: 390125877411094447}
   - component: {fileID: 4585042576726451927}
@@ -149,6 +149,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114529692711081598
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711816394935574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &9128197607768152992
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -163,7 +175,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  DefaultContents: []
+  initialContents: {fileID: 0}
   IsClosed: 1
   IsLocked: 0
   lockLight: {fileID: 0}
@@ -259,18 +271,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114529692711081598
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1711816394935574}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114039584032850022
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -319,6 +319,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Infos:
+    SpriteAndData:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
     spriteIndex: 0
     VariantIndex: 0
     AID: 27
@@ -476,5 +480,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 2395452554
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Medical/cloning_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Medical/cloning_0.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -76,7 +77,7 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!1 &1671969700958660
@@ -89,13 +90,13 @@ GameObject:
   m_Component:
   - component: {fileID: 4083625178683586}
   - component: {fileID: 61870206456321914}
+  - component: {fileID: 6925838030105335091}
   - component: {fileID: 8210323885322932869}
   - component: {fileID: 3673450989709832100}
   - component: {fileID: 114793930797753706}
   - component: {fileID: 114465014309967340}
   - component: {fileID: 114272959470978344}
   - component: {fileID: 934759992999344732}
-  - component: {fileID: 6925838030105335091}
   - component: {fileID: 4996135738252831923}
   - component: {fileID: 114141448509805176}
   m_Layer: 11
@@ -146,6 +147,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &6925838030105335091
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1671969700958660}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &8210323885322932869
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -181,7 +194,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  parentContainer: {fileID: 0}
   isNotPushable: 1
 --- !u!114 &114793930797753706
 MonoBehaviour:
@@ -215,6 +227,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114272959470978344
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -244,18 +257,6 @@ MonoBehaviour:
   backgroundColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   iconOverride: {fileID: 0}
   backgroundSprite: {fileID: 0}
---- !u!114 &6925838030105335091
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1671969700958660}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &4996135738252831923
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -290,6 +291,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114141448509805176
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -304,5 +306,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 2800176233
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Mining/mining_machines_34.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Mining/mining_machines_34.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4133012119868568}
   - component: {fileID: 61910813138851890}
   - component: {fileID: 61266689956877426}
+  - component: {fileID: 114077427598303000}
   - component: {fileID: 114749397987692030}
   - component: {fileID: 114544178280881718}
   - component: {fileID: 114442470563310948}
   - component: {fileID: 114841467697099240}
-  - component: {fileID: 114077427598303000}
   - component: {fileID: 114333039172537670}
   - component: {fileID: 114765053464709362}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114077427598303000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1838427742262268}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114749397987692030
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,18 +243,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114077427598303000
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1838427742262268}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114333039172537670
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -292,5 +292,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: f3277c354886f47d0a9d58e4ad69f8af
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Mining/mining_machines_46.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Mining/mining_machines_46.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4251782458226524}
   - component: {fileID: 61253315145502246}
   - component: {fileID: 61640450994276336}
+  - component: {fileID: 114488470715414510}
   - component: {fileID: 114100651845113182}
   - component: {fileID: 114643910341184668}
   - component: {fileID: 114331673985486056}
   - component: {fileID: 114118267668157820}
-  - component: {fileID: 114488470715414510}
   - component: {fileID: 114504161376742898}
   - component: {fileID: 114603017410074712}
   m_Layer: 11
@@ -92,6 +92,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114488470715414510
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1956934682388648}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114100651845113182
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -151,18 +163,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114488470715414510
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1956934682388648}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114504161376742898
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,7 +212,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 2f166541b5c4147c6b6f799beb31aa73
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1978739497846634
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Mining/mining_machines_54.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Mining/mining_machines_54.prefab
@@ -91,12 +91,12 @@ GameObject:
   - component: {fileID: 4600215391598352}
   - component: {fileID: 61553389341611554}
   - component: {fileID: 61108834247246526}
+  - component: {fileID: 114553154410610264}
+  - component: {fileID: 6253077211462791056}
   - component: {fileID: 114770512620025736}
   - component: {fileID: 114030207048474028}
   - component: {fileID: 114404534068749718}
-  - component: {fileID: 6253077211462791056}
   - component: {fileID: 114774815397134544}
-  - component: {fileID: 114553154410610264}
   - component: {fileID: 114698186089058472}
   - component: {fileID: 114430213137055408}
   m_Layer: 11
@@ -173,6 +173,31 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114553154410610264
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1148151089360074}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6253077211462791056
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1148151089360074}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d7277dcc993463cb6c7f79b663f36fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetTabType: 0
 --- !u!114 &114770512620025736
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -226,19 +251,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &6253077211462791056
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1148151089360074}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6d7277dcc993463cb6c7f79b663f36fc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  NetTabType: 0
 --- !u!114 &114774815397134544
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -252,18 +264,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114553154410610264
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1148151089360074}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114698186089058472
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -313,5 +313,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 8e03aa759c4c84574af1a9542be7093c
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/Spawner Turret.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/Spawner Turret.prefab
@@ -14,9 +14,9 @@ GameObject:
   - component: {fileID: 114584853831947100}
   - component: {fileID: 114323871763878754}
   - component: {fileID: 1133233680905039252}
+  - component: {fileID: 114855591448838058}
   - component: {fileID: 569383579459477248}
   - component: {fileID: 114844949805318444}
-  - component: {fileID: 114855591448838058}
   - component: {fileID: 114256258113864384}
   - component: {fileID: 114811512301134758}
   m_Layer: 11
@@ -125,6 +125,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &1133233680905039252
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -140,8 +141,19 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  parentContainer: {fileID: 0}
   isNotPushable: 0
+--- !u!114 &114855591448838058
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1395871990776010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &569383579459477248
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,18 +180,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114855591448838058
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1395871990776010}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114256258113864384
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -214,6 +214,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114811512301134758
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -228,8 +229,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3031946139
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1587334133710578
 GameObject:
   m_ObjectHideFlags: 0
@@ -286,6 +287,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/virology_10.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/virology_10.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -90,11 +91,11 @@ GameObject:
   - component: {fileID: 4714233141986244}
   - component: {fileID: 61488477938033214}
   - component: {fileID: 61463644908129064}
+  - component: {fileID: 114157081320625330}
   - component: {fileID: 114466637629456492}
   - component: {fileID: 114156069719369178}
   - component: {fileID: 114650667704552480}
   - component: {fileID: 114485287611980372}
-  - component: {fileID: 114157081320625330}
   - component: {fileID: 114941927157724086}
   - component: {fileID: 114139291964300218}
   m_Layer: 11
@@ -171,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114157081320625330
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1709509557121994}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114466637629456492
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -183,8 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58b822814682f460baa30059c4fd7f42, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   Message: Someone seems to have spilled liquid over the controls...
 --- !u!114 &114156069719369178
 MonoBehaviour:
@@ -218,6 +229,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114485287611980372
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,18 +243,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114157081320625330
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1709509557121994}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114941927157724086
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -277,6 +277,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114139291964300218
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -291,5 +292,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 2724618954
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/virology_16.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/virology_16.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4080535358746652}
   - component: {fileID: 61471094807506188}
   - component: {fileID: 61245833938444904}
+  - component: {fileID: 114833393703594538}
   - component: {fileID: 114383420103792714}
   - component: {fileID: 114119700415930210}
   - component: {fileID: 114035729701312404}
   - component: {fileID: 114696329622343504}
-  - component: {fileID: 114833393703594538}
   - component: {fileID: 114639833623588114}
   - component: {fileID: 114722453196611254}
   m_Layer: 11
@@ -92,6 +92,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114833393703594538
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1277573235473004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114383420103792714
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -104,8 +116,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58b822814682f460baa30059c4fd7f42, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   Message: Rater not touch this.... Who knows what has been in here?
 --- !u!114 &114119700415930210
 MonoBehaviour:
@@ -139,6 +149,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114696329622343504
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -152,18 +163,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114833393703594538
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1277573235473004}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114639833623588114
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -198,6 +197,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114722453196611254
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,8 +212,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 3772738757
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1399995917686288
 GameObject:
   m_ObjectHideFlags: 0
@@ -270,6 +270,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/washing_machine_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/washing_machine_0.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4113275882230610}
   - component: {fileID: 61733910100739344}
   - component: {fileID: 61258973622839504}
+  - component: {fileID: 114299341194960316}
   - component: {fileID: 114179702189733858}
   - component: {fileID: 114847283536098970}
   - component: {fileID: 114291218838927596}
   - component: {fileID: 114783204097868630}
-  - component: {fileID: 114299341194960316}
   - component: {fileID: 114310274171566966}
   - component: {fileID: 114024806994885904}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114299341194960316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1710115528436200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114179702189733858
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,18 +243,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114299341194960316
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1710115528436200}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114310274171566966
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -292,5 +292,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 13c6456f6969e4016997c043c2b62103
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/washing_machine_12.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/washing_machine_12.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4579640422876074}
   - component: {fileID: 61911433637712416}
   - component: {fileID: 61208635337344062}
+  - component: {fileID: 114866433971723904}
   - component: {fileID: 114707962163511360}
   - component: {fileID: 114366094499234188}
   - component: {fileID: 114077473371981760}
   - component: {fileID: 114881753031283620}
-  - component: {fileID: 114866433971723904}
   - component: {fileID: 114865412225388544}
   - component: {fileID: 114355026317012534}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114866433971723904
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1889486371327234}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114707962163511360
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,18 +243,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114866433971723904
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1889486371327234}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114865412225388544
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -292,5 +292,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: c8e7df404e1c64b65bd7e6d3e72ecc76
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Nuke/nuke.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Nuke/nuke.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -91,13 +92,13 @@ GameObject:
   - component: {fileID: 61248892928775766}
   - component: {fileID: 61315118008336824}
   - component: {fileID: 114558280790144458}
+  - component: {fileID: 114966510063373710}
   - component: {fileID: 114958218028397826}
   - component: {fileID: 114970301685184636}
   - component: {fileID: 114285602872890758}
   - component: {fileID: 3598894608692613034}
   - component: {fileID: 8332996165049030563}
   - component: {fileID: 114093552067593536}
-  - component: {fileID: 114966510063373710}
   - component: {fileID: 114554877333081812}
   - component: {fileID: 114138874156132524}
   m_Layer: 11
@@ -192,6 +193,18 @@ MonoBehaviour:
   ObjectType: 1
   AtmosPassable: 1
   Passable: 0
+--- !u!114 &114966510063373710
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1754288526301548}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114958218028397826
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -223,6 +236,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114285602872890758
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,7 +264,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  parentContainer: {fileID: 0}
   isNotPushable: 0
 --- !u!114 &8332996165049030563
 MonoBehaviour:
@@ -278,18 +291,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114966510063373710
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1754288526301548}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114554877333081812
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -324,6 +325,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114138874156132524
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -338,5 +340,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 113069566
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Research/research_122.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Research/research_122.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4601284643095036}
   - component: {fileID: 61167198093582328}
   - component: {fileID: 61175347420130598}
+  - component: {fileID: 114146527219243736}
   - component: {fileID: 114959499686943088}
   - component: {fileID: 114183482789793122}
   - component: {fileID: 114039797110835184}
   - component: {fileID: 114932806902075278}
-  - component: {fileID: 114146527219243736}
   - component: {fileID: 114125876712676998}
   - component: {fileID: 114798012568759624}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114146527219243736
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1796020255753286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114959499686943088
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,18 +243,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114146527219243736
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1796020255753286}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114125876712676998
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -292,5 +292,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: ec9ae10adb0dc4906bf525720314b210
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Research/teleporter_45.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Research/teleporter_45.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4252031003047014}
   - component: {fileID: 61688604584933318}
   - component: {fileID: 61709677808886820}
+  - component: {fileID: 114874006191773246}
   - component: {fileID: 114100013883783142}
   - component: {fileID: 114893426467972218}
   - component: {fileID: 114300179685491944}
   - component: {fileID: 114340925607793406}
-  - component: {fileID: 114874006191773246}
   - component: {fileID: 114479265071218124}
   - component: {fileID: 114550357364264288}
   m_Layer: 11
@@ -92,6 +92,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114874006191773246
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1321861167569466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114100013883783142
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -151,18 +163,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114874006191773246
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1321861167569466}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114479265071218124
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,7 +212,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: ac33401ba57264ad29be9aef7e6b3e53
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1844244231205976
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Research/teleporter_47.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Research/teleporter_47.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4409860773913266}
   - component: {fileID: 61089481086708514}
   - component: {fileID: 61863688535973892}
+  - component: {fileID: 114019091986045732}
   - component: {fileID: 114909228996891592}
   - component: {fileID: 114203913422603216}
   - component: {fileID: 114568927083047222}
   - component: {fileID: 114130822872460300}
-  - component: {fileID: 114019091986045732}
   - component: {fileID: 114193634347157676}
   - component: {fileID: 114519504495500056}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114019091986045732
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1609685257496530}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114909228996891592
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,18 +243,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114019091986045732
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1609685257496530}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114193634347157676
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -292,5 +292,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 08b1b62f71d104f16bae72f04014662d
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/ShuttleHeater.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/ShuttleHeater.prefab
@@ -12,11 +12,11 @@ GameObject:
   - component: {fileID: 61175210989043412}
   - component: {fileID: 61256080335844696}
   - component: {fileID: 4252939187967585031}
+  - component: {fileID: 114388043038700156}
   - component: {fileID: 114255515820156884}
   - component: {fileID: 114850447683734040}
   - component: {fileID: 114215226708324816}
   - component: {fileID: 6991340977674600867}
-  - component: {fileID: 114388043038700156}
   - component: {fileID: 114632911715988304}
   - component: {fileID: 3905972319176629353}
   - component: {fileID: 114635844588374680}
@@ -118,6 +118,18 @@ MonoBehaviour:
   - {fileID: 21300392, guid: 19f6ef6ee7639411ab17229343906b20, type: 3}
   spriteRenderer: {fileID: 212213825783837650}
   spriteSync: 0
+--- !u!114 &114388043038700156
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1547459616489196}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114255515820156884
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -178,18 +190,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
---- !u!114 &114388043038700156
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1547459616489196}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114632911715988304
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -255,7 +255,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 4da47599005396e47a0534bd2f998de1
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1663957144760596
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_E.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_E.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4739493471594798}
   - component: {fileID: 61986875606633926}
   - component: {fileID: 61767315606712684}
+  - component: {fileID: 114560964414760422}
   - component: {fileID: 114527569982132238}
   - component: {fileID: 114380035635842018}
   - component: {fileID: 114824315396042360}
   - component: {fileID: 114256220244991578}
-  - component: {fileID: 114560964414760422}
   - component: {fileID: 114995542676621280}
   - component: {fileID: 114432764300660568}
   m_Layer: 11
@@ -94,6 +94,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114560964414760422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1227037416355100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114527569982132238
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -155,18 +167,6 @@ MonoBehaviour:
   shipMatrixMove: {fileID: 0}
   particleFX: {fileID: 0}
   particleRateMultiplier: 4
---- !u!114 &114560964414760422
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1227037416355100}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114995542676621280
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -216,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: e86f06af3002a764caedacd0344d77cb
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1304629330313378
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_W.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_W.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4982547716752472}
   - component: {fileID: 61971458488180702}
   - component: {fileID: 61351321698559130}
+  - component: {fileID: 114550445035366406}
   - component: {fileID: 114660013788037466}
   - component: {fileID: 114297752066753362}
   - component: {fileID: 114542493565802846}
   - component: {fileID: 114776570642640068}
-  - component: {fileID: 114550445035366406}
   - component: {fileID: 114509864500058834}
   - component: {fileID: 114493828767894876}
   m_Layer: 11
@@ -174,6 +174,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114550445035366406
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1846819303320804}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114660013788037466
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -235,18 +247,6 @@ MonoBehaviour:
   shipMatrixMove: {fileID: 0}
   particleFX: {fileID: 0}
   particleRateMultiplier: 4
---- !u!114 &114550445035366406
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1846819303320804}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114509864500058834
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -296,7 +296,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 34122ff119ea4c841941a1b74e444146
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1875447609467830
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_center.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_center.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4699640297835872}
   - component: {fileID: 61988555908928504}
   - component: {fileID: 61740141861229380}
+  - component: {fileID: 114376483752658618}
   - component: {fileID: 114006670304239386}
   - component: {fileID: 114394273069994774}
   - component: {fileID: 114179810639766388}
   - component: {fileID: 114759381464305984}
-  - component: {fileID: 114376483752658618}
   - component: {fileID: 114723009705901262}
   - component: {fileID: 114460770380257942}
   m_Layer: 11
@@ -94,6 +94,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114376483752658618
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1418031129727510}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114006670304239386
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -155,18 +167,6 @@ MonoBehaviour:
   shipMatrixMove: {fileID: 0}
   particleFX: {fileID: 0}
   particleRateMultiplier: 4
---- !u!114 &114376483752658618
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1418031129727510}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114723009705901262
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -216,7 +216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: fa26dc8a7e76973489beed18bc59d792
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1649971036973084
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_0.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4108109716720978}
   - component: {fileID: 61788880596013338}
   - component: {fileID: 61389430903260124}
+  - component: {fileID: 114450900950458462}
   - component: {fileID: 114214643779669966}
   - component: {fileID: 114405981184973700}
   - component: {fileID: 114709262946049136}
   - component: {fileID: 114364703866793746}
-  - component: {fileID: 114450900950458462}
   - component: {fileID: 114350755448708140}
   - component: {fileID: 114009233771786904}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114450900950458462
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1948090295061614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114214643779669966
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -232,18 +244,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114450900950458462
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1948090295061614}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114350755448708140
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -293,5 +293,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 2e3b0620b2a9c43b086f67892f94dd2a
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_10.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_10.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4976179866772564}
   - component: {fileID: 61081513808194406}
   - component: {fileID: 61780570566590428}
+  - component: {fileID: 114046381311963218}
   - component: {fileID: 114356655867832706}
   - component: {fileID: 114950327901669162}
   - component: {fileID: 114368079120670070}
   - component: {fileID: 114695484631775568}
-  - component: {fileID: 114046381311963218}
   - component: {fileID: 114182564427891154}
   - component: {fileID: 114061157936040952}
   m_Layer: 11
@@ -92,6 +92,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114046381311963218
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1090834208327486}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114356655867832706
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -152,18 +164,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114046381311963218
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1090834208327486}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114182564427891154
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -213,7 +213,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: bce2184508eb740bcb423ebcd671a503
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1746354791454660
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_108.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_108.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4869280252403402}
   - component: {fileID: 61030014595387512}
   - component: {fileID: 61405525705198314}
+  - component: {fileID: 114433895363654956}
   - component: {fileID: 114081608491281346}
   - component: {fileID: 114186779001344108}
   - component: {fileID: 114671240230032476}
   - component: {fileID: 114688308938641898}
-  - component: {fileID: 114433895363654956}
   - component: {fileID: 114775680737956758}
   - component: {fileID: 114278311371172856}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114433895363654956
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1983841859323398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114081608491281346
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -232,18 +244,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114433895363654956
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1983841859323398}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114775680737956758
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -293,5 +293,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: dce780e3d7ebb459990212ba87e8d075
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_122.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_122.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4576255724643104}
   - component: {fileID: 61421824090989700}
   - component: {fileID: 61574834943858018}
+  - component: {fileID: 114557922893529782}
   - component: {fileID: 114345268826788508}
   - component: {fileID: 114076061302827320}
   - component: {fileID: 114187567739723964}
   - component: {fileID: 114602736169690456}
-  - component: {fileID: 114557922893529782}
   - component: {fileID: 114292576415758794}
   - component: {fileID: 114573418655668454}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114557922893529782
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1172751996906224}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114345268826788508
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -232,18 +244,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114557922893529782
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1172751996906224}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114292576415758794
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -293,5 +293,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: b8993f031a81a486382671bd2183e0d8
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_20.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_20.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4915435593579346}
   - component: {fileID: 61360347688741476}
   - component: {fileID: 61972294896979888}
+  - component: {fileID: 114282712819285018}
   - component: {fileID: 114829233351926904}
   - component: {fileID: 114981551608499804}
   - component: {fileID: 114792277892017054}
   - component: {fileID: 114372328484340406}
-  - component: {fileID: 114282712819285018}
   - component: {fileID: 114405460639820142}
   - component: {fileID: 114154460678621822}
   m_Layer: 11
@@ -92,6 +92,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114282712819285018
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1133078164265566}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114829233351926904
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -152,18 +164,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114282712819285018
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1133078164265566}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114405460639820142
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -213,7 +213,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: b102a55282e4d4f639b2da0307a4280a
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1723938365196182
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_46.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_46.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4929271832425124}
   - component: {fileID: 61021356370339768}
   - component: {fileID: 61753887793042994}
+  - component: {fileID: 114486487085970630}
   - component: {fileID: 114171613447144006}
   - component: {fileID: 114270653105659116}
   - component: {fileID: 114166963015068990}
   - component: {fileID: 114347200901971630}
-  - component: {fileID: 114486487085970630}
   - component: {fileID: 114937688718290338}
   - component: {fileID: 114830801377928260}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114486487085970630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1950281531339774}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114171613447144006
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -232,18 +244,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114486487085970630
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1950281531339774}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114937688718290338
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -293,5 +293,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: d46ddcee65b5b48e4bce5bb1360d5249
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_65.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_65.prefab
@@ -91,11 +91,11 @@ GameObject:
   - component: {fileID: 4843296343730728}
   - component: {fileID: 61966610595024420}
   - component: {fileID: 61684306562908144}
+  - component: {fileID: 114636491182838202}
   - component: {fileID: 114459644202765480}
   - component: {fileID: 114667200560179452}
   - component: {fileID: 114491891953060458}
   - component: {fileID: 114382289271072752}
-  - component: {fileID: 114636491182838202}
   - component: {fileID: 114976956384459130}
   - component: {fileID: 114922948948098656}
   m_Layer: 11
@@ -172,6 +172,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114636491182838202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1729264324595844}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114459644202765480
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -232,18 +244,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114636491182838202
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1729264324595844}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114976956384459130
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -293,5 +293,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 1ba213e2c87194953a66bba9e81793b0
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_74.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Telecomms/telecomms_74.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4391279419752480}
   - component: {fileID: 61268502126401446}
   - component: {fileID: 61585898098324350}
+  - component: {fileID: 114722124391408630}
   - component: {fileID: 114966561899050702}
   - component: {fileID: 114900132083158686}
   - component: {fileID: 114306988428377950}
   - component: {fileID: 114565920947944526}
-  - component: {fileID: 114722124391408630}
   - component: {fileID: 114619542767060204}
   - component: {fileID: 114744585338427044}
   m_Layer: 11
@@ -92,6 +92,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114722124391408630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1209943893372444}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114966561899050702
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -152,18 +164,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114722124391408630
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1209943893372444}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114619542767060204
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -213,7 +213,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: e53751632e2dd489fba0fb1479947636
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1233807659505288
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/BODA.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/BODA.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4176042359509128}
   - component: {fileID: 61752803408377482}
   - component: {fileID: 61635071643620272}
+  - component: {fileID: 114144596233833220}
   - component: {fileID: 114810295364911794}
   - component: {fileID: 114739519536560000}
   - component: {fileID: 114405417986018830}
   - component: {fileID: 1799849713025885935}
   - component: {fileID: 114677277710574418}
-  - component: {fileID: 114144596233833220}
   - component: {fileID: 114952505639166698}
   - component: {fileID: 114258074719940616}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114144596233833220
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1459620712919388}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114810295364911794
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -105,8 +117,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8ed381a72f1e344bb8020dc181414b43, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   VendorContent:
   - Item: {fileID: 1110193000772614, guid: ea3aced27602b4327bcbd90af271bba2, type: 3}
     Stock: 5
@@ -149,6 +159,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &1799849713025885935
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -175,18 +186,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114144596233833220
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1459620712919388}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114952505639166698
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -221,6 +220,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114258074719940616
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -235,8 +235,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 1028856064
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0
 --- !u!1 &1855299798957980
 GameObject:
   m_ObjectHideFlags: 0
@@ -293,6 +293,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_0.prefab
@@ -11,13 +11,13 @@ GameObject:
   - component: {fileID: 4829133243816028}
   - component: {fileID: 61160545876568756}
   - component: {fileID: 61362889932895036}
+  - component: {fileID: 114460020317382532}
   - component: {fileID: 114445863860112362}
   - component: {fileID: 114744021291581812}
   - component: {fileID: 61869229900283464}
   - component: {fileID: 114947365864617716}
   - component: {fileID: 171602551372974216}
   - component: {fileID: 114440441029515152}
-  - component: {fileID: 114460020317382532}
   - component: {fileID: 114167326288187806}
   - component: {fileID: 114472266138859352}
   m_Layer: 11
@@ -94,6 +94,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114460020317382532
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1093139424532032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114445863860112362
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -199,18 +211,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114460020317382532
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1093139424532032}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114167326288187806
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -260,7 +260,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: f287a880e85744218878407f6c4dff3d
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1905444731887362
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_100.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_100.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4937253134892974}
   - component: {fileID: 61953676750405236}
   - component: {fileID: 61496987257880160}
+  - component: {fileID: 114112629053677228}
   - component: {fileID: 114314910372283494}
   - component: {fileID: 114654592240877062}
   - component: {fileID: 114410048841761286}
   - component: {fileID: 8864697716916452962}
   - component: {fileID: 114673298413279252}
-  - component: {fileID: 114112629053677228}
   - component: {fileID: 114519731390717142}
   - component: {fileID: 114835540201679230}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114112629053677228
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1141717875945314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114314910372283494
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,18 +180,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114112629053677228
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1141717875945314}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114519731390717142
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -229,7 +229,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: d3b4e6f1828dd49328c77f3a08150b27
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1363802672641500
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_104.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_104.prefab
@@ -56,6 +56,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -90,12 +91,12 @@ GameObject:
   - component: {fileID: 4464733428291126}
   - component: {fileID: 61710048005940208}
   - component: {fileID: 61729624970629904}
+  - component: {fileID: 114556184854979150}
   - component: {fileID: 114524211834867648}
   - component: {fileID: 114775534740125254}
   - component: {fileID: 114548594117427474}
   - component: {fileID: 2380203876078740111}
   - component: {fileID: 114532474132266400}
-  - component: {fileID: 114556184854979150}
   - component: {fileID: 114146302605864432}
   - component: {fileID: 114503800418262852}
   m_Layer: 11
@@ -172,6 +173,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114556184854979150
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1538438828928774}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114524211834867648
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -184,8 +197,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8ed381a72f1e344bb8020dc181414b43, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   VendorContent: []
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -222,6 +233,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &2380203876078740111
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -248,18 +260,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114556184854979150
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1538438828928774}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114146302605864432
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -294,6 +294,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114503800418262852
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -308,5 +309,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
-  m_SceneId: 1552578654
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_110.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_110.prefab
@@ -91,12 +91,12 @@ GameObject:
   - component: {fileID: 4526164702059322}
   - component: {fileID: 61877866146655838}
   - component: {fileID: 61607435629107004}
+  - component: {fileID: 114106216584999228}
   - component: {fileID: 114953193946122312}
   - component: {fileID: 114826091611418058}
   - component: {fileID: 114169739028466732}
   - component: {fileID: 3874773588567333107}
   - component: {fileID: 114010528461381010}
-  - component: {fileID: 114106216584999228}
   - component: {fileID: 114966645824831244}
   - component: {fileID: 114146212067186094}
   m_Layer: 11
@@ -173,6 +173,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114106216584999228
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1641417262004324}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114953193946122312
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -248,18 +260,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114106216584999228
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1641417262004324}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114966645824831244
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -309,5 +309,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 6634be3f98f8b455a8df97fab03db31c
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_126.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_126.prefab
@@ -91,12 +91,12 @@ GameObject:
   - component: {fileID: 4604100555381878}
   - component: {fileID: 61112155310572852}
   - component: {fileID: 61000486868803618}
+  - component: {fileID: 114772980839582424}
   - component: {fileID: 114975881549111064}
   - component: {fileID: 114518179293593798}
   - component: {fileID: 114337553390059262}
   - component: {fileID: 1925344920049629367}
   - component: {fileID: 114463626805873948}
-  - component: {fileID: 114772980839582424}
   - component: {fileID: 114307420777048274}
   - component: {fileID: 114775338284287122}
   m_Layer: 11
@@ -173,6 +173,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114772980839582424
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1771454506785624}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114975881549111064
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -258,18 +270,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114772980839582424
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1771454506785624}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114307420777048274
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -319,5 +319,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: d10a1ec1e05d24b0bb892d49d712e6d5
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_133.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_133.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4031273896495148}
   - component: {fileID: 61402933100295738}
   - component: {fileID: 61542420624680502}
+  - component: {fileID: 114841402992530394}
   - component: {fileID: 114797005473115450}
   - component: {fileID: 114053083183076922}
   - component: {fileID: 114943133033173114}
   - component: {fileID: 6163104752560784945}
   - component: {fileID: 114958476941415564}
-  - component: {fileID: 114841402992530394}
   - component: {fileID: 114354139098577862}
   - component: {fileID: 114178607875353350}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114841402992530394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1774969866830608}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114797005473115450
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,18 +180,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114841402992530394
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1774969866830608}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114354139098577862
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -229,7 +229,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 69eced3fe40ab40b3b98f978222d77ba
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1857287679062152
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_159.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_159.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4141540462115696}
   - component: {fileID: 61712735282374782}
   - component: {fileID: 61903822560069514}
+  - component: {fileID: 114067933518654400}
   - component: {fileID: 114730075560479786}
   - component: {fileID: 114238357728416952}
   - component: {fileID: 114682330233778130}
   - component: {fileID: 3767729658313228839}
   - component: {fileID: 114543007015649088}
-  - component: {fileID: 114067933518654400}
   - component: {fileID: 114838364937994774}
   - component: {fileID: 114255719825010446}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114067933518654400
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1332633571299694}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114730075560479786
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,18 +180,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114067933518654400
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1332633571299694}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114838364937994774
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -229,7 +229,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 4c62780911a0444d0a817e69a6cdc983
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1530113436301856
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_16.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_16.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4255469279988742}
   - component: {fileID: 61646266593179672}
   - component: {fileID: 61361413312787530}
+  - component: {fileID: 114632102212996150}
   - component: {fileID: 114743727474145656}
   - component: {fileID: 114932710023623188}
   - component: {fileID: 114589214678579180}
   - component: {fileID: 3364178406384650387}
   - component: {fileID: 114606708682237604}
-  - component: {fileID: 114632102212996150}
   - component: {fileID: 114677574260028866}
   - component: {fileID: 114706761793951438}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114632102212996150
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1098428341378092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114743727474145656
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -172,18 +184,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114632102212996150
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1098428341378092}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114677574260028866
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -233,7 +233,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 0c59c3d4211674eefabe0f4cafc8fcc3
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1744033224997864
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_175.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_175.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4206782812307690}
   - component: {fileID: 61103962630731462}
   - component: {fileID: 61233260436209044}
+  - component: {fileID: 114242611032700334}
   - component: {fileID: 114636675896952666}
   - component: {fileID: 114623388142063974}
   - component: {fileID: 114710026204977004}
   - component: {fileID: 8122375580226885523}
   - component: {fileID: 114924540586458310}
-  - component: {fileID: 114242611032700334}
   - component: {fileID: 114897351131677626}
   - component: {fileID: 114514137679665224}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114242611032700334
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1308360596603050}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114636675896952666
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,18 +180,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114242611032700334
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1308360596603050}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114897351131677626
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -229,7 +229,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 947e1ea783be34de9b0e30e45068023d
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1647500721339698
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_185.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_185.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4975988611288262}
   - component: {fileID: 61263359288714902}
   - component: {fileID: 61679316691894918}
+  - component: {fileID: 114071187995863296}
   - component: {fileID: 114950690755873480}
   - component: {fileID: 114522046351845882}
   - component: {fileID: 114999616005251050}
   - component: {fileID: 455838319051819710}
   - component: {fileID: 114150982585383840}
-  - component: {fileID: 114071187995863296}
   - component: {fileID: 114224870589388836}
   - component: {fileID: 114014873698230268}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114071187995863296
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1367764145107636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114950690755873480
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -170,18 +182,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114071187995863296
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1367764145107636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114224870589388836
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,7 +231,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: d313575a2ea0a46b7a28df803e466338
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1439271476217088
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_188.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_188.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4980111975026280}
   - component: {fileID: 61210301608415710}
   - component: {fileID: 61282460781198216}
+  - component: {fileID: 114112659940722310}
   - component: {fileID: 114331424156736198}
   - component: {fileID: 114331300456246542}
   - component: {fileID: 114414702093615426}
   - component: {fileID: 8419963642986560554}
   - component: {fileID: 114087146383761586}
-  - component: {fileID: 114112659940722310}
   - component: {fileID: 114113096325558622}
   - component: {fileID: 114060126164565774}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114112659940722310
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1315125836679420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114331424156736198
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -170,18 +182,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114112659940722310
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1315125836679420}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114113096325558622
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,7 +231,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 31db299129eb54acdbcc038bd2d90897
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1668304983400538
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_190.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_190.prefab
@@ -91,12 +91,12 @@ GameObject:
   - component: {fileID: 4611671786400276}
   - component: {fileID: 61275453022780532}
   - component: {fileID: 61532532345769602}
+  - component: {fileID: 114047140382544820}
   - component: {fileID: 114982929168440566}
   - component: {fileID: 114783402830955602}
   - component: {fileID: 114102298114621054}
   - component: {fileID: 6720625136746480622}
   - component: {fileID: 114882900800809796}
-  - component: {fileID: 114047140382544820}
   - component: {fileID: 114559353448256750}
   - component: {fileID: 114665692247917754}
   m_Layer: 11
@@ -173,6 +173,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114047140382544820
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854253567727558}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114982929168440566
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,18 +262,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114047140382544820
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1854253567727558}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114559353448256750
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -311,5 +311,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: be4108548be50497ba7d8db84c6853e8
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_192.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_192.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4287659737582308}
   - component: {fileID: 61813007127300430}
   - component: {fileID: 61868680273675144}
+  - component: {fileID: 114746744017773578}
   - component: {fileID: 114295623627170416}
   - component: {fileID: 114923575346168048}
   - component: {fileID: 114236633167564510}
   - component: {fileID: 311037059637748646}
   - component: {fileID: 114669272459964594}
-  - component: {fileID: 114746744017773578}
   - component: {fileID: 114475142182648450}
   - component: {fileID: 114804075063903570}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114746744017773578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1387886441625860}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114295623627170416
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -170,18 +182,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114746744017773578
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1387886441625860}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114475142182648450
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,7 +231,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: f9d6bd1cf63124b3fbfbe23b71a13858
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1625856503880554
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_194.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_194.prefab
@@ -91,12 +91,12 @@ GameObject:
   - component: {fileID: 4787523133971860}
   - component: {fileID: 61320512918619720}
   - component: {fileID: 61640401483045012}
+  - component: {fileID: 114511614877201024}
   - component: {fileID: 114773434043782438}
   - component: {fileID: 114960973216336980}
   - component: {fileID: 114066524332886862}
   - component: {fileID: 4095215754473161605}
   - component: {fileID: 114104912121421044}
-  - component: {fileID: 114511614877201024}
   - component: {fileID: 114751963780255994}
   - component: {fileID: 114122805051230296}
   m_Layer: 11
@@ -173,6 +173,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114511614877201024
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1843656487461944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114773434043782438
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,18 +262,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114511614877201024
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1843656487461944}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114751963780255994
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -311,5 +311,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 1c62f1dcec5e342248120c7222bc1e1f
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_199.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_199.prefab
@@ -91,12 +91,12 @@ GameObject:
   - component: {fileID: 4537489602306896}
   - component: {fileID: 61827062856925538}
   - component: {fileID: 61571880214858618}
+  - component: {fileID: 114675384605708324}
   - component: {fileID: 114114203693278056}
   - component: {fileID: 114886149982349940}
   - component: {fileID: 114078157158861710}
   - component: {fileID: 8621169872471703127}
   - component: {fileID: 114003130341548132}
-  - component: {fileID: 114675384605708324}
   - component: {fileID: 114992355050654178}
   - component: {fileID: 114812768677892282}
   m_Layer: 11
@@ -173,6 +173,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114675384605708324
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1606703489037488}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114114203693278056
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -248,18 +260,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114675384605708324
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1606703489037488}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114992355050654178
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -309,5 +309,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: dad3f6e35bb4041b1825f68730a360e9
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_24.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_24.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4358312459003614}
   - component: {fileID: 61225684011644578}
   - component: {fileID: 61576640052361776}
+  - component: {fileID: 114446757256233438}
   - component: {fileID: 114629280033153252}
   - component: {fileID: 114358010644830310}
   - component: {fileID: 114890971556413904}
   - component: {fileID: 854799812517359676}
   - component: {fileID: 114103645965806802}
-  - component: {fileID: 114446757256233438}
   - component: {fileID: 114708887396403942}
   - component: {fileID: 114563860907259176}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114446757256233438
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1825784958154784}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114629280033153252
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -170,18 +182,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114446757256233438
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1825784958154784}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114708887396403942
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -231,7 +231,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 5b3b6252bb8c74b039e4d7926e55dee3
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1979686790347204
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_34.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_34.prefab
@@ -107,12 +107,12 @@ GameObject:
   - component: {fileID: 4097761617933384}
   - component: {fileID: 61230205263660572}
   - component: {fileID: 61925663357938400}
+  - component: {fileID: 114192731067590806}
   - component: {fileID: 114286896119653214}
   - component: {fileID: 114994836355027986}
   - component: {fileID: 114382407847818618}
   - component: {fileID: 2474263029294650900}
   - component: {fileID: 114027492520084390}
-  - component: {fileID: 114192731067590806}
   - component: {fileID: 114082324132692910}
   - component: {fileID: 114796018723647982}
   m_Layer: 11
@@ -189,6 +189,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114192731067590806
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1430744253466650}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114286896119653214
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -264,18 +276,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114192731067590806
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1430744253466650}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114082324132692910
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -325,5 +325,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: ad564df14e0bd4e0f9395ac826d7e103
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_51.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_51.prefab
@@ -91,12 +91,12 @@ GameObject:
   - component: {fileID: 4330041035155838}
   - component: {fileID: 61770703013218746}
   - component: {fileID: 61661140852906130}
+  - component: {fileID: 114272245637644638}
   - component: {fileID: 114608685007237984}
   - component: {fileID: 114778853778945220}
   - component: {fileID: 114862503678879326}
   - component: {fileID: 8759977713929278339}
   - component: {fileID: 114784396913096104}
-  - component: {fileID: 114272245637644638}
   - component: {fileID: 114620447940062844}
   - component: {fileID: 114343594154895826}
   m_Layer: 11
@@ -173,6 +173,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114272245637644638
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1699312583147682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114608685007237984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -254,18 +266,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114272245637644638
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1699312583147682}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114620447940062844
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -315,5 +315,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: eb515572856b64cfcacb99a939bf5671
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_69.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_69.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4683593748146636}
   - component: {fileID: 61921485825753430}
   - component: {fileID: 61576283321298232}
+  - component: {fileID: 114524032623094572}
   - component: {fileID: 114568226788970728}
   - component: {fileID: 114734017414174382}
   - component: {fileID: 114805206030907492}
   - component: {fileID: 7374880474366726541}
   - component: {fileID: 114214049433889708}
-  - component: {fileID: 114524032623094572}
   - component: {fileID: 114839055633971704}
   - component: {fileID: 114712713531201044}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114524032623094572
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1566295957001540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114568226788970728
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,18 +180,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114524032623094572
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1566295957001540}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114839055633971704
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -229,7 +229,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 23a86c7f552684d4c949d224badbaf4b
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1640601255468836
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_73.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_73.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4215328690730840}
   - component: {fileID: 61905137819514942}
   - component: {fileID: 61196210525515038}
+  - component: {fileID: 114223698751806424}
   - component: {fileID: 114700796985833104}
   - component: {fileID: 114642487412780520}
   - component: {fileID: 114243585560028574}
   - component: {fileID: 4605442509270556244}
   - component: {fileID: 114871789818658762}
-  - component: {fileID: 114223698751806424}
   - component: {fileID: 114428086918155428}
   - component: {fileID: 114041070060136478}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114223698751806424
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1699647258736684}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114700796985833104
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,18 +180,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114223698751806424
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1699647258736684}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114428086918155428
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -229,7 +229,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 0b853e1adc848472a9873d4af9aa41d4
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1958418935526468
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_76.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_76.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4947045871353674}
   - component: {fileID: 61594483765556988}
   - component: {fileID: 61364325503601486}
+  - component: {fileID: 114507539355500448}
   - component: {fileID: 114579340578427108}
   - component: {fileID: 114419965836037104}
   - component: {fileID: 114764024703624026}
   - component: {fileID: 4980645267845861527}
   - component: {fileID: 114280947688144450}
-  - component: {fileID: 114507539355500448}
   - component: {fileID: 114881596125346598}
   - component: {fileID: 114211682909943906}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114507539355500448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1566758848664630}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114579340578427108
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,18 +180,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114507539355500448
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1566758848664630}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114881596125346598
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -229,7 +229,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 23cabd08332f74aaa8c98365e35cc756
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1796110219090800
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_95.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_95.prefab
@@ -91,12 +91,12 @@ GameObject:
   - component: {fileID: 4284042978668472}
   - component: {fileID: 61638980204876758}
   - component: {fileID: 61493089766860954}
+  - component: {fileID: 114406705521278706}
   - component: {fileID: 114188108003767576}
   - component: {fileID: 114786537848864648}
   - component: {fileID: 114035917889724156}
   - component: {fileID: 6320681568022292907}
   - component: {fileID: 114402401360400166}
-  - component: {fileID: 114406705521278706}
   - component: {fileID: 114256322274674424}
   - component: {fileID: 114673894313725832}
   m_Layer: 11
@@ -173,6 +173,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114406705521278706
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1744922440429612}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114188108003767576
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -248,18 +260,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114406705521278706
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1744922440429612}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114256322274674424
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -309,5 +309,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: b4b119b3687e04dfc88130ea6ee49e9e
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_99.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_99.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4738084802847026}
   - component: {fileID: 61617544282292570}
   - component: {fileID: 61055955738484018}
+  - component: {fileID: 114888820776303900}
   - component: {fileID: 114686582971248454}
   - component: {fileID: 114417560557986084}
   - component: {fileID: 114496511731903232}
   - component: {fileID: 3902411070937180265}
   - component: {fileID: 114992745516836652}
-  - component: {fileID: 114888820776303900}
   - component: {fileID: 114089151901700838}
   - component: {fileID: 114909284845536794}
   m_Layer: 11
@@ -93,6 +93,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114888820776303900
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1321968994659816}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114686582971248454
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -168,18 +180,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
---- !u!114 &114888820776303900
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1321968994659816}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114089151901700838
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -229,7 +229,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: d975a11fbe2a84790a6460fcf3c04607
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1398704703133964
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/FireAlarm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/FireAlarm.prefab
@@ -106,13 +106,13 @@ GameObject:
   m_Component:
   - component: {fileID: 4000011119182976}
   - component: {fileID: 61000010130597256}
+  - component: {fileID: 114234539136935032}
   - component: {fileID: 114874730882314834}
   - component: {fileID: 114450786801091896}
   - component: {fileID: 114789676302844992}
   - component: {fileID: 114034692067134764}
   - component: {fileID: 114774275199163462}
   - component: {fileID: 114265084883189168}
-  - component: {fileID: 114234539136935032}
   - component: {fileID: 114949534438748220}
   - component: {fileID: 114146168231498696}
   m_Layer: 19
@@ -165,6 +165,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114234539136935032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000012425957516}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114874730882314834
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -252,18 +264,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &114234539136935032
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000012425957516}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114949534438748220
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -313,7 +313,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: d8ff8a6c4d044500806d2f0ab1cb6358
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1000013647327112
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/FireExtinguisherCabinet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/FireExtinguisherCabinet.prefab
@@ -90,13 +90,13 @@ GameObject:
   m_Component:
   - component: {fileID: 4000012228612998}
   - component: {fileID: 61000013459434012}
+  - component: {fileID: 114182471896023220}
   - component: {fileID: 114762163834158284}
   - component: {fileID: 114838689195169320}
   - component: {fileID: 114185868468834516}
   - component: {fileID: 114733857225162646}
   - component: {fileID: 114709804663316594}
   - component: {fileID: 114203729741223268}
-  - component: {fileID: 114182471896023220}
   - component: {fileID: 114791282851611692}
   - component: {fileID: 114714693557252334}
   - component: {fileID: 9199521041031586661}
@@ -148,6 +148,18 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &114182471896023220
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000014202525198}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114762163834158284
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -243,18 +255,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &114182471896023220
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000014202525198}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114791282851611692
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -304,7 +304,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: ced6ef1cf7604ad0884ca6e1f172ba99
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!114 &9199521041031586661
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/LightSwitch.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/LightSwitch.prefab
@@ -91,13 +91,13 @@ GameObject:
   - component: {fileID: 4000014215534684}
   - component: {fileID: 61000012989894210}
   - component: {fileID: 82306546317105916}
+  - component: {fileID: 114783072045832552}
   - component: {fileID: 114156815017434572}
   - component: {fileID: 114942625721484022}
   - component: {fileID: 114056794007261734}
   - component: {fileID: 114773043881674562}
   - component: {fileID: 114547392609398558}
   - component: {fileID: 114148094876921124}
-  - component: {fileID: 114783072045832552}
   - component: {fileID: 114026713173586346}
   - component: {fileID: 114330810423114948}
   m_Layer: 19
@@ -244,6 +244,18 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
+--- !u!114 &114783072045832552
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000014236108730}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114156815017434572
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -342,18 +354,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &114783072045832552
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000014236108730}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114026713173586346
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -403,5 +403,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 6b98e0a1341c4824a5457ef0e27020f8
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/MonitorAir.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/MonitorAir.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4000010739918412}
   - component: {fileID: 61000010182535082}
   - component: {fileID: 114563030221050354}
+  - component: {fileID: 114477462743865550}
   - component: {fileID: 114616085156888826}
   - component: {fileID: 114757767275401014}
   - component: {fileID: 114342586569914630}
   - component: {fileID: 114308127417147816}
   - component: {fileID: 114354702658253172}
-  - component: {fileID: 114477462743865550}
   - component: {fileID: 114670731178714064}
   - component: {fileID: 114229560136497920}
   m_Layer: 19
@@ -85,6 +85,18 @@ MonoBehaviour:
   ObjectType: 1
   AtmosPassable: 1
   Passable: 1
+--- !u!114 &114477462743865550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000010568484738}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114616085156888826
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -154,18 +166,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &114477462743865550
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000010568484738}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114670731178714064
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -215,7 +215,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 56c6161e9e0a4ac08ff26848e7c65019
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1000012059094926
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Poster.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Poster.prefab
@@ -15,8 +15,8 @@ GameObject:
   - component: {fileID: 2849084297104663897}
   - component: {fileID: 2005314267733314395}
   - component: {fileID: 842841108259978593}
-  - component: {fileID: 7154680421102874471}
   - component: {fileID: 5636789531504822047}
+  - component: {fileID: 7154680421102874471}
   - component: {fileID: 1721604302402341619}
   - component: {fileID: 1567170016700135650}
   m_Layer: 19
@@ -141,6 +141,18 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &5636789531504822047
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5466995241280763689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &7154680421102874471
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -159,18 +171,6 @@ MonoBehaviour:
   rolledPosterPrefab: {fileID: 5074129411573611090, guid: 96145b3165f5248b78302cd49658b0b2,
     type: 3}
   posterVariant: 85
---- !u!114 &5636789531504822047
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5466995241280763689}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1721604302402341619
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -220,7 +220,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &5583455716784618316
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Radio.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Radio.prefab
@@ -11,12 +11,12 @@ GameObject:
   - component: {fileID: 4000012623101898}
   - component: {fileID: 61000014015711244}
   - component: {fileID: 114861804437894934}
+  - component: {fileID: 114793970435373244}
   - component: {fileID: 114593833383210806}
   - component: {fileID: 114287771744456878}
   - component: {fileID: 114144320533980062}
   - component: {fileID: 114299188303023998}
   - component: {fileID: 114097754155958170}
-  - component: {fileID: 114793970435373244}
   - component: {fileID: 114605728347079626}
   - component: {fileID: 114914370789817346}
   m_Layer: 19
@@ -85,6 +85,18 @@ MonoBehaviour:
   ObjectType: 1
   AtmosPassable: 1
   Passable: 1
+--- !u!114 &114793970435373244
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000012293339564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114593833383210806
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -154,18 +166,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &114793970435373244
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000012293339564}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114605728347079626
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -215,7 +215,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1000012442742688
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/RequestConsole.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/RequestConsole.prefab
@@ -12,12 +12,12 @@ GameObject:
   - component: {fileID: 61000013231193044}
   - component: {fileID: 95687423394818094}
   - component: {fileID: 114630669365637708}
+  - component: {fileID: 114836004546667558}
   - component: {fileID: 114961671854977668}
   - component: {fileID: 114241946955262388}
   - component: {fileID: 114024760286136462}
   - component: {fileID: 114748768853426186}
   - component: {fileID: 114410258970618456}
-  - component: {fileID: 114836004546667558}
   - component: {fileID: 114558640520136156}
   - component: {fileID: 114665882604199916}
   m_Layer: 19
@@ -105,6 +105,18 @@ MonoBehaviour:
   ObjectType: 1
   AtmosPassable: 1
   Passable: 1
+--- !u!114 &114836004546667558
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000010652479536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114961671854977668
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -117,8 +129,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58b822814682f460baa30059c4fd7f42, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   Message: No requests available
 --- !u!114 &114241946955262388
 MonoBehaviour:
@@ -175,18 +185,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
---- !u!114 &114836004546667558
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000010652479536}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  IsFixedMatrix: 0
 --- !u!114 &114558640520136156
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -221,6 +220,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114665882604199916
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -235,7 +235,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: e40f8eea191249e4983505e18341cce1
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0
 --- !u!1 &1000013922535428
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/ShutterSwitch.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/ShutterSwitch.prefab
@@ -91,13 +91,13 @@ GameObject:
   - component: {fileID: 4000010339692354}
   - component: {fileID: 61000011563014182}
   - component: {fileID: 95822078298543166}
+  - component: {fileID: 114226656802731144}
   - component: {fileID: 114291632891074610}
   - component: {fileID: 114962742079591300}
   - component: {fileID: 114374503033707882}
   - component: {fileID: 114341615227042270}
   - component: {fileID: 114600582394960640}
   - component: {fileID: 114972156775761828}
-  - component: {fileID: 114226656802731144}
   - component: {fileID: 114188043817997682}
   - component: {fileID: 114809480150407966}
   m_Layer: 19
@@ -167,6 +167,18 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!114 &114226656802731144
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000013144118558}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114291632891074610
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -257,18 +269,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
---- !u!114 &114226656802731144
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000013144118558}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114188043817997682
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -318,5 +318,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 1325f48af15d4163ab952de2fcb5a184
+  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/botany/equipment_112.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/botany/equipment_112.prefab
@@ -11,11 +11,11 @@ GameObject:
   - component: {fileID: 4807428690779012}
   - component: {fileID: 61567084657152386}
   - component: {fileID: 61188688766551712}
-  - component: {fileID: 114051564363044936}
   - component: {fileID: 114623684767280132}
   - component: {fileID: 114075222325775338}
   - component: {fileID: 114422795345231308}
   - component: {fileID: 114454422526630500}
+  - component: {fileID: 114051564363044936}
   - component: {fileID: 114330429424926220}
   - component: {fileID: 114790299673989822}
   m_Layer: 11
@@ -92,19 +92,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!114 &114051564363044936
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1449387945419676}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 58b822814682f460baa30059c4fd7f42, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Message: You rather not get stung...
 --- !u!114 &114623684767280132
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -163,6 +150,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &114051564363044936
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1449387945419676}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58b822814682f460baa30059c4fd7f42, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Message: You rather not get stung...
 --- !u!114 &114330429424926220
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,7 +212,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: df8c885062b3643dea1605f5ca70ce73
+  m_AssetId: db8717f3f2a8a4170a0d870dcc9662e1
   m_SceneId: 0
 --- !u!1 &1611438165515314
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/botany/hydroponics  tray.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/botany/hydroponics  tray.prefab
@@ -92,10 +92,10 @@ GameObject:
   - component: {fileID: 61863688535973892}
   - component: {fileID: 114203913422603216}
   - component: {fileID: 114568927083047222}
-  - component: {fileID: 1612245312422546373}
-  - component: {fileID: 3468170437254342443}
   - component: {fileID: 114130822872460300}
   - component: {fileID: 114019091986045732}
+  - component: {fileID: 3468170437254342443}
+  - component: {fileID: 1612245312422546373}
   - component: {fileID: 114193634347157676}
   - component: {fileID: 114519504495500056}
   - component: {fileID: 17410868912263334}
@@ -185,6 +185,55 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   IsFixedMatrix: 0
+--- !u!114 &114130822872460300
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1609685257496530}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteMatrixRotationBehavior: 1
+--- !u!114 &114019091986045732
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1609685257496530}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3468170437254342443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1609685257496530}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  temperatureKelvin: 293.15
+  MaxCapacity: 200
+  InSolidForm: 0
+  Reagents:
+  - water
+  Amounts:
+  - 100
+  TraitWhitelist: []
+  ReagentWhitelist: []
+  TransferMode: 0
+  InitialTransferAmount: 20
+  PossibleTransferAmounts: []
 --- !u!114 &1612245312422546373
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -206,6 +255,7 @@ MonoBehaviour:
   PlantSyncStage: 0
   GrowingPlantStage: 0
   PlantSyncString: 
+  IsSoilPile: 0
   PotentialWeeds:
   - {fileID: 11400000, guid: 375fdb78e44a16f44bd8fed477aec2fa, type: 2}
   - {fileID: 11400000, guid: 8381b65b5721d454cbe2b03391fd34c4, type: 2}
@@ -223,7 +273,6 @@ MonoBehaviour:
   NutrimentNotifier: {fileID: 2269397715240448978}
   plantData:
     ProduceObject: {fileID: 0}
-    plantType: 0
     Name: 
     Plantname: 
     Description: 
@@ -271,51 +320,6 @@ MonoBehaviour:
   PlantHealth: 100
   ReadyToHarvest: 0
   HasFullyGrown: 0
---- !u!114 &3468170437254342443
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1609685257496530}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Temperature: 20
-  MaxCapacity: 200
-  MoveAmount: 0
-  InSolidForm: 0
-  Reagents:
-  - water
-  Amounts:
-  - 100
---- !u!114 &114130822872460300
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1609685257496530}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spriteMatrixRotationBehavior: 1
---- !u!114 &114019091986045732
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1609685257496530}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &114193634347157676
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -365,7 +369,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 1efec61511b50c844868cb49d1a711a1
+  m_AssetId: db8717f3f2a8a4170a0d870dcc9662e1
   m_SceneId: 0
 --- !u!114 &17410868912263334
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Player/Resources/Player_V3(uNet).prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Player/Resources/Player_V3(uNet).prefab
@@ -761,6 +761,7 @@ GameObject:
   - component: {fileID: 114803877374308862}
   - component: {fileID: 114449635359748350}
   - component: {fileID: 50851566022184656}
+  - component: {fileID: 8384177609795425991}
   - component: {fileID: 114908376472113748}
   - component: {fileID: 6017414943583453005}
   - component: {fileID: 6880295280032021907}
@@ -771,7 +772,6 @@ GameObject:
   - component: {fileID: 8566362239651287352}
   - component: {fileID: 114279031792796038}
   - component: {fileID: 441872716838640463}
-  - component: {fileID: 8384177609795425991}
   m_Layer: 8
   m_Name: Player_V3(uNet)
   m_TagString: Untagged
@@ -1160,6 +1160,18 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!114 &8384177609795425991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1133514949248654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72c43885acb654c59b452e7069cb64f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114908376472113748
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1297,7 +1309,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 44a8a3be9127f4465a50b7811d059bb3
   m_SceneId: 0
 --- !u!114 &441872716838640463
 MonoBehaviour:
@@ -1317,18 +1329,6 @@ MonoBehaviour:
     type: 2}
   itemStoragePopulator: {fileID: 11400000, guid: 4c48a40375c1b43718c78eee5582051a,
     type: 2}
---- !u!114 &8384177609795425991
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1133514949248654}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 72c43885acb654c59b452e7069cb64f8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1147423205297840
 GameObject:
   m_ObjectHideFlags: 0
@@ -4988,15 +4988,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61930e16e81db5c43a4ecc22422a0953, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &4299649681570296155 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1762630675659964, guid: e2b1333de46384f95876864de1911fff,
-    type: 3}
-  m_PrefabInstance: {fileID: 4300145449095171559}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &4304794156734570639 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4676201352523112, guid: e2b1333de46384f95876864de1911fff,
+    type: 3}
+  m_PrefabInstance: {fileID: 4300145449095171559}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4299649681570296155 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1762630675659964, guid: e2b1333de46384f95876864de1911fff,
     type: 3}
   m_PrefabInstance: {fileID: 4300145449095171559}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/InteractionUtils.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/InteractionUtils.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 /// <summary>
@@ -29,7 +30,8 @@ public static class InteractionUtils
 	}
 
 	/// <summary>
-	/// Client side interaction checking logic. Goes through each interactable component and checks for triggered interactions, returning the first one that
+	/// Client side interaction checking logic. Goes through each interactable component (starting from the bottom of the object's
+	/// component list) and checks for triggered interactions, returning the first one that
 	/// triggers an interaction, null if none are triggered. Messages the server to request an interaction for the interaction that
 	/// was triggered (if any).
 	/// </summary>
@@ -43,7 +45,7 @@ public static class InteractionUtils
 	{
 		Logger.LogTraceFormat("Checking {0} interactions",
 			Category.Interaction, typeof(T).Name);
-		foreach (var interactable in interactables)
+		foreach (var interactable in interactables.Reverse())
 		{
 			if (interactable.CheckInteract(interaction, NetworkSide.Client))
 			{

--- a/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
@@ -341,7 +341,7 @@ public class MouseInputController : MonoBehaviour
 			Logger.LogTraceFormat("Checking HandApply / PositionalHandApply interactions from {0} targeting {1}",
 				Category.Interaction, handApply.HandObject.name, target.name);
 
-			foreach (var handAppliable in handAppliables)
+			foreach (var handAppliable in handAppliables.Reverse())
 			{
 				var interacted = false;
 				if (handAppliable is IBaseInteractable<HandApply>)
@@ -368,7 +368,7 @@ public class MouseInputController : MonoBehaviour
 		//call the hand apply interaction methods on the target object if it has any
 		var targetHandAppliables = handApply.TargetObject.GetComponents<MonoBehaviour>()
 			.Where(c => c != null && c.enabled && (c is IBaseInteractable<HandApply> || c is IBaseInteractable<PositionalHandApply>));
-		foreach (var targetHandAppliable in targetHandAppliables)
+		foreach (var targetHandAppliable in targetHandAppliables.Reverse())
 		{
 			var interacted = false;
 			if (targetHandAppliable is IBaseInteractable<HandApply>)

--- a/UnityProject/Assets/Scripts/Items/Others/VendingRestock.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/VendingRestock.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
+//TODO: No point to this. Delete it and add Pickupable to VendingRestock, use ItemTraits instead of this marker component
 public class VendingRestock : Pickupable
 {
 	//Whatever


### PR DESCRIPTION
### Purpose
Fixes #2382 

The changes to each prefab are just rearranging the interactable components to be reversed.

Updated the wiki on IF2 explaining the order.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [x]  Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [x]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ]  This PR has been tested with round restarts.
- [x]  This PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
