### PR TITLE
General working on handcuffs

### DIFF
--- a/UnityProject/Assets/Firebase/Plugins.meta
+++ b/UnityProject/Assets/Firebase/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef056909b7a95c94391285f547aa691c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Firebase/Plugins/Http.meta
+++ b/UnityProject/Assets/Firebase/Plugins/Http.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bbf3680af9cff81408a710f339f8754e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scenes/Lobby.unity
+++ b/UnityProject/Assets/Scenes/Lobby.unity
@@ -2477,6 +2477,25 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 195420176}
   m_CullTransparentMesh: 0
+--- !u!1 &197895536 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1135621667743380, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+    type: 3}
+  m_PrefabInstance: {fileID: 488811643}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &197895543
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 197895536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f2be26c4aed0b948827dc4e4f436c17, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sprite: {fileID: 21300000, guid: 1ffe07caa421d164c8c7499fb6b592df, type: 3}
 --- !u!1 &209857475
 GameObject:
   m_ObjectHideFlags: 0
@@ -3865,6 +3884,80 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 916ee089a0d7b63419075f91e1c657ec, type: 3}
+--- !u!1 &375622596
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 375622597}
+  - component: {fileID: 375622599}
+  - component: {fileID: 375622598}
+  m_Layer: 5
+  m_Name: Handcuffs
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &375622597
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 375622596}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.2312504, y: 1.2312504, z: 1.2312504}
+  m_Children:
+  - {fileID: 583940268}
+  m_Father: {fileID: 1830534172}
+  m_RootOrder: 17
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 1058.8752, y: 757.389}
+  m_SizeDelta: {x: 64, y: 64}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &375622598
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 375622596}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300068, guid: 21c79b8453b04bf6aca87f6e4b496d5d, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &375622599
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 375622596}
+  m_CullTransparentMesh: 0
 --- !u!1 &376383249
 GameObject:
   m_ObjectHideFlags: 0
@@ -6803,6 +6896,98 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 0
+--- !u!1 &583940267
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 583940268}
+  - component: {fileID: 583940271}
+  - component: {fileID: 583940270}
+  - component: {fileID: 583940269}
+  m_Layer: 5
+  m_Name: itemSlot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &583940268
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 583940267}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1151919677}
+  m_Father: {fileID: 375622597}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &583940269
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 583940267}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &583940270
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 583940267}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3b731d242a842c2916749940e8916ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  namedSlot: 14
+  forLocalPlayer: 1
+  hoverName: You're handcuffed and can't act. If anyone drags you, you won't be able
+    to move. Click the alert to free yourself.
+  initiallyHidden: 1
+--- !u!222 &583940271
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 583940267}
+  m_CullTransparentMesh: 0
 --- !u!1 &591605419
 GameObject:
   m_ObjectHideFlags: 0
@@ -7441,6 +7626,25 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 653672246}
   m_CullTransparentMesh: 0
+--- !u!1 &660058376 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1410616181861638, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+    type: 3}
+  m_PrefabInstance: {fileID: 488811643}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &660058383
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 660058376}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f2be26c4aed0b948827dc4e4f436c17, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sprite: {fileID: 21300000, guid: 262e76d6b192e2e4383908fcc4edd1c6, type: 3}
 --- !u!1 &667207391
 GameObject:
   m_ObjectHideFlags: 0
@@ -12649,6 +12853,79 @@ RectTransform:
   m_AnchoredPosition: {x: 190, y: 28}
   m_SizeDelta: {x: 380, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1151919676
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1151919677}
+  - component: {fileID: 1151919679}
+  - component: {fileID: 1151919678}
+  m_Layer: 5
+  m_Name: SecondaryItemSprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1151919677
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1151919676}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 583940268}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1151919678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1151919676}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1151919679
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1151919676}
+  m_CullTransparentMesh: 0
 --- !u!1 &1167271700
 GameObject:
   m_ObjectHideFlags: 0
@@ -19851,6 +20128,12 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1825871516}
   m_CullTransparentMesh: 0
+--- !u!224 &1830534172 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 224342957805719492, guid: 829f4ca992b848d6bb4d007fb9c112e1,
+    type: 3}
+  m_PrefabInstance: {fileID: 488811643}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1857722331
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Inventory/ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/Inventory/ItemSlot.cs
@@ -267,10 +267,6 @@ public class ItemSlot
 			}
 		}
 
-
-
-
-
 		UpdateItemSlotMessage.Send(serverObserverPlayers, this);
 	}
 

--- a/UnityProject/Assets/Scripts/Items/Others/Restraint.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Restraint.cs
@@ -18,7 +18,12 @@ public class Restraint : MonoBehaviour, ICheckedInteractable<HandApply>
 	private float removeTime;
 	public float RemoveTime => removeTime;
 
-	// TODO: Add time it takes to resist out of handcuffs
+	/// <summary>
+	/// How long it takes for self to remove the restraints
+	/// </summary>
+	[SerializeField]
+	private float resistTime;
+	public float ResistTime => resistTime;
 
 	/// <summary>
 	/// Sound to be played when applying restraints

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -376,13 +376,22 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn
 		SyncCuffed(true);
 
 		var targetStorage = interaction.TargetObject.GetComponent<ItemStorage>();
-		//transfer cuffs to the special cuff slot (not exposed in UI ATM)
-		Inventory.ServerTransfer(interaction.HandSlot,
-			targetStorage.GetNamedItemSlot(NamedSlot.handcuffs));
+
+		//transfer cuffs to the special cuff slot
+		ItemSlot handcuffSlot = targetStorage.GetNamedItemSlot(NamedSlot.handcuffs);
+		Inventory.ServerTransfer(interaction.HandSlot, handcuffSlot);
+
 		//drop hand items
 		Inventory.ServerDrop(targetStorage.GetNamedItemSlot(NamedSlot.leftHand));
 		Inventory.ServerDrop(targetStorage.GetNamedItemSlot(NamedSlot.rightHand));
 
+		// Set a special sprite for player's hands.
+		UI_ItemSlot itemSlot;
+		itemSlot = targetStorage.GetNamedItemSlot(NamedSlot.leftHand).LocalUISlot;
+		itemSlot.SetSecondaryImage(itemSlot.GetComponentInParent<Handcuff>().HandcuffSprite);
+
+		itemSlot = targetStorage.GetNamedItemSlot(NamedSlot.rightHand).LocalUISlot;
+		itemSlot.SetSecondaryImage(itemSlot.GetComponentInParent<Handcuff>().HandcuffSprite);
 	}
 
 	[Server]

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/Handcuff.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/Handcuff.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using UnityEngine;
+
+[Serializable]
+public class Handcuff : TooltipMonoBehaviour
+{
+	// The image that should be displayed when the player is handcuffed
+	[Tooltip("The image that should be displayed when the player is handcuffed")]
+	[SerializeField]
+	private Sprite sprite;
+
+	public Sprite HandcuffSprite => sprite;
+}

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/Handcuff.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/Handcuff.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f2be26c4aed0b948827dc4e4f436c17
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
@@ -184,6 +184,13 @@ public class UI_ItemSlot : TooltipMonoBehaviour
 			return;
 		}
 
+		// If player is cuffed, a special icon appears on his hand slots, exit without changing it.
+		if ((namedSlot == NamedSlot.leftHand || namedSlot == NamedSlot.rightHand) &&
+			PlayerManager.LocalPlayerScript.playerMove.IsCuffed)
+		{
+			return;
+		}
+
 		if (!nullItem)
 		{
 			//determine the sprites to display based on the new item


### PR DESCRIPTION
Cuffs now appear in left and right hand of the player when the player is handcuffed.

The existing code refered to a inventory slot named "Handcuffs" which has been added.

Sprite for left and right cuffs has been added as a property inside a monobehaviour object to the left and right hands UI slots.

Code has been added to set the secondary sprite of Left/Right hand UI slots by  getting the sprite from that property.

What remains to be done : rework the AlertUI to make it generic and accept a new alert UI action that will trigger the uncuff of the player.  I'm not proficient enough (yet) with the project and Unity to do that.  Please put back that feature in the To-Do list for a more pro to finish it (sorry 'bout that, I'm now more conscient of my Unity proficiency level)

### Purpose
_Describe the problem the PR fixes or the feature it introduces_<br>
_Don't forget to use "Fixes #issuenumber" to select issues and auto close them on merge_

### Notes:
_Please enter any other relevant information here_

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
