### PR TITLE
fix(git): added setting to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,15 @@
 *.meta linguist-generated
 *.prefab linguist-generated
 *.unity linguist-generated
+
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+###############################################################################
+# Set the project and solution files to use CRLF line endings.
+###############################################################################
+
+*.sln    text eol=crlf
+*.csproj text eol=crlf


### PR DESCRIPTION
### Purpose
Ensures everyone's git automatically changes line endings to LF for all text files except the .sln and .csproj files which should be CRLF.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
