### PR TITLE
Fixes issue #2339 - Backpacks fitting in backpacks

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Backwear.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Backwear.prefab
@@ -17,22 +17,6 @@ PrefabInstance:
       propertyPath: m_TagString
       value: Abstract
       objectReference: {fileID: 0}
-    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
-        type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
-        type: 3}
-      propertyPath: initialTraits.Array.data[0]
-      value: 
-      objectReference: {fileID: 11400000, guid: b05bab692e98c487eb4996a0614d143d,
-        type: 2}
-    - target: {fileID: 2917128564446547862, guid: 6b5f74a79e023479cb5b30a2879621da,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 3025309822768713558, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -87,6 +71,27 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2917128564446547862, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: initialTraits.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: b05bab692e98c487eb4996a0614d143d,
+        type: 2}
+    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 3107053823204540798, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}


### PR DESCRIPTION
This fixes issue #2339 - Base backpack prefab was set to tiny in it's item traits. Just set it to huge like the actual use backpacks. First PR celebration!