### PR TITLE
Toggle Throw Action when Grenade HandActivate

### DIFF
--- a/UnityProject/Assets/Scripts/Weapons/Grenade.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Grenade.cs
@@ -96,6 +96,8 @@ public class Grenade : NetworkBehaviour, IInteractable<HandActivate>, IClientSpa
 		{
 			timerRunning = true;
 			PlayPinSFX(originator.transform.position);
+			UIManager.Action.Throw();
+
 			if (unstableFuse)
 			{
 				float fuseVariation = fuseLength / 4;
@@ -107,7 +109,7 @@ public class Grenade : NetworkBehaviour, IInteractable<HandActivate>, IClientSpa
 				radius = Random.Range(radius - radiusVariation, radius + radiusVariation);
 			}
 			yield return WaitFor.Seconds(fuseLength);
-			Explode("explosion");
+			Explode();
 		}
 	}
 
@@ -140,7 +142,7 @@ public class Grenade : NetworkBehaviour, IInteractable<HandActivate>, IClientSpa
 
 	}
 
-	public void Explode(string damagedBy)
+	public void Explode()
 	{
 		if (hasExploded)
 		{
@@ -151,7 +153,7 @@ public class Grenade : NetworkBehaviour, IInteractable<HandActivate>, IClientSpa
 		{
 			PlaySoundAndShake();
 			CreateShape();
-			CalcAndApplyExplosionDamage(damagedBy);
+			CalcAndApplyExplosionDamage();
 			Despawn.ServerSingle(gameObject);
 		}
 	}
@@ -160,9 +162,8 @@ public class Grenade : NetworkBehaviour, IInteractable<HandActivate>, IClientSpa
 	/// Calculate and apply the damage that should be caused by the explosion, updating the server's state for the damaged
 	/// objects. Currently always uses a circle
 	/// </summary>
-	/// <param name="thanksTo">string of the entity that caused the explosion</param>
 	[Server]
-	public void CalcAndApplyExplosionDamage(string thanksTo)
+	public void CalcAndApplyExplosionDamage()
 	{
 		Vector2 explosionPos = objectBehaviour.AssumedWorldPositionServer().To2Int();
 		//trigger a hotspot caused by grenade explosion

--- a/UnityProject/Assets/Scripts/Weapons/Grenade.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Grenade.cs
@@ -22,7 +22,7 @@ public enum ExplosionType
 ///     Generic grenade base.
 /// </summary>
 [RequireComponent(typeof(Pickupable))]
-public class Grenade : NetworkBehaviour, IInteractable<HandActivate>, IClientSpawn
+public class Grenade : NetworkBehaviour, IPredictedInteractable<HandActivate>, IClientSpawn
 {
 	[TooltipAttribute("If the fuse is precise or has a degree of error equal to fuselength / 4")]
 	public bool unstableFuse = false;
@@ -85,8 +85,22 @@ public class Grenade : NetworkBehaviour, IInteractable<HandActivate>, IClientSpa
 		UpdateSprite(LOCKED_SPRITE);
 	}
 
+	public void ClientPredictInteraction(HandActivate interaction)
+	{
+		// Toggle the throw action after activation
+		UIManager.Action.Throw();
+	}
+
+	public void ServerRollbackClient(HandActivate interaction)
+	{
+	}
+
 	public void ServerPerformInteraction(HandActivate interaction)
 	{
+		if (interaction.Performer == PlayerManager.LocalPlayer)
+		{
+			UIManager.Action.Throw();
+		}
 		StartCoroutine(TimeExplode(interaction.Performer));
 	}
 
@@ -96,7 +110,6 @@ public class Grenade : NetworkBehaviour, IInteractable<HandActivate>, IClientSpa
 		{
 			timerRunning = true;
 			PlayPinSFX(originator.transform.position);
-			UIManager.Action.Throw();
 
 			if (unstableFuse)
 			{


### PR DESCRIPTION
Toggles the throw action when a grenade is interacted with.

Remove unused "explosion" string.

### Purpose
_Fixes #1754 to allow grenades thrown after activation without manual throw toggle_<br>

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor

![Grenade](https://user-images.githubusercontent.com/8658239/71644311-0a6a3e80-2c8c-11ea-91cd-4c89291435a9.gif)

