### PR TITLE
Restore AirVent / Scrubber functionality

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/AirVent.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/AirVent.prefab
@@ -22,6 +22,7 @@ GameObject:
   - component: {fileID: 114798627279048580}
   - component: {fileID: 114511699214781296}
   - component: {fileID: -678374216968888500}
+  - component: {fileID: 8341462466351120766}
   m_Layer: 10
   m_Name: AirVent
   m_TagString: Untagged
@@ -100,7 +101,15 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  isNotPushable: 0
+  floorDecal: {fileID: 0}
+  isInitiallyNotPushable: 0
+  pushPullSound: 
+  soundDelayTime: 0
+  soundMinimumPitchVariance: 1
+  soundMaximumPitchVariance: 1
+  OnPullingSomethingChangedServer:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &6479037130962053368
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -115,8 +124,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  layer: {fileID: 0}
-  ObjectType: 0
+  matrixDebugLogging: 0
+  objectType: 0
 --- !u!114 &3953549719403137607
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -129,6 +138,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114207068481858528
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -157,20 +169,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  registerTile: {fileID: 0}
-  objectBehaviour: {fileID: 0}
-  nodes: []
   direction: 0
   anchored: 0
   volume: 70
   pipeSprites:
-  - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
+  - {fileID: 21300040, guid: b9e58be60cbc7ce45a1cb2938d57b239, type: 3}
   - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
   - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
   - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
   - {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
   spriteRenderer: {fileID: 8418407404781841632}
-  spriteSync: 0
   MinimumPressure: 101.325
 --- !u!114 &6203799934882642808
 MonoBehaviour:
@@ -289,6 +297,9 @@ MonoBehaviour:
   syncInterval: 0.1
   initialName: Vent
   initialDescription: 
+  exportCost: 0
+  exportName: 
+  exportMessage: 
   initialTraits: []
   initialSize: 1
   hitDamage: 0
@@ -300,6 +311,19 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+--- !u!114 &8341462466351120766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000010733523080}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteMatrixRotationBehavior: 1
 --- !u!1 &8513106460640881890
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Connector.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Connector.prefab
@@ -102,6 +102,7 @@ GameObject:
   - component: {fileID: 114933713635356078}
   - component: {fileID: 1479264743170500274}
   - component: {fileID: -3465280134105671477}
+  - component: {fileID: 6334083418781041707}
   m_Layer: 10
   m_Name: Connector
   m_TagString: Untagged
@@ -177,6 +178,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114007797438959630
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,9 +209,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  registerTile: {fileID: 0}
-  objectBehaviour: {fileID: 0}
-  nodes: []
   direction: 0
   anchored: 0
   volume: 70
@@ -218,7 +219,6 @@ MonoBehaviour:
   - {fileID: 21300076, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
   - {fileID: 21300078, guid: 15ef494d1ff854fa69eab656aa860854, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
-  spriteSync: 0
 --- !u!114 &1017861296826197586
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -246,7 +246,15 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  isNotPushable: 0
+  floorDecal: {fileID: 0}
+  isInitiallyNotPushable: 0
+  pushPullSound: 
+  soundDelayTime: 0
+  soundMinimumPitchVariance: 1
+  soundMaximumPitchVariance: 1
+  OnPullingSomethingChangedServer:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &114185907784239616
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -261,8 +269,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  layer: {fileID: 0}
-  ObjectType: 0
+  matrixDebugLogging: 0
+  objectType: 0
 --- !u!114 &114643104810596728
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -368,6 +376,9 @@ MonoBehaviour:
   syncInterval: 0.1
   initialName: Connector
   initialDescription: 
+  exportCost: 0
+  exportName: 
+  exportMessage: 
   initialTraits: []
   initialSize: 1
   hitDamage: 0
@@ -379,3 +390,16 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+--- !u!114 &6334083418781041707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteMatrixRotationBehavior: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Scrubber.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Scrubber.prefab
@@ -22,6 +22,7 @@ GameObject:
   - component: {fileID: 114519943041861588}
   - component: {fileID: 114276172641375114}
   - component: {fileID: -1233506647488304563}
+  - component: {fileID: 6583049513569107849}
   m_Layer: 10
   m_Name: Scrubber
   m_TagString: Untagged
@@ -97,6 +98,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &493655120697083372
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -125,20 +129,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  registerTile: {fileID: 0}
-  objectBehaviour: {fileID: 0}
-  nodes: []
   direction: 0
   anchored: 0
   volume: 70
   pipeSprites:
-  - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
+  - {fileID: 21300000, guid: 320ec0ebfcc2f234c85188ef36b2de8f, type: 3}
   - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
   - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
   - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
   - {fileID: 21300000, guid: 338b7b6da09887b4a8e2f5416e2ce867, type: 3}
   spriteRenderer: {fileID: 3335986396963275010}
-  spriteSync: 0
   MinimumPressure: 101.325
 --- !u!114 &6963528815061158835
 MonoBehaviour:
@@ -167,7 +167,15 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  isNotPushable: 0
+  floorDecal: {fileID: 0}
+  isInitiallyNotPushable: 0
+  pushPullSound: 
+  soundDelayTime: 0
+  soundMinimumPitchVariance: 1
+  soundMaximumPitchVariance: 1
+  OnPullingSomethingChangedServer:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &200003959481001672
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -182,8 +190,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  layer: {fileID: 0}
-  ObjectType: 0
+  matrixDebugLogging: 0
+  objectType: 0
 --- !u!114 &114754654923298058
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -289,6 +297,9 @@ MonoBehaviour:
   syncInterval: 0.1
   initialName: Scrubber
   initialDescription: 
+  exportCost: 0
+  exportName: 
+  exportMessage: 
   initialTraits: []
   initialSize: 1
   hitDamage: 0
@@ -300,6 +311,19 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+--- !u!114 &6583049513569107849
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011763452766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteMatrixRotationBehavior: 1
 --- !u!1 &3223271260076572928
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/shuttle fuel connector.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/shuttle fuel connector.prefab
@@ -97,6 +97,7 @@ GameObject:
   - component: {fileID: 3860291930917928882}
   - component: {fileID: 2409827327891946488}
   - component: {fileID: 4361150713506660881}
+  - component: {fileID: 6453293926267948013}
   m_Layer: 10
   m_Name: shuttle fuel connector
   m_TagString: Untagged
@@ -175,7 +176,15 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
-  isNotPushable: 0
+  floorDecal: {fileID: 0}
+  isInitiallyNotPushable: 1
+  pushPullSound: 
+  soundDelayTime: 0
+  soundMinimumPitchVariance: 1
+  soundMaximumPitchVariance: 1
+  OnPullingSomethingChangedServer:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &114079759797594526
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -188,6 +197,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &383125038757771000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -203,7 +215,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 1028230888
+  m_SceneId: 0
 --- !u!114 &3860291930917928882
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -218,8 +230,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  layer: {fileID: 0}
-  ObjectType: 1
+  matrixDebugLogging: 0
+  objectType: 1
   AtmosPassable: 1
   Passable: 1
 --- !u!114 &2409827327891946488
@@ -270,3 +282,16 @@ MonoBehaviour:
     FreezeProof: 0
   HeatResistance: 100
   initialIntegrity: 100
+--- !u!114 &6453293926267948013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645856876941636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteMatrixRotationBehavior: 1

--- a/UnityProject/Assets/Scripts/GameModes/GameModeData.asset
+++ b/UnityProject/Assets/Scripts/GameModes/GameModeData.asset
@@ -13,7 +13,5 @@ MonoBehaviour:
   m_Name: GameModeData
   m_EditorClassIdentifier: 
   GameModes:
-  - {fileID: 11400000, guid: 52f8f627d68d9974a9d2376f6a9a2e61, type: 2}
   - {fileID: 11400000, guid: a07c32cfb5b43954c908ca8910ad76e5, type: 2}
-  - {fileID: 11400000, guid: 05fce6636cea92c45b994911665cde8e, type: 2}
   DefaultGameMode: {fileID: 11400000, guid: a07c32cfb5b43954c908ca8910ad76e5, type: 2}

--- a/UnityProject/Assets/Scripts/Objects/Canister.cs
+++ b/UnityProject/Assets/Scripts/Objects/Canister.cs
@@ -123,7 +123,7 @@ public class Canister : NetworkBehaviour, ICheckedInteractable<HandApply>
 				var foundConnectors = registerTile.Matrix.Get<Connector>(registerTile.LocalPositionServer, true);
 				foreach (var conn in foundConnectors)
 				{
-					if (conn.objectBehaviour.IsNotPushable)
+					if (conn.ObjectBehavior.IsNotPushable)
 					{
 						SoundManager.PlayNetworkedAtPos("Wrench", registerTile.WorldPositionServer, 1f);
 						connector = conn;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -23,13 +23,13 @@ public class MetaDataLayer : MonoBehaviour
 		metaTileMap = GetComponent<MetaTileMap>();
 	}
 
-	public MetaDataNode Get(Vector3Int position, bool createIfNotExists = true)
+	public MetaDataNode Get(Vector3Int localPosition, bool createIfNotExists = true)
 	{
-		if (!nodes.ContainsKey(position))
+		if (!nodes.ContainsKey(localPosition))
 		{
 			if (createIfNotExists)
 			{
-				nodes[position] = new MetaDataNode(position, reactionManager);
+				nodes[localPosition] = new MetaDataNode(localPosition, reactionManager);
 			}
 			else
 			{
@@ -37,7 +37,7 @@ public class MetaDataLayer : MonoBehaviour
 			}
 		}
 
-		return nodes[position];
+		return nodes[localPosition];
 	}
 
 	public bool IsSpaceAt(Vector3Int position)
@@ -183,8 +183,8 @@ public class MetaDataLayer : MonoBehaviour
 	}
 
 
-	public void UpdateSystemsAt(Vector3Int position)
+	public void UpdateSystemsAt(Vector3Int localPosition)
 	{
-		subsystemManager.UpdateAt(position);
+		subsystemManager.UpdateAt(localPosition);
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosManager.cs
@@ -9,7 +9,7 @@ public class AtmosManager : MonoBehaviour
 	/// <summary>
 	/// Time it takes per update in milliseconds
 	/// </summary>
-	public float Speed = 40; 
+	public float Speed = 40;
 	public int NumberThreads = 1;
 
 	public AtmosMode Mode = AtmosMode.Threaded;
@@ -113,7 +113,7 @@ public class AtmosManager : MonoBehaviour
 		yield return new WaitForSeconds(2);
 		for (int i = 0; i < inGamePipes.Count; i++)
 		{
-			inGamePipes[i].Attach();
+			inGamePipes[i].ServerAttach();
 		}
 
 		roundStartedServer = true;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
@@ -16,8 +16,8 @@ public class AtmosSystem : SubsystemBehaviour
 		}
 	}
 
-	public override void UpdateAt(Vector3Int position)
+	public override void UpdateAt(Vector3Int localPosition)
 	{
-		AtmosThread.Enqueue(metaDataLayer.Get(position));
+		AtmosThread.Enqueue(metaDataLayer.Get(localPosition));
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/BentPipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/BentPipe.cs
@@ -39,7 +39,7 @@ public class BentPipe : SimplePipe
 				for (int i = 0; i < nodes.Count; i++)
 				{
 					var pipe = nodes[i];
-					if (pipe.registerTile.WorldPositionServer.y < registerTile.WorldPositionServer.y)
+					if (pipe.RegisterTile.WorldPositionServer.y < RegisterTile.WorldPositionServer.y)
 					{
 						if (HasDirection(direction, Direction.EAST))
 						{
@@ -50,7 +50,7 @@ public class BentPipe : SimplePipe
 							SetSprite(6);
 						}
 					}
-					else if (pipe.registerTile.WorldPositionServer.y > registerTile.WorldPositionServer.y)
+					else if (pipe.RegisterTile.WorldPositionServer.y > RegisterTile.WorldPositionServer.y)
 					{
 						if (HasDirection(direction, Direction.EAST))
 						{
@@ -61,7 +61,7 @@ public class BentPipe : SimplePipe
 							SetSprite(8);
 						}
 					}
-					else if (pipe.registerTile.WorldPositionServer.x > registerTile.WorldPositionServer.x)
+					else if (pipe.RegisterTile.WorldPositionServer.x > RegisterTile.WorldPositionServer.x)
 					{
 						if (HasDirection(direction, Direction.SOUTH))
 						{
@@ -72,7 +72,7 @@ public class BentPipe : SimplePipe
 							SetSprite(10);
 						}
 					}
-					else if (pipe.registerTile.WorldPositionServer.x < registerTile.WorldPositionServer.x)
+					else if (pipe.RegisterTile.WorldPositionServer.x < RegisterTile.WorldPositionServer.x)
 					{
 						if (HasDirection(direction, Direction.SOUTH))
 						{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/InteractablePipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/InteractablePipe.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 
 /// <summary>
+/// TODO: Not much need for this to be separate from Pipe.
 /// Component for allowing a Pipe to be interacted with
 /// </summary>
 [RequireComponent(typeof(Pipe))]
@@ -24,6 +25,6 @@ public class InteractablePipe : MonoBehaviour, ICheckedInteractable<HandApply>
 
 	public void ServerPerformInteraction(HandApply interaction)
 	{
-		pipe.WrenchAct();
+		pipe.ServerWrenchAct();
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Manifold.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Manifold.cs
@@ -20,22 +20,22 @@ public class Manifold : SimplePipe
 			for (int i = 0; i < nodes.Count; i++)
 			{
 				var pipe = nodes[i];
-				if (pipe.registerTile.WorldPositionServer.y < registerTile.WorldPositionServer.y)
+				if (pipe.RegisterTile.WorldPositionServer.y < RegisterTile.WorldPositionServer.y)
 				{
 					syncValue |= Direction.SOUTH;
 					SetConnectionSprite(0);
 				}
-				else if (pipe.registerTile.WorldPositionServer.y > registerTile.WorldPositionServer.y)
+				else if (pipe.RegisterTile.WorldPositionServer.y > RegisterTile.WorldPositionServer.y)
 				{
 					syncValue |= Direction.NORTH;
 					SetConnectionSprite(1);
 				}
-				else if (pipe.registerTile.WorldPositionServer.x > registerTile.WorldPositionServer.x)
+				else if (pipe.RegisterTile.WorldPositionServer.x > RegisterTile.WorldPositionServer.x)
 				{
 					syncValue |= Direction.EAST;
 					SetConnectionSprite(2);
 				}
-				else if (pipe.registerTile.WorldPositionServer.x < registerTile.WorldPositionServer.x)
+				else if (pipe.RegisterTile.WorldPositionServer.x < RegisterTile.WorldPositionServer.x)
 				{
 					syncValue |= Direction.WEST;
 					SetConnectionSprite(3);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
@@ -6,9 +6,8 @@ using Mirror;
 using Atmospherics;
 using Tilemaps.Behaviours.Meta;
 
-//TODO: These need to be reworked to make proper use of Directional and DirectionalRotationSprite.
-//Currently they try to manage the sprite rotation themselves. They should actually work
-//more like wires and be different objects when anchored.
+//TODO: These need to be reworked when pipenets are worked on next. See various todo comments.
+//it needs to make proper use of Directional rather than rolling its own direction / sprite rotation logic
 [RequireComponent(typeof(Pickupable))]
 public class Pipe : NetworkBehaviour, IServerSpawn
 {
@@ -19,8 +18,8 @@ public class Pipe : NetworkBehaviour, IServerSpawn
 
 	[NonSerialized]
 	public List<Pipe> nodes = new List<Pipe>();
+	//TODO: This needs to use Directional instead of custom direction logic
 	public Direction direction = Direction.NORTH | Direction.SOUTH;
-	private Directional directional;
 	public Pipenet pipenet;
 	public bool anchored;
 	public float volume = 70;
@@ -49,7 +48,6 @@ public class Pipe : NetworkBehaviour, IServerSpawn
 	{
 		registerTile = GetComponent<RegisterTile>();
 		objectBehaviour = GetComponent<ObjectBehaviour>();
-		directional = GetComponent<Directional>();
 		//TODO: This component needs to be reworked to use Directional / DirectionalRotationSprites
 		//directional.OnDirectionChange.AddListener(OnDirectionChange);
 		pickupable = GetComponent<Pickupable>();
@@ -58,7 +56,8 @@ public class Pipe : NetworkBehaviour, IServerSpawn
 	private void ServerInit()
 	{
 		pickupable.ServerSetCanPickup(!anchored);
-		CalculateDirection();
+		//TODO: Restore when pipenets implemented
+		//CalculateDirection();
 	}
 
 	public override void OnStartServer()
@@ -93,16 +92,16 @@ public class Pipe : NetworkBehaviour, IServerSpawn
 	/// </summary>
 	public virtual void TickUpdate() { }
 
-	public void WrenchAct()
+	[Server]
+	public void ServerWrenchAct()
 	{
 		if (anchored)
 		{
-			Detach();
-			CalculateSprite();
+			ServerDetach();
 		}
 		else
 		{
-			if (Attach() == false)
+			if (ServerAttach() == false)
 			{
 				// show message to the player 'theres something attached in this direction already'
 				return;
@@ -112,37 +111,47 @@ public class Pipe : NetworkBehaviour, IServerSpawn
 		SoundManager.PlayNetworkedAtPos("Wrench", registerTile.WorldPositionServer, 1f);
 	}
 
-	public virtual bool Attach()
+	[Server]
+	public virtual bool ServerAttach()
 	{
-		CalculateDirection();
-		if (GetAnchoredPipe(registerTile.WorldPositionServer, direction) != null)
-		{
-			return false;
-		}
+		//TODO: Restore pipe attach logic when pipenets are fully implemented.
+		//Until then, we will just anchor the pipe so it can't be moved around.
+		//
+		// CalculateDirection();
+		// if (GetAnchoredPipe(registerTile.WorldPositionServer, direction) != null)
+		// {
+		// 	return false;
+		// }
+		//
+		// CalculateAttachedNodes();
+		//
+		// Pipenet foundPipenet;
+		// if (nodes.Count > 0)
+		// {
+		// 	foundPipenet = nodes[0].pipenet;
+		// }
+		// else
+		// {
+		// 	foundPipenet = new Pipenet();
+		// }
+		//
+		// foundPipenet.AddPipe(this);
 
-		CalculateAttachedNodes();
-
-		Pipenet foundPipenet;
-		if (nodes.Count > 0)
-		{
-			foundPipenet = nodes[0].pipenet;
-		}
-		else
-		{
-			foundPipenet = new Pipenet();
-		}
-
-		foundPipenet.AddPipe(this);
-		SetAnchored(true);
+		//just anchor it so it can't be moved and appears in the correct layer
+		ServerSetAnchored(true);
 		SetSpriteLayer(true);
 
-		transform.position = registerTile.WorldPositionServer;
-		CalculateSprite();
+		//snap to tile position
+		transform.localPosition = registerTile.LocalPositionServer;
+		//show the down-facing anchored sprite, modify this to show correct direction
+		//when pipenets are implemented
+		SetSprite(1);
 
 		return true;
 	}
 
-	public virtual void SetAnchored(bool value)
+	[Server]
+	protected virtual void ServerSetAnchored(bool value)
 	{
 		anchored = value;
 		objectBehaviour.ServerSetPushable(!value);
@@ -155,16 +164,7 @@ public class Pipe : NetworkBehaviour, IServerSpawn
 
 	public void SyncSprite(int value)
 	{
-		if (value == 0) // its using the item sprite
-		{
-			SetSpriteLayer(false);
-		}
-		else
-		{
-			transform.rotation = Quaternion.identity; //counter shuttle rotation
-			SetSpriteLayer(true);
-		}
-
+		SetSpriteLayer(value != 0);
 		SetSprite(value);
 	}
 
@@ -175,49 +175,58 @@ public class Pipe : NetworkBehaviour, IServerSpawn
 	}
 
 
-	public void Detach()
+	[Server]
+	private void ServerDetach()
 	{
-		var foundMeters = MatrixManager.GetAt<Meter>(registerTile.WorldPositionServer, true);
-		for (int i = 0; i < foundMeters.Count; i++)
-		{
-			var meter = foundMeters[i];
-			if (meter.anchored)
-			{
-				foundMeters[i].Detach();
-			}
-		}
+		//TODO: Restore full detach logic when pipenets are fully implemented. Until then
+		//we will just change the sprite and make it pickupable again.
 
-		//TODO: release gas to environmental air
-		SetAnchored(false);
+		// var foundMeters = MatrixManager.GetAt<Meter>(registerTile.WorldPositionServer, true);
+		// for (int i = 0; i < foundMeters.Count; i++)
+		// {
+		// 	var meter = foundMeters[i];
+		// 	if (meter.anchored)
+		// 	{
+		// 		foundMeters[i].Detach();
+		// 	}
+		// }
+		//
+		// //TODO: release gas to environmental air
+		// SetAnchored(false);
+		// SetSpriteLayer(false);
+		// int neighboorPipes = 0;
+		// for (int i = 0; i < nodes.Count; i++)
+		// {
+		// 	var pipe = nodes[i];
+		// 	pipe.nodes.Remove(this);
+		// 	pipe.CalculateSprite();
+		// 	neighboorPipes++;
+		// }
+		//
+		// nodes = new List<Pipe>();
+		//
+		// Pipenet oldPipenet = pipenet;
+		// pipenet.RemovePipe(this);
+		//
+		// if (oldPipenet.members.Count == 0)
+		// {
+		// 	//we're the only pipe on the net, delete it
+		// 	oldPipenet.DeletePipenet();
+		// 	return;
+		// }
+		//
+		// if (neighboorPipes == 1)
+		// {
+		// 	//we're at an edge of the pipenet, safe to remove
+		// 	return;
+		// }
+		//
+		// oldPipenet.Separate();
+
+		ServerSetAnchored(false);
 		SetSpriteLayer(false);
-		int neighboorPipes = 0;
-		for (int i = 0; i < nodes.Count; i++)
-		{
-			var pipe = nodes[i];
-			pipe.nodes.Remove(this);
-			pipe.CalculateSprite();
-			neighboorPipes++;
-		}
-
-		nodes = new List<Pipe>();
-
-		Pipenet oldPipenet = pipenet;
-		pipenet.RemovePipe(this);
-
-		if (oldPipenet.members.Count == 0)
-		{
-			//we're the only pipe on the net, delete it
-			oldPipenet.DeletePipenet();
-			return;
-		}
-
-		if (neighboorPipes == 1)
-		{
-			//we're at an edge of the pipenet, safe to remove
-			return;
-		}
-
-		oldPipenet.Separate();
+		//unanchored sprite
+		SetSprite(0);
 	}
 
 
@@ -268,22 +277,23 @@ public class Pipe : NetworkBehaviour, IServerSpawn
 		}
 	}
 
-	private void CalculateDirection()
-	{
-		float rotation = transform.rotation.eulerAngles.z;
-		var orientation = Orientation.GetOrientation(rotation);
-		if (orientation == Orientation.Up) //look over later
-		{
-			orientation = Orientation.Down;
-		}
-		else if (orientation == Orientation.Down)
-		{
-			orientation = Orientation.Up;
-		}
-
-		SetDirection(orientation);
-		directional.FaceDirection(orientation);
-	}
+	//TODO: Revisit when pipenets implemented
+	// private void CalculateDirection()
+	// {
+	// 	float rotation = transform.rotation.eulerAngles.z;
+	// 	var orientation = Orientation.GetOrientation(rotation);
+	// 	if (orientation == Orientation.Up) //look over later
+	// 	{
+	// 		orientation = Orientation.Down;
+	// 	}
+	// 	else if (orientation == Orientation.Down)
+	// 	{
+	// 		orientation = Orientation.Up;
+	// 	}
+	//
+	// 	SetDirection(orientation);
+	// 	directional.FaceDirection(orientation);
+	// }
 
 	private void OnDirectionChange(Orientation direction)
 	{
@@ -396,8 +406,17 @@ public class Pipe : NetworkBehaviour, IServerSpawn
 		direction = Direction.SOUTH;
 	}
 
-	public void SetSprite(int value)
+	protected void SetSprite(int value)
 	{
+		//TODO: Restore pipe sprites once pipenets are implemented.
+
+		//Until then, we only support the unanchored and anchored pointing down sprites
+		//force it to be the downward pointing pipe sprite if it's one of the other directions
+		if (value != 0 && value != 1)
+		{
+			value = 1;
+		}
+
 		spriteSync = value;
 		spriteRenderer.sprite = pipeSprites[value];
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Pipe.cs
@@ -12,9 +12,12 @@ using Tilemaps.Behaviours.Meta;
 [RequireComponent(typeof(Pickupable))]
 public class Pipe : NetworkBehaviour, IServerSpawn
 {
-	public RegisterTile registerTile;
-	public ObjectBehaviour objectBehaviour;
+	public RegisterTile RegisterTile => registerTile;
+	private RegisterTile registerTile;
+	public ObjectBehaviour ObjectBehavior => objectBehaviour;
+	private ObjectBehaviour objectBehaviour;
 
+	[NonSerialized]
 	public List<Pipe> nodes = new List<Pipe>();
 	public Direction direction = Direction.NORTH | Direction.SOUTH;
 	private Directional directional;
@@ -24,7 +27,8 @@ public class Pipe : NetworkBehaviour, IServerSpawn
 
 	public Sprite[] pipeSprites;
 	public SpriteRenderer spriteRenderer;
-	[SyncVar(hook = nameof(SyncSprite))] public int spriteSync;
+	[SyncVar(hook = nameof(SyncSprite))]
+	private int spriteSync;
 
 	protected Pickupable pickupable;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/SimplePipe.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/SimplePipe.cs
@@ -26,19 +26,19 @@ public class SimplePipe : Pipe
 				for (int i = 0; i < nodes.Count; i++)
 				{
 					var pipe = nodes[i];
-					if (pipe.registerTile.WorldPositionServer.y < registerTile.WorldPositionServer.y)
+					if (pipe.RegisterTile.WorldPositionServer.y < RegisterTile.WorldPositionServer.y)
 					{
 						SetSprite(3);
 					}
-					else if (pipe.registerTile.WorldPositionServer.y > registerTile.WorldPositionServer.y)
+					else if (pipe.RegisterTile.WorldPositionServer.y > RegisterTile.WorldPositionServer.y)
 					{
 						SetSprite(4);
 					}
-					else if (pipe.registerTile.WorldPositionServer.x > registerTile.WorldPositionServer.x)
+					else if (pipe.RegisterTile.WorldPositionServer.x > RegisterTile.WorldPositionServer.x)
 					{
 						SetSprite(5);
 					}
-					else if (pipe.registerTile.WorldPositionServer.x < registerTile.WorldPositionServer.x)
+					else if (pipe.RegisterTile.WorldPositionServer.x < RegisterTile.WorldPositionServer.x)
 					{
 						SetSprite(6);
 					}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -62,18 +62,18 @@ public class MetaDataSystem : SubsystemBehaviour
 		Logger.Log("MetaData init: " + sw.ElapsedMilliseconds + " ms", Category.Matrix);
 	}
 
-	public override void UpdateAt(Vector3Int position)
+	public override void UpdateAt(Vector3Int localPosition)
 	{
-		MetaDataNode node = metaDataLayer.Get(position);
+		MetaDataNode node = metaDataLayer.Get(localPosition);
 
 		MetaUtils.RemoveFromNeighbors(node);
 		externalNodes.TryRemove(node, out MetaDataNode nothing);
 
-		if (metaTileMap.IsAtmosPassableAt(position, true))
+		if (metaTileMap.IsAtmosPassableAt(localPosition, true))
 		{
 			node.ClearNeighbors();
 
-			node.Type = metaTileMap.IsSpaceAt(position, true) ? NodeType.Space : NodeType.Room;
+			node.Type = metaTileMap.IsSpaceAt(localPosition, true) ? NodeType.Space : NodeType.Room;
 			SetupNeighbors(node);
 			MetaUtils.AddToNeighbors(node);
 			node.IsClosedAirlock = false;
@@ -81,7 +81,7 @@ public class MetaDataSystem : SubsystemBehaviour
 		else
 		{
 			node.Type = NodeType.Occupied;
-			if ( matrix.GetFirst<RegisterDoor>(position, true) )
+			if ( matrix.GetFirst<RegisterDoor>(localPosition, true) )
 			{
 				node.IsClosedAirlock = true;
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SubsystemManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SubsystemManager.cs
@@ -32,7 +32,7 @@ public class SubsystemManager : NetworkBehaviour
 		systems.Add(system);
 	}
 
-	public void UpdateAt(Vector3Int position)
+	public void UpdateAt(Vector3Int localPosition)
 	{
 		if (!initialized)
 		{
@@ -41,7 +41,7 @@ public class SubsystemManager : NetworkBehaviour
 
 		for (int i = 0; i < systems.Count; i++)
 		{
-			systems[i].UpdateAt(position);
+			systems[i].UpdateAt(localPosition);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SystemBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SystemBehaviour.cs
@@ -19,5 +19,5 @@ public abstract class SubsystemBehaviour : MonoBehaviour
 
 		public abstract void Initialize();
 
-		public abstract void UpdateAt(Vector3Int position);
+		public abstract void UpdateAt(Vector3Int localPosition);
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/AirVent.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/AirVent.cs
@@ -9,9 +9,9 @@ public class AirVent : AdvancedPipe
 	private MetaDataNode metaNode;
 	private MetaDataLayer metaDataLayer;
 
-	public override bool Attach()
+	public override bool ServerAttach()
 	{
-		if (base.Attach() == false)
+		if (base.ServerAttach() == false)
 		{
 			return false;
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/AirVent.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/AirVent.cs
@@ -21,8 +21,8 @@ public class AirVent : AdvancedPipe
 
 	private void LoadTurf()
 	{
-		metaDataLayer = MatrixManager.AtPoint(registerTile.WorldPositionServer, true).MetaDataLayer;
-		metaNode = metaDataLayer.Get(registerTile.WorldPositionServer, false);
+		metaDataLayer = MatrixManager.AtPoint(RegisterTile.WorldPositionServer, true).MetaDataLayer;
+		metaNode = metaDataLayer.Get(RegisterTile.LocalPositionServer, false);
 	}
 
 	public override void TickUpdate()
@@ -38,10 +38,15 @@ public class AirVent : AdvancedPipe
 	{
 		if (metaNode.GasMix.Pressure < MinimumPressure)
 		{
-			GasMix gasMix = pipenet.gasMix;
-			pipenet.gasMix = gasMix / 2;
-			metaNode.GasMix = metaNode.GasMix + gasMix;
-			metaDataLayer.UpdateSystemsAt(registerTile.WorldPositionServer);
+			//TODO: Can restore this when pipenets are implemented so they actually pull from what
+			//they are connected to. In the meantime
+			//we are reverting scrubbers / airvents to the old behavior of just shoving or removing air
+			//regardless of what they are connected to.
+			// GasMix gasMix = pipenet.gasMix;
+			// pipenet.gasMix = gasMix / 2;
+			// metaNode.GasMix = metaNode.GasMix + gasMix;
+			metaNode.GasMix = new GasMix(GasMixes.Air);
+			metaDataLayer.UpdateSystemsAt(RegisterTile.LocalPositionServer);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
@@ -21,8 +21,8 @@ public class Scrubber : AdvancedPipe
 
 	private void LoadTurf()
 	{
-		metaDataLayer = MatrixManager.AtPoint(registerTile.WorldPositionServer, true).MetaDataLayer;
-		metaNode = metaDataLayer.Get(registerTile.WorldPositionServer, false);
+		metaDataLayer = MatrixManager.AtPoint(RegisterTile.WorldPositionServer, true).MetaDataLayer;
+		metaNode = metaDataLayer.Get(RegisterTile.LocalPositionServer, false);
 	}
 
 	public override void TickUpdate()
@@ -38,10 +38,15 @@ public class Scrubber : AdvancedPipe
 	{
 		if (metaNode.GasMix.Pressure > MinimumPressure)
 		{
-			var suckedAir =  metaNode.GasMix / 2;
-			pipenet.gasMix += suckedAir;
-			metaNode.GasMix -= suckedAir;
-			metaDataLayer.UpdateSystemsAt(registerTile.WorldPositionServer);
+			//TODO: Can restore this when pipenets are implemented so they actually pull from what
+			//they are connected to. In the meantime
+			//we are reverting scrubbers / airvents to the old behavior of just shoving or removing air
+			//regardless of what they are connected to.
+			// var suckedAir =  metaNode.GasMix / 2;
+			// pipenet.gasMix += suckedAir;
+			// metaNode.GasMix -= suckedAir;
+			metaNode.GasMix = new GasMix(GasMixes.Space);
+			metaDataLayer.UpdateSystemsAt(RegisterTile.LocalPositionServer);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
@@ -9,9 +9,9 @@ public class Scrubber : AdvancedPipe
 	private MetaDataNode metaNode;
 	private MetaDataLayer metaDataLayer;
 
-	public override bool Attach()
+	public override bool ServerAttach()
 	{
-		if(base.Attach() == false)
+		if(base.ServerAttach() == false)
 		{
 			return false;
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
@@ -45,7 +45,10 @@ public class Scrubber : AdvancedPipe
 			// var suckedAir =  metaNode.GasMix / 2;
 			// pipenet.gasMix += suckedAir;
 			// metaNode.GasMix -= suckedAir;
-			metaNode.GasMix = new GasMix(GasMixes.Space);
+
+			//suck out a fraction of the current gasmix
+			var suckedAir = metaNode.GasMix / 4;
+			metaNode.GasMix -= suckedAir;
 			metaDataLayer.UpdateSystemsAt(RegisterTile.LocalPositionServer);
 		}
 	}


### PR DESCRIPTION
### Purpose
Part of #2639 . The mapping change needs to be made, however, to map airvents and scrubbers into each shuttle. I will do that in a different PR.

This also simplifies the logic of/removes stuff for pipenets in Pipe.cs that wasn't fully implemented and wasn't working anyway. Also simplifies logic / sprites for attaching / detaching them so it's clear what state it is.

Also makes connectors un-pushable.

AirVents now revert to their old behavior (turn tile into GasMix.Air) and Scrubbers were changed to remove a fraction of the gases from their tile (the old behavior for scrubbers was to turn their tile into Space gasmix which causes really strong wind). In my testing this combination produced the best results for gameplay. 

There is probably room for improvement but this should do for now. Trying to change the way that they worked too much was becoming a time sink, would rather focus on more pressing issues as long as this stuff is in a playable / working state.