### PR TITLE
Dark FOV

### DIFF
--- a/UnityProject/Assets/Shaders/Post Process/PostProcess MaskBlit.shader
+++ b/UnityProject/Assets/Shaders/Post Process/PostProcess MaskBlit.shader
@@ -73,7 +73,7 @@
 
 				// Blend light with scene.
 				half3 bloom = (screenUnlit.rgb + bloomAdd) * pow(mixedLight.rgb, bloomSensitivity) * step(0.005, bloomSensitivity);
-				fixed4 screenLit = screenUnlit + fixed4(screenUnlit.rgb * mixedLight.rgb * lightMultyplier + bloom, screenUnlit.a) * 1;
+				fixed4 screenLit =  fixed4(screenUnlit.rgb * mixedLight.rgb * lightMultyplier + bloom, screenUnlit.a) * 1;
 
 				// Mix Background.
 				fixed4 background = tex2D(_BackgroundTex, i.uv);


### PR DESCRIPTION
### Purpose
Some people don't like the fact you can see the layout of the station, this could address it slightly, With a simple fix

Currently only limitations are that you can see a little bit further into walls Than you should be able to but it's only tiny amount, Wall brightness is is a separate issue
and space isn't covered by FOV

### Open Questions and Pre-Merge TODOs

- [x]  This fix is tested on the same branch it is PR'ed to.
- [?]  I correctly commented my code
- [x]  My code is indented with tabs and not spaces
- [x]  This PR does not include any unnecessary .meta, .prefab or .unity (scene) changes
- [x]  This PR does not bring up any new compile errors
- [x]  This PR has been tested in editor
- [ ]  Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [ ]  Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [ ]  Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [ ]  This PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ]  This PR has been tested with round restarts.
- [ ]  This PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)

### Notes:
It's up for the maintainers to decide
