### PR TITLE
Removed AnnounceNewPlayer method

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/Client/RequestSyncMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/RequestSyncMessage.cs
@@ -21,20 +21,8 @@ public class RequestSyncMessage : ClientMessage
 			//marking player as synced to avoid sending that data pile again
 			SentByPlayer.Synced = true;
 
-			AnnounceNewPlayer( SentByPlayer );
 		}
 		yield return null;
-	}
-
-	private static void AnnounceNewPlayer( ConnectedPlayer newPlayer ) {
-		if ( newPlayer.Job == JobType.SYNDICATE ) {
-			return;
-		}
-
-		var msg = $"{newPlayer.Job.JobString()} {newPlayer.Name} has arrived at the station. " +
-		          $"Have a pleasant day! Try not to die...";
-		Chat.AddSystemMsgToChat($"<color=white>{msg}</color>", MatrixManager.MainStationMatrix);
-		AnnouncementMessage.SendToAll( msg );
 	}
 
 	public override string ToString()


### PR DESCRIPTION
### Purpose
Fixes #2598 
### Notes:
- Removed the announcement code when a player joins from the RequestSyncMessage class
- Not sure if it it was supposed to be completely removed or add a player dead check, so just tell me if you want the check to be added instead ! 