### PR TITLE
Client restart round fixes

### DIFF
--- a/UnityProject/Assets/Mirror/Runtime/ClientScene.cs
+++ b/UnityProject/Assets/Mirror/Runtime/ClientScene.cs
@@ -425,7 +425,7 @@ namespace Mirror
         {
             if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity))
             {
-                return identity.gameObject;
+	            if(identity != null) return identity.gameObject;
             }
             return null;
         }

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -432,16 +432,24 @@ public partial class GameManager : MonoBehaviour
 		return OccupationList.Instance.Get(JobType.ASSISTANT);
 	}
 
+	//Only called on the server
 	public void RestartRound()
 	{
 		waitForRestart = false;
 		if (CustomNetworkManager.Instance._isServer)
 		{
-			//TODO allow map change from admin portal
-
-			CurrentRoundState = RoundState.Ended;
-			EventManager.Broadcast(EVENT.RoundEnded);
-			CustomNetworkManager.Instance.ServerChangeScene(Maps[0]);
+			StartCoroutine(ServerRoundRestart());
 		}
+	}
+
+	IEnumerator ServerRoundRestart()
+	{
+		CurrentRoundState = RoundState.Ended;
+		//Notify all clients that the round has ended
+		ServerToClientEventsMsg.SendToAll(EVENT.RoundEnded);
+		
+		yield return WaitFor.Seconds(0.2f);
+
+		CustomNetworkManager.Instance.ServerChangeScene(Maps[0]);
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
@@ -87,6 +87,7 @@ public class UpdateManager : MonoBehaviour
 		UpdateMe = null;
 		FixedUpdateMe = null;
 		LateUpdateMe = null;
+		UpdateAction = null;
 	}
 
 	private void Update()

--- a/UnityProject/Assets/Scripts/Messages/MessageTypes.cs
+++ b/UnityProject/Assets/Scripts/Messages/MessageTypes.cs
@@ -47,6 +47,7 @@ internal enum MessageTypes : short
 	SubBookshelfNetMessage = 1043,
 	UpdateCountdownMessage = 1044,
 	ObserveInteractableStorage = 1045,
+	ServerToClientEvents = 1046,
 
 	//Client messages - 2xxx
 	UpdateHeadsetKeyMessage = 2000,

--- a/UnityProject/Assets/Scripts/Messages/Server/HealthMessages/HealthBrainMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/HealthMessages/HealthBrainMessage.cs
@@ -16,7 +16,7 @@ public class HealthBrainMessage : ServerMessage
 	public override IEnumerator Process()
 	{
 		yield return WaitFor(EntityToUpdate);
-		NetworkObject.GetComponent<LivingHealthBehaviour>().UpdateClientBrainStats(IsHusk, BrainDamage);
+		if(NetworkObject != null) NetworkObject.GetComponent<LivingHealthBehaviour>().UpdateClientBrainStats(IsHusk, BrainDamage);
 	}
 
 	public static HealthBrainMessage Send(GameObject recipient, GameObject entityToUpdate, bool isHusk, int brainDamage)

--- a/UnityProject/Assets/Scripts/Messages/Server/ServerToClientEventsMsg.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/ServerToClientEventsMsg.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections;
+
+/// <summary>
+///     A way to broadcast messages on the client via the server
+/// </summary>
+public class ServerToClientEventsMsg : ServerMessage
+{
+	public static short MessageType = (short) MessageTypes.ServerToClientEvents;
+	public EVENT Event;
+
+	public override IEnumerator Process()
+	{
+		yield return null;
+
+		EventManager.Broadcast(Event);
+	}
+	
+	/// <summary>
+	/// Send an event from EventManager to all clients
+	/// </summary>
+	public static ServerToClientEventsMsg SendToAll(EVENT _event)
+	{
+		ServerToClientEventsMsg msg = new ServerToClientEventsMsg {Event = _event};
+
+		msg.SendToAll();
+
+		return msg;
+	}
+}

--- a/UnityProject/Assets/Scripts/Messages/Server/ServerToClientEventsMsg.cs.meta
+++ b/UnityProject/Assets/Scripts/Messages/Server/ServerToClientEventsMsg.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dca7c2d206f55b74abc2e52f519336e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Fixes a whole bunch of NRE's and events on round end

Also added a ServerToClient message that has the ability to broadcast events from the EventManager. Now the OnRoundEnded event works correctly on the client. Previously it was only being broadcast locally on the server