### PR TITLE
#2535 Fix Object Descriptions

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -99,13 +99,13 @@ public class Attributes : NetworkBehaviour, IRightClickable, IServerSpawn
 	public void OnHoverStart()
 	{
 		UIManager.SetToolTip =
-			initialName.First().ToString().ToUpper() + initialName.Substring(1) + 
-			(String.IsNullOrEmpty(articleDescription) ? "" : $" ({articleDescription})");
+			initialName.First().ToString().ToUpper() + initialName.Substring(1) +
+			(string.IsNullOrEmpty(articleDescription) ? "" : $" ({ articleDescription })");
 	}
 
 	public void OnHoverEnd()
 	{
-		UIManager.SetToolTip = String.Empty;
+		UIManager.SetToolTip = string.Empty;
 	}
 
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterObject.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterObject.cs
@@ -32,14 +32,18 @@ public class RegisterObject : RegisterTile
 
 	public void OnHoverStart()
 	{
+		if (GetComponent<Attributes>())
+		{
+			return;
+		}
+
 		//thanks stack overflow!
 		Regex r = new Regex(@"
                 (?<=[A-Z])(?=[A-Z][a-z]) |
                  (?<=[^A-Z])(?=[A-Z]) |
                  (?<=[A-Za-z])(?=[^A-Za-z])", RegexOptions.IgnorePatternWhitespace);
 
-		string tmp = r.Replace(name, " ");
-		UIManager.SetToolTip = tmp;
+		UIManager.SetToolTip = r.Replace(name, " ");
 	}
 
 	public void OnHoverEnd()


### PR DESCRIPTION
### Purpose
Checks if Attributes component exists when setting tooltip. Not every object has Attributes, but if it does, it should have priority. Eventually everything (I think?) should have attributes.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
