### PR TITLE
Fix rejoining after round restart

### DIFF
--- a/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
@@ -376,6 +376,16 @@ public static class PlayerSpawn
 		}
 	}
 
+	/// <summary>
+	/// Spawns a viewer for the specified connection and transfer the connection to this viewer.
+	/// </summary>
+	/// <param name="conn"></param>
+	public static void ServerSpawnViewer(NetworkConnection conn)
+	{
+		GameObject joinedViewer = Object.Instantiate(CustomNetworkManager.Instance.playerPrefab);
+		NetworkServer.AddPlayerForConnection(conn, joinedViewer, System.Guid.NewGuid());
+	}
+
 	private static Transform GetSpawnForJob(JobType jobType)
 	{
 		if (jobType == JobType.NULL)

--- a/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
@@ -376,17 +376,6 @@ public static class PlayerSpawn
 		}
 	}
 
-
-	/// <summary>
-	/// Spawns a viewer for the specified connection and transfer the connection to this viewer.
-	/// </summary>
-	/// <param name="conn"></param>
-	public static void ServerSpawnViewer(NetworkConnection conn)
-	{
-		GameObject joinedViewer = Object.Instantiate(CustomNetworkManager.Instance.playerPrefab);
-		NetworkServer.AddPlayerForConnection(conn, joinedViewer, System.Guid.NewGuid());
-	}
-
 	private static Transform GetSpawnForJob(JobType jobType)
 	{
 		if (jobType == JobType.NULL)

--- a/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
+++ b/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
@@ -189,6 +189,6 @@ public class ConnectedPlayer
 
 	public override string ToString()
 	{
-		return $"[conn={Connection.connectionId}|go={gameObject}|name='{name}'|job={job}|synced={synced}]";
+		return $"[clientID={ClientId}|conn={Connection.connectionId}|go={gameObject}|name='{name}'|job={job}|synced={synced}]";
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -190,6 +190,7 @@ public class CustomNetworkManager : NetworkManager
 	/// Warning: sending a lot of data, make sure client receives it only once
 	public void SyncPlayerData(GameObject playerGameObject)
 	{
+		Logger.LogFormat("SyncPlayerData (the big one). This server sending a bunch of sync data to new client {0}", Category.Connections, playerGameObject);
 		//All matrices
 		MatrixMove[] matrices = FindObjectsOfType<MatrixMove>();
 		for (var i = 0; i < matrices.Length; i++)

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -152,17 +152,21 @@ public class PlayerList : NetworkBehaviour
 		});
 
 	[Server]
-	private void TryAdd(ConnectedPlayer player)
+	public void Add(ConnectedPlayer player)
 	{
 		if ( player.Equals(ConnectedPlayer.Invalid) )
 		{
-			Logger.Log("Refused to add invalid connected player", Category.Connections);
+			Logger.Log("Refused to add invalid connected player to this server's player list", Category.Connections);
 			return;
 		}
 		if ( ContainsConnection(player.Connection) )
 		{
 //			Logger.Log($"Updating {Get(player.Connection)} with {player}");
+
 			ConnectedPlayer existingPlayer = Get(player.Connection);
+			Logger.LogFormat("ConnectedPlayer {0} already exists in this server's PlayerList as {1}. Will update GameObject," +
+				" Name, and Job for the existing player instead of adding this new connected player.", Category.Connections, player, existingPlayer);
+			//TODO: Are we sure these are the only things that need to be updated?
 			existingPlayer.GameObject = player.GameObject;
 			existingPlayer.Name = player.Name; //Note that name won't be changed to empties/nulls
 			existingPlayer.Job = player.Job;
@@ -170,7 +174,7 @@ public class PlayerList : NetworkBehaviour
 		else
 		{
 			values.Add(player);
-			Logger.LogFormat("Added {0}. Total:{1}; {2}", Category.Connections, player, values.Count, string.Join(";", values));
+			Logger.LogFormat("Added to this server's PlayerList {0}. Total:{1}; {2}", Category.Connections, player, values.Count, string.Join(";", values));
 		}
 		CheckRcon();
 	}
@@ -185,9 +189,6 @@ public class PlayerList : NetworkBehaviour
 		UpdateConnectedPlayersMessage.Send();
 		CheckRcon();
 	}
-
-	[Server]
-	public void Add(ConnectedPlayer player) => TryAdd(player);
 
 	[Server]
 	public bool ContainsConnection(NetworkConnection connection)
@@ -306,4 +307,6 @@ public struct ClientConnectedPlayer
 	{
 		return $"[{nameof( Name )}='{Name}', {nameof( Job )}={Job}]";
 	}
+
+
 }

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -151,32 +151,40 @@ public class PlayerList : NetworkBehaviour
 			return list;
 		});
 
+	/// <summary>
+	/// Adds this connected player to the list, or updates an existing entry if there's already one for
+	/// this player's networkconnection. Returns the ConnectedPlayer that was added or updated.
+	/// </summary>
+	/// <param name="player"></param>
 	[Server]
-	public void Add(ConnectedPlayer player)
+	public ConnectedPlayer AddOrUpdate(ConnectedPlayer player)
 	{
 		if ( player.Equals(ConnectedPlayer.Invalid) )
 		{
 			Logger.Log("Refused to add invalid connected player to this server's player list", Category.Connections);
-			return;
+			return player;
 		}
 		if ( ContainsConnection(player.Connection) )
 		{
 //			Logger.Log($"Updating {Get(player.Connection)} with {player}");
 
 			ConnectedPlayer existingPlayer = Get(player.Connection);
-			Logger.LogFormat("ConnectedPlayer {0} already exists in this server's PlayerList as {1}. Will update GameObject," +
-				" Name, and Job for the existing player instead of adding this new connected player.", Category.Connections, player, existingPlayer);
+			Logger.LogFormat("ConnectedPlayer {0} already exists in this server's PlayerList as {1}. Will update existing player instead of adding this new connected player.", Category.Connections, player, existingPlayer);
 			//TODO: Are we sure these are the only things that need to be updated?
 			existingPlayer.GameObject = player.GameObject;
 			existingPlayer.Name = player.Name; //Note that name won't be changed to empties/nulls
 			existingPlayer.Job = player.Job;
+			existingPlayer.ClientId = player.ClientId;
+			CheckRcon();
+			return existingPlayer;
 		}
 		else
 		{
 			values.Add(player);
 			Logger.LogFormat("Added to this server's PlayerList {0}. Total:{1}; {2}", Category.Connections, player, values.Count, string.Join(";", values));
+			CheckRcon();
+			return player;
 		}
-		CheckRcon();
 	}
 
 	[Server]
@@ -274,8 +282,10 @@ public class PlayerList : NetworkBehaviour
 	[Server]
 	public GameObject TakeLoggedOffPlayer(string clientId)
 	{
+		Logger.LogTraceFormat("Searching for logged off players with id {0}", Category.Connections, clientId);
 		foreach (var player in loggedOff)
 		{
+			Logger.LogTraceFormat("Found logged off player with id {0}", Category.Connections, player.ClientId);
 			if (player.ClientId == clientId)
 			{
 				loggedOff.Remove(player);

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateConnectedPlayersMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateConnectedPlayersMessage.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using NUnit.Framework.Internal;
 
 /// <summary>
 ///     Message that tells clients what their ConnectedPlayers list should contain
@@ -12,6 +13,9 @@ public class UpdateConnectedPlayersMessage : ServerMessage
 	public override IEnumerator Process()
 	{
 //		Logger.Log("Processed " + ToString());
+
+		Logger.LogFormat("This client got an updated PlayerList state: {0}", Category.Connections,
+			string.Join(",", Players));
 
 		PlayerList.Instance.ClientConnectedPlayers.Clear();
 		if (Players != null)
@@ -28,6 +32,8 @@ public class UpdateConnectedPlayersMessage : ServerMessage
 
 	public static UpdateConnectedPlayersMessage Send()
 	{
+		Logger.LogFormat("This server informing all clients of the new PlayerList state: {0}", Category.Connections,
+			string.Join(",", PlayerList.Instance.AllPlayers));
 		UpdateConnectedPlayersMessage msg = new UpdateConnectedPlayersMessage();
 		var prepareConnectedPlayers = new List<ClientConnectedPlayer>();
 

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -16,11 +16,15 @@ public class JoinedViewer : NetworkBehaviour
 	{
 		base.OnStartLocalPlayer();
 
+
 		if (!PlayerPrefs.HasKey(PlayerPrefKeys.ClientID))
 		{
 			PlayerPrefs.SetString(PlayerPrefKeys.ClientID, "");
 			PlayerPrefs.Save();
 		}
+
+		Logger.LogFormat("JoinedViewer on this client calling CmdServerSetupPlayer, our clientID: {0} username: {1}", Category.Connections,
+			PlayerPrefs.GetString(PlayerPrefKeys.ClientID), PlayerManager.CurrentCharacterSettings.username);
 
 		CmdServerSetupPlayer(PlayerPrefs.GetString(PlayerPrefKeys.ClientID), PlayerManager.CurrentCharacterSettings.username);
 	}
@@ -28,6 +32,8 @@ public class JoinedViewer : NetworkBehaviour
 	[Command]
 	private void CmdServerSetupPlayer(string clientID, string username)
 	{
+		Logger.LogFormat("A joinedviewer called CmdServerSetupPlayer on this server, clientID: {0} username: {1}", Category.Connections,
+			clientID, username);
 		var connPlayer = new ConnectedPlayer
 		{
 			Connection = connectionToClient,

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -42,7 +42,7 @@ public class JoinedViewer : NetworkBehaviour
 			Job = JobType.NULL,
 			ClientId = clientID
 		};
-		//Add player to player list
+		//Add player to player list (logging code exists in PlayerList so no need for extra logging here)
 		PlayerList.Instance.Add(connPlayer);
 
 		// Sync all player data and the connected player count

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -15,7 +15,7 @@ public class JoinedViewer : NetworkBehaviour
 	public override void OnStartLocalPlayer()
 	{
 		base.OnStartLocalPlayer();
-
+		PlayerManager.SetViewerForControl(this);
 
 		if (!PlayerPrefs.HasKey(PlayerPrefKeys.ClientID))
 		{
@@ -34,29 +34,33 @@ public class JoinedViewer : NetworkBehaviour
 	{
 		Logger.LogFormat("A joinedviewer called CmdServerSetupPlayer on this server, clientID: {0} username: {1}", Category.Connections,
 			clientID, username);
-		var connPlayer = new ConnectedPlayer
+
+		// Check if they have a player to rejoin. If not, assign them a new client ID
+		var loggedOffPlayer = PlayerList.Instance.TakeLoggedOffPlayer(clientID);
+		if (loggedOffPlayer == null)
+		{
+			//This is the players first time connecting to this round, assign them a Client ID;
+			var oldID = clientID;
+			clientID = System.Guid.NewGuid().ToString();
+			Logger.LogFormat("This server did not find a logged off player with clientID {0}, assigning" +
+			                 " joined viewer a new ID {1}", Category.Connections, oldID, clientID);
+
+		}
+		//Register player to player list (logging code exists in PlayerList so no need for extra logging here)
+		var connPlayer = PlayerList.Instance.AddOrUpdate(new ConnectedPlayer
 		{
 			Connection = connectionToClient,
 			GameObject = gameObject,
 			Username = username,
 			Job = JobType.NULL,
 			ClientId = clientID
-		};
-		//Add player to player list (logging code exists in PlayerList so no need for extra logging here)
-		PlayerList.Instance.Add(connPlayer);
+		});
 
 		// Sync all player data and the connected player count
 		CustomNetworkManager.Instance.SyncPlayerData(gameObject);
 		UpdateConnectedPlayersMessage.Send();
 
-		// If they have a player to rejoin send the client the player to rejoin, otherwise send a null gameobject.
-		var loggedOffPlayer = PlayerList.Instance.TakeLoggedOffPlayer(clientID);
-		if (loggedOffPlayer == null)
-		{
-			//This is the players first time connecting to this round, assign them a Client ID;
-			clientID = System.Guid.NewGuid().ToString();
-			connPlayer.ClientId = clientID;
-		}
+
 
 		// Only sync the pre-round countdown if it's already started
 		if (GameManager.Instance.CurrentRoundState == RoundState.PreRound)
@@ -71,17 +75,36 @@ public class JoinedViewer : NetworkBehaviour
 			}
 		}
 
-		TargetLocalPlayerSetupPlayer(connectionToClient, loggedOffPlayer, clientID, GameManager.Instance.CurrentRoundState);
+		//if there's a logged off player, we will force them to rejoin. Previous logic allowed client to reenter
+		//their body or not, which should not be up to the client!
+		if (loggedOffPlayer != null)
+		{
+			PlayerSpawn.ServerRejoinPlayer(this, loggedOffPlayer);
+		}
+		else
+		{
+			TargetLocalPlayerSetupNewPlayer(connectionToClient, connPlayer.ClientId, GameManager.Instance.CurrentRoundState);
+		}
 	}
 
+	/// <summary>
+	/// Target which tells this joined viewer they are a new player, tells them what their ID is,
+	/// and tells them what round state the game is on
+	/// </summary>
+	/// <param name="target">this connection</param>
+	/// <param name="serverClientID">client ID server</param>
+	/// <param name="roundState"></param>
 	[TargetRpc]
-	private void TargetLocalPlayerSetupPlayer(NetworkConnection target, GameObject loggedOffPlayer,
+	private void TargetLocalPlayerSetupNewPlayer(NetworkConnection target,
 		string serverClientID, RoundState roundState)
 	{
+		Logger.LogFormat("JoinedViewer on this client updating our client id to what server tells us, from {0} to {1}", Category.Connections,
+			PlayerPrefs.GetString(PlayerPrefKeys.ClientID), serverClientID);
+		//save our ID so we can rejoin
 		PlayerPrefs.SetString(PlayerPrefKeys.ClientID, serverClientID);
 		PlayerPrefs.Save();
 
-		PlayerManager.SetViewerForControl(this);
+		//clear our UI because we're about to change it based on the round state
 		UIManager.ResetAllUI();
 
 		// Determine what to do depending on the state of the round
@@ -94,16 +117,9 @@ public class JoinedViewer : NetworkBehaviour
 			// case RoundState.Started:
 			// TODO spawn a ghost if round has already ended?
 			default:
-				// If player is joining for the first time let them pick a job, otherwise rejoin character.
-				if (loggedOffPlayer == null)
-				{
-					UIManager.Display.SetScreenForJobSelect();
-				}
-				else
-				{
-					loggedOffPlayer.GetComponent<NetworkIdentity>().SetLocal();
-					CmdRejoin(loggedOffPlayer);
-				}
+				// occupation select
+				UIManager.Display.SetScreenForJobSelect();
+
 				break;
 		}
 	}
@@ -116,16 +132,6 @@ public class JoinedViewer : NetworkBehaviour
 	{
 		PlayerSpawn.ServerSpawnPlayer(this, GameManager.Instance.GetRandomFreeOccupation(jobType),
 			characterSettings);
-	}
-
-	/// <summary>
-	/// Asks the server to let the client rejoin into a logged off character.
-	/// </summary>
-	/// <param name="loggedOffPlayer">The character to be rejoined into.</param>
-	[Command]
-	public void CmdRejoin(GameObject loggedOffPlayer)
-	{
-		PlayerSpawn.ServerRejoinPlayer(this, loggedOffPlayer);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -104,12 +104,6 @@ public partial class PlayerSync
 	/// Do current and target server positions match?
 	private bool ServerPositionsMatch => serverState.WorldPosition == serverLerpState.WorldPosition;
 
-	public override void OnStartServer()
-		{
-			base.OnStartServer();
-			InitServerState();
-			registerPlayer = GetComponent<RegisterPlayer>();
-		}
 
 	///
 		[Server]
@@ -335,7 +329,7 @@ public partial class PlayerSync
 	[Server]
 	private void SyncMatrix()
 	{
-		registerTile.ParentNetId = MatrixManager.Get(serverState.MatrixId).NetID;
+		registerPlayer.ParentNetId = MatrixManager.Get(serverState.MatrixId).NetID;
 	}
 
 	/// Send current serverState to just one player

--- a/UnityProject/Assets/Scripts/UI/Lobby/GUI_LobbyDialogue.cs
+++ b/UnityProject/Assets/Scripts/UI/Lobby/GUI_LobbyDialogue.cs
@@ -344,11 +344,10 @@ namespace Lobby
 			}
 
 			// Init network client
-			Logger.LogFormat("Client tryint to connect to {0}:{1}", Category.Connections, serverAddress, serverPort);
+			Logger.LogFormat("Client trying to connect to {0}:{1}", Category.Connections, serverAddress, serverPort);
 			networkManager.networkAddress = serverAddress;
 			networkManager.GetComponent<TelepathyTransport>().port = serverPort;
-			NetworkClient.Connect(serverAddress);
-
+			networkManager.StartClient();
 		}
 
 		void InitPlayerName()

--- a/UnityProject/Assets/Scripts/UI/Lobby/GUI_LobbyDialogue.cs
+++ b/UnityProject/Assets/Scripts/UI/Lobby/GUI_LobbyDialogue.cs
@@ -344,9 +344,11 @@ namespace Lobby
 			}
 
 			// Init network client
+			Logger.LogFormat("Client tryint to connect to {0}:{1}", Category.Connections, serverAddress, serverPort);
 			networkManager.networkAddress = serverAddress;
 			networkManager.GetComponent<TelepathyTransport>().port = serverPort;
-			networkManager.StartClient();
+			NetworkClient.Connect(serverAddress);
+
 		}
 
 		void InitPlayerName()


### PR DESCRIPTION
### Purpose
Part of #2262 

Adds a bunch of logging code to connection logic. Fixes an issue where players were spawned into new bodies after round was restarted and they logged in and then relogged (client ID sync issue).

KNOWN ISSUES - when round restarts while player is connected, the client side is spammed with a bunch of NREs and IndexOutOfBounds, but these were already happening prior to this and they don't happen upon relogging. Will look into those next. Want to push this now to see if it fixes up issues on server.