### PR TITLE
Update PlayerMove.cs (Player able to move while handcuffed)

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -150,7 +150,10 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn
 			// }
 			if (KeyboardInputManager.CheckMoveAction(moveList[i]))
 			{
-				if(allowInput && !IsBuckled && !IsCuffed){
+				/// <summary>
+				/// Checks if the input is allowed and if the player isnt buckled,if true then the action is added to the moveList
+				/// <summary>
+				if(allowInput && !IsBuckled){
 					actionKeys.Add((int)moveList[i]);
 				}
 				else


### PR DESCRIPTION
### Purpose
The player will now be able to move when they are handcuffed
This fixes issue #2032 

### Open Questions and Pre-Merge TODOs

- [X ]  This fix is tested on the same branch it is PR'ed to.
- [X ]  I correctly commented my code
- [X ]  My code is indented with tabs and not spaces
- [X ]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [X ]  This PR does not bring up any new compile errors
- [X ]  This PR has been tested in editor
- [X ]  Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [X ]  Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [ ]  Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [X ]  This PR has been tested with round restarts.
- [ ]  This PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)

### Notes:
_Please enter any other relevant information here_
