### PR TITLE
Matrix Rotation Small Fixes Followup

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/UnitystationPoster3.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Wallmounts/UnitystationPoster3.prefab
@@ -17,6 +17,7 @@ GameObject:
   - component: {fileID: 114802099853820208}
   - component: {fileID: 114931094214022604}
   - component: {fileID: 114477464032290438}
+  - component: {fileID: 7063116758254510336}
   m_Layer: 19
   m_Name: UnitystationPoster3
   m_TagString: Untagged
@@ -79,8 +80,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  layer: {fileID: 0}
-  ObjectType: 1
+  matrixDebugLogging: 0
+  objectType: 1
   AtmosPassable: 1
   Passable: 1
 --- !u!114 &114342113035124884
@@ -109,7 +110,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  InitialDirection: 2
+  InitialDirection: 3
   ChangeDirectionWithMatrix: 1
 --- !u!114 &114728076805570486
 MonoBehaviour:
@@ -125,6 +126,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  IsFixedMatrix: 0
 --- !u!114 &114802099853820208
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -171,6 +173,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
+  initialIntegrity: 100
 --- !u!114 &114477464032290438
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -186,7 +189,20 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 83756955
+  m_SceneId: 0
+--- !u!114 &7063116758254510336
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011522901538}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44c7afb8a6dc4ed8bf0f983b7ff65e10, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prefabSpriteOrientation: 3
 --- !u!1 &1000013907114358
 GameObject:
   m_ObjectHideFlags: 0
@@ -213,7 +229,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1000013907114358}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0.7071068, w: -0.7071068}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 0.7369004, y: 0.7369004, z: 0.7369004}
   m_Children: []
@@ -245,6 +261,7 @@ SpriteRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/UnityProject/Assets/Scripts/Closets/InteractableFireCabinet.cs
+++ b/UnityProject/Assets/Scripts/Closets/InteractableFireCabinet.cs
@@ -25,7 +25,6 @@ public class InteractableFireCabinet : NetworkBehaviour, ICheckedInteractable<Ha
 	private void Awake()
 	{
 		//we have an item storage with only 1 slot.
-		//TODO: Populate with fire extinguisher in item storage config
 		storageObject = GetComponent<ItemStorage>();
 		slot = storageObject.GetIndexedItemSlot(0);
 		//TODO: Can probably refactor this component to rely more on ItemStorage and do less of its own logic.

--- a/UnityProject/Assets/Scripts/Inventory/Inventory.cs
+++ b/UnityProject/Assets/Scripts/Inventory/Inventory.cs
@@ -143,6 +143,21 @@ public static class Inventory
 			return false;
 		}
 
+		if (toPerform.FromSlot != null && toPerform.FromSlot.Invalid)
+		{
+			Logger.LogErrorFormat("Inventory move attempted with invalid slot {0}. This slot reference should've" +
+			                      " been cleaned up when the round restarted yet somehow didn't.", Category.Inventory,
+				toPerform.FromSlot);
+			return false;
+		}
+		if (toPerform.ToSlot != null && toPerform.ToSlot.Invalid)
+		{
+			Logger.LogErrorFormat("Inventory move attempted with invalid slot {0}. This slot reference should've" +
+			                      " been cleaned up when the round restarted yet somehow didn't.", Category.Inventory,
+				toPerform.ToSlot);
+			return false;
+		}
+
 		//figure out which kind of move to do
 		if (toPerform.InventoryMoveType == InventoryMoveType.Add)
 		{

--- a/UnityProject/Assets/Scripts/Inventory/ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/Inventory/ItemSlot.cs
@@ -1,5 +1,6 @@
 
 using System.Collections.Generic;
+using System.Linq;
 using Mirror;
 using UnityEngine;
 using UnityEngine.Events;
@@ -29,7 +30,7 @@ public class ItemSlot
 	private readonly int itemStorageNetId;
 
 	/// <summary>
-	/// ItemStorage which contains this slot
+	/// ItemStorage which contains this slot. Every slot has an item storage (except Invalid ones).
 	/// </summary>
 	public ItemStorage ItemStorage => itemStorage;
 	private readonly ItemStorage itemStorage;
@@ -99,6 +100,15 @@ public class ItemSlot
 
 	private Pickupable item;
 	private UI_ItemSlot localUISlot;
+
+	/// <summary>
+	/// True if this slot is no longer valid for any use, this only happens
+	/// when the slot pool is cleaned up when a new round begins. It should not be possible to
+	/// obtain a reference to an invalid slot since this happens on scene change, but this is here
+	/// as a safeguard.
+	/// </summary>
+	public bool Invalid => invalid;
+	private bool invalid;
 
 	/// <summary>
 	/// Server-side only. Players server thinks are currently looking at this slot (and thus will receive
@@ -402,11 +412,54 @@ public class ItemSlot
 	}
 
 	/// <summary>
-	/// Completely clears out the slot pool.
+	/// Removes entries from the pool for objects that no longer exist.
+	/// Some components cache slots in their Awake methods so we can't simply delete the entire pool
+	/// or those objects will be left with a reference to an invalid slot
 	/// </summary>
-	public static void EmptyPool()
+	public static void Cleanup()
 	{
-		slots = new Dictionary<int, Dictionary<SlotIdentifier, ItemSlot>>();
+		var instanceIdsToRemove = new List<int>();
+		//find existing storage instance IDs which have no slots or which are for no longer existing objects
+		foreach (var instanceIdToSlots in slots)
+		{
+			var instanceID = instanceIdToSlots.Key;
+			if (instanceIdToSlots.Value == null || instanceIdToSlots.Value.Keys.Count == 0)
+			{
+				instanceIdsToRemove.Add(instanceID);
+				continue;
+			}
+
+			//The dictionary doesn't have a mapping to ItemStorage objects, and
+			//we can't use the instance ID to look up the game object except in editor,
+			//so we instead figure out which game object this instance ID maps to by looking at
+			//one of its slots and getting its item storage field
+			var slotWithStorage = instanceIdToSlots.Value.Values
+				.Where(slot => slot.itemStorage != null)
+				.Select(slot => slot.itemStorage).FirstOrDefault();
+
+			//we only keep the slot if it is for an object that actually exists,
+			//i.e. the ItemStorage is not null and the ItemStorage gameObject is not null
+			//since unity null check on game objects will tell us if object still exists.
+			if (slotWithStorage == null || slotWithStorage.gameObject == null)
+			{
+				instanceIdsToRemove.Add(instanceID);
+				continue;
+			}
+		}
+
+		//now perform the actual removals and mark removed slots as invalid.
+		foreach (var instanceId in instanceIdsToRemove)
+		{
+			var slotDict = slots[instanceId];
+			//mark the slots as invalid
+			foreach (var slot in slotDict.Values)
+			{
+				slot.invalid = true;
+			}
+			//delete
+			slotDict.Clear();
+			slots.Remove(instanceId);
+		}
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -176,8 +176,8 @@ public partial class GameManager : MonoBehaviour
 	{
 		//reset pools
 		Spawn._ClearPools();
-		//reset inventory system
-		ItemSlot.EmptyPool();
+		//clean up inventory system
+		ItemSlot.Cleanup();
 		//reset matrix init events
 		NetworkedMatrix._ClearInitEvents();
 	}

--- a/UnityProject/Assets/Scripts/UI/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/UIManager.cs
@@ -423,7 +423,6 @@ public class UIManager : MonoBehaviour
 		Camera.main.orthographicSize = originalZoom;
 		//turn everything back on
 		yield return null;
-		SoundManager.PlayAmbience();
 		UIManager.PlayerHealthUI.gameObject.SetActive(true);
 		if (PlayerManager.LocalPlayerScript.IsGhost)
 		{


### PR DESCRIPTION
### Purpose
Small follow up for #2483 

Fixes bar poster rotation (that's the mapping change).
Don't start ambiance after ending finishes.
Fix mapped extinguisher cabinets so they actually work, there was a bug in inventory system which caused objects who cached ItemSlot in Awake to have a reference to an invalid / outdated item slot. Changed how inventory cleanup works.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
