### PR TITLE
Fixes Plasma Burning in the Generator and Adjusts some SoundFX

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/AirLock.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/AirLock.prefab
@@ -85,6 +85,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114232321497863980
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -403,7 +406,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  IsFixedMatrix: 0
+  IsFixedMatrix: 1
 --- !u!114 &114936590258962662
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -466,7 +469,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: e1a9ff52d12442f3bf8a03873bcab8ee
   m_SceneId: 0
 --- !u!114 &4518357836073184054
 MonoBehaviour:
@@ -671,7 +674,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1335001101035598}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -799,11 +802,10 @@ AudioSource:
   m_GameObject: {fileID: 1679390965448050}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 24300001, guid: 94208a0928046438d9b8a00796e7a5a7,
-    type: 2}
+  OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -972,11 +974,10 @@ AudioSource:
   m_GameObject: {fileID: 1787265023359374}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 24300001, guid: 94208a0928046438d9b8a00796e7a5a7,
-    type: 2}
+  OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/AtmosDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/AtmosDoor.prefab
@@ -43,7 +43,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -215,7 +215,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -541,6 +541,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114201876269245600
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -890,7 +893,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: a23e58fb4b7934db882d53524c72afe9
   m_SceneId: 0
 --- !u!114 &3428408671806122639
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/CommandDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/CommandDoor.prefab
@@ -150,6 +150,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114136653046911712
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -466,7 +469,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 76310bb0552ad4ee2b5edeee6bfa8d72
   m_SceneId: 0
 --- !u!114 &-9160553101885179674
 MonoBehaviour:
@@ -530,7 +533,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -862,7 +865,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/EngineeringDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/EngineeringDoor.prefab
@@ -315,7 +315,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -562,6 +562,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114566587194028974
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -878,7 +881,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 91429d1c42fde4e5aa2d3bab554dbc64
   m_SceneId: 0
 --- !u!114 &2513312637528682473
 MonoBehaviour:
@@ -942,7 +945,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MaintDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MaintDoor.prefab
@@ -118,6 +118,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114898495208177878
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -434,7 +437,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 8df037bc1ed3b4d88bb0bee4f4607fd9
   m_SceneId: 0
 --- !u!114 &7741864275218123481
 MonoBehaviour:
@@ -610,7 +613,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -862,7 +865,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MedBayDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MedBayDoor.prefab
@@ -118,6 +118,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114203827934596338
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -434,7 +437,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: ec6eeefaaeea7497ea5e197269ce0699
   m_SceneId: 0
 --- !u!114 &-1296996462333317458
 MonoBehaviour:
@@ -658,7 +661,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -862,7 +865,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MiningDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MiningDoor.prefab
@@ -123,7 +123,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -530,6 +530,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114968749450346888
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -846,7 +849,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 2f11faffcc8d1416093ad67cfb5f9b3d
   m_SceneId: 0
 --- !u!114 &-4457766696863131193
 MonoBehaviour:
@@ -942,7 +945,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/PublicDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/PublicDoor.prefab
@@ -358,6 +358,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114287951213915578
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -744,7 +747,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: d19beea78b794c15b11895ee6f847c27
   m_SceneId: 0
 --- !u!114 &-3331040946134907951
 MonoBehaviour:
@@ -808,7 +811,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -980,7 +983,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/ResearchDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/ResearchDoor.prefab
@@ -123,7 +123,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -407,7 +407,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -654,6 +654,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114071899722853512
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -970,7 +973,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 1569133c9183e4f97accbba5cabafab1
   m_SceneId: 0
 --- !u!114 &-7017711085307090504
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/ScienceDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/ScienceDoor.prefab
@@ -235,7 +235,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -482,6 +482,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114636056436692218
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -798,7 +801,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: bdb6490795479439ba2b7178af028a7f
   m_SceneId: 0
 --- !u!114 &-5375123352294692325
 MonoBehaviour:
@@ -862,7 +865,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/SecDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/SecDoor.prefab
@@ -390,6 +390,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114776570776623186
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -706,7 +709,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: bb81f26da933e4ed399d5c5e55011b15
   m_SceneId: 0
 --- !u!114 &-4174774034122027383
 MonoBehaviour:
@@ -770,7 +773,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -942,7 +945,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/SpaceshipDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/SpaceshipDoor.prefab
@@ -118,6 +118,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114082268845705964
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -424,7 +427,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 964f2b6b3d44a9b41821c6a79c4b0645
   m_SceneId: 0
 --- !u!114 &-4074528644012801057
 MonoBehaviour:
@@ -728,7 +731,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -932,7 +935,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/Virology.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/Virology.prefab
@@ -75,7 +75,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -402,6 +402,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114235526540606744
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -718,7 +721,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 1128e4dfd61654128ab077635dc8c09a
   m_SceneId: 0
 --- !u!114 &6967039355434788337
 MonoBehaviour:
@@ -782,7 +785,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/WhiteServiceDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/WhiteServiceDoor.prefab
@@ -278,6 +278,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114672552748689518
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -630,7 +633,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 37b07457c4df4dc29163cbf5f441b9ed
   m_SceneId: 0
 --- !u!114 &4595622538382479424
 MonoBehaviour:
@@ -806,7 +809,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 13792128ab4b4a9bbe78491650423df1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -978,7 +981,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 98b5308a2adb43d49b3471da7a9057dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/WinDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/WinDoor.prefab
@@ -43,7 +43,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: e7bdcdf163c0343f9a2f856c21bf43dc, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.344
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -215,7 +215,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: e7bdcdf163c0343f9a2f856c21bf43dc, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.37
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -506,6 +506,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114424348708298150
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -682,7 +685,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: aec802ad975d3418d9b782880452b7bf
   m_SceneId: 0
 --- !u!114 &7724401135494436923
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/PowerGeneratorPlasma.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/PowerGeneratorPlasma.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4361290719400894}
   - component: {fileID: 82174488758175454}
+  - component: {fileID: 5629643076531796556}
   m_Layer: 0
   m_Name: GeneratorEnd
   m_TagString: SoundFX
@@ -40,12 +41,11 @@ AudioSource:
   m_GameObject: {fileID: 1057408846216166}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 24300001, guid: 94208a0928046438d9b8a00796e7a5a7,
-    type: 2}
+  OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: a5fe2fccd2f9dda41a0a3bb9d261789c, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.3
-  m_Pitch: 0.73
+  m_Volume: 0.07
+  m_Pitch: 0.5
   Loop: 0
   Mute: 0
   Spatialize: 0
@@ -155,6 +155,29 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
+--- !u!164 &5629643076531796556
+AudioReverbFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057408846216166}
+  m_Enabled: 1
+  m_DryLevel: 0
+  m_Room: -1000
+  m_RoomHF: -151
+  m_DecayTime: 7.56
+  m_DecayHFRatio: 0.91
+  m_ReflectionsLevel: -626
+  m_ReverbLevel: 774
+  m_ReverbDelay: 0.03
+  m_Diffusion: 100
+  m_Density: 100
+  m_HFReference: 5000
+  m_RoomLF: 0
+  m_LFReference: 250
+  m_ReflectionsDelay: 0
+  m_ReverbPreset: 26
 --- !u!1 &1076112860634574
 GameObject:
   m_ObjectHideFlags: 0
@@ -165,6 +188,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4075463178367750}
   - component: {fileID: 82901662514687406}
+  - component: {fileID: 3448766932173826381}
   m_Layer: 0
   m_Name: GeneratorRun
   m_TagString: SoundFX
@@ -195,12 +219,11 @@ AudioSource:
   m_GameObject: {fileID: 1076112860634574}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 24300001, guid: 94208a0928046438d9b8a00796e7a5a7,
-    type: 2}
+  OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: e6922f54f3ba04e4cbb49b4e688fd0b2, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.3
-  m_Pitch: 0.73
+  m_Volume: 0.07
+  m_Pitch: 0.5
   Loop: 1
   Mute: 0
   Spatialize: 0
@@ -310,6 +333,29 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
+--- !u!164 &3448766932173826381
+AudioReverbFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1076112860634574}
+  m_Enabled: 1
+  m_DryLevel: 0
+  m_Room: -1000
+  m_RoomHF: -151
+  m_DecayTime: 7.56
+  m_DecayHFRatio: 0.91
+  m_ReflectionsLevel: -626
+  m_ReverbLevel: 774
+  m_ReverbDelay: 0.03
+  m_Diffusion: 100
+  m_Density: 100
+  m_HFReference: 5000
+  m_RoomLF: 0
+  m_LFReference: 250
+  m_ReflectionsDelay: 0
+  m_ReverbPreset: 26
 --- !u!1 &1161029308456310
 GameObject:
   m_ObjectHideFlags: 0
@@ -5227,8 +5273,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  layer: {fileID: 0}
-  ObjectType: 1
+  matrixDebugLogging: 0
+  objectType: 1
   AtmosPassable: 1
   Passable: 0
 --- !u!114 &114537316452419530
@@ -5292,6 +5338,13 @@ MonoBehaviour:
   syncInterval: 0.1
   registerTile: {fileID: 114738137265545768}
   isInitiallyNotPushable: 1
+  pushPullSound: 
+  soundDelayTime: 0
+  soundMinimumPitchVariance: 1
+  soundMaximumPitchVariance: 1
+  OnPullingSomethingChangedServer:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &7281671087508858390
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5411,5 +5464,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serverOnly: 0
   localPlayerAuthority: 0
-  m_AssetId: 
+  m_AssetId: 69c27c4a07b053d458c6fec363e66403
   m_SceneId: 0

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/SoundManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/SoundManager.prefab
@@ -199,7 +199,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 60bc2538ab3a99144b839b79c0a1fffe, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -487,7 +487,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: cea1c67af33dee742931e84872e8d92b, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -809,7 +809,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: d19b23be48007f948b20dd0356dd3fb2, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -964,7 +964,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: dca1e27b53f4e244ab7538daef075d65, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -1119,7 +1119,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 7a6b5df02fae80d40bfecf4f7224f012, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -1566,7 +1566,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 4f757d2108dedcd4a958d7c4c041a9b5, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -1876,7 +1876,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 2e73bd1ab259bb5499cda0c4b914d2b8, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -2350,7 +2350,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 833712404ed59004aa0f065d75d9b59c, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -2505,7 +2505,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: cb48bd749e1a24d49b0af16db0e6564d, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -2660,7 +2660,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 91e6dcb139819da4392de04ba5a1b3be, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -3639,7 +3639,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 09ca1705c6414fd4b9b166d14f201a76, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -3794,7 +3794,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: f73c1048f40216e4ba0d9fc425da4fe3, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -4077,7 +4077,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: eb1c5d8d5ef732f48950084417ef9c87, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -4360,7 +4360,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 513bbf3c4f995374c967a48682377386, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -4515,7 +4515,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 5c7a84c9dd720b44598cfe5a743f5a23, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -7299,8 +7299,7 @@ AudioSource:
   m_GameObject: {fileID: 5631977054488097951}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 24300001, guid: 94208a0928046438d9b8a00796e7a5a7,
-    type: 2}
+  OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: c9e3ed57f05fa44079d8c9ddecdea939, type: 3}
   m_PlayOnAwake: 0
   m_Volume: 0.33
@@ -10814,8 +10813,7 @@ AudioSource:
   m_GameObject: {fileID: 5632402882081158037}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 24300001, guid: 94208a0928046438d9b8a00796e7a5a7,
-    type: 2}
+  OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 60c47d2a95fe456b8f3da5fa60e88b89, type: 3}
   m_PlayOnAwake: 0
   m_Volume: 0.33
@@ -13241,8 +13239,7 @@ AudioSource:
   m_GameObject: {fileID: 5633800558105604767}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 24300001, guid: 94208a0928046438d9b8a00796e7a5a7,
-    type: 2}
+  OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: de158abd8cf5d4ac18c2426a2628c9f8, type: 3}
   m_PlayOnAwake: 0
   m_Volume: 0.211
@@ -14741,7 +14738,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: d2270bd99253f9e40aa6c7269d987cf1, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -14896,7 +14893,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 8e83e102d4231d54c9b947a7e01690e5, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -15396,7 +15393,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: f3735e3d254eeb0458cfb5f2ccf0becb, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -15551,7 +15548,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: e5c565f362f71a6469688349f007e733, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -15706,7 +15703,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: dcdcdc3dcd64c224eb855d68ddf24c13, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -16016,7 +16013,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: ffe276b8e57e4224293f2759f68534dd, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -16769,7 +16766,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: f29613830fa6d534d95cd3b37a7f8098, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -17088,7 +17085,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 755d19048d4dd9e4ea64c7536b1d0b4e, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -17243,7 +17240,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: ed73cd0107a3c374a8397e8372027c21, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -17553,7 +17550,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 05e8980edef6bf84a96e48bdfd0e36c2, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -17863,7 +17860,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 9ceb3c1f220cfa043aab7408ae76dfb2, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -18018,7 +18015,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 96aff7d9bf946224c8538ba94231a7fb, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -18173,7 +18170,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 8ef82244b8121d947be59b201f25bbd7, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -18328,7 +18325,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: d18624acbdb61434ca4f7fbd5c71f98a, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.35
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/Steal.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/Steal.cs
@@ -58,6 +58,14 @@ namespace Antagonists
 			// Pick a random item and add it to the targeted list
 			var itemEntry = possibleItems.PickRandom();
 			ItemName = itemEntry.Key.Item().InitialName;
+
+			if (string.IsNullOrEmpty(ItemName))
+			{
+				Logger.LogError($"Objective steal item target failed because the InitialName has not been" +
+				                $" set on this objects ItemAttributes. " +
+				                $"Item: {itemEntry.Key.Item().gameObject.name}", Category.Round);
+				return;
+			}
 			Amount = itemEntry.Value;
 			AntagManager.Instance.TargetedItems.Add(itemEntry.Key);
 			// TODO randomise amount based on range/weightings?

--- a/UnityProject/Assets/Scripts/Electricity/PowerSupplies/PowerGenerator.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PowerSupplies/PowerGenerator.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 using Mirror;
 public class PowerGenerator : NetworkBehaviour, IInteractable<HandApply>, INodeControl
 {
-	private const float PlasmaConsumptionRate = 0.4f;
+	private const float PlasmaConsumptionRate = 0.02f;
 
 	public ObjectBehaviour objectBehaviour;
 	[SyncVar(hook = nameof(UpdateSecured))]
@@ -180,8 +180,8 @@ public class PowerGenerator : NetworkBehaviour, IInteractable<HandApply>, INodeC
 		var solidPlasma = slot.Item != null ? slot.Item.GetComponent<SolidPlasma>() : null;
 		if (solidPlasma != null)
 		{
-			plasmaFuel.Add(solidPlasma);
-			Inventory.ServerConsume(interaction.HandSlot, 1);
+			var plasma = Inventory.ServerVanishStackable(interaction.HandSlot);
+			plasmaFuel.Add(plasma.GetComponent<SolidPlasma>());
 			return;
 		}
 

--- a/UnityProject/Assets/Scripts/Inventory/Inventory.cs
+++ b/UnityProject/Assets/Scripts/Inventory/Inventory.cs
@@ -117,6 +117,29 @@ public static class Inventory
 	}
 
 	/// <summary>
+	/// Same as above but can support stackables (playing item one at a time into a machine)
+	/// returns the object that was removed from the stack also
+	/// </summary>
+	/// <param name="fromSlot"></param>
+	/// <returns></returns>
+	public static GameObject ServerVanishStackable(ItemSlot fromSlot)
+	{
+		if (fromSlot.ItemObject == null) return null;
+		var stackable = fromSlot.ItemObject.GetComponent<Stackable>();
+		if (stackable != null)
+		{
+			var clone = stackable.ServerRemoveOne();
+			ServerPerform(new InventoryMove(InventoryMoveType.Remove, clone.GetComponent<Pickupable>(), fromSlot, null, InventoryRemoveType.Vanish));
+			return clone;
+		}
+		else
+		{
+			ServerPerform(InventoryMove.Vanish(fromSlot));
+			return fromSlot.Item.gameObject;
+		}
+	}
+
+	/// <summary>
 	/// Inventory move in which the object in the slot is thrown into the world from the location of its root storage
 	/// </summary>
 	/// <param name="fromSlot"></param>

--- a/UnityProject/Assets/Scripts/Inventory/InventoryMoveType.cs
+++ b/UnityProject/Assets/Scripts/Inventory/InventoryMoveType.cs
@@ -79,7 +79,7 @@ public class InventoryMove
 	public RegisterPlayer ToRootPlayer => ToSlot?.RootPlayer();
 
 
-	private InventoryMove(InventoryMoveType inventoryMoveType, Pickupable movedObject, ItemSlot fromSlot, ItemSlot slot,
+	public InventoryMove(InventoryMoveType inventoryMoveType, Pickupable movedObject, ItemSlot fromSlot, ItemSlot slot,
 		InventoryRemoveType? removeType = null, BodyPartType? throwAim = null, Vector2? worldTargetVector = null, SpinMode? throwSpinMode = null,
 		ReplacementStrategy replacementStrategy = ReplacementStrategy.Cancel)
 	{

--- a/UnityProject/Assets/Scripts/Items/Others/SolidPlasma.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/SolidPlasma.cs
@@ -49,7 +49,7 @@ public class SolidPlasma : NetworkBehaviour
 	{
 		if (burningPlasma)
 		{
-			Amount -= (0.05f * Time.deltaTime) * burnSpeed;
+			Amount -= Time.deltaTime * burnSpeed;
 			if (Amount <= 0f)
 			{
 				burningPlasma = false;

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -156,6 +156,23 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	}
 
 	/// <summary>
+	/// Removes one item from a stack and returns it
+	/// </summary>
+	/// <returns></returns>
+	[Server]
+	public GameObject ServerRemoveOne()
+	{
+		SyncAmount(amount - 1);
+		if (amount <= 0)
+		{
+			return gameObject;
+		}
+
+		var spawnInfo = Spawn.ServerPrefab(prefab, gameObject.transform.position, gameObject.transform);
+		return spawnInfo.GameObject;
+	}
+
+	/// <summary>
 	/// Adds the quantity in toAdd to this stackable (up to maxAmount) and despawns toAdd
 	/// if it is entirely used up.
 	/// Does nothing if they aren't the same thing

--- a/UnityProject/Assets/Sounds/MainMixer.mixer
+++ b/UnityProject/Assets/Sounds/MainMixer.mixer
@@ -1,5 +1,27 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!244 &-3985186153619265451
+AudioMixerEffectController:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_EffectID: 7a0a0797f2449634983cc3312bc99abc
+  m_EffectName: Compressor
+  m_MixLevel: 1a38fcb5085a2824e9a8b57c15135ebc
+  m_Parameters:
+  - m_ParameterName: Threshold
+    m_GUID: 3593f6c14d81a614f849371eabe83fb9
+  - m_ParameterName: Attack
+    m_GUID: 42bb00fa413d40243bbcdc922e7a8524
+  - m_ParameterName: Release
+    m_GUID: 0b16236f398e27141a70898d4165a7a9
+  - m_ParameterName: Make up gain
+    m_GUID: 282ada877c6e5c946bd0a4c3fe316c95
+  m_SendTarget: {fileID: 0}
+  m_EnableWetMix: 0
+  m_Bypass: 0
 --- !u!244 &-9401582929567971
 AudioMixerEffectController:
   m_ObjectHideFlags: 3
@@ -53,6 +75,7 @@ AudioMixerGroupController:
   m_Send: 00000000000000000000000000000000
   m_Effects:
   - {fileID: 24400002}
+  - {fileID: -3985186153619265451}
   m_UserColorIndex: 0
   m_Mute: 0
   m_Solo: 0
@@ -81,15 +104,22 @@ AudioMixerSnapshotController:
   m_AudioMixer: {fileID: 24100000}
   m_SnapshotID: c2f8296e77b99483caa5a805ae34f0fa
   m_FloatValues:
+    4aa22e50e76fa554186d447f12877ac5: 1
+    3593f6c14d81a614f849371eabe83fb9: -17.3
     310a9a72a23951642a803c391ba9cfe1: 1
+    579221d3a74f2074aa8cc60307bb9e3b: 1.23
     feb85804ebcde054f8fef8d183596870: 3
     926160f42adac7c49b7c522d6fa2ec2a: 2000
+    282ada877c6e5c946bd0a4c3fe316c95: 5.1
     c3fe1248a255b4de59cc9ff7060750ed: -22
     6cf6c3e96384d44129a54e5fcfba90f3: 10
     0df76a2a63b4f47bbb6fd09182dbfebd: 16.4
+    43bde5ca71f1a6a41ae29e84a98bf4f4: 4511.368
+    42bb00fa413d40243bbcdc922e7a8524: 43
     8a7b712dd41fe49e5ba3d25d65e7a113: 3
     53f709ae2165f44b0b0c00b641be9163: -19
     cfd0a05f0fa564a1db5826e4a2fc02a3: 19.7
+    0b16236f398e27141a70898d4165a7a9: 43
   m_TransitionOverrides: {}
 --- !u!244 &2675562247271655640
 AudioMixerEffectController:


### PR DESCRIPTION
As per the title.
Fixes #2612 
- Correctly removes plasma from the stack and creates a clone to be burned by the generator
- Adjusted the burn time of the plasma power generator and tested it in a full round

Adds a check for empty Initial names in objective item target assigning as per comments in #2613 

Added a compressor to the Main Mixer and started to mix some of the station sounds. Aim is to get all sound volumes playing within a 12db window.
