### PR TITLE
Fixed missing item names with steal objective

### DIFF
--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/Steal.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/Steal.cs
@@ -57,7 +57,7 @@ namespace Antagonists
 
 			// Pick a random item and add it to the targeted list
 			var itemEntry = possibleItems.PickRandom();
-			ItemName = itemEntry.Key.Item().ArticleName;
+			ItemName = itemEntry.Key.Item().InitialName;
 			Amount = itemEntry.Value;
 			AntagManager.Instance.TargetedItems.Add(itemEntry.Key);
 			// TODO randomise amount based on range/weightings?
@@ -70,7 +70,7 @@ namespace Antagonists
 			foreach (var slot in Owner.body.ItemStorage.GetItemSlotTree())
 			{
 				// TODO find better way to determine item types (ScriptableObjects/item IDs could work but would need to refactor all items)
-				if (slot.ItemObject != null && slot.ItemObject.GetComponent<ItemAttributesV2>()?.ArticleName == ItemName)
+				if (slot.ItemObject != null && slot.ItemObject.GetComponent<ItemAttributesV2>()?.InitialName == ItemName)
 				{
 					count++;
 				}

--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -25,6 +25,8 @@ public class Attributes : NetworkBehaviour, IRightClickable, IServerSpawn
 	/// </summary>
 	public string ArticleName => articleName;
 
+	public string InitialName => initialName;
+
 	[Tooltip("Description of this item when spawned.")]
 	[SerializeField]
 	private string initialDescription;


### PR DESCRIPTION
As per the title. This fixes #2565 

The item name was being taken from IA2.ArticleName which is the name given to an item after it is spawned on the server. The objective asset actually looks at the prefab in asset resources where it has not spawned yet. I created a readonly property to read the actual Item name and I also use that for the green text validation of the stolen item on round end.

Tested in MP