### PR TITLE
Fixes posters after textures were removed from Resources

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Cargo.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Cargo.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 99aaeed6cfb76e54db0a1609ca1313f4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Other/Rolled Poster.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Other/Rolled Poster.prefab
@@ -247,10 +247,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b12aa9f5931c4146a22a84bd038fa5b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
   wallPrefab: {fileID: 5466995241280763689, guid: f421de3b3604142099b272d77faafeb6,
     type: 3}
   posterVariant: 1
-  sprite: {fileID: 0}
+  spriteRend: {fileID: 856240420534071871}
   legitSprite: {fileID: 21300000, guid: e3686f4fd49b3da478b3e180a674bd37, type: 3}
   contrabandSprite: {fileID: 21300000, guid: 18ac39b3a4c2e6347bb4431b95103a1a, type: 3}
 --- !u!114 &4868340152356198127
@@ -302,7 +304,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 96145b3165f5248b78302cd49658b0b2
   m_SceneId: 0
 --- !u!114 &1683984791003869720
 MonoBehaviour:
@@ -341,7 +343,12 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   initialName: Poster
+  ArticleName: 
   initialDescription: A large piece of space-resistant printed paper.
+  exportCost: 0
+  exportName: 
+  exportMessage: 
+  ArticleDescription: 
   initialTraits: []
   initialSize: 2
   hitDamage: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Poster.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Poster.prefab
@@ -19,6 +19,9 @@ GameObject:
   - component: {fileID: 7154680421102874471}
   - component: {fileID: 1721604302402341619}
   - component: {fileID: 1567170016700135650}
+  - component: {fileID: 7396077619560169508}
+  - component: {fileID: 4740298950607332326}
+  - component: {fileID: 1140414460732144086}
   m_Layer: 19
   m_Name: Poster
   m_TagString: Untagged
@@ -176,194 +179,231 @@ MonoBehaviour:
     Description: A poster glorifying the station's security force.
     Icon: poster1_legit
     sprite: {fileID: 21300000, guid: cbe0600a00e84644b85d61b2e7432749, type: 3}
+    PosterName: 4
     Type: 0
   - Name: Nanotrasen Logo
     Description: A poster depicting the Nanotrasen logo.
     Icon: poster2_legit
     sprite: {fileID: 21300000, guid: 0f5e695af727248489b24e49ff8f5d8c, type: 3}
+    PosterName: 5
     Type: 0
   - Name: Cleanliness
     Description: A poster warning of the dangers of poor hygiene.
     Icon: poster3_legit
     sprite: {fileID: 21300000, guid: 25fcd46371c369a4ea2752fef052bc7d, type: 3}
+    PosterName: 6
     Type: 0
   - Name: Help Others
     Description: A poster encouraging you to help fellow crewmembers.
     Icon: poster4_legit
     sprite: {fileID: 21300000, guid: 7390023b43bf9104aa2a30925a237555, type: 3}
+    PosterName: 7
     Type: 0
   - Name: Build
     Description: A poster glorifying the engineering team.
     Icon: poster5_legit
     sprite: {fileID: 21300000, guid: f057bfd7ebc03c6498b30d9cfc36aecf, type: 3}
+    PosterName: 8
     Type: 0
   - Name: Bless This Spess
     Description: A poster blessing this area.
     Icon: poster6_legit
     sprite: {fileID: 21300000, guid: 418218fc236baf24b954de84e47c6fa2, type: 3}
+    PosterName: 9
     Type: 0
   - Name: Science
     Description: A poster depicting an atom.
     Icon: poster7_legit
     sprite: {fileID: 21300000, guid: b0e0593fa3ce0ab4687e0f25cde41664, type: 3}
+    PosterName: 10
     Type: 0
   - Name: Ian
     Description: Arf arf. Yap.
     Icon: poster8_legit
     sprite: {fileID: 21300000, guid: ccea40663b910a14c8995f452e74f107, type: 3}
+    PosterName: 11
     Type: 0
   - Name: Obey
     Description: A poster instructing the viewer to obey authority.
     Icon: poster9_legit
     sprite: {fileID: 21300000, guid: b6aae61dd07e2644db7b71c87b1ead29, type: 3}
+    PosterName: 12
     Type: 0
   - Name: Walk
     Description: A poster instructing the viewer to walk instead of running.
     Icon: poster10_legit
     sprite: {fileID: 21300000, guid: 2c929a52242ec9f46858037a288692e2, type: 3}
+    PosterName: 13
     Type: 0
   - Name: State Laws
     Description: A poster instructing cyborgs to state their laws.
     Icon: poster11_legit
     sprite: {fileID: 21300000, guid: 85453e86a68c91e489ca801aebfe5301, type: 3}
+    PosterName: 14
     Type: 0
   - Name: Love Ian
     Description: Ian is love, Ian is life.
     Icon: poster12_legit
     sprite: {fileID: 21300000, guid: 24c358555fa57fd4e879fbbf0ab58919, type: 3}
+    PosterName: 15
     Type: 0
   - Name: Space Cops.
     Description: A poster advertising the television show Space Cops.
     Icon: poster13_legit
     sprite: {fileID: 21300000, guid: df421de19c115f447852cb18cbc7e9fa, type: 3}
+    PosterName: 16
     Type: 0
   - Name: Ue No.
     Description: This thing is all in Japanese.
     Icon: poster14_legit
     sprite: {fileID: 21300000, guid: 7086a8cd84e54174ab33edddcee06635, type: 3}
+    PosterName: 17
     Type: 0
   - Name: Get Your LEGS
     Description: 'LEGS: Leadership, Experience, Genius, Subordination.'
     Icon: poster15_legit
     sprite: {fileID: 21300000, guid: fd3dac031df779449a34b17f403581d7, type: 3}
+    PosterName: 18
     Type: 0
   - Name: Do Not Question
     Description: A poster instructing the viewer not to ask about things they aren't
       meant to know.
     Icon: poster16_legit
     sprite: {fileID: 21300000, guid: 2518beb78340ad440b86672c7d0d3507, type: 3}
+    PosterName: 19
     Type: 0
   - Name: Work For A Future
     Description: ' A poster encouraging you to work for your future.'
     Icon: poster17_legit
     sprite: {fileID: 21300000, guid: e8ff72ad7dcb79244aeff004e1a6cf3c, type: 3}
+    PosterName: 20
     Type: 0
   - Name: Soft Cap Pop Art
     Description: A poster reprint of some cheap pop art.
     Icon: poster18_legit
     sprite: {fileID: 21300000, guid: 3ca0ccca753ca054fa4e85b89b6d5561, type: 3}
+    PosterName: 21
     Type: 0
   - Name: 'Safety: Internals'
     Description: A poster instructing the viewer to wear internals in the rare environments
       where there is no oxygen or the air has been rendered toxic.
     Icon: poster19_legit
     sprite: {fileID: 21300000, guid: 18a4fd229236fe14abd2c26c6b13b7bd, type: 3}
+    PosterName: 22
     Type: 0
   - Name: 'Safety: Eye Protection'
     Description: A poster instructing the viewer to wear eye protection when dealing
       with chemicals, smoke, or bright lights.
     Icon: poster20_legit
     sprite: {fileID: 21300000, guid: f7c93867c6857de46b55635b9e1b748f, type: 3}
+    PosterName: 23
     Type: 0
   - Name: 'Safety: Report'
     Description: A poster instructing the viewer to report suspicious activity to
       the security force.
     Icon: poster21_legit
     sprite: {fileID: 21300000, guid: 1e91bc27fdded0549a123fdf66640202, type: 3}
+    PosterName: 24
     Type: 0
   - Name: Report Crimes
     Description: A poster encouraging the swift reporting of crime or seditious behavior
       to station security.
     Icon: poster22_legit
     sprite: {fileID: 21300000, guid: fdcf7463a1d88cc49aecd40890aa0722, type: 3}
+    PosterName: 25
     Type: 0
   - Name: Ion Rifle
     Description: A poster displaying an Ion Rifle.
     Icon: poster23_legit
     sprite: {fileID: 21300000, guid: 0f3ed2ca0789c324e989d119f587b1bd, type: 3}
+    PosterName: 26
     Type: 0
   - Name: Foam Force Ad
     Description: Foam Force, it's Foam or be Foamed!
     Icon: poster24_legit
     sprite: {fileID: 21300000, guid: 9a4b2e2024af2a749936aeb5f82f41b8, type: 3}
+    PosterName: 27
     Type: 0
   - Name: Cohiba Robusto Ad
     Description: Cohiba Robusto, the classy cigar.
     Icon: poster25_legit
     sprite: {fileID: 21300000, guid: 9215f7476fd2f0849ae107cd182821dd, type: 3}
+    PosterName: 28
     Type: 0
   - Name: 50th Anniversary Vintage Reprint
     Description: A reprint of a poster from 2505, commemorating the 50th Anniversary
       of Nanoposters Manufacturing, a subsidiary of Nanotrasen.
     Icon: poster26_legit
     sprite: {fileID: 21300000, guid: 3bddae21b2fee274790eeb62e9c568d6, type: 3}
+    PosterName: 29
     Type: 0
   - Name: Fruit Bowl
     Description: ' Simple, yet awe-inspiring.'
     Icon: poster27_legit
     sprite: {fileID: 21300000, guid: 6b68c059763546e4eabccb5f8ebb7ff4, type: 3}
+    PosterName: 30
     Type: 0
   - Name: PDA Ad
     Description: A poster advertising the latest PDA from Nanotrasen suppliers.
     Icon: poster28_legit
     sprite: {fileID: 21300000, guid: 5159ba75725176543b7e7cc9358bbf8b, type: 3}
+    PosterName: 31
     Type: 0
   - Name: Enlist
     Description: Enlist in the Nanotrasen Deathsquadron reserves today!
     Icon: poster29_legit
     sprite: {fileID: 21300000, guid: 898e2293eea96b64b94eb5082a0e9f8e, type: 3}
+    PosterName: 32
     Type: 0
   - Name: Nanomichi Ad
     Description: ' A poster advertising Nanomichi brand audio cassettes.'
     Icon: poster30_legit
     sprite: {fileID: 21300000, guid: 1c78a1fc74c3d104ebe756b2837c1ae6, type: 3}
+    PosterName: 33
     Type: 0
   - Name: 12 Gauge
     Description: A poster boasting about the superiority of 12 gauge shotgun shells.
     Icon: poster31_legit
     sprite: {fileID: 21300000, guid: 89edc361539858e488834ccd0cd1d8aa, type: 3}
+    PosterName: 34
     Type: 0
   - Name: High-Class Martini
     Description: I told you to shake it, no stirring.
     Icon: poster32_legit
     sprite: {fileID: 21300000, guid: 4818a76fae4e93a4ea93774a37242418, type: 3}
+    PosterName: 35
     Type: 0
   - Name: The Owl
     Description: The Owl would do his best to protect the station. Will you?
     Icon: poster33_legit
     sprite: {fileID: 21300000, guid: b743315fcb6eb1746a7882ff9fc6ed79, type: 3}
+    PosterName: 36
     Type: 0
   - Name: No ERP
     Description: This poster reminds the crew that Eroticism, Rape and Pornography
       are banned on Nanotrasen stations.
     Icon: poster34_legit
     sprite: {fileID: 21300000, guid: ffae759fb2d1249429c202c626eeb355, type: 3}
+    PosterName: 37
     Type: 0
   - Name: Carbon Dioxide
     Description: This informational poster teaches the viewer what carbon dioxide
       is.
     Icon: poster35_legit
     sprite: {fileID: 21300000, guid: 2a5fea2feff921f42bf348af821bb608, type: 3}
+    PosterName: 38
     Type: 0
   - Name: Unite Today
     Description: This poster inspires crew to unite under a new common codebase.
     Icon: unity_poster1
     sprite: {fileID: 21300000, guid: bbcac2fc148dc4c56836c755377537d3, type: 3}
+    PosterName: 85
     Type: 0
   - Name: Unitystation Poster
     Description: A poster displaying a large 'U'.
     Icon: unity_poster2
     sprite: {fileID: 21300000, guid: 370b536cc781c4205873df2f055e3e6d, type: 3}
+    PosterName: 86
     Type: 0
   ContrabandPosters:
   - Name: Free Tonto
@@ -371,243 +411,289 @@ MonoBehaviour:
       faded from age.
     Icon: poster1
     sprite: {fileID: 21300000, guid: e32821336d8c9ea4cbecc2af1a1ba752, type: 3}
+    PosterName: 39
     Type: 1
   - Name: Atmosia Declaration of Independence
     Description: A relic of a failed rebellion.
     Icon: poster2
     sprite: {fileID: 21300000, guid: 745420e0b6a81f9429f6678b1857d438, type: 3}
+    PosterName: 40
     Type: 1
   - Name: Fun Police
     Description: A poster condemning the station's security forces.
     Icon: poster3
     sprite: {fileID: 21300000, guid: cceaacfdc5e8e5e4784dec935ebb2186, type: 3}
+    PosterName: 41
     Type: 1
   - Name: Lusty Xenomorph
     Description: A heretical poster depicting the titular star of an equally heretical
       book.
     Icon: poster4
     sprite: {fileID: 21300000, guid: 9c6c10e4fbeeaa5419fb14583c6c9d28, type: 3}
+    PosterName: 42
     Type: 1
   - Name: Syndicate Recruitment
     Description: See the galaxy! Shatter corrupt megacorporations! Join today!
     Icon: poster5
     sprite: {fileID: 21300000, guid: 6d1f88cb1fde9f1448e6208e9faeab2c, type: 3}
+    PosterName: 43
     Type: 1
   - Name: Clown
     Description: Honk.
     Icon: poster6
     sprite: {fileID: 21300000, guid: fd6afc24d5bf7224bbf0ff547463067a, type: 3}
+    PosterName: 44
     Type: 1
   - Name: Smoke
     Description: A poster advertising a rival corporate brand of cigarettes.
     Icon: poster7
     sprite: {fileID: 21300000, guid: abfe562407f87244980a9348da5818f1, type: 3}
+    PosterName: 45
     Type: 1
   - Name: Grey Tide
     Description: A rebellious poster symbolizing assistant solidarity.
     Icon: poster8
     sprite: {fileID: 21300000, guid: daf8d7c74689a5a42beeb56911ed71e0, type: 3}
+    PosterName: 46
     Type: 1
   - Name: Missing Gloves
     Description: This poster references the uproar that followed Nanotrasen's financial
       cuts toward insulated-glove purchases.
     Icon: poster9
     sprite: {fileID: 21300000, guid: fa6d5ff051e093a4ebad2e0ab1ea1e8a, type: 3}
+    PosterName: 47
     Type: 1
   - Name: Hacking Guide
     Description: This poster details the internal workings of the common Nanotrasen
       airlock. Sadly, it appears out of date.
     Icon: poster10
     sprite: {fileID: 21300000, guid: b19c98ff0fcab49429b261c116e8bd54, type: 3}
+    PosterName: 48
     Type: 1
   - Name: RIP Badger
     Description: This seditious poster references Nanotrasen's genocide of a space
       station full of badgers.
     Icon: poster11
     sprite: {fileID: 21300000, guid: 799e4094ce43f1741a9f3ae3fa1de629, type: 3}
+    PosterName: 49
     Type: 1
   - Name: Ambrosia Vulgaris
     Description: This poster is lookin' pretty trippy man.
     Icon: poster12
     sprite: {fileID: 21300000, guid: fff52baf72a828f47a88b4df3a65e08e, type: 3}
+    PosterName: 50
     Type: 1
   - Name: Donut Corp.
     Description: This poster is an unauthorized advertisement for Donut Corp.
     Icon: poster13
     sprite: {fileID: 21300000, guid: 3f3a44abc211d1f478d0e1c48dbc39ab, type: 3}
+    PosterName: 51
     Type: 1
   - Name: EAT.
     Description: This poster promotes rank gluttony.
     Icon: poster14
     sprite: {fileID: 21300000, guid: 24c3f41ed7784ee4c8625a957b1900fc, type: 3}
+    PosterName: 52
     Type: 1
   - Name: Tools
     Description: This poster looks like an advertisement for tools, but is in fact
       a subliminal jab at the tools at CentCom.
     Icon: poster15
     sprite: {fileID: 21300000, guid: 9bbf5cc3b4b06e3489f989f48ea8b7e6, type: 3}
+    PosterName: 53
     Type: 1
   - Name: Power
     Description: A poster that positions the seat of power outside Nanotrasen.
     Icon: poster16
     sprite: {fileID: 21300000, guid: 6df359c3f165507499d9ad1594ec921b, type: 3}
+    PosterName: 54
     Type: 1
   - Name: Space Cube
     Description: Ignorant of Nature's Harmonic 6 Side Space Cube Creation, the Spacemen
       are Dumb, Educated Singularity Stupid and Evil.
     Icon: poster17
     sprite: {fileID: 21300000, guid: cdd4fccc4d9778e4fa980f03bd945fb6, type: 3}
+    PosterName: 55
     Type: 1
   - Name: Communist State
     Description: All hail the Communist party!
     Icon: poster18
     sprite: {fileID: 21300000, guid: 0a9c68d02ac656343821ac024ee2abc6, type: 3}
+    PosterName: 56
     Type: 1
   - Name: Lamarr
     Description: This poster depicts Lamarr. Probably made by a traitorous Research
       Director.
     Icon: poster19
     sprite: {fileID: 21300000, guid: c89da4c16e2c6834eab94304db33c0f6, type: 3}
+    PosterName: 57
     Type: 1
   - Name: Borg Fancy
     Description: Being fancy can be for any borg, just need a suit.
     Icon: poster20
     sprite: {fileID: 21300000, guid: 689b3163aa085cb45b4201698054c5fa, type: 3}
+    PosterName: 58
     Type: 1
   - Name: Borg Fancy v2
     Description: Borg Fancy, Now only taking the most fancy.
     Icon: poster21
     sprite: {fileID: 21300000, guid: f138792f0d8c9a444be6a88ac4191e68, type: 3}
+    PosterName: 59
     Type: 1
   - Name: Kosmicheskaya Stantsiya 13 Does Not Exist
     Description: A poster mocking CentCom's denial of the existence of the derelict
       station near Space Station 13.
     Icon: poster22
     sprite: {fileID: 21300000, guid: f9314ba3f0ab0a14caa80c4ced02ffb8, type: 3}
+    PosterName: 60
     Type: 1
   - Name: Rebels Unite
     Description: A poster urging the viewer to rebel against Nanotrasen.
     Icon: poster23
     sprite: {fileID: 21300000, guid: b9210ea10c9e44e4a954a37c0253c478, type: 3}
+    PosterName: 61
     Type: 1
   - Name: C-20r
     Description: A poster advertising the Scarborough Arms C-20r.
     Icon: poster24
     sprite: {fileID: 21300000, guid: 775c1e6859a02c9489b934383330b6f3, type: 3}
+    PosterName: 62
     Type: 1
   - Name: Have a Puff
     Description: Who cares about lung cancer when you're high as a kite?
     Icon: poster25
     sprite: {fileID: 21300000, guid: 1863d40450ef2da4b9658e4891a9c2f6, type: 3}
+    PosterName: 63
     Type: 1
   - Name: Revolver
     Description: Because seven shots are all you need.
     Icon: poster26
     sprite: {fileID: 21300000, guid: 3d6e5322b54edea4aa6db214dcb75f2e, type: 3}
+    PosterName: 64
     Type: 1
   - Name: D-Day Promo
     Description: A promotional poster for some rapper.
     Icon: poster27
     sprite: {fileID: 21300000, guid: d0433396ca83a114792c6b281bb106bb, type: 3}
+    PosterName: 65
     Type: 1
   - Name: Syndicate Pistol
     Description: A poster advertising syndicate pistols as being 'classy as fuck'.
       It is covered in faded gang tags.
     Icon: poster28
     sprite: {fileID: 21300000, guid: d0829fb9e1587b24ea34abcfd3874fd2, type: 3}
+    PosterName: 66
     Type: 1
   - Name: Energy Swords
     Description: All the colors of the bloody murder rainbow.
     Icon: poster29
     sprite: {fileID: 21300000, guid: 80c7e028bedb29f4fb08c19074a92c5f, type: 3}
+    PosterName: 67
     Type: 1
   - Name: Red Rum
     Description: Looking at this poster makes you want to kill.
     Icon: poster30
     sprite: {fileID: 21300000, guid: 7a0ec619d902d6343b897daff77fb44e, type: 3}
+    PosterName: 68
     Type: 1
   - Name: CC 64K Ad
     Description: The latest portable computer from Comrade Computing, with a whole
       64kB of ram!
     Icon: poster31
     sprite: {fileID: 21300000, guid: 6c3be5035d4ad5945a3404ff2ad35002, type: 3}
+    PosterName: 69
     Type: 1
   - Name: Punch Shit
     Description: Fight things for no reason, like a man!
     Icon: poster32
     sprite: {fileID: 21300000, guid: 40d6cdc4665cbdb498ef43dd92db4ca3, type: 3}
+    PosterName: 70
     Type: 1
   - Name: The Griffin
     Description: The Griffin commands you to be the worst you can be. Will you?
     Icon: poster33
     sprite: {fileID: 21300000, guid: 232bd00bb76b87a4f9db329c8a6bedae, type: 3}
+    PosterName: 71
     Type: 1
   - Name: Lizard
     Description: This lewd poster depicts a lizard preparing to mate.
     Icon: poster34
     sprite: {fileID: 21300000, guid: f6706854cd6af894391123a264f0a184, type: 3}
+    PosterName: 72
     Type: 1
   - Name: Free Drone
     Description: This poster commemorates the bravery of the rogue drone; once exiled,
       and then ultimately destroyed by CentCom.
     Icon: poster35
     sprite: {fileID: 21300000, guid: e592369a1f066c745a1bd6241c3fc78b, type: 3}
+    PosterName: 73
     Type: 1
   - Name: Busty Backdoor Xeno Babes 6
     Description: Get a load, or give, of these all natural Xenos!
     Icon: poster36
     sprite: {fileID: 21300000, guid: 9a00af3d2e894224ea687e728f1d1205, type: 3}
+    PosterName: 74
     Type: 1
   - Name: Robust Softdrinks
     Description: 'Robust Softdrinks: More robust than a toolbox to the head!'
     Icon: poster37
     sprite: {fileID: 21300000, guid: 979edb55eadad6c418dd91e433aa53a3, type: 3}
+    PosterName: 75
     Type: 1
   - Name: Shambler's Juice
     Description: ~Shake me up some of that Shambler's Juice!~
     Icon: poster38
     sprite: {fileID: 21300000, guid: 2f4ae5183eecc5841afb7d6adfa5d183, type: 3}
+    PosterName: 76
     Type: 1
   - Name: Pwr Game
     Description: The POWER that gamers CRAVE! In partnership with Vlad's Salad.
     Icon: poster39
     sprite: {fileID: 21300000, guid: 2e8c2e0e0eb2bb54eb8f16c9ff779bbc, type: 3}
+    PosterName: 77
     Type: 1
   - Name: Sun-kist
     Description: Drink the stars!
     Icon: poster40
     sprite: {fileID: 21300000, guid: 9ebbb3c2fa222d64686f6f55d332cb23, type: 3}
+    PosterName: 78
     Type: 1
   - Name: Space Cola
     Description: Your favorite cola, in space.
     Icon: poster41
     sprite: {fileID: 21300000, guid: dee08319b9110544c849419df7b1860f, type: 3}
+    PosterName: 79
     Type: 1
   - Name: Space-Up!
     Description: Sucked out into space by the FLAVOR!
     Icon: poster42
     sprite: {fileID: 21300000, guid: b241cea6dbfc5734cbf930b33484907c, type: 3}
+    PosterName: 80
     Type: 1
   - Name: Kudzu
     Description: A poster advertising a movie about plants. How dangerous could they
       possibly be?
     Icon: poster43
     sprite: {fileID: 21300000, guid: a6503976a2445b04c814313ba0a99692, type: 3}
+    PosterName: 81
     Type: 1
   - Name: Masked Men
     Description: A poster advertising a movie about some masked men.
     Icon: poster44
     sprite: {fileID: 21300000, guid: 74f43f4cf7698a449bb32e2e42f2a5bd, type: 3}
+    PosterName: 82
     Type: 1
   - Name: Free Syndicate Encryption Key
     Description: A poster about traitors begging for more.
     Icon: poster46
     sprite: {fileID: 0}
+    PosterName: 83
     Type: 1
   - Name: Bounty Hunters
     Description: A poster advertising bounty hunting services. "I hear you got a problem."
     Icon: poster47
     sprite: {fileID: 0}
+    PosterName: 84
     Type: 1
   OtherPosters:
   - Name: Ripped Poster
@@ -615,21 +701,7 @@ MonoBehaviour:
       ruined.
     Icon: poster_ripped
     sprite: {fileID: 21300000, guid: ce1a5a40bb07b71459d0b6eac14a7a26, type: 3}
-    Type: -1
-  - Name: Random Poster
-    Description: random_anything
-    Icon: 
-    sprite: {fileID: 0}
-    Type: -1
-  - Name: Random Official Poster
-    Description: 
-    Icon: random_official
-    sprite: {fileID: 21300000, guid: cf4848a8ef4ba4646a656d9ee57905fb, type: 3}
-    Type: -1
-  - Name: Random Contraband Poster
-    Description: 
-    Icon: random_contraband
-    sprite: {fileID: 21300000, guid: c371afa2d32f24d48a5ae9fbe231e336, type: 3}
+    PosterName: 0
     Type: -1
 --- !u!114 &1721604302402341619
 MonoBehaviour:
@@ -682,6 +754,52 @@ MonoBehaviour:
   localPlayerAuthority: 0
   m_AssetId: f421de3b3604142099b272d77faafeb6
   m_SceneId: 0
+--- !u!114 &7396077619560169508
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5466995241280763689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1ce0dbeeeb473dae66fb3610953c99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+--- !u!114 &4740298950607332326
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5466995241280763689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  registerTile: {fileID: 0}
+  isNotPushable: 0
+--- !u!114 &1140414460732144086
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5466995241280763689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 322493e979844b028b86387c7a0aa50c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  layer: {fileID: 0}
+  ObjectType: 0
 --- !u!1 &5583455716784618316
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Poster.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/Poster.prefab
@@ -171,6 +171,466 @@ MonoBehaviour:
   rolledPosterPrefab: {fileID: 5074129411573611090, guid: 96145b3165f5248b78302cd49658b0b2,
     type: 3}
   posterVariant: 85
+  OfficialPosters:
+  - Name: Here For Your Safety
+    Description: A poster glorifying the station's security force.
+    Icon: poster1_legit
+    sprite: {fileID: 21300000, guid: cbe0600a00e84644b85d61b2e7432749, type: 3}
+    Type: 0
+  - Name: Nanotrasen Logo
+    Description: A poster depicting the Nanotrasen logo.
+    Icon: poster2_legit
+    sprite: {fileID: 21300000, guid: 0f5e695af727248489b24e49ff8f5d8c, type: 3}
+    Type: 0
+  - Name: Cleanliness
+    Description: A poster warning of the dangers of poor hygiene.
+    Icon: poster3_legit
+    sprite: {fileID: 21300000, guid: 25fcd46371c369a4ea2752fef052bc7d, type: 3}
+    Type: 0
+  - Name: Help Others
+    Description: A poster encouraging you to help fellow crewmembers.
+    Icon: poster4_legit
+    sprite: {fileID: 21300000, guid: 7390023b43bf9104aa2a30925a237555, type: 3}
+    Type: 0
+  - Name: Build
+    Description: A poster glorifying the engineering team.
+    Icon: poster5_legit
+    sprite: {fileID: 21300000, guid: f057bfd7ebc03c6498b30d9cfc36aecf, type: 3}
+    Type: 0
+  - Name: Bless This Spess
+    Description: A poster blessing this area.
+    Icon: poster6_legit
+    sprite: {fileID: 21300000, guid: 418218fc236baf24b954de84e47c6fa2, type: 3}
+    Type: 0
+  - Name: Science
+    Description: A poster depicting an atom.
+    Icon: poster7_legit
+    sprite: {fileID: 21300000, guid: b0e0593fa3ce0ab4687e0f25cde41664, type: 3}
+    Type: 0
+  - Name: Ian
+    Description: Arf arf. Yap.
+    Icon: poster8_legit
+    sprite: {fileID: 21300000, guid: ccea40663b910a14c8995f452e74f107, type: 3}
+    Type: 0
+  - Name: Obey
+    Description: A poster instructing the viewer to obey authority.
+    Icon: poster9_legit
+    sprite: {fileID: 21300000, guid: b6aae61dd07e2644db7b71c87b1ead29, type: 3}
+    Type: 0
+  - Name: Walk
+    Description: A poster instructing the viewer to walk instead of running.
+    Icon: poster10_legit
+    sprite: {fileID: 21300000, guid: 2c929a52242ec9f46858037a288692e2, type: 3}
+    Type: 0
+  - Name: State Laws
+    Description: A poster instructing cyborgs to state their laws.
+    Icon: poster11_legit
+    sprite: {fileID: 21300000, guid: 85453e86a68c91e489ca801aebfe5301, type: 3}
+    Type: 0
+  - Name: Love Ian
+    Description: Ian is love, Ian is life.
+    Icon: poster12_legit
+    sprite: {fileID: 21300000, guid: 24c358555fa57fd4e879fbbf0ab58919, type: 3}
+    Type: 0
+  - Name: Space Cops.
+    Description: A poster advertising the television show Space Cops.
+    Icon: poster13_legit
+    sprite: {fileID: 21300000, guid: df421de19c115f447852cb18cbc7e9fa, type: 3}
+    Type: 0
+  - Name: Ue No.
+    Description: This thing is all in Japanese.
+    Icon: poster14_legit
+    sprite: {fileID: 21300000, guid: 7086a8cd84e54174ab33edddcee06635, type: 3}
+    Type: 0
+  - Name: Get Your LEGS
+    Description: 'LEGS: Leadership, Experience, Genius, Subordination.'
+    Icon: poster15_legit
+    sprite: {fileID: 21300000, guid: fd3dac031df779449a34b17f403581d7, type: 3}
+    Type: 0
+  - Name: Do Not Question
+    Description: A poster instructing the viewer not to ask about things they aren't
+      meant to know.
+    Icon: poster16_legit
+    sprite: {fileID: 21300000, guid: 2518beb78340ad440b86672c7d0d3507, type: 3}
+    Type: 0
+  - Name: Work For A Future
+    Description: ' A poster encouraging you to work for your future.'
+    Icon: poster17_legit
+    sprite: {fileID: 21300000, guid: e8ff72ad7dcb79244aeff004e1a6cf3c, type: 3}
+    Type: 0
+  - Name: Soft Cap Pop Art
+    Description: A poster reprint of some cheap pop art.
+    Icon: poster18_legit
+    sprite: {fileID: 21300000, guid: 3ca0ccca753ca054fa4e85b89b6d5561, type: 3}
+    Type: 0
+  - Name: 'Safety: Internals'
+    Description: A poster instructing the viewer to wear internals in the rare environments
+      where there is no oxygen or the air has been rendered toxic.
+    Icon: poster19_legit
+    sprite: {fileID: 21300000, guid: 18a4fd229236fe14abd2c26c6b13b7bd, type: 3}
+    Type: 0
+  - Name: 'Safety: Eye Protection'
+    Description: A poster instructing the viewer to wear eye protection when dealing
+      with chemicals, smoke, or bright lights.
+    Icon: poster20_legit
+    sprite: {fileID: 21300000, guid: f7c93867c6857de46b55635b9e1b748f, type: 3}
+    Type: 0
+  - Name: 'Safety: Report'
+    Description: A poster instructing the viewer to report suspicious activity to
+      the security force.
+    Icon: poster21_legit
+    sprite: {fileID: 21300000, guid: 1e91bc27fdded0549a123fdf66640202, type: 3}
+    Type: 0
+  - Name: Report Crimes
+    Description: A poster encouraging the swift reporting of crime or seditious behavior
+      to station security.
+    Icon: poster22_legit
+    sprite: {fileID: 21300000, guid: fdcf7463a1d88cc49aecd40890aa0722, type: 3}
+    Type: 0
+  - Name: Ion Rifle
+    Description: A poster displaying an Ion Rifle.
+    Icon: poster23_legit
+    sprite: {fileID: 21300000, guid: 0f3ed2ca0789c324e989d119f587b1bd, type: 3}
+    Type: 0
+  - Name: Foam Force Ad
+    Description: Foam Force, it's Foam or be Foamed!
+    Icon: poster24_legit
+    sprite: {fileID: 21300000, guid: 9a4b2e2024af2a749936aeb5f82f41b8, type: 3}
+    Type: 0
+  - Name: Cohiba Robusto Ad
+    Description: Cohiba Robusto, the classy cigar.
+    Icon: poster25_legit
+    sprite: {fileID: 21300000, guid: 9215f7476fd2f0849ae107cd182821dd, type: 3}
+    Type: 0
+  - Name: 50th Anniversary Vintage Reprint
+    Description: A reprint of a poster from 2505, commemorating the 50th Anniversary
+      of Nanoposters Manufacturing, a subsidiary of Nanotrasen.
+    Icon: poster26_legit
+    sprite: {fileID: 21300000, guid: 3bddae21b2fee274790eeb62e9c568d6, type: 3}
+    Type: 0
+  - Name: Fruit Bowl
+    Description: ' Simple, yet awe-inspiring.'
+    Icon: poster27_legit
+    sprite: {fileID: 21300000, guid: 6b68c059763546e4eabccb5f8ebb7ff4, type: 3}
+    Type: 0
+  - Name: PDA Ad
+    Description: A poster advertising the latest PDA from Nanotrasen suppliers.
+    Icon: poster28_legit
+    sprite: {fileID: 21300000, guid: 5159ba75725176543b7e7cc9358bbf8b, type: 3}
+    Type: 0
+  - Name: Enlist
+    Description: Enlist in the Nanotrasen Deathsquadron reserves today!
+    Icon: poster29_legit
+    sprite: {fileID: 21300000, guid: 898e2293eea96b64b94eb5082a0e9f8e, type: 3}
+    Type: 0
+  - Name: Nanomichi Ad
+    Description: ' A poster advertising Nanomichi brand audio cassettes.'
+    Icon: poster30_legit
+    sprite: {fileID: 21300000, guid: 1c78a1fc74c3d104ebe756b2837c1ae6, type: 3}
+    Type: 0
+  - Name: 12 Gauge
+    Description: A poster boasting about the superiority of 12 gauge shotgun shells.
+    Icon: poster31_legit
+    sprite: {fileID: 21300000, guid: 89edc361539858e488834ccd0cd1d8aa, type: 3}
+    Type: 0
+  - Name: High-Class Martini
+    Description: I told you to shake it, no stirring.
+    Icon: poster32_legit
+    sprite: {fileID: 21300000, guid: 4818a76fae4e93a4ea93774a37242418, type: 3}
+    Type: 0
+  - Name: The Owl
+    Description: The Owl would do his best to protect the station. Will you?
+    Icon: poster33_legit
+    sprite: {fileID: 21300000, guid: b743315fcb6eb1746a7882ff9fc6ed79, type: 3}
+    Type: 0
+  - Name: No ERP
+    Description: This poster reminds the crew that Eroticism, Rape and Pornography
+      are banned on Nanotrasen stations.
+    Icon: poster34_legit
+    sprite: {fileID: 21300000, guid: ffae759fb2d1249429c202c626eeb355, type: 3}
+    Type: 0
+  - Name: Carbon Dioxide
+    Description: This informational poster teaches the viewer what carbon dioxide
+      is.
+    Icon: poster35_legit
+    sprite: {fileID: 21300000, guid: 2a5fea2feff921f42bf348af821bb608, type: 3}
+    Type: 0
+  - Name: Unite Today
+    Description: This poster inspires crew to unite under a new common codebase.
+    Icon: unity_poster1
+    sprite: {fileID: 21300000, guid: bbcac2fc148dc4c56836c755377537d3, type: 3}
+    Type: 0
+  - Name: Unitystation Poster
+    Description: A poster displaying a large 'U'.
+    Icon: unity_poster2
+    sprite: {fileID: 21300000, guid: 370b536cc781c4205873df2f055e3e6d, type: 3}
+    Type: 0
+  ContrabandPosters:
+  - Name: Free Tonto
+    Description: A salvaged shred of a much larger flag, colors bled together and
+      faded from age.
+    Icon: poster1
+    sprite: {fileID: 21300000, guid: e32821336d8c9ea4cbecc2af1a1ba752, type: 3}
+    Type: 1
+  - Name: Atmosia Declaration of Independence
+    Description: A relic of a failed rebellion.
+    Icon: poster2
+    sprite: {fileID: 21300000, guid: 745420e0b6a81f9429f6678b1857d438, type: 3}
+    Type: 1
+  - Name: Fun Police
+    Description: A poster condemning the station's security forces.
+    Icon: poster3
+    sprite: {fileID: 21300000, guid: cceaacfdc5e8e5e4784dec935ebb2186, type: 3}
+    Type: 1
+  - Name: Lusty Xenomorph
+    Description: A heretical poster depicting the titular star of an equally heretical
+      book.
+    Icon: poster4
+    sprite: {fileID: 21300000, guid: 9c6c10e4fbeeaa5419fb14583c6c9d28, type: 3}
+    Type: 1
+  - Name: Syndicate Recruitment
+    Description: See the galaxy! Shatter corrupt megacorporations! Join today!
+    Icon: poster5
+    sprite: {fileID: 21300000, guid: 6d1f88cb1fde9f1448e6208e9faeab2c, type: 3}
+    Type: 1
+  - Name: Clown
+    Description: Honk.
+    Icon: poster6
+    sprite: {fileID: 21300000, guid: fd6afc24d5bf7224bbf0ff547463067a, type: 3}
+    Type: 1
+  - Name: Smoke
+    Description: A poster advertising a rival corporate brand of cigarettes.
+    Icon: poster7
+    sprite: {fileID: 21300000, guid: abfe562407f87244980a9348da5818f1, type: 3}
+    Type: 1
+  - Name: Grey Tide
+    Description: A rebellious poster symbolizing assistant solidarity.
+    Icon: poster8
+    sprite: {fileID: 21300000, guid: daf8d7c74689a5a42beeb56911ed71e0, type: 3}
+    Type: 1
+  - Name: Missing Gloves
+    Description: This poster references the uproar that followed Nanotrasen's financial
+      cuts toward insulated-glove purchases.
+    Icon: poster9
+    sprite: {fileID: 21300000, guid: fa6d5ff051e093a4ebad2e0ab1ea1e8a, type: 3}
+    Type: 1
+  - Name: Hacking Guide
+    Description: This poster details the internal workings of the common Nanotrasen
+      airlock. Sadly, it appears out of date.
+    Icon: poster10
+    sprite: {fileID: 21300000, guid: b19c98ff0fcab49429b261c116e8bd54, type: 3}
+    Type: 1
+  - Name: RIP Badger
+    Description: This seditious poster references Nanotrasen's genocide of a space
+      station full of badgers.
+    Icon: poster11
+    sprite: {fileID: 21300000, guid: 799e4094ce43f1741a9f3ae3fa1de629, type: 3}
+    Type: 1
+  - Name: Ambrosia Vulgaris
+    Description: This poster is lookin' pretty trippy man.
+    Icon: poster12
+    sprite: {fileID: 21300000, guid: fff52baf72a828f47a88b4df3a65e08e, type: 3}
+    Type: 1
+  - Name: Donut Corp.
+    Description: This poster is an unauthorized advertisement for Donut Corp.
+    Icon: poster13
+    sprite: {fileID: 21300000, guid: 3f3a44abc211d1f478d0e1c48dbc39ab, type: 3}
+    Type: 1
+  - Name: EAT.
+    Description: This poster promotes rank gluttony.
+    Icon: poster14
+    sprite: {fileID: 21300000, guid: 24c3f41ed7784ee4c8625a957b1900fc, type: 3}
+    Type: 1
+  - Name: Tools
+    Description: This poster looks like an advertisement for tools, but is in fact
+      a subliminal jab at the tools at CentCom.
+    Icon: poster15
+    sprite: {fileID: 21300000, guid: 9bbf5cc3b4b06e3489f989f48ea8b7e6, type: 3}
+    Type: 1
+  - Name: Power
+    Description: A poster that positions the seat of power outside Nanotrasen.
+    Icon: poster16
+    sprite: {fileID: 21300000, guid: 6df359c3f165507499d9ad1594ec921b, type: 3}
+    Type: 1
+  - Name: Space Cube
+    Description: Ignorant of Nature's Harmonic 6 Side Space Cube Creation, the Spacemen
+      are Dumb, Educated Singularity Stupid and Evil.
+    Icon: poster17
+    sprite: {fileID: 21300000, guid: cdd4fccc4d9778e4fa980f03bd945fb6, type: 3}
+    Type: 1
+  - Name: Communist State
+    Description: All hail the Communist party!
+    Icon: poster18
+    sprite: {fileID: 21300000, guid: 0a9c68d02ac656343821ac024ee2abc6, type: 3}
+    Type: 1
+  - Name: Lamarr
+    Description: This poster depicts Lamarr. Probably made by a traitorous Research
+      Director.
+    Icon: poster19
+    sprite: {fileID: 21300000, guid: c89da4c16e2c6834eab94304db33c0f6, type: 3}
+    Type: 1
+  - Name: Borg Fancy
+    Description: Being fancy can be for any borg, just need a suit.
+    Icon: poster20
+    sprite: {fileID: 21300000, guid: 689b3163aa085cb45b4201698054c5fa, type: 3}
+    Type: 1
+  - Name: Borg Fancy v2
+    Description: Borg Fancy, Now only taking the most fancy.
+    Icon: poster21
+    sprite: {fileID: 21300000, guid: f138792f0d8c9a444be6a88ac4191e68, type: 3}
+    Type: 1
+  - Name: Kosmicheskaya Stantsiya 13 Does Not Exist
+    Description: A poster mocking CentCom's denial of the existence of the derelict
+      station near Space Station 13.
+    Icon: poster22
+    sprite: {fileID: 21300000, guid: f9314ba3f0ab0a14caa80c4ced02ffb8, type: 3}
+    Type: 1
+  - Name: Rebels Unite
+    Description: A poster urging the viewer to rebel against Nanotrasen.
+    Icon: poster23
+    sprite: {fileID: 21300000, guid: b9210ea10c9e44e4a954a37c0253c478, type: 3}
+    Type: 1
+  - Name: C-20r
+    Description: A poster advertising the Scarborough Arms C-20r.
+    Icon: poster24
+    sprite: {fileID: 21300000, guid: 775c1e6859a02c9489b934383330b6f3, type: 3}
+    Type: 1
+  - Name: Have a Puff
+    Description: Who cares about lung cancer when you're high as a kite?
+    Icon: poster25
+    sprite: {fileID: 21300000, guid: 1863d40450ef2da4b9658e4891a9c2f6, type: 3}
+    Type: 1
+  - Name: Revolver
+    Description: Because seven shots are all you need.
+    Icon: poster26
+    sprite: {fileID: 21300000, guid: 3d6e5322b54edea4aa6db214dcb75f2e, type: 3}
+    Type: 1
+  - Name: D-Day Promo
+    Description: A promotional poster for some rapper.
+    Icon: poster27
+    sprite: {fileID: 21300000, guid: d0433396ca83a114792c6b281bb106bb, type: 3}
+    Type: 1
+  - Name: Syndicate Pistol
+    Description: A poster advertising syndicate pistols as being 'classy as fuck'.
+      It is covered in faded gang tags.
+    Icon: poster28
+    sprite: {fileID: 21300000, guid: d0829fb9e1587b24ea34abcfd3874fd2, type: 3}
+    Type: 1
+  - Name: Energy Swords
+    Description: All the colors of the bloody murder rainbow.
+    Icon: poster29
+    sprite: {fileID: 21300000, guid: 80c7e028bedb29f4fb08c19074a92c5f, type: 3}
+    Type: 1
+  - Name: Red Rum
+    Description: Looking at this poster makes you want to kill.
+    Icon: poster30
+    sprite: {fileID: 21300000, guid: 7a0ec619d902d6343b897daff77fb44e, type: 3}
+    Type: 1
+  - Name: CC 64K Ad
+    Description: The latest portable computer from Comrade Computing, with a whole
+      64kB of ram!
+    Icon: poster31
+    sprite: {fileID: 21300000, guid: 6c3be5035d4ad5945a3404ff2ad35002, type: 3}
+    Type: 1
+  - Name: Punch Shit
+    Description: Fight things for no reason, like a man!
+    Icon: poster32
+    sprite: {fileID: 21300000, guid: 40d6cdc4665cbdb498ef43dd92db4ca3, type: 3}
+    Type: 1
+  - Name: The Griffin
+    Description: The Griffin commands you to be the worst you can be. Will you?
+    Icon: poster33
+    sprite: {fileID: 21300000, guid: 232bd00bb76b87a4f9db329c8a6bedae, type: 3}
+    Type: 1
+  - Name: Lizard
+    Description: This lewd poster depicts a lizard preparing to mate.
+    Icon: poster34
+    sprite: {fileID: 21300000, guid: f6706854cd6af894391123a264f0a184, type: 3}
+    Type: 1
+  - Name: Free Drone
+    Description: This poster commemorates the bravery of the rogue drone; once exiled,
+      and then ultimately destroyed by CentCom.
+    Icon: poster35
+    sprite: {fileID: 21300000, guid: e592369a1f066c745a1bd6241c3fc78b, type: 3}
+    Type: 1
+  - Name: Busty Backdoor Xeno Babes 6
+    Description: Get a load, or give, of these all natural Xenos!
+    Icon: poster36
+    sprite: {fileID: 21300000, guid: 9a00af3d2e894224ea687e728f1d1205, type: 3}
+    Type: 1
+  - Name: Robust Softdrinks
+    Description: 'Robust Softdrinks: More robust than a toolbox to the head!'
+    Icon: poster37
+    sprite: {fileID: 21300000, guid: 979edb55eadad6c418dd91e433aa53a3, type: 3}
+    Type: 1
+  - Name: Shambler's Juice
+    Description: ~Shake me up some of that Shambler's Juice!~
+    Icon: poster38
+    sprite: {fileID: 21300000, guid: 2f4ae5183eecc5841afb7d6adfa5d183, type: 3}
+    Type: 1
+  - Name: Pwr Game
+    Description: The POWER that gamers CRAVE! In partnership with Vlad's Salad.
+    Icon: poster39
+    sprite: {fileID: 21300000, guid: 2e8c2e0e0eb2bb54eb8f16c9ff779bbc, type: 3}
+    Type: 1
+  - Name: Sun-kist
+    Description: Drink the stars!
+    Icon: poster40
+    sprite: {fileID: 21300000, guid: 9ebbb3c2fa222d64686f6f55d332cb23, type: 3}
+    Type: 1
+  - Name: Space Cola
+    Description: Your favorite cola, in space.
+    Icon: poster41
+    sprite: {fileID: 21300000, guid: dee08319b9110544c849419df7b1860f, type: 3}
+    Type: 1
+  - Name: Space-Up!
+    Description: Sucked out into space by the FLAVOR!
+    Icon: poster42
+    sprite: {fileID: 21300000, guid: b241cea6dbfc5734cbf930b33484907c, type: 3}
+    Type: 1
+  - Name: Kudzu
+    Description: A poster advertising a movie about plants. How dangerous could they
+      possibly be?
+    Icon: poster43
+    sprite: {fileID: 21300000, guid: a6503976a2445b04c814313ba0a99692, type: 3}
+    Type: 1
+  - Name: Masked Men
+    Description: A poster advertising a movie about some masked men.
+    Icon: poster44
+    sprite: {fileID: 21300000, guid: 74f43f4cf7698a449bb32e2e42f2a5bd, type: 3}
+    Type: 1
+  - Name: Free Syndicate Encryption Key
+    Description: A poster about traitors begging for more.
+    Icon: poster46
+    sprite: {fileID: 0}
+    Type: 1
+  - Name: Bounty Hunters
+    Description: A poster advertising bounty hunting services. "I hear you got a problem."
+    Icon: poster47
+    sprite: {fileID: 0}
+    Type: 1
+  OtherPosters:
+  - Name: Ripped Poster
+    Description: You can't make out anything from the poster's original print. It's
+      ruined.
+    Icon: poster_ripped
+    sprite: {fileID: 21300000, guid: ce1a5a40bb07b71459d0b6eac14a7a26, type: 3}
+    Type: -1
+  - Name: Random Poster
+    Description: random_anything
+    Icon: 
+    sprite: {fileID: 0}
+    Type: -1
+  - Name: Random Official Poster
+    Description: 
+    Icon: random_official
+    sprite: {fileID: 21300000, guid: cf4848a8ef4ba4646a656d9ee57905fb, type: 3}
+    Type: -1
+  - Name: Random Contraband Poster
+    Description: 
+    Icon: random_contraband
+    sprite: {fileID: 21300000, guid: c371afa2d32f24d48a5ae9fbe231e336, type: 3}
+    Type: -1
 --- !u!114 &1721604302402341619
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -220,7 +680,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: e062be43b6f3a44d8be77756383e6bc8
+  m_AssetId: f421de3b3604142099b272d77faafeb6
   m_SceneId: 0
 --- !u!1 &5583455716784618316
 GameObject:

--- a/UnityProject/Assets/Scripts/Cargo.meta
+++ b/UnityProject/Assets/Scripts/Cargo.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9f80e80ef508fb543b4ff22cbdad2809
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/PosterBehaviour.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/PosterBehaviour.cs.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: 815148f04bd24613abae9285eea1e68d
-timeCreated: 1572196618

--- a/UnityProject/Assets/Scripts/Objects/Posters.meta
+++ b/UnityProject/Assets/Scripts/Objects/Posters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ca39cac511cdb241a6746dea1414cb7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/Posters/Poster.cs
+++ b/UnityProject/Assets/Scripts/Objects/Posters/Poster.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using UnityEngine;
+
+[Serializable]
+public class Poster
+{
+	public string Name;
+	public string Description;
+	public string Icon;
+	public Sprite sprite;
+	public PosterType Type = PosterType.None;
+}
+
+public enum PosterType
+{
+	None = -1,
+	Official = 0,
+	Contraband = 1
+}
+
+public enum Posters
+{
+	Ripped,
+	Random,
+	RandomOfficial,
+	RandomContraband,
+	HereForYourSafety,
+	NanotrasenLogo,
+	Cleanliness,
+	HelpOthers,
+	Build,
+	BlessThisSpess,
+	Science,
+	Ian,
+	Obey,
+	Walk,
+	StateLaws,
+	LoveIan,
+	SpaceCops,
+	UeNo,
+	GetYourLegs,
+	DoNotQuestion,
+	WorkForAFuture,
+	SoftCapPopArt,
+	SafetyInternals,
+	SafetyEyeProtection,
+	SafetyReport,
+	ReportCrimes,
+	IonRifle,
+	FoamForceAd,
+	CohibaRobustoAd,
+	AnniversaryVintageReprint,
+	FruitBowl,
+	PdaAd,
+	Enlist,
+	NanomichiAd,
+	TwelveGauge,
+	HighClassMartini,
+	TheOwl,
+	NoErp,
+	WtfIsCo2,
+	FreeTonto,
+	AtmosiaIndependence,
+	FunPolice,
+	LustyXenomorph,
+	SyndicateRecruitment,
+	Clown,
+	Smoke,
+	GreyTide,
+	MissingGloves,
+	HackingGuide,
+	RipBadger,
+	AmbrosiaVulgaris,
+	DonutCorp,
+	Eat,
+	Tools,
+	Power,
+	SpaceCube,
+	CommunistState,
+	Lamarr,
+	BorgFancy1,
+	BorgFancy2,
+	Kss13,
+	RebelsUnite,
+	C20r,
+	HaveAPuff,
+	Revolver,
+	DDayPromo,
+	SyndicatePistol,
+	EnergySwords,
+	RedRum,
+	CC64kAd,
+	PunchShit,
+	TheGriffin,
+	Lizard,
+	FreeDrone,
+	BustyBackdoorXenoBabes6,
+	RobustSoftdrinks,
+	ShamblersJuice,
+	PwrGame,
+	SunKist,
+	SpaceCola,
+	SpaceUp,
+	Kudzu,
+	MaskedMen,
+	FreeKey,
+	BountyHunters,
+	UnityUniteToday,
+	UnityPlanet
+}

--- a/UnityProject/Assets/Scripts/Objects/Posters/Poster.cs
+++ b/UnityProject/Assets/Scripts/Objects/Posters/Poster.cs
@@ -8,6 +8,7 @@ public class Poster
 	public string Description;
 	public string Icon;
 	public Sprite sprite;
+	public Posters PosterName;
 	public PosterType Type = PosterType.None;
 }
 

--- a/UnityProject/Assets/Scripts/Objects/Posters/Poster.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Posters/Poster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ac0c24eef5d19046bdab404f15a958e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/Posters/PosterBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Objects/Posters/PosterBehaviour.cs
@@ -17,6 +17,8 @@ public class PosterBehaviour : NetworkBehaviour, ICheckedInteractable<HandApply>
 
 	public override void OnStartClient()
 	{
+		var starterPoster = GetPoster(posterVariant);
+		posterVariant = starterPoster.PosterName;
 		SyncPosterType(posterVariant);
 		base.OnStartClient();
 	}

--- a/UnityProject/Assets/Scripts/Objects/Posters/PosterBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Objects/Posters/PosterBehaviour.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Mirror;
 using Newtonsoft.Json;
@@ -13,6 +14,10 @@ public class PosterBehaviour : NetworkBehaviour, ICheckedInteractable<HandApply>
 
 	[SyncVar (hook = nameof(SyncPosterType))]
 	public Posters posterVariant = Posters.Random;
+
+	public List<Poster> OfficialPosters = new List<Poster>();
+	public List<Poster> ContrabandPosters = new List<Poster>();
+	public List<Poster> OtherPosters = new List<Poster>();
 
 	private void Awake()
 	{
@@ -78,7 +83,8 @@ public class PosterBehaviour : NetworkBehaviour, ICheckedInteractable<HandApply>
 		}
 	}
 
-	private static void JsonImportInitialization()
+	[ContextMenu("Load all posters")]
+	private void JsonImportInitialization()
 	{
 		var json = (Resources.Load (@"Metadata\Posters") as TextAsset)?.ToString();
 		var jsonPosters = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, System.Object>>>(json);
@@ -102,19 +108,26 @@ public class PosterBehaviour : NetworkBehaviour, ICheckedInteractable<HandApply>
 				poster.Type = (PosterType)int.Parse(entry.Value["type"].ToString());
 			}
 
+			poster.sprite = PosterSpriteLoader(poster.Icon);
+
 			switch (poster.Type)
 			{
 				case PosterType.None:
-					Globals.OtherPosters.Add(entry.Key, poster);
+					OtherPosters.Add(poster);
 					break;
 				case PosterType.Official:
-					Globals.OfficialPosters.Add(entry.Key, poster);
+					OfficialPosters.Add(poster);
 					break;
 				case PosterType.Contraband:
-					Globals.ContrabandPosters.Add(entry.Key, poster);
+					ContrabandPosters.Add(poster);
 					break;
 			}
 		}
+	}
+
+	Sprite PosterSpriteLoader(string icon)
+	{
+		return UnityEditor.AssetDatabase.LoadAssetAtPath<Sprite>($"Assets/Textures/objects/contraband/contraband_{icon}.png");
 	}
 
 	// Only interact with empty hands and wirecutter
@@ -176,119 +189,12 @@ public class PosterBehaviour : NetworkBehaviour, ICheckedInteractable<HandApply>
 		SyncPosterType(Posters.Ripped);
 	}
 
-
-	public class Poster
-	{
-		public string Name;
-		public string Description;
-		public string Icon;
-		public PosterType Type = PosterType.None;
-	}
-
 	private static class Globals
 	{
 		public static bool IsInitialised = false;
 		public static Dictionary<string, Poster> OfficialPosters = new Dictionary<string, Poster>();
 		public static Dictionary<string, Poster> ContrabandPosters = new Dictionary<string, Poster>();
 		public static Dictionary<string, Poster> OtherPosters = new Dictionary<string, Poster>();
-	}
-
-	public enum PosterType
-	{
-		None = -1,
-		Official = 0,
-		Contraband = 1
-	}
-
-	public enum Posters
-	{
-		Ripped,
-		Random,
-		RandomOfficial,
-		RandomContraband,
-		HereForYourSafety,
-		NanotrasenLogo,
-		Cleanliness,
-		HelpOthers,
-		Build,
-		BlessThisSpess,
-		Science,
-		Ian,
-		Obey,
-		Walk,
-		StateLaws,
-		LoveIan,
-		SpaceCops,
-		UeNo,
-		GetYourLegs,
-		DoNotQuestion,
-		WorkForAFuture,
-		SoftCapPopArt,
-		SafetyInternals,
-		SafetyEyeProtection,
-		SafetyReport,
-		ReportCrimes,
-		IonRifle,
-		FoamForceAd,
-		CohibaRobustoAd,
-		AnniversaryVintageReprint,
-		FruitBowl,
-		PdaAd,
-		Enlist,
-		NanomichiAd,
-		TwelveGauge,
-		HighClassMartini,
-		TheOwl,
-		NoErp,
-		WtfIsCo2,
-		FreeTonto,
-		AtmosiaIndependence,
-		FunPolice,
-		LustyXenomorph,
-		SyndicateRecruitment,
-		Clown,
-		Smoke,
-		GreyTide,
-		MissingGloves,
-		HackingGuide,
-		RipBadger,
-		AmbrosiaVulgaris,
-		DonutCorp,
-		Eat,
-		Tools,
-		Power,
-		SpaceCube,
-		CommunistState,
-		Lamarr,
-		BorgFancy1,
-		BorgFancy2,
-		Kss13,
-		RebelsUnite,
-		C20r,
-		HaveAPuff,
-		Revolver,
-		DDayPromo,
-		SyndicatePistol,
-		EnergySwords,
-		RedRum,
-		CC64kAd,
-		PunchShit,
-		TheGriffin,
-		Lizard,
-		FreeDrone,
-		BustyBackdoorXenoBabes6,
-		RobustSoftdrinks,
-		ShamblersJuice,
-		PwrGame,
-		SunKist,
-		SpaceCola,
-		SpaceUp,
-		Kudzu,
-		MaskedMen,
-		FreeKey,
-		BountyHunters,
-		UnityUniteToday,
-		UnityPlanet
 	}
 }
 

--- a/UnityProject/Assets/Scripts/Objects/Posters/PosterBehaviour.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Posters/PosterBehaviour.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 815148f04bd24613abae9285eea1e68d
+timeCreated: 1572196618

--- a/UnityProject/Assets/Scripts/Objects/RolledPoster.cs
+++ b/UnityProject/Assets/Scripts/Objects/RolledPoster.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Collections.Generic;
 using Mirror;
@@ -8,114 +7,107 @@ using UnityEngine;
 public class RolledPoster : MonoBehaviour, ICheckedInteractable<PositionalHandApply>, IServerSpawn
 {
 	public GameObject wallPrefab;
-	public PosterBehaviour.Posters posterVariant;
+	public Posters posterVariant;
 	public SpriteRenderer sprite;
 	public Sprite legitSprite;
 	public Sprite contrabandSprite;
 
 	private void Awake()
 	{
-
-		if (!Globals.IsInitialised)
-		{
-			JsonImportInitialization();
-			Globals.IsInitialised = true;
-		}
-
-		sprite = GetComponentInChildren<SpriteRenderer>();
-		var attributes = GetComponent<ItemAttributesV2>();
-		var poster = Globals.Posters[posterVariant.ToString()];
-		string posterName;
-		string desc;
-		Sprite icon;
-
-		if (posterVariant == PosterBehaviour.Posters.RandomContraband)
-		{
-			posterName = "Contraband Poster";
-			desc =
-				"This poster comes with its own automatic adhesive mechanism, for easy pinning to any vertical surface. Its vulgar themes have marked it as contraband aboard Nanotrasen space facilities.";
-			icon = contrabandSprite;
-		}
-		else if (posterVariant == PosterBehaviour.Posters.RandomOfficial)
-		{
-			posterName = "Motivational Poster";
-			desc =
-				"An official Nanotrasen-issued poster to foster a compliant and obedient workforce. It comes with state-of-the-art adhesive backing, for easy pinning to any vertical surface.";
-			icon = legitSprite;
-		}
-		else
-		{
-			posterName = poster.Name;
-			desc = poster.Description;
-			icon = poster.Type == PosterBehaviour.PosterType.Contraband ? contrabandSprite : legitSprite;
-		}
-
-		attributes.ServerSetArticleName(posterName);
-		attributes.ServerSetArticleDescription(desc);
-		sprite.sprite = icon;
+//		sprite = GetComponentInChildren<SpriteRenderer>();
+//		var attributes = GetComponent<ItemAttributesV2>();
+//	//	var poster = Globals.Posters[posterVariant.ToString()];
+//		string posterName;
+//		string desc;
+//		Sprite icon;
+//
+//		if (posterVariant == Posters.RandomContraband)
+//		{
+//			posterName = "Contraband Poster";
+//			desc =
+//				"This poster comes with its own automatic adhesive mechanism, for easy pinning to any vertical surface. Its vulgar themes have marked it as contraband aboard Nanotrasen space facilities.";
+//			icon = contrabandSprite;
+//		}
+//		else if (posterVariant == Posters.RandomOfficial)
+//		{
+//			posterName = "Motivational Poster";
+//			desc =
+//				"An official Nanotrasen-issued poster to foster a compliant and obedient workforce. It comes with state-of-the-art adhesive backing, for easy pinning to any vertical surface.";
+//			icon = legitSprite;
+//		}
+//		else
+//		{
+//			posterName = poster.Name;
+//			desc = poster.Description;
+//			icon = poster.Type == PosterType.Contraband ? contrabandSprite : legitSprite;
+//		}
+//
+//		attributes.ServerSetArticleName(posterName);
+//		attributes.ServerSetArticleDescription(desc);
+//		sprite.sprite = icon;
 	}
 
 	public void OnSpawnServer(SpawnInfo info)
 	{
-		var attributes = GetComponent<ItemAttributesV2>();
-		var poster = Globals.Posters[posterVariant.ToString()];
-		string posterName;
-		string desc;
-		Sprite icon;
-
-		if (posterVariant == PosterBehaviour.Posters.RandomContraband)
-		{
-			posterName = "Contraband Poster";
-			desc =
-				"This poster comes with its own automatic adhesive mechanism, for easy pinning to any vertical surface. Its vulgar themes have marked it as contraband aboard Nanotrasen space facilities.";
-			icon = contrabandSprite;
-		}
-		else if (posterVariant == PosterBehaviour.Posters.RandomOfficial)
-		{
-			posterName = "Motivational Poster";
-			desc =
-				"An official Nanotrasen-issued poster to foster a compliant and obedient workforce. It comes with state-of-the-art adhesive backing, for easy pinning to any vertical surface.";
-			icon = legitSprite;
-		}
-		else
-		{
-			posterName = poster.Name;
-			desc = poster.Description;
-			icon = poster.Type == PosterBehaviour.PosterType.Contraband ? contrabandSprite : legitSprite;
-		}
-
-		attributes.ServerSetArticleName(posterName);
-		attributes.ServerSetArticleDescription(desc);
-		sprite.sprite = icon;
+//		var attributes = GetComponent<ItemAttributesV2>();
+//		var poster = Globals.Posters[posterVariant.ToString()];
+//		string posterName;
+//		string desc;
+//		Sprite icon;
+//
+//		if (posterVariant == Posters.RandomContraband)
+//		{
+//			posterName = "Contraband Poster";
+//			desc =
+//				"This poster comes with its own automatic adhesive mechanism, for easy pinning to any vertical surface. Its vulgar themes have marked it as contraband aboard Nanotrasen space facilities.";
+//			icon = contrabandSprite;
+//		}
+//		else if (posterVariant == Posters.RandomOfficial)
+//		{
+//			posterName = "Motivational Poster";
+//			desc =
+//				"An official Nanotrasen-issued poster to foster a compliant and obedient workforce. It comes with state-of-the-art adhesive backing, for easy pinning to any vertical surface.";
+//			icon = legitSprite;
+//		}
+//		else
+//		{
+//			posterName = poster.Name;
+//			desc = poster.Description;
+//			icon = poster.Type == PosterType.Contraband ? contrabandSprite : legitSprite;
+//		}
+//
+//		attributes.ServerSetArticleName(posterName);
+//		attributes.ServerSetArticleDescription(desc);
+//		sprite.sprite = icon;
 	}
 
-	private static void JsonImportInitialization()
-	{
-		var json = (Resources.Load (@"Metadata\Posters") as TextAsset)?.ToString();
-		var jsonPosters = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, System.Object>>>(json);
-		foreach (KeyValuePair<string, Dictionary<string, System.Object>> entry in jsonPosters)
-		{
-			var poster = new PosterBehaviour.Poster();
-			if (entry.Value.ContainsKey("name"))
-			{
-				poster.Name = entry.Value["name"].ToString();
-			}
-			if (entry.Value.ContainsKey("desc"))
-			{
-				poster.Description = entry.Value["desc"].ToString();
-			}
-			if (entry.Value.ContainsKey("icon"))
-			{
-				poster.Icon = entry.Value["icon"].ToString();
-			}
-			if (entry.Value.ContainsKey("type"))
-			{
-				poster.Type = (PosterBehaviour.PosterType)int.Parse(entry.Value["type"].ToString());
-			}
-
-			Globals.Posters.Add(entry.Key, poster);
-		}
-	}
+//	private static void JsonImportInitialization()
+//	{
+//		var json = (Resources.Load (@"Metadata\Posters") as TextAsset)?.ToString();
+//		var jsonPosters = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, System.Object>>>(json);
+//		foreach (KeyValuePair<string, Dictionary<string, System.Object>> entry in jsonPosters)
+//		{
+//			var poster = new Poster();
+//			if (entry.Value.ContainsKey("name"))
+//			{
+//				poster.Name = entry.Value["name"].ToString();
+//			}
+//			if (entry.Value.ContainsKey("desc"))
+//			{
+//				poster.Description = entry.Value["desc"].ToString();
+//			}
+//			if (entry.Value.ContainsKey("icon"))
+//			{
+//				poster.Icon = entry.Value["icon"].ToString();
+//			}
+//			if (entry.Value.ContainsKey("type"))
+//			{
+//				poster.Type = (PosterType)int.Parse(entry.Value["type"].ToString());
+//			}
+//
+//			Globals.Posters.Add(entry.Key, poster);
+//		}
+//	}
 
 	public bool WillInteract(PositionalHandApply interaction, NetworkSide side)
 	{
@@ -141,7 +133,8 @@ public class RolledPoster : MonoBehaviour, ICheckedInteractable<PositionalHandAp
 	public void ServerPerformInteraction(PositionalHandApply interaction)
 	{
 		wallPrefab.GetComponent<PosterBehaviour>().posterVariant = posterVariant;
-		wallPrefab.GetComponent<Directional>().InitialDirection = Orientation.From(interaction.Performer.TileWorldPosition() - interaction.WorldPositionTarget).AsEnum();
+		wallPrefab.GetComponent<Directional>().InitialDirection = Orientation
+			.From(interaction.Performer.TileWorldPosition() - interaction.WorldPositionTarget).AsEnum();
 
 		Spawn.ServerPrefab(wallPrefab, interaction.WorldPositionTarget.RoundToInt(),
 			interaction.Performer.transform.parent);
@@ -149,11 +142,9 @@ public class RolledPoster : MonoBehaviour, ICheckedInteractable<PositionalHandAp
 		Inventory.ServerDespawn(interaction.HandSlot);
 	}
 
-	private static class Globals
-	{
-		public static bool IsInitialised = false;
-		public static Dictionary<string, PosterBehaviour.Poster> Posters = new Dictionary<string, PosterBehaviour.Poster>();
-	}
-
-
+//	private static class Globals
+//	{
+//		public static bool IsInitialised = false;
+//		public static Dictionary<string, PosterBehaviour.Poster> Posters = new Dictionary<string, PosterBehaviour.Poster>();
+//	}
 }

--- a/UnityProject/Assets/Scripts/Objects/RolledPoster.cs
+++ b/UnityProject/Assets/Scripts/Objects/RolledPoster.cs
@@ -12,6 +12,8 @@ public class RolledPoster : NetworkBehaviour, ICheckedInteractable<PositionalHan
 
 	public override void OnStartServer()
 	{
+		var startPoster = wallPrefab.GetComponent<PosterBehaviour>().GetPoster(posterVariant);
+		posterVariant = startPoster.PosterName;
 		SyncPosterType(posterVariant);
 		base.OnStartServer();
 	}

--- a/UnityProject/Assets/Scripts/Objects/RolledPoster.cs
+++ b/UnityProject/Assets/Scripts/Objects/RolledPoster.cs
@@ -1,113 +1,56 @@
-using System;
-using System.Collections.Generic;
 using Mirror;
-using Newtonsoft.Json;
 using UnityEngine;
 
-public class RolledPoster : MonoBehaviour, ICheckedInteractable<PositionalHandApply>, IServerSpawn
+public class RolledPoster : NetworkBehaviour, ICheckedInteractable<PositionalHandApply>
 {
 	public GameObject wallPrefab;
+	[SyncVar (hook = nameof(SyncPosterType))]
 	public Posters posterVariant;
-	public SpriteRenderer sprite;
+	public SpriteRenderer spriteRend;
 	public Sprite legitSprite;
 	public Sprite contrabandSprite;
 
-	private void Awake()
+	public override void OnStartServer()
 	{
-//		sprite = GetComponentInChildren<SpriteRenderer>();
-//		var attributes = GetComponent<ItemAttributesV2>();
-//	//	var poster = Globals.Posters[posterVariant.ToString()];
-//		string posterName;
-//		string desc;
-//		Sprite icon;
-//
-//		if (posterVariant == Posters.RandomContraband)
-//		{
-//			posterName = "Contraband Poster";
-//			desc =
-//				"This poster comes with its own automatic adhesive mechanism, for easy pinning to any vertical surface. Its vulgar themes have marked it as contraband aboard Nanotrasen space facilities.";
-//			icon = contrabandSprite;
-//		}
-//		else if (posterVariant == Posters.RandomOfficial)
-//		{
-//			posterName = "Motivational Poster";
-//			desc =
-//				"An official Nanotrasen-issued poster to foster a compliant and obedient workforce. It comes with state-of-the-art adhesive backing, for easy pinning to any vertical surface.";
-//			icon = legitSprite;
-//		}
-//		else
-//		{
-//			posterName = poster.Name;
-//			desc = poster.Description;
-//			icon = poster.Type == PosterType.Contraband ? contrabandSprite : legitSprite;
-//		}
-//
-//		attributes.ServerSetArticleName(posterName);
-//		attributes.ServerSetArticleDescription(desc);
-//		sprite.sprite = icon;
+		SyncPosterType(posterVariant);
+		base.OnStartServer();
 	}
 
-	public void OnSpawnServer(SpawnInfo info)
+	public void SyncPosterType(Posters p)
 	{
-//		var attributes = GetComponent<ItemAttributesV2>();
-//		var poster = Globals.Posters[posterVariant.ToString()];
-//		string posterName;
-//		string desc;
-//		Sprite icon;
-//
-//		if (posterVariant == Posters.RandomContraband)
-//		{
-//			posterName = "Contraband Poster";
-//			desc =
-//				"This poster comes with its own automatic adhesive mechanism, for easy pinning to any vertical surface. Its vulgar themes have marked it as contraband aboard Nanotrasen space facilities.";
-//			icon = contrabandSprite;
-//		}
-//		else if (posterVariant == Posters.RandomOfficial)
-//		{
-//			posterName = "Motivational Poster";
-//			desc =
-//				"An official Nanotrasen-issued poster to foster a compliant and obedient workforce. It comes with state-of-the-art adhesive backing, for easy pinning to any vertical surface.";
-//			icon = legitSprite;
-//		}
-//		else
-//		{
-//			posterName = poster.Name;
-//			desc = poster.Description;
-//			icon = poster.Type == PosterType.Contraband ? contrabandSprite : legitSprite;
-//		}
-//
-//		attributes.ServerSetArticleName(posterName);
-//		attributes.ServerSetArticleDescription(desc);
-//		sprite.sprite = icon;
-	}
+		posterVariant = p;
 
-//	private static void JsonImportInitialization()
-//	{
-//		var json = (Resources.Load (@"Metadata\Posters") as TextAsset)?.ToString();
-//		var jsonPosters = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, System.Object>>>(json);
-//		foreach (KeyValuePair<string, Dictionary<string, System.Object>> entry in jsonPosters)
-//		{
-//			var poster = new Poster();
-//			if (entry.Value.ContainsKey("name"))
-//			{
-//				poster.Name = entry.Value["name"].ToString();
-//			}
-//			if (entry.Value.ContainsKey("desc"))
-//			{
-//				poster.Description = entry.Value["desc"].ToString();
-//			}
-//			if (entry.Value.ContainsKey("icon"))
-//			{
-//				poster.Icon = entry.Value["icon"].ToString();
-//			}
-//			if (entry.Value.ContainsKey("type"))
-//			{
-//				poster.Type = (PosterType)int.Parse(entry.Value["type"].ToString());
-//			}
-//
-//			Globals.Posters.Add(entry.Key, poster);
-//		}
-//	}
+		var attributes = GetComponent<ItemAttributesV2>();
+		var poster = wallPrefab.GetComponent<PosterBehaviour>().GetPoster(p);
+		string posterName;
+		string desc;
+		Sprite icon;
+
+		if (posterVariant == Posters.RandomContraband)
+		{
+			posterName = "Contraband Poster";
+			desc =
+				"This poster comes with its own automatic adhesive mechanism, for easy pinning to any vertical surface. Its vulgar themes have marked it as contraband aboard Nanotrasen space facilities.";
+			icon = contrabandSprite;
+		}
+		else if (posterVariant == Posters.RandomOfficial)
+		{
+			posterName = "Motivational Poster";
+			desc =
+				"An official Nanotrasen-issued poster to foster a compliant and obedient workforce. It comes with state-of-the-art adhesive backing, for easy pinning to any vertical surface.";
+			icon = legitSprite;
+		}
+		else
+		{
+			posterName = poster.Name;
+			desc = poster.Description;
+			icon = poster.Type == PosterType.Contraband ? contrabandSprite : legitSprite;
+		}
+
+		attributes.ServerSetArticleName(posterName);
+		attributes.ServerSetArticleDescription(desc);
+		spriteRend.sprite = icon;
+	}
 
 	public bool WillInteract(PositionalHandApply interaction, NetworkSide side)
 	{
@@ -141,10 +84,4 @@ public class RolledPoster : MonoBehaviour, ICheckedInteractable<PositionalHandAp
 
 		Inventory.ServerDespawn(interaction.HandSlot);
 	}
-
-//	private static class Globals
-//	{
-//		public static bool IsInitialised = false;
-//		public static Dictionary<string, PosterBehaviour.Poster> Posters = new Dictionary<string, PosterBehaviour.Poster>();
-//	}
 }


### PR DESCRIPTION
### Purpose
As per title the posters now show their sprites correctly. I cached the sprite reference in the Posters Prefab.

### Open Questions and Pre-Merge TODOs
Checked in MP