### PR TITLE
2261 Add prices to item attributes, add cargo scanner

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Cargo/Export Scanner.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Cargo/Export Scanner.prefab
@@ -1,0 +1,130 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &2945292044612777412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1004031135681812318}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 22e648b503e9446a5a32c187bce189a4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1003351756831189988
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_Name
+      value: Export Scanner
+      objectReference: {fileID: 0}
+    - target: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114077084986960180, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: spriteList.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114077084986960180, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: Infos.AID
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114077084986960180, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: spriteList.Array.data[0]
+      value: 
+      objectReference: {fileID: 21300002, guid: cfbf369a667bab1419fe01877da31c9f,
+        type: 3}
+    - target: {fileID: 114077084986960180, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: spriteList.Array.data[1]
+      value: 
+      objectReference: {fileID: 21300002, guid: 3f5aa3f83d7ea954aa0bb16b692aa2d6,
+        type: 3}
+    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 58b6dd249983efb4e9e6c85bfbcaf611,
+        type: 3}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialName
+      value: export scanner
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialDescription
+      value: A device used to check objects against Nanotrasen exports and bounty
+        database.
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialSize
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+--- !u!1 &1004031135681812318 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298,
+    type: 3}
+  m_PrefabInstance: {fileID: 1003351756831189988}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Cargo/Export Scanner.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Cargo/Export Scanner.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7540880d4dc7c4d8c9e3d3cd83ccef06
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/SolidPlasma.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/SolidPlasma.prefab
@@ -258,7 +258,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 2993903919
 --- !u!114 &877203043203998857
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -286,6 +286,9 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 200
+  ExportName: 
+  ExportMessage: cm3 of plasma
 --- !u!1 &1668617562811696
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/SolidPlasma.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/SolidPlasma.prefab
@@ -258,7 +258,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 2993903919
+  m_SceneId: 1176855723
 --- !u!114 &877203043203998857
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -286,9 +286,9 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
-  ExportCost: 200
-  ExportName: 
-  ExportMessage: cm3 of plasma
+  exportCost: 200
+  exportName: 
+  exportMessage: cm3 of plasma
 --- !u!1 &1668617562811696
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Security/Handcuffs.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Security/Handcuffs.prefab
@@ -259,7 +259,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 575557643
 --- !u!114 &414819323616783928
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -288,3 +288,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 3
+  ExportName: pair
+  ExportMessage: of handcuffs

--- a/UnityProject/Assets/Resources/Prefabs/Items/Security/Handcuffs.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Security/Handcuffs.prefab
@@ -259,7 +259,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 575557643
+  m_SceneId: 3029518109
 --- !u!114 &414819323616783928
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -288,6 +288,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
-  ExportCost: 3
-  ExportName: pair
-  ExportMessage: of handcuffs
+  exportCost: 3
+  exportName: pair
+  exportMessage: of handcuffs

--- a/UnityProject/Assets/Resources/Prefabs/Items/Security/Stun Baton.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Security/Stun Baton.prefab
@@ -198,7 +198,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 2187696878
+  m_SceneId: 3907065497
 --- !u!114 &-2084047483786155350
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -227,9 +227,9 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
-  ExportCost: 100
-  ExportName: 
-  ExportMessage: 
+  exportCost: 100
+  exportName: stun baton
+  exportMessage: 
 --- !u!1 &7503752899205498039
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Security/Stun Baton.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Security/Stun Baton.prefab
@@ -198,7 +198,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 2187696878
 --- !u!114 &-2084047483786155350
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -227,6 +227,9 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 100
+  ExportName: 
+  ExportMessage: 
 --- !u!1 &7503752899205498039
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Storage/Toolbox.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Storage/Toolbox.prefab
@@ -241,7 +241,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 2031722507
 --- !u!114 &3112443706636641109
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -302,6 +302,9 @@ MonoBehaviour:
   isEVACapable: 0
   attackVerbs:
   - robusted
+  ExportCost: 4
+  ExportName: 
+  ExportMessage: 
 --- !u!1 &8124923591362471050
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Storage/Toolbox.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Storage/Toolbox.prefab
@@ -241,7 +241,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 2031722507
+  m_SceneId: 3010262781
 --- !u!114 &3112443706636641109
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -302,9 +302,9 @@ MonoBehaviour:
   isEVACapable: 0
   attackVerbs:
   - robusted
-  ExportCost: 4
-  ExportName: 
-  ExportMessage: 
+  exportCost: 0
+  exportName: toolbox
+  exportMessage: 
 --- !u!1 &8124923591362471050
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Crowbar.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Crowbar.prefab
@@ -396,7 +396,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 763136616
 --- !u!114 &1144006968439912978
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -425,3 +425,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 2
+  ExportName: 
+  ExportMessage: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Extinguisher.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Extinguisher.prefab
@@ -368,7 +368,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 2637265618
+  m_SceneId: 697385888
 --- !u!114 &5519721869088170442
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -434,9 +434,9 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
-  ExportCost: 15
-  ExportName: fire extinguisher
-  ExportMessage: 
+  exportCost: 15
+  exportName: fire extinguisher
+  exportMessage: 
 --- !u!1 &1645206611696558437
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Extinguisher.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Extinguisher.prefab
@@ -209,6 +209,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   temperatureKelvin: 293.15
   MaxCapacity: 50
+  itemAttributes: {fileID: 0}
   InSolidForm: 0
   Reagents:
   - water
@@ -367,7 +368,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 2637265618
 --- !u!114 &5519721869088170442
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -433,6 +434,9 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 15
+  ExportName: fire extinguisher
+  ExportMessage: 
 --- !u!1 &1645206611696558437
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Handheld Torch.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Handheld Torch.prefab
@@ -503,7 +503,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 3690394854
+  m_SceneId: 3476636610
 --- !u!114 &-3339322490579092172
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -531,6 +531,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
-  ExportCost: 5
-  ExportName: 
-  ExportMessage: 
+  exportCost: 5
+  exportName: 
+  exportMessage: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Handheld Torch.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Handheld Torch.prefab
@@ -503,7 +503,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 3690394854
 --- !u!114 &-3339322490579092172
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -518,8 +518,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  initialName: Lamp
-  initialDescription: A Lamp
+  initialName: flashlight
+  initialDescription: 
   initialTraits: []
   initialSize: 1
   hitDamage: 0
@@ -531,3 +531,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 5
+  ExportName: 
+  ExportMessage: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Screwdriver.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Screwdriver.prefab
@@ -349,7 +349,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 3810379140
 --- !u!114 &-1190028257943365882
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -400,6 +400,9 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 2
+  ExportName: 
+  ExportMessage: 
 --- !u!1 &5751769075716656209
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Welder.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Welder.prefab
@@ -513,7 +513,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 2823870962
 --- !u!114 &4692721297068657182
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -542,6 +542,9 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 5
+  ExportName: welding tool
+  ExportMessage: 
 --- !u!1 &8596341256241081698
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Welder.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Welder.prefab
@@ -513,7 +513,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 2823870962
+  m_SceneId: 2881604182
 --- !u!114 &4692721297068657182
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -542,9 +542,9 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
-  ExportCost: 5
-  ExportName: welding tool
-  ExportMessage: 
+  exportCost: 5
+  exportName: welding tool
+  exportMessage: 
 --- !u!1 &8596341256241081698
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wirecutter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wirecutter.prefab
@@ -344,7 +344,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 1141419397
+  m_SceneId: 2024014231
 --- !u!114 &-3189124480840120252
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -373,6 +373,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
-  ExportCost: 2
-  ExportName: pair
-  ExportMessage: of wirecutters
+  exportCost: 2
+  exportName: pair
+  exportMessage: of wirecutters

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wirecutter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wirecutter.prefab
@@ -344,7 +344,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 1141419397
 --- !u!114 &-3189124480840120252
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -373,3 +373,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 2
+  ExportName: pair
+  ExportMessage: of wirecutters

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wrench.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wrench.prefab
@@ -418,7 +418,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 873924287
 --- !u!114 &8230273158682710619
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -447,3 +447,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 2
+  ExportName: 
+  ExportMessage: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wrench.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wrench.prefab
@@ -418,7 +418,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 873924287
+  m_SceneId: 1617197189
 --- !u!114 &8230273158682710619
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -447,6 +447,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
-  ExportCost: 2
-  ExportName: 
-  ExportMessage: 
+  exportCost: 2
+  exportName: wrench
+  exportMessage: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Cshotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Cshotgun_Ballistic.prefab
@@ -412,7 +412,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 3807670716
+  m_SceneId: 2599442964
 --- !u!114 &1144437016424961650
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -458,6 +458,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
-  ExportCost: 300
-  ExportName: 
-  ExportMessage: 
+  exportCost: 300
+  exportName: combat shotgun
+  exportMessage: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Cshotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Cshotgun_Ballistic.prefab
@@ -412,7 +412,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 3807670716
 --- !u!114 &1144437016424961650
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -458,3 +458,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 300
+  ExportName: 
+  ExportMessage: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Energy/Resources/LaserGun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Energy/Resources/LaserGun.prefab
@@ -258,7 +258,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 2025934988
 --- !u!114 &2060794053325888610
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -291,7 +291,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  initialName: LaserGun
+  initialName: laser gun
   initialDescription: 
   initialTraits: []
   initialSize: 1
@@ -304,6 +304,9 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 200
+  ExportName: 
+  ExportMessage: 
 --- !u!1 &1940283646410426
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/Metal.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/Metal.prefab
@@ -398,7 +398,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 1858515933
+  m_SceneId: 2422933096
 --- !u!114 &1418731889289770694
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -440,6 +440,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
-  ExportCost: 5
-  ExportName: 
-  ExportMessage: cm3 of metal
+  exportCost: 5
+  exportName: 
+  exportMessage: cm3 of metal

--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/Metal.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/Metal.prefab
@@ -398,7 +398,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 1858515933
 --- !u!114 &1418731889289770694
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -440,3 +440,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 5
+  ExportName: 
+  ExportMessage: cm3 of metal

--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/glass sheet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/glass sheet.prefab
@@ -301,7 +301,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
+  m_SceneId: 1590220627
 --- !u!114 &-2672449906344805648
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -351,3 +351,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  ExportCost: 5
+  ExportName: 
+  ExportMessage: cm3 of glass

--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/glass sheet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/glass sheet.prefab
@@ -301,7 +301,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 1590220627
+  m_SceneId: 1747070716
 --- !u!114 &-2672449906344805648
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -351,6 +351,6 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
-  ExportCost: 5
-  ExportName: 
-  ExportMessage: cm3 of glass
+  exportCost: 5
+  exportName: 
+  exportMessage: cm3 of glass

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/BaseCanister.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/BaseCanister.prefab
@@ -374,8 +374,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 1efec61511b50c844868cb49d1a711a1
-  m_SceneId: 0
+  m_AssetId: 
+  m_SceneId: 1318664337
 --- !u!1 &3261001144065486905
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Cargo/ExportScanner.cs
+++ b/UnityProject/Assets/Scripts/Cargo/ExportScanner.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+public class ExportScanner : MonoBehaviour, ICheckedInteractable<HandApply>
+{
+	public bool WillInteract(HandApply interaction, NetworkSide side)
+	{
+		if (!DefaultWillInteract.Default(interaction, side))
+		{
+			return false;
+		}
+
+		if (interaction.HandObject != gameObject)
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	public void ServerPerformInteraction(HandApply interaction)
+	{
+		var attributes = interaction.TargetObject.GetComponent<ItemAttributesV2>();
+		var price = attributes ? attributes.GetExportCost() : 0;
+		var exportName = interaction.TargetObject.ExpensiveName();
+		var message = price > 0
+			? $"Scanned { exportName }, value: { price } credits."
+			: $"Scanned { exportName }, no export value.";
+
+		// TODO #2400 if it has contents say contents included.
+
+		Chat.AddExamineMsg(interaction.Performer, message);
+	}
+}

--- a/UnityProject/Assets/Scripts/Cargo/ExportScanner.cs
+++ b/UnityProject/Assets/Scripts/Cargo/ExportScanner.cs
@@ -20,13 +20,13 @@ public class ExportScanner : MonoBehaviour, ICheckedInteractable<HandApply>
 	public void ServerPerformInteraction(HandApply interaction)
 	{
 		var attributes = interaction.TargetObject.GetComponent<ItemAttributesV2>();
-		var price = attributes ? attributes.GetExportCost() : 0;
+		var price = attributes ? attributes.ExportCost : 0;
 		var exportName = interaction.TargetObject.ExpensiveName();
 		var message = price > 0
 			? $"Scanned { exportName }, value: { price } credits."
 			: $"Scanned { exportName }, no export value.";
 
-		// TODO #2400 if it has contents say contents included.
+		// TODO #2400 if it has contents add " (contents included)"
 
 		Chat.AddExamineMsg(interaction.Performer, message);
 	}

--- a/UnityProject/Assets/Scripts/Cargo/ExportScanner.cs.meta
+++ b/UnityProject/Assets/Scripts/Cargo/ExportScanner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22e648b503e9446a5a32c187bce189a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -25,6 +25,8 @@ public class ItemAttributesV2 : NetworkBehaviour, IRightClickable, IServerSpawn
 	[Tooltip("Display name of this item when spawned.")]
 	[SerializeField]
 	private string initialName;
+	public string InitialName => initialName;
+
 	/// <summary>
 	/// Current name
 	/// </summary>
@@ -158,6 +160,16 @@ public class ItemAttributesV2 : NetworkBehaviour, IRightClickable, IServerSpawn
 		get => attackVerbs;
 		set => attackVerbs = new List<string>(value);
 	}
+
+	[Tooltip("How much does one of these sell for when shipped on the cargo shuttle?")]
+	[SerializeField]
+	private int ExportCost; // Use GetExportCost to obtain!
+
+	[Tooltip("Should an alternate name be used when displaying this in the cargo console report?")]
+	public string ExportName;
+
+	[Tooltip("Additional message to display in the cargo console report.")]
+	public string ExportMessage;
 
 	/// <summary>
 	/// Actual current traits, accounting for dynamic add / remove. Note that these adds / removes
@@ -357,5 +369,15 @@ public class ItemAttributesV2 : NetworkBehaviour, IRightClickable, IServerSpawn
 		SyncSize(newSize);
 	}
 
+	public int GetExportCost()
+	{
+		var stackable = GetComponent<Stackable>();
 
+		if (stackable != null)
+		{
+			return ExportCost * stackable.Amount;
+		}
+
+		return ExportCost;
+	}
 }

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -163,13 +163,32 @@ public class ItemAttributesV2 : NetworkBehaviour, IRightClickable, IServerSpawn
 
 	[Tooltip("How much does one of these sell for when shipped on the cargo shuttle?")]
 	[SerializeField]
-	private int ExportCost; // Use GetExportCost to obtain!
+	private int exportCost;
+	public int ExportCost
+	{
+		get
+		{
+			var stackable = GetComponent<Stackable>();
+
+			if (stackable != null)
+			{
+				return exportCost * stackable.Amount;
+			}
+
+			return exportCost;
+		}
+
+	}
 
 	[Tooltip("Should an alternate name be used when displaying this in the cargo console report?")]
-	public string ExportName;
+	[SerializeField]
+	private string exportName;
+	public string ExportName => exportName;
 
 	[Tooltip("Additional message to display in the cargo console report.")]
-	public string ExportMessage;
+	[SerializeField]
+	private string exportMessage;
+	public string ExportMessage => exportMessage;
 
 	/// <summary>
 	/// Actual current traits, accounting for dynamic add / remove. Note that these adds / removes
@@ -367,17 +386,5 @@ public class ItemAttributesV2 : NetworkBehaviour, IRightClickable, IServerSpawn
 	public void ServerSetSize(ItemSize newSize)
 	{
 		SyncSize(newSize);
-	}
-
-	public int GetExportCost()
-	{
-		var stackable = GetComponent<Stackable>();
-
-		if (stackable != null)
-		{
-			return ExportCost * stackable.Amount;
-		}
-
-		return ExportCost;
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -127,7 +127,7 @@ public class CargoManager : MonoBehaviour
 
 				if (!string.IsNullOrEmpty(entry.Value.ExportMessage) && string.IsNullOrEmpty(entry.Value.ExportName))
 				{ // Special handling for items that don't want pluralisation after
-					CentcomMessage += $" { entry.Value.ExportMessage }";
+					CentcomMessage += $" { entry.Value.ExportMessage }\n";
 				}
 				else
 				{
@@ -300,7 +300,7 @@ public class CargoManager : MonoBehaviour
 			return 0;
 		}
 
-		return attributes.GetExportCost();
+		return attributes.ExportCost;
 	}
 
 	private class ExportedItem

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -1,46 +1,46 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Lucene.Net.Support;
 using UnityEngine;
 using UnityEngine.Events;
 
 public class CargoManager : MonoBehaviour
 {
-	private static CargoManager cargoManager;
+	private static CargoManager _cargoManager;
 	public static CargoManager Instance
 	{
 		get
 		{
-			if (cargoManager == null)
+			if (_cargoManager == null)
 			{
-				cargoManager = FindObjectOfType<CargoManager>();
+				_cargoManager = FindObjectOfType<CargoManager>();
 			}
-			return cargoManager;
+			return _cargoManager;
 		}
 	}
 
-	[SerializeField]
-	private CargoData cargoData = null;
-	public int Credits = 0;
+	public int Credits;
 	public ShuttleStatus ShuttleStatus = ShuttleStatus.DockedStation;
-	[SerializeField]
-	private float shuttleFlyDuration = 10f;
 	public float CurrentFlyTime = 0f;
-	//Message that will appear in status tab. Resets on sending shuttle to centcom.
-	public string CentcomMessage = "";
-
-	//Supplies - all the stuff cargo can order
-	public List<CargoOrderCategory> Supplies = new List<CargoOrderCategory>();
-	public CargoOrderCategory CurrentCategory = null;
-	//Orders - payed orders that will spawn in shuttle on centcom arrival
-	public List<CargoOrder> CurrentOrders = new List<CargoOrder>();
-	//Cart - current orders, that haven't been payed for/ordered yet
-	public List<CargoOrder> CurrentCart = new List<CargoOrder>();
+	public string CentcomMessage = "";	// Message that will appear in status tab. Resets on sending shuttle to centcom.
+	public List<CargoOrderCategory> Supplies = new List<CargoOrderCategory>(); // Supplies - all the stuff cargo can order
+	public CargoOrderCategory CurrentCategory ;
+	public List<CargoOrder> CurrentOrders = new List<CargoOrder>(); // Orders - payed orders that will spawn in shuttle on centcom arrival
+	public List<CargoOrder> CurrentCart = new List<CargoOrder>(); // Cart - current orders, that haven't been payed for/ordered yet
 
 	public CargoUpdateEvent OnCartUpdate = new CargoUpdateEvent();
 	public CargoUpdateEvent OnShuttleUpdate = new CargoUpdateEvent();
 	public CargoUpdateEvent OnCreditsUpdate = new CargoUpdateEvent();
 	public CargoUpdateEvent OnCategoryUpdate = new CargoUpdateEvent();
 	public CargoUpdateEvent OnTimerUpdate = new CargoUpdateEvent();
+
+	[SerializeField]
+	private CargoData cargoData;
+
+	[SerializeField]
+	private float shuttleFlyDuration = 10f;
+
+	private HashMap<string, ExportedItem> exportedItems = new HashMap<string, ExportedItem>();
 
 	/// <summary>
 	/// Calls the shuttle.
@@ -57,6 +57,7 @@ public class CargoManager : MonoBehaviour
 		{
 			return;
 		}
+
 		if (CustomNetworkManager.Instance._isServer)
 		{
 			CurrentFlyTime = shuttleFlyDuration;
@@ -77,9 +78,11 @@ public class CargoManager : MonoBehaviour
 				CargoShuttle.Instance.MoveToCentcom();
 				ShuttleStatus = ShuttleStatus.OnRouteCentcom;
 				CentcomMessage = "";
+				exportedItems.Clear();
 				StartCoroutine(Timer(false));
 			}
 		}
+
 		OnShuttleUpdate?.Invoke();
 	}
 
@@ -116,28 +119,93 @@ public class CargoManager : MonoBehaviour
 
 		if (ShuttleStatus == ShuttleStatus.OnRouteCentcom)
 		{
+
+			foreach(var entry in exportedItems)
+			{
+				CentcomMessage += $"+{ entry.Value.TotalValue } credits: " +
+				                  $"{ entry.Value.Count }";
+
+				if (!string.IsNullOrEmpty(entry.Value.ExportMessage) && string.IsNullOrEmpty(entry.Value.ExportName))
+				{ // Special handling for items that don't want pluralisation after
+					CentcomMessage += $" { entry.Value.ExportMessage }";
+				}
+				else
+				{
+					CentcomMessage += $" { entry.Key }";
+
+					if (entry.Value.Count > 1)
+					{
+						CentcomMessage += "s";
+					}
+
+					CentcomMessage += $" { entry.Value.ExportMessage }\n";
+				}
+			}
+
 			ShuttleStatus = ShuttleStatus.DockedCentcom;
 		}
 		else if (ShuttleStatus == ShuttleStatus.OnRouteStation)
 		{
 			ShuttleStatus = ShuttleStatus.DockedStation;
 		}
+
 		OnShuttleUpdate?.Invoke();
 	}
 
 	public void DestroyItem(ObjectBehaviour item)
 	{
-		//If there is no bounty for the item - we dont destroy it.
-		float credits = CargoManager.Instance.AddCredits(item);
+		// If there is no bounty for the item - we dont destroy it.
+		var credits = Instance.GetSellPrice(item);
 		if (credits <= 0f)
 		{
 			return;
 		}
 
-		if (CentcomMessage == "")
-			CentcomMessage = "Bounty items received.\n";
-		//1 - quantity of items
-		CentcomMessage += $"+{credits} credits: received 1 {item.gameObject.ExpensiveName()}.\n";
+		Credits += credits;
+		OnCreditsUpdate?.Invoke();
+
+		var attributes = item.gameObject.GetComponent<ItemAttributesV2>();
+		string exportName;
+		if (attributes)
+		{
+			if (string.IsNullOrEmpty(attributes.ExportName))
+			{
+				exportName = attributes.InitialName;
+			}
+			else
+			{
+				exportName = attributes.ExportName;
+			}
+		}
+		else
+		{
+			exportName = item.gameObject.ExpensiveName();
+		}
+		ExportedItem export;
+		if (exportedItems.ContainsKey(exportName))
+		{
+			export = exportedItems[exportName];
+		}
+		else
+		{
+			export = new ExportedItem
+			{
+				ExportMessage = attributes ? attributes.ExportMessage : "",
+				ExportName = attributes ? attributes.ExportName : "" // Need to always use the given export name
+			};
+			exportedItems.Add(exportName, export);
+		}
+
+		var stackable = item.gameObject.GetComponent<Stackable>();
+		var count = 1;
+		if (stackable)
+		{
+			count = stackable.Amount;
+		}
+
+		export.Count += count;
+		export.TotalValue += credits;
+
 		item.registerTile.UnregisterClient();
 		item.registerTile.UnregisterServer();
 		Despawn.ServerSingle(item.gameObject);
@@ -218,23 +286,29 @@ public class CargoManager : MonoBehaviour
 		return;
 	}
 
-	/// <summary>
-	/// Adds the credits.
-	/// </summary>
-	/// <returns><c>true</c>, if credits were added, <c>false</c> otherwise.</returns>
-	/// <param name="item">Item.</param>
-	public float AddCredits(ObjectBehaviour item)
+	public int GetSellPrice(ObjectBehaviour item)
 	{
 		if (!CustomNetworkManager.Instance._isServer)
 		{
 			return 0;
 		}
 
-		int credits = cargoData.GetBounty(item);
-		Credits += credits;
-		OnCreditsUpdate?.Invoke();
+		var attributes = item.GetComponent<ItemAttributesV2>();
 
-		return credits;
+		if (attributes == null)
+		{
+			return 0;
+		}
+
+		return attributes.GetExportCost();
+	}
+
+	private class ExportedItem
+	{
+		public string ExportMessage;
+		public string ExportName;
+		public int Count;
+		public int TotalValue;
 	}
 }
 

--- a/UnityProject/Assets/Scripts/UI/Cargo/CargoData.cs
+++ b/UnityProject/Assets/Scripts/UI/Cargo/CargoData.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+﻿
 using System.Collections.Generic;
 using UnityEngine;
 


### PR DESCRIPTION
Fixes #2261 

### Purpose
Adds the cargo export scanner, and adds export fields to item attributes.
In the future, the fields will need to be added to objects as well, to handle crates.

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [x]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [x]  Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x]  Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [x]  Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ]  This PR has been tested with round restarts.
- [ ]  This PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
