### PR TITLE
Sets the chat bubbles to default on

### DIFF
--- a/UnityProject/Assets/Scripts/Chat/ChatUI.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatUI.cs
@@ -112,7 +112,7 @@ public class ChatUI : MonoBehaviour
 	{
 		if (!PlayerPrefs.HasKey(PlayerPrefKeys.ChatBubbleKey))
 		{
-			PlayerPrefs.SetInt(PlayerPrefKeys.ChatBubbleKey, 0);
+			PlayerPrefs.SetInt(PlayerPrefKeys.ChatBubbleKey, 1);
 			PlayerPrefs.Save();
 		}
 


### PR DESCRIPTION
note 
Fixes  #2544
If you have preexisting player references you'll have to turn it  on manually