### PR TITLE
Adds GameData.OfflineMode

### DIFF
--- a/UnityProject/Assets/Scripts/Database/ServerData.ValidateUser.cs
+++ b/UnityProject/Assets/Scripts/Database/ServerData.ValidateUser.cs
@@ -101,7 +101,12 @@ namespace DatabaseAPI
 			}
 			catch(Exception e)
 			{
-				Logger.LogError($"Something went wrong with token validation {e.Message}", Category.Hub);
+				//fail silently for local offline testing
+				if (!GameData.Instance.OfflineMode)
+				{
+					Logger.LogError($"Something went wrong with token validation {e.Message}", Category.Hub);
+				}
+
 				return null;
 			}
 

--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -19,8 +19,8 @@ public class GameData : MonoBehaviour
 {
 	private static GameData gameData;
 
-	[Tooltip("Toggle this on to allow the game to work offline or when auth server can't be reached, to" +
-	         " allow skipping login. " +
+	[Tooltip("Only use this when offline or you can't reach the auth server! Allows the game to still work in that situation and " +
+	         " allows skipping login. Host player will also be given admin privs." +
 	         "Not supported in release builds.")]
 	[SerializeField]
 	private bool offlineMode;

--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -19,6 +19,18 @@ public class GameData : MonoBehaviour
 {
 	private static GameData gameData;
 
+	[Tooltip("Toggle this on to allow the game to work offline or when auth server can't be reached, to" +
+	         " allow skipping login. " +
+	         "Not supported in release builds.")]
+	[SerializeField]
+	private bool offlineMode;
+
+	/// <summary>
+	/// Is offline mode enabled, allowing login skip / working without connection to server.?
+	/// Disabled always for release builds.
+	/// </summary>
+	public bool OfflineMode => !BuildPreferences.isForRelease && offlineMode;
+
 	public bool testServer;
 	private RconManager rconManager;
 

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -83,8 +83,14 @@ public partial class PlayerList
 	[Server]
 	public GameObject GetAdmin(string userID, string token)
 	{
+
 		if (string.IsNullOrEmpty(userID))
 		{
+			//allow null admin when doing offline testing
+			if (GameData.Instance.OfflineMode)
+			{
+				return PlayerManager.LocalPlayer;
+			}
 			Logger.LogError("The User ID for Admin is null!", Category.Admin);
 			if (string.IsNullOrEmpty(token))
 			{
@@ -204,8 +210,8 @@ public partial class PlayerList
 			}
 		}
 
-		//full admin privs for local offline testing
-		if (adminUsers.Contains(userid) || GameData.Instance.OfflineMode)
+		//full admin privs for local offline testing for host player
+		if (adminUsers.Contains(userid) || (GameData.Instance.OfflineMode && playerConn.GameObject == PlayerManager.LocalViewerScript.gameObject))
 		{
 			//This is an admin, send admin notify to the users client
 			Logger.Log($"{playerConn.Username} logged in as Admin. " +

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -131,7 +131,8 @@ public partial class PlayerList
 	//Check if tokens match and if the player is an admin or is banned
 	private async Task<bool> CheckUserState(string userid, string token, ConnectedPlayer playerConn, string clientID)
 	{
-		if (string.IsNullOrEmpty(token) || string.IsNullOrEmpty(userid))
+		//allow empty token for local offline testing
+		if ((string.IsNullOrEmpty(token) || string.IsNullOrEmpty(userid)) && !GameData.Instance.OfflineMode)
 		{
 			StartCoroutine(KickPlayer(playerConn, $"Server Error: Account has invalid cookie."));
 			Logger.Log($"A user tried to connect with null userid or token value" +
@@ -140,8 +141,8 @@ public partial class PlayerList
 			return false;
 		}
 
-		//Do not allow users to log in twice for release servers:
-		if (BuildPreferences.isForRelease)
+		//check if they are already logged in, skip this check if offline mode is enabled.
+		if (!GameData.Instance.OfflineMode)
 		{
 			if (GetByUserID(userid) != null)
 			{
@@ -163,7 +164,14 @@ public partial class PlayerList
 		var refresh = new RefreshToken {userID = userid, refreshToken = token};
 		var response = await ServerData.ValidateToken(refresh, true);
 
-		if (response.errorCode == 1)
+		//fail, unless doing local offline testing
+		if (response == null && !GameData.Instance.OfflineMode)
+		{
+			return false;
+		}
+
+		//allow error response for local offline testing
+		if (response != null && response.errorCode == 1 && !GameData.Instance.OfflineMode)
 		{
 			StartCoroutine(KickPlayer(playerConn, $"Server Error: Account has invalid cookie."));
 			Logger.Log($"A spoof attempt was recorded. " +
@@ -171,6 +179,7 @@ public partial class PlayerList
 				Category.Admin);
 			return false;
 		}
+
 
 		var banEntry = banList.CheckForEntry(userid);
 		if (banEntry != null)
@@ -195,7 +204,8 @@ public partial class PlayerList
 			}
 		}
 
-		if (adminUsers.Contains(userid))
+		//full admin privs for local offline testing
+		if (adminUsers.Contains(userid) || GameData.Instance.OfflineMode)
 		{
 			//This is an admin, send admin notify to the users client
 			Logger.Log($"{playerConn.Username} logged in as Admin. " +

--- a/UnityProject/Assets/Scripts/UI/Lobby/GUI_LobbyDialogue.cs
+++ b/UnityProject/Assets/Scripts/UI/Lobby/GUI_LobbyDialogue.cs
@@ -96,19 +96,19 @@ namespace Lobby
 
 		private void Update()
 		{
-			if (Input.GetKeyDown(KeyCode.F6))
-				if (Input.GetKeyDown(KeyCode.F6) && !BuildPreferences.isForRelease)
+			//login skip only allowed (and only works properly) in offline mode
+			if (Input.GetKeyDown(KeyCode.F6) && GameData.Instance.OfflineMode)
+			{
+				//skip login
+				HideAllPanels();
+				connectionPanel.SetActive(true);
+				dialogueTitle.text = "Connection Panel";
+				//if there aren't char settings, default
+				if (PlayerManager.CurrentCharacterSettings == null)
 				{
-					//skip login
-					HideAllPanels();
-					connectionPanel.SetActive(true);
-					dialogueTitle.text = "Connection Panel";
-					//if there aren't char settings, default
-					if (PlayerManager.CurrentCharacterSettings == null)
-					{
-						PlayerManager.CurrentCharacterSettings = new CharacterSettings();
-					}
+					PlayerManager.CurrentCharacterSettings = new CharacterSettings();
 				}
+			}
 		}
 
 		public void ShowConnectionPanel()


### PR DESCRIPTION
### Purpose

Adds a special field on GameData called OfflineMode. Checking this will allow you to skip login and allow the game to work even if you can't connect to the auth server. By default it is disabled - it's only to be used in those uncommon circumstances.

Also disables login skip (which doesn't work anyway) unless OfflineMode is enabled.