### PR TITLE
Better swap prediction and rollback

### DIFF
--- a/UnityProject/Assets/Scripts/Chemistry/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/Chemistry/ReagentContainer.cs
@@ -401,7 +401,7 @@ public class ReagentContainer : Container, IRightClickable, IServerSpawn,
 		var playerScript = interaction.Performer.GetComponent<PlayerScript>();
 		if (!playerScript) return false;
 
-		if (playerScript.playerMove.IsHelpIntent)
+		if (interaction.Intent == Intent.Help)
 		{ //checks if it's possible to transfer from container to container
 			if (!WillInteractHelp(interaction.HandObject, interaction.TargetObject, side)) return false;
 		}
@@ -472,7 +472,7 @@ public class ReagentContainer : Container, IRightClickable, IServerSpawn,
 	{
 		var srcPlayer = interaction.Performer.GetComponent<PlayerScript>();
 
-		if (srcPlayer.playerMove.IsHelpIntent)
+		if (interaction.Intent == Intent.Help)
 		{
 			var one = interaction.HandObject.GetComponent<ReagentContainer>();
 			var two = interaction.TargetObject.GetComponent<ReagentContainer>();

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -178,9 +178,23 @@ public partial class MatrixManager : MonoBehaviour
 	public static BumpType GetBumpTypeAt(Vector3Int worldOrigin, Vector2Int dir, PlayerMove bumper, bool isServer)
 	{
 		Vector3Int targetPos = worldOrigin + dir.To3Int();
-		if (bumper.IsSwappable)
+
+
+		bool hasHelpIntent = false;
+		if (bumper.gameObject == PlayerManager.LocalPlayer && !isServer)
 		{
-			//check for other players with help intent
+			//locally predict based on our set intent.
+			hasHelpIntent = UIManager.CurrentIntent == Intent.Help;
+		}
+		if (isServer)
+		{
+			//use value known to server
+			hasHelpIntent = bumper.IsHelpIntentServer;
+		}
+
+		if (hasHelpIntent)
+		{
+			//check for other players we can swap with
 			PlayerMove other = GetSwappableAt(targetPos, bumper.gameObject, isServer);
 			if (other != null)
 			{

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -345,15 +345,7 @@ public partial class MatrixManager : MonoBehaviour
 		var playerMoves = GetAt<PlayerMove>(targetWorldPos, isServer);
 		foreach (PlayerMove playerMove in playerMoves)
 		{
-			//TODO: Incorporate all this logic into IsSwappable syncvar so it's the only needed check
-			if (playerMove
-			    && !playerMove.PlayerScript.IsGhost
-				&& playerMove.IsSwappable
-			    && !playerMove.PlayerScript.playerHealth.IsDead
-			    && !playerMove.PlayerScript.registerTile.IsPassable(isServer)
-			    && playerMove.gameObject != mover
-			    && !playerMove.PlayerScript.pushPull.IsPullingSomething
-			    && !playerMove.IsBuckled)
+			if (playerMove && playerMove.IsSwappable && playerMove.gameObject != mover)
 			{
 				return playerMove;
 			}

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -178,20 +178,20 @@ public partial class MatrixManager : MonoBehaviour
 	public static BumpType GetBumpTypeAt(Vector3Int worldOrigin, Vector2Int dir, PlayerMove bumper, bool isServer)
 	{
 		Vector3Int targetPos = worldOrigin + dir.To3Int();
-		if (bumper.IsHelpIntent)
+		if (bumper.IsSwappable)
 		{
 			//check for other players with help intent
-			PlayerMove other = GetHelpIntentAt(targetPos, bumper.gameObject, isServer);
+			PlayerMove other = GetSwappableAt(targetPos, bumper.gameObject, isServer);
 			if (other != null)
 			{
 				//if we are pulling something, we can only swap with that thing
 				if (bumper.PlayerScript.pushPull.IsPullingSomething && bumper.PlayerScript.pushPull.PulledObject == other.PlayerScript.pushPull)
 				{
-					return BumpType.HelpIntent;
+					return BumpType.Swappable;
 				}
 				else if (!bumper.PlayerScript.pushPull.IsPullingSomething)
 				{
-					return BumpType.HelpIntent;
+					return BumpType.Swappable;
 				}
 			}
 		}
@@ -335,20 +335,20 @@ public partial class MatrixManager : MonoBehaviour
 	}
 
 	/// <summary>
-	/// Return the playermove if there is a non-passable player with help intent at the specified position who is
-	/// not pulling something and not restrained (it is not possible to swap with someone who is pulling something)
+	/// Gets the player move at the position which is currently able to be swapped with (if one exists).
 	/// </summary>
 	/// <param name="targetWorldPos">Position to check</param>
 	/// <param name="mover">gameobject of the thing attempting the move, only used to prevent itself from being checked</param>
-	/// <returns>the player move if they have help intent and are not passable, otherwise null</returns>
-	public static PlayerMove GetHelpIntentAt(Vector3Int targetWorldPos, GameObject mover, bool isServer)
+	/// <returns>the player move that is swappable, otherwise null</returns>
+	public static PlayerMove GetSwappableAt(Vector3Int targetWorldPos, GameObject mover, bool isServer)
 	{
 		var playerMoves = GetAt<PlayerMove>(targetWorldPos, isServer);
 		foreach (PlayerMove playerMove in playerMoves)
 		{
+			//TODO: Incorporate all this logic into IsSwappable syncvar so it's the only needed check
 			if (playerMove
 			    && !playerMove.PlayerScript.IsGhost
-				&& playerMove.IsHelpIntent
+				&& playerMove.IsSwappable
 			    && !playerMove.PlayerScript.playerHealth.IsDead
 			    && !playerMove.PlayerScript.registerTile.IsPassable(isServer)
 			    && playerMove.gameObject != mover
@@ -869,6 +869,6 @@ public enum BumpType
 	/// Bump which blocks movement and causes nothing else to happen
 	Blocked,
 
-	// A help intent player
-	HelpIntent
+	// Something we can swap places with
+	Swappable
 }

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -275,7 +275,22 @@ public class PushPull : NetworkBehaviour, IRightClickable, IServerSpawn {
 	public PushPull PulledObject => isServer ? PulledObjectServer : PulledObjectClient;
 
 	public bool IsPullingSomethingServer => PulledObjectServer != null;
-	public PushPull PulledObjectServer { get; private set; }
+
+	/// <summary>
+	/// Invoked server side only when this object starts / stops pulling something, after the change is made.
+	/// </summary>
+	public UnityEvent OnPullingSomethingChangedServer = new UnityEvent();
+
+	public PushPull PulledObjectServer
+	{
+		get => pulledObjectServer;
+		private set
+		{
+			pulledObjectServer = value;
+			OnPullingSomethingChangedServer.Invoke();
+		}
+	}
+	private PushPull pulledObjectServer;
 
 	public bool IsPullingSomethingClient => PulledObjectClient != null;
 	public PushPull PulledObjectClient { get; set; }

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -57,12 +57,16 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn
 	[SyncVar]
 	private bool isSwappable;
 
-	//server side only, tracks whether this player has indicated they are on help intent.
+	/// <summary>
+	/// server side only, tracks whether this player has indicated they are on help intent. Used
+	/// for checking for swaps.
+	/// </summary>
+	public bool IsHelpIntentServer => isHelpIntentServer;
 	//starts true because all players spawn with help intent.
 	private bool isHelpIntentServer = true;
 
 	/// <summary>
-	/// Whether this player meets all the conditions for being swapped with.
+	/// Whether this player meets all the conditions for being swapped with (being the swapee).
 	/// </summary>
 	public bool IsSwappable
 	{

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -47,48 +47,8 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn
 	[NonSerialized]
 	public CuffEvent OnCuffChangeServer = new CuffEvent();
 
-	/// <summary>
-	/// Tracks the server's idea of whether we have help intent
-	/// </summary>
-	[SyncVar] private bool serverIsHelpIntent = true;
-
-	/// <summary>
-	/// Tracks our idea of whether we have help intent so we can use it for client prediction
-	/// </summary>
-	private bool localIsHelpIntent = true;
-
-	/// <summary>
-	/// True iff this player is set to help intent, thus should swap places with players
-	/// that they collide with if the other player also has help intent
-	/// </summary>
-	public bool IsHelpIntent
-	{
-		get
-		{
-			if (isLocalPlayer)
-			{
-				return localIsHelpIntent;
-			}
-			else
-			{
-				return serverIsHelpIntent;
-			}
-		}
-		set
-		{
-			if (isLocalPlayer)
-			{
-				localIsHelpIntent = value;
-				//tell the server we want this to be our setting
-				CmdChangeHelpIntent(value);
-			}
-			else
-			{
-				//accept what the server is telling us about someone other than our local player
-				serverIsHelpIntent = value;
-			}
-		}
-	}
+	//TODO: Implement this instead of IsHelpIntent stuff
+	public bool IsSwappable => true;
 
 	private readonly List<MoveAction> moveActionList = new List<MoveAction>();
 
@@ -125,12 +85,6 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn
 	{
 		SyncCuffed(this.cuffed);
 		base.OnStartClient();
-	}
-
-	[Command]
-	private void CmdChangeHelpIntent(bool isHelpIntent)
-	{
-		serverIsHelpIntent = isHelpIntent;
 	}
 
 	public PlayerAction SendAction()

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -64,13 +64,31 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn
 	/// <summary>
 	/// Whether this player meets all the conditions for being swapped with.
 	/// </summary>
-	public bool IsSwappable => isSwappable
-	                           //don't swap with ghosts
-	                           && !PlayerScript.IsGhost
-	                           //pass through players if we can
-	                           && !registerPlayer.IsPassable(isServer)
-	                           //can't swap with buckled players, they're strapped down
-	                           && !IsBuckled;
+	public bool IsSwappable
+	{
+		get
+		{
+			bool canSwap;
+			if (isLocalPlayer && !isServer)
+			{
+				//locally predict
+				canSwap = UIManager.CurrentIntent == Intent.Help
+				          && !PlayerScript.pushPull.IsPullingSomething;
+			}
+			else
+			{
+				//rely on server synced value
+				canSwap = isSwappable;
+			}
+			return canSwap
+			       //don't swap with ghosts
+			       && !PlayerScript.IsGhost
+			       //pass through players if we can
+			       && !registerPlayer.IsPassable(isServer)
+			       //can't swap with buckled players, they're strapped down
+			       && !IsBuckled;
+		}
+	}
 
 	private readonly List<MoveAction> moveActionList = new List<MoveAction>();
 

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -453,11 +453,12 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn
 	}
 
 	/// <summary>
-	/// Checks if the server-only conditions for swappability are met and updates the syncvar.
+	/// Checks if the conditions for swappability that aren't
+	/// known by clients are met and updates the syncvar.
 	/// </summary>
 	private void ServerUpdateIsSwappable()
 	{
-		isSwappable = isHelpIntentServer && PlayerScript.pushPull.IsPullingSomethingServer;
+		isSwappable = isHelpIntentServer && !PlayerScript.pushPull.IsPullingSomethingServer;
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -134,7 +134,7 @@ public partial class PlayerSync
 					LastDirectionClient = action.Direction();
 					UpdatePredictedState();
 				}
-				else if (clientBump == BumpType.HelpIntent)
+				else if (clientBump == BumpType.Swappable)
 				{
 					//note we don't check isgrounded here, client is allowed to swap with another player when
 					//they are both stopped in space

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -478,6 +478,17 @@ public partial class PlayerSync
 		if (!isClientBump && serverBump != BumpType.None && serverBump != BumpType.Swappable) {
 			Logger.LogWarningFormat( "isBump mismatch, resetting: C={0} S={1}", Category.Movement, isClientBump, serverBump != BumpType.None );
 			RollbackPosition();
+			//laggy client may have predicted a swap with another player,
+			//in which case they must also roll back that player
+			if (serverBump == BumpType.Push || serverBump == BumpType.Blocked)
+			{
+				var worldTarget = state.WorldPosition.RoundToInt() + (Vector3Int) action.Direction();
+				var swapee = MatrixManager.GetAt<PlayerSync>(worldTarget, true);
+				if (swapee != null && swapee.Count > 0)
+				{
+					swapee[0].RollbackPosition();
+				}
+			}
 		}
 		if ( isClientBump || (serverBump != BumpType.None && serverBump != BumpType.Swappable)) {
 			// we bumped something, an interaction might occur

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -475,11 +475,11 @@ public partial class PlayerSync
 
 		//we only lerp back if the client thinks it's passable  but server does not...if client
 		//thinks it's not passable and server thinks it's passable, then it's okay to let the client continue
-		if (!isClientBump && serverBump != BumpType.None && serverBump != BumpType.HelpIntent) {
+		if (!isClientBump && serverBump != BumpType.None && serverBump != BumpType.Swappable) {
 			Logger.LogWarningFormat( "isBump mismatch, resetting: C={0} S={1}", Category.Movement, isClientBump, serverBump != BumpType.None );
 			RollbackPosition();
 		}
-		if ( isClientBump || (serverBump != BumpType.None && serverBump != BumpType.HelpIntent)) {
+		if ( isClientBump || (serverBump != BumpType.None && serverBump != BumpType.Swappable)) {
 			// we bumped something, an interaction might occur
 			// try pushing things / opening doors
 			if ( Validations.CanInteract(playerScript, NetworkSide.Server, allowCuffed: true) || serverBump == BumpType.ClosedDoor )
@@ -499,7 +499,7 @@ public partial class PlayerSync
 
 		//check for a swap
 		bool swapped = false;
-		if (serverBump == BumpType.HelpIntent)
+		if (serverBump == BumpType.Swappable)
 		{
 			swapped = CheckAndDoSwap(state.WorldPosition.RoundToInt() + action.Direction().To3Int(), action.Direction() * -1
 				, isServer: true);

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -192,12 +192,12 @@ public partial class PlayerSync : NetworkBehaviour, IPushable
 		MoveAction? newAction = null;
 		BumpType? newBump = null;
 
-		if (bump1 == BumpType.None || bump1 == BumpType.HelpIntent)
+		if (bump1 == BumpType.None || bump1 == BumpType.Swappable)
 		{
 			newAction = PlayerAction.GetMoveAction(dir1);
 			newBump = bump1;
 		}
-		else if (bump2 == BumpType.None || bump2 == BumpType.HelpIntent)
+		else if (bump2 == BumpType.None || bump2 == BumpType.Swappable)
 		{
 			newAction = PlayerAction.GetMoveAction(dir2);
 			newBump = bump2;
@@ -377,7 +377,7 @@ public partial class PlayerSync : NetworkBehaviour, IPushable
 	/// <returns>true iff swap was performed</returns>
 	private bool CheckAndDoSwap(Vector3Int targetWorldPos, Vector2 inDirection, bool isServer)
 	{
-		PlayerMove other = MatrixManager.GetHelpIntentAt(targetWorldPos, gameObject, isServer);
+		PlayerMove other = MatrixManager.GetSwappableAt(targetWorldPos, gameObject, isServer);
 		if (other != null)
 		{
 			// on server, must verify that position matches
@@ -689,11 +689,11 @@ public partial class PlayerSync : NetworkBehaviour, IPushable
 		DebugGizmoUtils.DrawArrow(clientState + Vector3.right / 5, playerState.WorldImpulse);
 		if (drawMoves) DebugGizmoUtils.DrawText(playerState.MoveNumber.ToString(), clientState + Vector3.right, 15);
 
-		//help intent
+		//swappable
 		Gizmos.color = isLocalPlayer ? color4 : color1;
-		if (playerMove.IsHelpIntent)
+		if (playerMove.IsSwappable)
 		{
-			DebugGizmoUtils.DrawText("Help", clientState + Vector3.up / 2, 15);
+			DebugGizmoUtils.DrawText("Swap", clientState + Vector3.up / 2, 15);
 		}
 	}
 #endif

--- a/UnityProject/Assets/Scripts/Storage/Rack.cs
+++ b/UnityProject/Assets/Scripts/Storage/Rack.cs
@@ -44,7 +44,7 @@ public class Rack : NetworkBehaviour, ICheckedInteractable<PositionalHandApply>
 
 		// If the player is using a wrench on the rack, deconstruct it
 		if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench)
-		    && !interaction.Performer.Player().Script.playerMove.IsHelpIntent)
+		    && interaction.Intent != Intent.Help)
 		{
 			SoundManager.PlayNetworkedAtPos("Wrench", interaction.WorldPositionTarget, 1f);
 			Spawn.ServerPrefab(rackParts, interaction.WorldPositionTarget.RoundToInt(),

--- a/UnityProject/Assets/Scripts/UI/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/UIManager.cs
@@ -139,11 +139,12 @@ public class UIManager : MonoBehaviour
 		set
 		{
 			currentIntent = value;
+			//TODO: Set IsSwappable syncvar
 			//update the intent of the player so it can be synced
-			if (PlayerManager.LocalPlayerScript != null)
-			{
-				PlayerManager.LocalPlayerScript.playerMove.IsHelpIntent = value == global::Intent.Help;
-			}
+			// if (PlayerManager.LocalPlayerScript != null)
+			// {
+			// 	PlayerManager.LocalPlayerScript.playerMove.IsHelpIntent = value == global::Intent.Help;
+			// }
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/UI/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/UIManager.cs
@@ -139,12 +139,12 @@ public class UIManager : MonoBehaviour
 		set
 		{
 			currentIntent = value;
-			//TODO: Set IsSwappable syncvar
-			//update the intent of the player so it can be synced
-			// if (PlayerManager.LocalPlayerScript != null)
-			// {
-			// 	PlayerManager.LocalPlayerScript.playerMove.IsHelpIntent = value == global::Intent.Help;
-			// }
+
+			//update the intent of the player on server so server knows we are swappable or not
+			if (PlayerManager.LocalPlayerScript != null)
+			{
+				PlayerManager.LocalPlayerScript.playerMove.CmdSetHelpIntent(currentIntent == global::Intent.Help);
+			}
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Weapons/Melee/MeleeStun.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Melee/MeleeStun.cs
@@ -50,8 +50,7 @@ public class MeleeStun : MonoBehaviour, ICheckedInteractable<HandApply>
 		// If we're not on help intent we deal damage!
 		// Note: this has to be done before the stun, because otherwise if we hit ourselves with an activated stun baton on harm intent
 		// we wouldn't deal damage to ourselves because CmdRequestMeleeAttack checks whether we're stunned
-		bool helpIntent = interaction.Performer.GetComponent<PlayerMove>().IsHelpIntent;
-		if (!helpIntent)
+		if (interaction.Intent != Intent.Help)
 		{
 			// Direction of attack towards the attack target.
 			wna.CmdRequestMeleeAttack(target, dir, interaction.TargetBodyPart, LayerType.None);
@@ -66,7 +65,7 @@ public class MeleeStun : MonoBehaviour, ICheckedInteractable<HandApply>
 			SoundManager.PlayNetworkedAtPos(stunSound, target.transform.position);
 
 			// Special case: If we're on help intent (only stun), we should still show the lerp (unless we're hitting ourselves)
-			if (helpIntent && performer != target)
+			if (interaction.Intent == Intent.Help && performer != target)
 			{
 				wna.RpcMeleeAttackLerp(dir, gameObject);
 			}


### PR DESCRIPTION
### Purpose
Fixes #1953 

Clients also will no longer predict a swap if another player is pulling something - server syncs a value to them that lets them know if another player is swappable based on things only server is allowed to know.