### PR TITLE
Fixed memory leak

### DIFF
--- a/UnityProject/Assets/Scripts/Lighting System/LightingSystem.cs
+++ b/UnityProject/Assets/Scripts/Lighting System/LightingSystem.cs
@@ -340,7 +340,8 @@ public class LightingSystem : MonoBehaviour
 
 		if (mTextureDataRequest != null)
 		{
-			mTextureDataRequest.DeallocateOnClose();
+			mTextureDataRequest.Dispose();
+			mTextureDataRequest = null;
 		}
 	}
 


### PR DESCRIPTION
- TextureDataRequest now implements IDisposable
- LightSystem now correctly calls Dispose and sets mTextureDataRequest to null

### Purpose
Fixes #2517 

### Notes:
Changed TextureDataRequest to implement IDisposable correctly, also cleaned up TextureDataRequest formatting