### PR TITLE
Various microwave improvements, and player movement can cancel itself

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/Microwave.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/Microwave.prefab
@@ -189,8 +189,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  cookTime: 10
-  onSprite: {fileID: 21300000, guid: 47022b2620601ec4e87ddd6e2f22e370, type: 3}
+  COOK_TIME: 10
+  microwaveTimer: 0
+  meal: 
+  SPRITE_ON: {fileID: 21300000, guid: 47022b2620601ec4e87ddd6e2f22e370, type: 3}
 --- !u!114 &114643057465573826
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -217,8 +219,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  layer: {fileID: 0}
-  ObjectType: 1
+  matrixDebugLogging: 0
+  objectType: 1
   AtmosPassable: 1
   Passable: 1
 --- !u!114 &114348264163667782
@@ -298,7 +300,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 462ac978126b468baa6b4ba377070a17
+  m_AssetId: 
   m_SceneId: 0
 --- !u!1 &1000010906387252
 GameObject:

--- a/UnityProject/Assets/Scripts/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.cs
@@ -57,7 +57,7 @@ public partial class Chat : MonoBehaviour
 			message = message,
 			modifiers = (player == null) ? ChatModifier.None : player.GetCurrentChatModifiers(),
 			speaker = (player == null) ? sentByPlayer.Username : player.name,
-			position = ((player == null) ? Vector2.zero : (Vector2) player.gameObject.transform.position),
+			position = ((player == null) ? Vector2.zero : (Vector2)player.gameObject.transform.position),
 			channels = channels,
 			originator = sentByPlayer.GameObject
 		};
@@ -96,331 +96,331 @@ public partial class Chat : MonoBehaviour
 		}
 
 		// There could be multiple channels we need to send a message for each.
-			// We do this on the server side that local chans can be determined correctly
-			foreach (Enum value in Enum.GetValues(channels.GetType()))
+		// We do this on the server side that local chans can be determined correctly
+		foreach (Enum value in Enum.GetValues(channels.GetType()))
+		{
+			if (channels.HasFlag((ChatChannel)value))
 			{
-				if (channels.HasFlag((ChatChannel) value))
+				//Using HasFlag will always return true for flag at value 0 so skip it
+				if ((ChatChannel)value == ChatChannel.None) continue;
+
+				if (IsNamelessChan((ChatChannel)value)) continue;
+
+				chatEvent.channels = (ChatChannel)value;
+				Instance.addChatLogServer.Invoke(chatEvent);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Adds a system message to all players on the given matrix
+	/// You must color your own system messages as they are not done automatically!
+	/// Server side only
+	/// </summary>
+	/// <param name="message"> message to add to each clients chat stream</param>
+	/// <param name="stationMatrix"> the matrix to broadcast the message too</param>
+	public static void AddSystemMsgToChat(string message, MatrixInfo stationMatrix)
+	{
+		if (!IsServer()) return;
+
+		Instance.addChatLogServer.Invoke(new ChatEvent
+		{
+			message = message,
+			channels = ChatChannel.System,
+			matrix = stationMatrix
+		});
+	}
+
+	/// <summary>
+	/// For game wide system messages like admin messages or
+	/// messages related to the round itself.
+	/// You must color your own system messages as they are not done automatically!
+	/// </summary>
+	public static void AddGameWideSystemMsgToChat(string message)
+	{
+		if (!IsServer()) return;
+
+		Instance.addChatLogServer.Invoke(new ChatEvent
+		{
+			message = message,
+			channels = ChatChannel.System
+		});
+	}
+
+	/// <summary>
+	/// For all general action based messages (i.e. The clown hugged runtime)
+	/// Do not use this method for combat messages
+	/// Remember to only use this server side
+	/// </summary>
+	/// <param name="originator"> The player who caused the action</param>
+	/// <param name="originatorMessage"> The message that should be given to the originator only (i.e you hugged ian) </param>
+	/// <param name="othersMessage"> The message that will be shown to other players (i.e. Cuban Pete hugged ian)</param>
+	public static void AddActionMsgToChat(GameObject originator, string originatorMessage,
+		string othersMessage)
+	{
+		if (!IsServer()) return;
+
+		//dont send message if originator message is blank
+		if (string.IsNullOrWhiteSpace(originatorMessage)) return;
+
+		Instance.addChatLogServer.Invoke(new ChatEvent
+		{
+			channels = ChatChannel.Action,
+			speaker = originator.name,
+			message = originatorMessage,
+			messageOthers = othersMessage,
+			position = originator.transform.position,
+			originator = originator
+		});
+	}
+
+	/// <see cref="Chat.AddActionMsgToChat"/>
+	/// <param name="interaction"> The interaction which caused this action (performer will be originator)</param>
+	/// <param name="originatorMessage"> The message that should be given to the originator only (i.e you hugged ian) </param>
+	/// <param name="othersMessage"> The message that will be shown to other players (i.e. Cuban Pete hugged ian)</param>
+	public static void AddActionMsgToChat(Interaction interaction, string originatorMessage,
+		string othersMessage)
+	{
+		AddActionMsgToChat(interaction.Performer, originatorMessage, othersMessage);
+	}
+
+	/// <summary>
+	/// Use this for general combat messages
+	/// </summary>
+	/// <param name="originator"> Who is doing the attacking</param>
+	/// <param name="originatorMsg"> The message to be shown to the originator</param>
+	/// <param name="othersMsg"> The message to be shown to everyone else</param>
+	/// <param name="hitZone"> Hitzone of the attack on the victim</param>
+	public static void AddCombatMsgToChat(GameObject originator, string originatorMsg,
+		string othersMsg, BodyPartType hitZone = BodyPartType.None)
+	{
+		if (!IsServer()) return;
+
+		Instance.addChatLogServer.Invoke(new ChatEvent
+		{
+			channels = ChatChannel.Combat,
+			message = originatorMsg,
+			messageOthers = othersMsg,
+			speaker = originator.name,
+			position = originator.transform.position,
+			originator = originator
+		});
+	}
+
+	/// <summary>
+	/// Sends a message to all players about an attack that took place
+	/// </summary>
+	/// <param name="attacker">GameObject of the player that attacked</param>
+	/// <param name="victim">GameObject of the player hat was the victim</param>
+	/// <param name="damage">damage done</param>
+	/// <param name="hitZone">zone that was damaged</param>
+	/// <param name="item">optional gameobject with an itemattributes, representing the item the attack was made with</param>
+	/// <param name="customAttackVerb">If you want to override the attack verb then pass the verb here</param>
+	/// <param name="attackedTile">If attacking a particular tile, the layer tile being attacked</param>
+	public static void AddAttackMsgToChat(GameObject attacker, GameObject victim,
+		BodyPartType hitZone = BodyPartType.None, GameObject item = null, string customAttackVerb = "", LayerTile attackedTile = null)
+	{
+		string attackVerb;
+		string attack;
+
+		if (item)
+		{
+			var itemAttributes = item.GetComponent<ItemAttributesV2>();
+			attackVerb = itemAttributes.ServerAttackVerbs.PickRandom() ?? "attacked";
+			attack = $" with {itemAttributes.ArticleName}";
+		}
+		else
+		{
+			// Punch attack as there is no item.
+			attackVerb = "punched";
+			attack = "";
+		}
+
+		if (!string.IsNullOrEmpty(customAttackVerb))
+		{
+			attackVerb = customAttackVerb;
+		}
+
+		var player = victim.Player();
+		if (player == null)
+		{
+			hitZone = BodyPartType.None;
+		}
+
+		string victimName;
+		string victimNameOthers = "";
+		if (attacker == victim)
+		{
+			victimName = "yourself";
+			if (player != null)
+			{
+				if (player.Script.characterSettings.Gender == Gender.Female)
 				{
-					//Using HasFlag will always return true for flag at value 0 so skip it
-					if ((ChatChannel) value == ChatChannel.None) continue;
-
-					if (IsNamelessChan((ChatChannel) value)) continue;
-
-					chatEvent.channels = (ChatChannel) value;
-					Instance.addChatLogServer.Invoke(chatEvent);
+					victimNameOthers = "herself";
 				}
-			}
-		}
 
-		/// <summary>
-		/// Adds a system message to all players on the given matrix
-		/// You must color your own system messages as they are not done automatically!
-		/// Server side only
-		/// </summary>
-		/// <param name="message"> message to add to each clients chat stream</param>
-		/// <param name="stationMatrix"> the matrix to broadcast the message too</param>
-		public static void AddSystemMsgToChat(string message, MatrixInfo stationMatrix)
-		{
-			if (!IsServer()) return;
-
-			Instance.addChatLogServer.Invoke(new ChatEvent
-			{
-				message = message,
-				channels = ChatChannel.System,
-				matrix = stationMatrix
-			});
-		}
-
-		/// <summary>
-		/// For game wide system messages like admin messages or
-		/// messages related to the round itself.
-		/// You must color your own system messages as they are not done automatically!
-		/// </summary>
-		public static void AddGameWideSystemMsgToChat(string message)
-		{
-			if (!IsServer()) return;
-
-			Instance.addChatLogServer.Invoke(new ChatEvent
-			{
-				message = message,
-				channels = ChatChannel.System
-			});
-		}
-
-		/// <summary>
-		/// For all general action based messages (i.e. The clown hugged runtime)
-		/// Do not use this method for combat messages
-		/// Remember to only use this server side
-		/// </summary>
-		/// <param name="originator"> The player who caused the action</param>
-		/// <param name="originatorMessage"> The message that should be given to the originator only (i.e you hugged ian) </param>
-		/// <param name="othersMessage"> The message that will be shown to other players (i.e. Cuban Pete hugged ian)</param>
-		public static void AddActionMsgToChat(GameObject originator, string originatorMessage,
-			string othersMessage)
-		{
-			if (!IsServer()) return;
-
-			//dont send message if originator message is blank
-			if (string.IsNullOrWhiteSpace(originatorMessage)) return;
-
-			Instance.addChatLogServer.Invoke(new ChatEvent
-			{
-				channels = ChatChannel.Action,
-				speaker = originator.name,
-				message = originatorMessage,
-				messageOthers = othersMessage,
-				position = originator.transform.position,
-				originator = originator
-			});
-		}
-
-		/// <see cref="Chat.AddActionMsgToChat"/>
-		/// <param name="interaction"> The interaction which caused this action (performer will be originator)</param>
-		/// <param name="originatorMessage"> The message that should be given to the originator only (i.e you hugged ian) </param>
-		/// <param name="othersMessage"> The message that will be shown to other players (i.e. Cuban Pete hugged ian)</param>
-		public static void AddActionMsgToChat(Interaction interaction, string originatorMessage,
-			string othersMessage)
-		{
-			AddActionMsgToChat(interaction.Performer, originatorMessage, othersMessage);
-		}
-
-		/// <summary>
-		/// Use this for general combat messages
-		/// </summary>
-		/// <param name="originator"> Who is doing the attacking</param>
-		/// <param name="originatorMsg"> The message to be shown to the originator</param>
-		/// <param name="othersMsg"> The message to be shown to everyone else</param>
-		/// <param name="hitZone"> Hitzone of the attack on the victim</param>
-		public static void AddCombatMsgToChat(GameObject originator, string originatorMsg,
-			string othersMsg, BodyPartType hitZone = BodyPartType.None)
-		{
-			if (!IsServer()) return;
-
-			Instance.addChatLogServer.Invoke(new ChatEvent
-			{
-				channels = ChatChannel.Combat,
-				message = originatorMsg,
-				messageOthers = othersMsg,
-				speaker = originator.name,
-				position = originator.transform.position,
-				originator = originator
-			});
-		}
-
-		/// <summary>
-		/// Sends a message to all players about an attack that took place
-		/// </summary>
-		/// <param name="attacker">GameObject of the player that attacked</param>
-		/// <param name="victim">GameObject of the player hat was the victim</param>
-		/// <param name="damage">damage done</param>
-		/// <param name="hitZone">zone that was damaged</param>
-		/// <param name="item">optional gameobject with an itemattributes, representing the item the attack was made with</param>
-		/// <param name="customAttackVerb">If you want to override the attack verb then pass the verb here</param>
-		/// <param name="attackedTile">If attacking a particular tile, the layer tile being attacked</param>
-		public static void AddAttackMsgToChat(GameObject attacker, GameObject victim,
-			BodyPartType hitZone = BodyPartType.None, GameObject item = null, string customAttackVerb = "", LayerTile attackedTile = null)
-		{
-			string attackVerb;
-			string attack;
-
-			if (item)
-			{
-				var itemAttributes = item.GetComponent<ItemAttributesV2>();
-				attackVerb = itemAttributes.ServerAttackVerbs.PickRandom() ?? "attacked";
-				attack = $" with {itemAttributes.ArticleName}";
-			}
-			else
-			{
-				// Punch attack as there is no item.
-				attackVerb = "punched";
-				attack = "";
-			}
-
-			if (!string.IsNullOrEmpty(customAttackVerb))
-			{
-				attackVerb = customAttackVerb;
-			}
-
-			var player = victim.Player();
-			if (player == null)
-			{
-				hitZone = BodyPartType.None;
-			}
-
-			string victimName;
-			string victimNameOthers = "";
-			if (attacker == victim)
-			{
-				victimName = "yourself";
-				if (player != null)
+				if (player.Script.characterSettings.Gender == Gender.Male)
 				{
-					if (player.Script.characterSettings.Gender == Gender.Female)
-					{
-						victimNameOthers = "herself";
-					}
-
-					if (player.Script.characterSettings.Gender == Gender.Male)
-					{
-						victimNameOthers = "himself";
-					}
-
-					if (player.Script.characterSettings.Gender == Gender.Neuter)
-					{
-						victimNameOthers = "itself";
-					}
+					victimNameOthers = "himself";
 				}
-				else
+
+				if (player.Script.characterSettings.Gender == Gender.Neuter)
 				{
 					victimNameOthers = "itself";
 				}
 			}
-			else if (attackedTile != null)
+			else
 			{
-				victimName = attackedTile.DisplayName;
-				victimNameOthers = victimName;
+				victimNameOthers = "itself";
+			}
+		}
+		else if (attackedTile != null)
+		{
+			victimName = attackedTile.DisplayName;
+			victimNameOthers = victimName;
+		}
+		else
+		{
+			victimName = victim.ExpensiveName();
+			victimNameOthers = victimName;
+		}
+
+		var attackerName = attacker.Player()?.Name;
+		if (string.IsNullOrEmpty(attackerName))
+		{
+			var mobAi = attacker.GetComponent<MobAI>();
+			if (mobAi != null)
+			{
+				attackerName = mobAi.mobName;
 			}
 			else
 			{
-				victimName = victim.ExpensiveName();
-				victimNameOthers = victimName;
+				attackerName = "Unknown";
 			}
-
-			var attackerName = attacker.Player()?.Name;
-			if (string.IsNullOrEmpty(attackerName))
-			{
-				var mobAi = attacker.GetComponent<MobAI>();
-				if (mobAi != null)
-				{
-					attackerName = mobAi.mobName;
-				}
-				else
-				{
-					attackerName = "Unknown";
-				}
-			}
-
-			var messageOthers = $"{attackerName} has {attackVerb} {victimNameOthers}{InTheZone(hitZone)}{attack}!";
-			var message = $"You {attackVerb} {victimName}{InTheZone(hitZone)}{attack}!";
-
-			Instance.addChatLogServer.Invoke(new ChatEvent
-			{
-				channels = ChatChannel.Combat,
-				message = message,
-				messageOthers = messageOthers,
-				position = attacker.transform.position,
-				speaker = attacker.name,
-				originator = attacker
-			});
 		}
 
-		/// <summary>
-		/// Adds a hit msg from a thrown item to all nearby players chat stream
-		/// Serverside only
-		/// </summary>
-		public static void AddThrowHitMsgToChat(GameObject item, GameObject victim,
-			BodyPartType hitZone = BodyPartType.None)
+		var messageOthers = $"{attackerName} has {attackVerb} {victimNameOthers}{InTheZone(hitZone)}{attack}!";
+		var message = $"You {attackVerb} {victimName}{InTheZone(hitZone)}{attack}!";
+
+		Instance.addChatLogServer.Invoke(new ChatEvent
 		{
-			if (!IsServer()) return;
+			channels = ChatChannel.Combat,
+			message = message,
+			messageOthers = messageOthers,
+			position = attacker.transform.position,
+			speaker = attacker.name,
+			originator = attacker
+		});
+	}
 
-			var player = victim.Player();
-			if (player == null)
-			{
-				hitZone = BodyPartType.None;
-			}
+	/// <summary>
+	/// Adds a hit msg from a thrown item to all nearby players chat stream
+	/// Serverside only
+	/// </summary>
+	public static void AddThrowHitMsgToChat(GameObject item, GameObject victim,
+		BodyPartType hitZone = BodyPartType.None)
+	{
+		if (!IsServer()) return;
 
-			var message =
-				$"{victim.ExpensiveName()} has been hit by {item.Item()?.ArticleName ?? item.name}{InTheZone(hitZone)}";
-			Instance.addChatLogServer.Invoke(new ChatEvent
-			{
-				channels = ChatChannel.Combat,
-				message = message,
-				position = victim.transform.position
-			});
-		}
-
-		#region Destroy Message
-
-		private static Dictionary<string, UniqueQueue<DestroyChatMessage>> messageQueueDict = new Dictionary<string, UniqueQueue<DestroyChatMessage>>();
-		private static Coroutine composeMessageHandle;
-		private static StringBuilder stringBuilder = new StringBuilder();
-		private struct DestroyChatMessage
+		var player = victim.Player();
+		if (player == null)
 		{
-			public string Message;
-			public Vector2Int WorldPosition;
+			hitZone = BodyPartType.None;
 		}
 
-		/// <summary>
-		/// Allows grouping destruction messages into one if they happen in short period of time.
-		/// Average position is calculated in that case.
-		/// </summary>
-		/// <param name="message"></param>
-		/// <param name="postfix">Common, amount agnostic postfix</param>
-		/// <param name="worldPos"></param>
-		public static void AddLocalDestroyMsgToChat( string message, string postfix, Vector2Int worldPos )
+		var message =
+			$"{victim.ExpensiveName()} has been hit by {item.Item()?.ArticleName ?? item.name}{InTheZone(hitZone)}";
+		Instance.addChatLogServer.Invoke(new ChatEvent
 		{
-			if ( !messageQueueDict.ContainsKey( postfix ) )
-			{
-				messageQueueDict.Add( postfix, new UniqueQueue<DestroyChatMessage>() );
-			}
+			channels = ChatChannel.Combat,
+			message = message,
+			position = victim.transform.position
+		});
+	}
 
-			messageQueueDict[postfix].Enqueue( new DestroyChatMessage{Message = message, WorldPosition = worldPos} );
+	#region Destroy Message
 
-			if ( composeMessageHandle == null )
-			{
-				Instance.StartCoroutine( Instance.ComposeDestroyMessage(), ref composeMessageHandle );
-			}
-		}
+	private static Dictionary<string, UniqueQueue<DestroyChatMessage>> messageQueueDict = new Dictionary<string, UniqueQueue<DestroyChatMessage>>();
+	private static Coroutine composeMessageHandle;
+	private static StringBuilder stringBuilder = new StringBuilder();
+	private struct DestroyChatMessage
+	{
+		public string Message;
+		public Vector2Int WorldPosition;
+	}
 
-
-
-		private IEnumerator ComposeDestroyMessage()
+	/// <summary>
+	/// Allows grouping destruction messages into one if they happen in short period of time.
+	/// Average position is calculated in that case.
+	/// </summary>
+	/// <param name="message"></param>
+	/// <param name="postfix">Common, amount agnostic postfix</param>
+	/// <param name="worldPos"></param>
+	public static void AddLocalDestroyMsgToChat(string message, string postfix, Vector2Int worldPos)
+	{
+		if (!messageQueueDict.ContainsKey(postfix))
 		{
-			yield return WaitFor.Seconds( 0.3f );
-
-			foreach ( var postfix in messageQueueDict.Keys )
-			{
-				var messageQueue = messageQueueDict[postfix];
-
-				if ( messageQueue.IsEmpty )
-				{
-					Instance.TryStopCoroutine( ref composeMessageHandle );
-					continue;
-				}
-
-				//Normal separate messages with precise location
-				if ( messageQueue.Count <= 3 )
-				{
-					while ( messageQueue.TryDequeue( out var msg ) )
-					{
-						AddLocalMsgToChat( msg.Message + postfix, msg.WorldPosition );
-					}
-					continue;
-				}
-
-				//Combined message at average position
-				stringBuilder.Clear();
-
-				int averageX = 0;
-				int averageY = 0;
-				int count = 1;
-
-				while ( messageQueue.TryDequeue( out DestroyChatMessage msg ) )
-				{
-					if ( count > 1 )
-					{
-						stringBuilder.Append( ", " );
-					}
-					stringBuilder.Append( msg.Message );
-					averageX += msg.WorldPosition.x;
-					averageY += msg.WorldPosition.y;
-					count++;
-				}
-
-				AddLocalMsgToChat( stringBuilder.Append( postfix ).ToString(), new Vector2Int(averageX/count,averageY/count) );
-			}
+			messageQueueDict.Add(postfix, new UniqueQueue<DestroyChatMessage>());
 		}
 
-		#endregion
+		messageQueueDict[postfix].Enqueue(new DestroyChatMessage { Message = message, WorldPosition = worldPos });
+
+		if (composeMessageHandle == null)
+		{
+			Instance.StartCoroutine(Instance.ComposeDestroyMessage(), ref composeMessageHandle);
+		}
+	}
+
+
+
+	private IEnumerator ComposeDestroyMessage()
+	{
+		yield return WaitFor.Seconds(0.3f);
+
+		foreach (var postfix in messageQueueDict.Keys)
+		{
+			var messageQueue = messageQueueDict[postfix];
+
+			if (messageQueue.IsEmpty)
+			{
+				Instance.TryStopCoroutine(ref composeMessageHandle);
+				continue;
+			}
+
+			//Normal separate messages with precise location
+			if (messageQueue.Count <= 3)
+			{
+				while (messageQueue.TryDequeue(out var msg))
+				{
+					AddLocalMsgToChat(msg.Message + postfix, msg.WorldPosition);
+				}
+				continue;
+			}
+
+			//Combined message at average position
+			stringBuilder.Clear();
+
+			int averageX = 0;
+			int averageY = 0;
+			int count = 1;
+
+			while (messageQueue.TryDequeue(out DestroyChatMessage msg))
+			{
+				if (count > 1)
+				{
+					stringBuilder.Append(", ");
+				}
+				stringBuilder.Append(msg.Message);
+				averageX += msg.WorldPosition.x;
+				averageY += msg.WorldPosition.y;
+				count++;
+			}
+
+			AddLocalMsgToChat(stringBuilder.Append(postfix).ToString(), new Vector2Int(averageX / count, averageY / count));
+		}
+	}
+
+	#endregion
 
 	/// <summary>
 	/// For any other local messages that are not an Action or a Combat Action.
@@ -432,120 +432,120 @@ public partial class Chat : MonoBehaviour
 	public static void AddLocalMsgToChat(string message, Vector2 worldPos)
 	{
 		if (!IsServer()) return;
-		Instance.TryStopCoroutine( ref composeMessageHandle );
+		Instance.TryStopCoroutine(ref composeMessageHandle);
 
-			Instance.addChatLogServer.Invoke(new ChatEvent
-			{
-				channels = ChatChannel.Local,
-				message = message,
-				position = worldPos
-			});
-		}
-
-		/// <summary>
-		/// Used on the server to send examine messages to a player
-		/// Server only
-		/// </summary>
-		/// <param name="recipient">The player object to send the message too</param>
-		/// <param name="msg">The examine message</param>
-		public static void AddExamineMsgFromServer(GameObject recipient, string msg)
+		Instance.addChatLogServer.Invoke(new ChatEvent
 		{
-			if (!IsServer()) return;
-			UpdateChatMessage.Send(recipient, ChatChannel.Examine, ChatModifier.None, msg);
-		}
+			channels = ChatChannel.Local,
+			message = message,
+			position = worldPos
+		});
+	}
 
-		/// <summary>
-		/// Used on the client for examine messages.
-		/// Use client side only!
-		/// </summary>
-		/// <param name="message"> The message to add to the client chat stream</param>
-		public static void AddExamineMsgToClient(string message)
+	/// <summary>
+	/// Used on the server to send examine messages to a player
+	/// Server only
+	/// </summary>
+	/// <param name="recipient">The player object to send the message too</param>
+	/// <param name="msg">The examine message</param>
+	public static void AddExamineMsgFromServer(GameObject recipient, string msg)
+	{
+		if (!IsServer()) return;
+		UpdateChatMessage.Send(recipient, ChatChannel.Examine, ChatModifier.None, msg);
+	}
+
+	/// <summary>
+	/// Used on the client for examine messages.
+	/// Use client side only!
+	/// </summary>
+	/// <param name="message"> The message to add to the client chat stream</param>
+	public static void AddExamineMsgToClient(string message)
+	{
+		Instance.addChatLogClient.Invoke(message, ChatChannel.Examine);
+	}
+
+	/// <summary>
+	/// Creates an examine message for a particular client, correctly choosing the
+	/// method to use based on the network side it's called from.
+	/// </summary>
+	/// <param name="recipient">The player object to send the message too</param>
+	/// <param name="msg">The examine message</param>
+	/// <param name="side">side this is being called from</param>
+	public static void AddExamineMsg(GameObject recipient, string message, NetworkSide side)
+	{
+		switch (side)
 		{
-			Instance.addChatLogClient.Invoke(message, ChatChannel.Examine);
-		}
-
-		/// <summary>
-		/// Creates an examine message for a particular client, correctly choosing the
-		/// method to use based on the network side it's called from.
-		/// </summary>
-		/// <param name="recipient">The player object to send the message too</param>
-		/// <param name="msg">The examine message</param>
-		/// <param name="side">side this is being called from</param>
-		public static void AddExamineMsg(GameObject recipient, string message, NetworkSide side)
-		{
-			switch (side)
-			{
-				case NetworkSide.Client:
-					AddExamineMsgToClient(message);
-					break;
-				case NetworkSide.Server:
-					AddExamineMsgFromServer(recipient, message);
-					break;
-			}
-		}
-
-		/// <summary>
-		/// replaces the provided string occurence's of {performer} with the performer's name
-		/// </summary>
-		/// <param name="toReplace"></param>
-		/// <returns></returns>
-		public static string ReplacePerformer(string toReplace, GameObject performer)
-		{
-			if (!string.IsNullOrWhiteSpace(toReplace))
-			{
-				return toReplace.Replace("{performer}", performer.ExpensiveName());
-			}
-
-			return toReplace;
-		}
-
-		/// <summary>
-		/// Creates an examine message for a particular client, correctly choosing the
-		/// method to use based on the network side it's called from.
-		/// </summary>
-		/// <param name="recipient">The player object to send the message too</param>
-		/// <param name="msg">The examine message</param>
-		public static void AddExamineMsg(GameObject recipient, string message)
-		{
-			AddExamineMsg(recipient, message,
-				CustomNetworkManager.IsServer ? NetworkSide.Server : NetworkSide.Client);
-		}
-
-		/// <summary>
-		/// This should only be called via UpdateChatMessage
-		/// on the client. Do not use for anything else!
-		/// </summary>
-		public static void ProcessUpdateChatMessage(uint recipient, uint originator, string message,
-			string messageOthers, ChatChannel channels, ChatModifier modifiers, string speaker)
-		{
-			//If there is a message in MessageOthers then determine
-			//if it should be the main message or not.
-			if (!string.IsNullOrEmpty(messageOthers))
-			{
-				//This is not the originator so use the messageOthers
-				if (recipient != originator)
-				{
-					message = messageOthers;
-				}
-			}
-
-			var msg = ProcessMessageFurther(message, speaker, channels, modifiers);
-			Instance.addChatLogClient.Invoke(msg, channels);
-		}
-
-		private static string InTheZone(BodyPartType hitZone)
-		{
-			return hitZone == BodyPartType.None ? "" : $" in the {hitZone.ToString().ToLower().Replace("_", " ")}";
-		}
-
-		private static bool IsServer()
-		{
-			if (!CustomNetworkManager.Instance._isServer)
-			{
-				Logger.LogError("A server only method was called on a client in chat.cs", Category.Chat);
-				return false;
-			}
-
-			return true;
+			case NetworkSide.Client:
+				AddExamineMsgToClient(message);
+				break;
+			case NetworkSide.Server:
+				AddExamineMsgFromServer(recipient, message);
+				break;
 		}
 	}
+
+	/// <summary>
+	/// replaces the provided string occurence's of {performer} with the performer's name
+	/// </summary>
+	/// <param name="toReplace"></param>
+	/// <returns></returns>
+	public static string ReplacePerformer(string toReplace, GameObject performer)
+	{
+		if (!string.IsNullOrWhiteSpace(toReplace))
+		{
+			return toReplace.Replace("{performer}", performer.ExpensiveName());
+		}
+
+		return toReplace;
+	}
+
+	/// <summary>
+	/// Creates an examine message for a particular client, correctly choosing the
+	/// method to use based on the network side it's called from.
+	/// </summary>
+	/// <param name="recipient">The player object to send the message too</param>
+	/// <param name="msg">The examine message</param>
+	public static void AddExamineMsg(GameObject recipient, string message)
+	{
+		AddExamineMsg(recipient, message,
+			CustomNetworkManager.IsServer ? NetworkSide.Server : NetworkSide.Client);
+	}
+
+	/// <summary>
+	/// This should only be called via UpdateChatMessage
+	/// on the client. Do not use for anything else!
+	/// </summary>
+	public static void ProcessUpdateChatMessage(uint recipient, uint originator, string message,
+		string messageOthers, ChatChannel channels, ChatModifier modifiers, string speaker)
+	{
+		//If there is a message in MessageOthers then determine
+		//if it should be the main message or not.
+		if (!string.IsNullOrEmpty(messageOthers))
+		{
+			//This is not the originator so use the messageOthers
+			if (recipient != originator)
+			{
+				message = messageOthers;
+			}
+		}
+
+		var msg = ProcessMessageFurther(message, speaker, channels, modifiers);
+		Instance.addChatLogClient.Invoke(msg, channels);
+	}
+
+	private static string InTheZone(BodyPartType hitZone)
+	{
+		return hitZone == BodyPartType.None ? "" : $" in the {hitZone.ToString().ToLower().Replace("_", " ")}";
+	}
+
+	private static bool IsServer()
+	{
+		if (!CustomNetworkManager.Instance._isServer)
+		{
+			Logger.LogError("A server only method was called on a client in chat.cs", Category.Chat);
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/UnityProject/Assets/Scripts/Machines/Microwave.cs
+++ b/UnityProject/Assets/Scripts/Machines/Microwave.cs
@@ -34,7 +34,17 @@ public class Microwave : NetworkBehaviour
 	/// <summary>
 	/// AudioSource for playing the celebratory "ding" when cooking is finished.
 	/// </summary>
-	private AudioSource audioSource;
+	private AudioSource audioSourceDing;
+
+	/// <summary>
+	/// Amount of time the "ding" audio source will start playing before the microwave has finished cooking (in seconds).
+	/// </summary>
+	private static float dingPlayTime = 1.54f;
+
+	/// <summary>
+	/// True if the microwave has already played the "ding" sound for the current meal.
+	/// </summary>
+	private bool dingHasPlayed = false;
 
 	/// <summary>
 	/// Set up the microwave sprite and the AudioSource.
@@ -42,7 +52,7 @@ public class Microwave : NetworkBehaviour
 	private void Start()
 	{
 		spriteRenderer = GetComponentInChildren<SpriteRenderer>();
-		audioSource = GetComponent<AudioSource>();
+		audioSourceDing = GetComponent<AudioSource>();
 		SPRITE_OFF = spriteRenderer.sprite;
 	}
 
@@ -54,6 +64,12 @@ public class Microwave : NetworkBehaviour
 		if (microwaveTimer > 0)
 		{
 			microwaveTimer = Mathf.Max(0, microwaveTimer - Time.deltaTime);
+
+			if (!dingHasPlayed && microwaveTimer <= dingPlayTime)
+			{
+				audioSourceDing.Play();
+				dingHasPlayed = true;
+			}
 
 			if (microwaveTimer <= 0)
 			{
@@ -75,15 +91,15 @@ public class Microwave : NetworkBehaviour
 	{
 		microwaveTimer = COOK_TIME;
 		spriteRenderer.sprite = SPRITE_ON;
+		dingHasPlayed = false;
 	}
 
 	/// <summary>
-	/// Finish cooking the microwaved meal and play a 'ding'-sound.
+	/// Finish cooking the microwaved meal.
 	/// </summary>
 	private void FinishCooking()
 	{
 		spriteRenderer.sprite = SPRITE_OFF;
-		audioSource.Play();
 		if (isServer)
 		{
 			GameObject mealPrefab = CraftingManager.Meals.FindOutputMeal(meal);

--- a/UnityProject/Assets/Scripts/Machines/Microwave.cs
+++ b/UnityProject/Assets/Scripts/Machines/Microwave.cs
@@ -1,37 +1,63 @@
 ﻿using UnityEngine;
 using Mirror;
 
+/// <summary>
+/// A machine into which players can insert certain food items.
+/// After some time the food is cooked and gets ejected from the microwave.
+/// </summary>
 public class Microwave : NetworkBehaviour
 {
-	private AudioSource audioSource;
+	/// <summary>
+	/// Time it takes for the microwave to cook a meal (in seconds).
+	/// </summary>
+	[Range(0, 60)]
+	public float COOK_TIME = 10;
 
-	private float cookingTime;
-	public float cookTime = 10;
-	private string meal;
-	private Sprite offSprite;
-	public Sprite onSprite;
+	/// <summary>
+	/// Time left until the meal has finished cooking (in seconds).
+	/// </summary>
+	[HideInInspector]
+	public float microwaveTimer = 0;
+
+	/// <summary>
+	/// Meal currently being cooked.
+	/// </summary>
+	[HideInInspector]
+	public string meal;
+
+	// Sprites for when the microwave is on or off.
+	public Sprite SPRITE_ON;
+	private Sprite SPRITE_OFF;
 
 	private SpriteRenderer spriteRenderer;
 
-	public bool Cooking { get; private set; }
+	/// <summary>
+	/// AudioSource for playing the celebratory "ding" when cooking is finished.
+	/// </summary>
+	private AudioSource audioSource;
 
-
+	/// <summary>
+	/// Set up the microwave sprite and the AudioSource.
+	/// </summary>
 	private void Start()
 	{
 		spriteRenderer = GetComponentInChildren<SpriteRenderer>();
 		audioSource = GetComponent<AudioSource>();
-		offSprite = spriteRenderer.sprite;
+		SPRITE_OFF = spriteRenderer.sprite;
 	}
 
+	/// <summary>
+	/// Count remaining time to microwave previously inserted food.
+	/// </summary>
 	private void Update()
 	{
-		if (Cooking)
+		if (microwaveTimer > 0)
 		{
-			cookingTime += Time.deltaTime;
+			microwaveTimer = Mathf.Max(0, microwaveTimer - Time.deltaTime);
 
-			if (cookingTime >= cookTime)
+			if (microwaveTimer <= 0)
 			{
-				StopCooking();
+				FinishCooking();
 			}
 		}
 	}
@@ -41,24 +67,29 @@ public class Microwave : NetworkBehaviour
 		meal = mealName;
 	}
 
+	/// <summary>
+	/// Starts the microwave, cooking the food for {microwaveTimer} seconds.
+	/// </summary>
 	[ClientRpc]
 	public void RpcStartCooking()
 	{
-		Cooking = true;
-		cookingTime = 0;
-		spriteRenderer.sprite = onSprite;
+		microwaveTimer = COOK_TIME;
+		spriteRenderer.sprite = SPRITE_ON;
 	}
 
-	private void StopCooking()
+	/// <summary>
+	/// Finish cooking the microwaved meal and play a 'ding'-sound.
+	/// </summary>
+	private void FinishCooking()
 	{
-		Cooking = false;
-		spriteRenderer.sprite = offSprite;
+		spriteRenderer.sprite = SPRITE_OFF;
 		audioSource.Play();
 		if (isServer)
 		{
 			GameObject mealPrefab = CraftingManager.Meals.FindOutputMeal(meal);
-			Spawn.ServerPrefab(mealPrefab, transform.position, transform.parent);
+			Spawn.ServerPrefab(mealPrefab, GetComponent<RegisterTile>().WorldPosition, transform.parent);
 		}
 		meal = null;
 	}
+
 }

--- a/UnityProject/Assets/Scripts/Objects/InteractableMicrowave.cs
+++ b/UnityProject/Assets/Scripts/Objects/InteractableMicrowave.cs
@@ -48,7 +48,7 @@ public class InteractableMicrowave : MonoBehaviour, ICheckedInteractable<HandApp
 			}
 			else
 			{
-				Chat.AddExamineMsgFromServer(interaction.Performer, $"The microwave can not cook your {attr.ArticleName}.");
+				Chat.AddExamineMsgFromServer(interaction.Performer, $"Your {attr.ArticleName} can not be microwaved.");
 				// Alternative suggestions:
 				// "$"The microwave is not programmed to cook your {attr.ArticleName}."
 				// "$"The microwave does not know how to cook your{attr.ArticleName}."


### PR DESCRIPTION
### Purpose

- Added comments!
- Microwaves now count down instead of up.
- Players can interact with the microwave to see:
  - How much cooking time is remaining
  - If the microwave is empty
  - If the microwave rejects their held item
- RegisterTile is now used to spawn the cooked meal (instead of transform.position)
- The microwave 'ding' sound now plays 1.5 seconds before the microwave is finished. The soundfile contains some 'warm-up' noises at the start and did previously not sync up with the microwave being done cooking
---
- Opposite player movement directions (e.g. left and right) now cancel each other
- Fixes #2527
- _Kind of_ addresses #1745?
- Autoformatted Chat.cs

### Self checks:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
  - One client in editor, one in a Development Build
  - The behaviour of the microwave is largely unchanged, so multiplayer checks were not extensive.
  - Player movement is only changed client-side
