### PR TITLE
Attempted fix for rejoining / reentering and mirror setlocal bug

### DIFF
--- a/UnityProject/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -992,10 +992,14 @@ namespace Mirror
 			OnDeserializeAllSafely(payload.payloadReader, payload.initialPayload);
 		}
 
-		//Temp fix until issue is resolved: https://github.com/vis2k/Mirror/issues/962
+		//mirrorworkaround: Temp fix until issue is resolved: https://github.com/vis2k/Mirror/issues/962
 		public void SetLocal()
 		{
 			isLocalPlayer = true;
+		}
+		public void UnsetLocal()
+		{
+			isLocalPlayer = false;
 		}
 
 		internal void SetLocalPlayer()

--- a/UnityProject/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkManager.cs
@@ -324,6 +324,8 @@ namespace Mirror
                 StopServer();
                 print("OnApplicationQuit: stopped server");
             }
+
+            Transport.activeTransport.Shutdown();
         }
 
         /// <summary>

--- a/UnityProject/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkManager.cs
@@ -324,13 +324,6 @@ namespace Mirror
                 StopServer();
                 print("OnApplicationQuit: stopped server");
             }
-
-            // stop transport (e.g. to shut down threads)
-            // (when pressing Stop in the Editor, Unity keeps threads alive
-            //  until we press Start again. so if Transports use threads, we
-            //  really want them to end now and not after next start)
-            TelepathyTransport telepathy = GetComponent<TelepathyTransport>();
-            telepathy.Shutdown();
         }
 
         /// <summary>

--- a/UnityProject/Assets/Scripts/Health/Living/HealthStateMonitor.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/HealthStateMonitor.cs
@@ -220,6 +220,11 @@ public class HealthStateMonitor : ManagedNetworkBehaviour
 		HealthOverallMessage.Send(requestor, gameObject, livingHealthBehaviour.OverallHealth);
 	}
 
+	void SendConsciousUpdate(GameObject requestor)
+	{
+		HealthConsciousMessage.Send(requestor, gameObject, livingHealthBehaviour.ConsciousState);
+	}
+
 	void SendBloodUpdate(GameObject requestor)
 	{
 		HealthBloodMessage.Send(requestor, gameObject, heartRateCache, bloodLevelCache,
@@ -267,6 +272,10 @@ public class HealthStateMonitor : ManagedNetworkBehaviour
 	/// </summary>
 	IEnumerator ControlledClientUpdate(GameObject requestor)
 	{
+		SendConsciousUpdate(requestor);
+
+		yield return WaitFor.Seconds(.1f);
+
 		SendOverallUpdate(requestor);
 
 		yield return WaitFor.Seconds(.1f);

--- a/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
@@ -317,6 +317,7 @@ public static class PlayerSpawn
 			{
 				oldPlayerNetworkActions.RpcBeforeBodyTransfer();
 			}
+
 			//no longer can observe their inventory
 			oldBody.GetComponent<ItemStorage>()?.ServerRemoveObserverPlayer(oldBody);
 		}
@@ -335,13 +336,12 @@ public static class PlayerSpawn
 			{
 				NetworkServer.ReplacePlayerForConnection(new NetworkConnection("0.0.0.0"), oldBody);
 			}
-			TriggerEventMessage.Send(newBody, eventType);
+			//mirrorworkaround: only added setLocal/unsetlocal for workaround for https://github.com/vis2k/Mirror/issues/962
+			TriggerEventMessage.Send(newBody, eventType, oldBody, newBody);
 
 			//can observe their new inventory
 			newBody.GetComponent<ItemStorage>()?.ServerAddObserverPlayer(newBody);
 		}
-
-
 
 		var playerScript = newBody.GetComponent<PlayerScript>();
 		if (playerScript.PlayerSync != null)

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -277,6 +277,17 @@ public class CustomNetworkManager : NetworkManager
 		}
 	}
 
+	public override void OnApplicationQuit()
+	{
+		base.OnApplicationQuit();
+		// stop transport (e.g. to shut down threads)
+		// (when pressing Stop in the Editor, Unity keeps threads alive
+		//  until we press Start again. so if Transports use threads, we
+		//  really want them to end now and not after next start)
+		TelepathyTransport telepathy = GetComponent<TelepathyTransport>();
+		telepathy.Shutdown();
+	}
+
 	//Editor item transform dance experiments
 #if UNITY_EDITOR
 	public void MoveAll()

--- a/UnityProject/Assets/Scripts/Messages/Server/TriggerEventMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/TriggerEventMessage.cs
@@ -10,10 +10,25 @@ public class TriggerEventMessage : ServerMessage
 	public static short MessageType = (short)MessageTypes.TriggerEvent;
 
 	public EVENT EventType;
+	//mirrorworkaround: Temporary workaround for Mirror issue https://github.com/vis2k/Mirror/issues/962
+	//please remove when mirror release next version with this fix to asset store and we upgrade.
+	public uint SetLocal;
+	public uint UnsetLocal;
 
 	public override IEnumerator Process()
 	{
-		yield return null;
+		yield return WaitFor(UnsetLocal, SetLocal);
+		if (NetworkObjects[0] != null)
+		{
+			var netId = NetworkObjects[0].GetComponent<NetworkIdentity>();
+			netId.UnsetLocal();
+		}
+		if (NetworkObjects[1] != null)
+		{
+			var netId = NetworkObjects[1].GetComponent<NetworkIdentity>();
+			netId.SetLocal();
+		}
+
 		TriggerEvent();
 	}
 
@@ -22,11 +37,20 @@ public class TriggerEventMessage : ServerMessage
 	{
 		EventManager.Broadcast(EventType);
 	}
-	///     Sends the message to the player
-	public static TriggerEventMessage Send(GameObject recipient, EVENT eventType)
+	/// <summary>
+	/// Sends the event message to the player.
+	/// </summary>
+	/// <param name="recipient"></param>
+	/// <param name="eventType"></param>
+	/// /// <param name="unsetLocal">if specified, client will call UnsetLocal on this object so they think they are no longer in control of it.</param>
+	/// <param name="setLocal">if specified, client will call SetLocal on this object so they think they are in control of it.</param>
+	/// <returns></returns>
+	public static TriggerEventMessage Send(GameObject recipient, EVENT eventType, GameObject unsetLocal = null, GameObject setLocal =  null)
 	{
 		TriggerEventMessage msg = new TriggerEventMessage();
 		msg.EventType = eventType;
+		msg.SetLocal = setLocal == null ?  NetId.Invalid : setLocal.NetId();
+		msg.UnsetLocal = unsetLocal == null ?  NetId.Invalid : unsetLocal.NetId();
 		msg.SendTo(recipient);
 		return msg;
 	}

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -215,10 +215,13 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	private void UpdateInventorySlots()
 	{
 		var body = playerScript.mind.body.gameObject;
-		//player gets inventory slot updates again
-		foreach (var slot in itemStorage.GetItemSlotTree())
+		if (itemStorage != null)
 		{
-			slot.ServerAddObserverPlayer(body);
+			//player gets inventory slot updates again
+			foreach (var slot in itemStorage.GetItemSlotTree())
+			{
+				slot.ServerAddObserverPlayer(body);
+			}
 		}
 	}
 
@@ -342,7 +345,9 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 			Logger.LogWarningFormat( "Either player {0} is not dead or not currently a ghost, ignoring EnterBody", Category.Health, body );
 			return;
 		}
-		if ( body.WorldPos == TransformState.HiddenPos )
+
+		//body might be in a container, reentering should still be allowed in that case
+		if (body.pushPull.parentContainer == null && body.WorldPos == TransformState.HiddenPos )
 		{
 			Logger.LogFormat( "There's nothing left of {0}'s body, not entering it", Category.Health, body );
 			return;


### PR DESCRIPTION
Attempts fixes related to #2443 and #2262 

Need to test on headless to be sure.

Implements a workaround for the mirror SetLocal issue, required adding one method to mirror which can be overwritten when their fix is released.

Refactors customizations of mirror to live in Custom Network Manager so we'll be ready for the upgrade (any other customizations are safe to overwrite).