### PR TITLE
Changes in range for footsteps

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/SoundManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/SoundManager.prefab
@@ -208,9 +208,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -496,9 +496,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -818,9 +818,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -973,9 +973,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -1128,9 +1128,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -1575,9 +1575,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -1885,9 +1885,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -2359,9 +2359,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -2514,9 +2514,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -2669,9 +2669,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -3648,9 +3648,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -3803,9 +3803,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -4086,9 +4086,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -4241,9 +4241,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -4396,9 +4396,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -14334,9 +14334,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -14489,9 +14489,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -14989,9 +14989,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -15144,9 +15144,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -15299,9 +15299,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -15609,9 +15609,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -16229,9 +16229,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -16548,9 +16548,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -16703,9 +16703,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -17013,9 +17013,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -17323,9 +17323,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -17478,9 +17478,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -17633,9 +17633,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0
@@ -17788,9 +17788,9 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1.05
   MinDistance: 1
-  MaxDistance: 25
+  MaxDistance: 16
   Pan2D: 0
-  rolloffMode: 2
+  rolloffMode: 1
   BypassEffects: 0
   BypassListenerEffects: 0
   BypassReverbZones: 0


### PR DESCRIPTION
### Purpose
Change it to the range of the FOV 13 Blocks but to the sound system 16 For the sound system Since that correlates when you can stop seeing stuff

### Notes:
_Please enter any other relevant information here_

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented n/a
- Code is indented with tabs and not spaces  n/a
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b> /
- The PR does not bring up any new compile errors  n/a
- The PR has been tested in editor /
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)  n/a
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)  n/a 
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants)   n/a(especially concerning the use of prefab variants) n/a
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable /
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
