### PR TITLE
Full spacesuit hide hair

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/MiningHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/MiningHardsuitHelmet.prefab
@@ -7,28 +7,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: initialName
-      value: mining hardsuit helmet
-      objectReference: {fileID: 0}
-    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: initialDescription
-      value: A special helmet designed for work in a hazardous, low pressure environment.
-        Has reinforced plating for wildlife encounters and dual floodlights.
-      objectReference: {fileID: 0}
-    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: isEVACapable
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 4e809dd5dff1ac0408db58d51e5487c8,
-        type: 3}
     - target: {fileID: 2179959185564930015, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Name
@@ -39,65 +17,16 @@ PrefabInstance:
       propertyPath: m_TagString
       value: Clothing
       objectReference: {fileID: 0}
-    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2293722870276993643, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: m_AssetId
+      propertyPath: clothData
       value: 
+      objectReference: {fileID: 11400000, guid: 4211cd5ce5094ab498bac3b63a8afd9d,
+        type: 2}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: hideClothingFlags
+      value: 2032
       objectReference: {fileID: 0}
     - target: {fileID: 2295559571915120171, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
@@ -154,11 +83,87 @@ PrefabInstance:
       propertyPath: HeatResistance
       value: 30000
       objectReference: {fileID: 0}
-    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+    - target: {fileID: 2293722870276993643, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
-      propertyPath: clothData
+      propertyPath: m_AssetId
       value: 
-      objectReference: {fileID: 11400000, guid: 4211cd5ce5094ab498bac3b63a8afd9d,
-        type: 2}
+      objectReference: {fileID: 0}
+    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2185168809060922027, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialName
+      value: mining hardsuit helmet
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialDescription
+      value: A special helmet designed for work in a hazardous, low pressure environment.
+        Has reinforced plating for wildlife encounters and dual floodlights.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: isEVACapable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 4e809dd5dff1ac0408db58d51e5487c8,
+        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7a048f6c330048e9a2358fb6f71d385, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SynidcateHardsuitHead.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SynidcateHardsuitHead.prefab
@@ -72,21 +72,16 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
-      propertyPath: initialName
-      value: blood-red hardsuit helmet
-      objectReference: {fileID: 0}
-    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+      propertyPath: clothData
+      value: 
+      objectReference: {fileID: 11400000, guid: 6a75b09ca69d8a045adc47a8f8997112,
+        type: 2}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
-      propertyPath: initialDescription
-      value: A dual-mode advanced helmet designed for work in special operations.
-        It is in EVA mode. Property of Gorlex Marauders.
-      objectReference: {fileID: 0}
-    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
-        type: 3}
-      propertyPath: isEVACapable
-      value: 1
+      propertyPath: hideClothingFlags
+      value: 2032
       objectReference: {fileID: 0}
     - target: {fileID: 2295559571915120171, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
@@ -153,12 +148,22 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
-      propertyPath: clothData
-      value: 
-      objectReference: {fileID: 11400000, guid: 6a75b09ca69d8a045adc47a8f8997112,
-        type: 2}
+      propertyPath: initialName
+      value: blood-red hardsuit helmet
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialDescription
+      value: A dual-mode advanced helmet designed for work in special operations.
+        It is in EVA mode. Property of Gorlex Marauders.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: isEVACapable
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/MiningHardsuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/MiningHardsuit.prefab
@@ -17,6 +17,22 @@ PrefabInstance:
       propertyPath: m_TagString
       value: Clothing
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialName
+      value: mining hardsuit
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialDescription
+      value: A special suit that protects against hazardous, low pressure environments.
+        Has reinforced plating for wildlife encounters.
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: isEVACapable
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3530414307939662948, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -132,33 +148,22 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 3611036598041473612, guid: a0c29a11d2c864b7982765b5340eed0e,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: b6265b678cb9a3c4b9b47d0ca43fcbcd,
-        type: 3}
-    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
-        type: 3}
-      propertyPath: initialName
-      value: mining hardsuit
-      objectReference: {fileID: 0}
-    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
-        type: 3}
-      propertyPath: initialDescription
-      value: A special suit that protects against hazardous, low pressure environments.
-        Has reinforced plating for wildlife encounters.
-      objectReference: {fileID: 0}
-    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
-        type: 3}
-      propertyPath: isEVACapable
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData
       value: 
       objectReference: {fileID: 11400000, guid: ab60e98a1ba74e24cbccb1290fbc6e92,
         type: 2}
+    - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: hideClothingFlags
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 3611036598041473612, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: b6265b678cb9a3c4b9b47d0ca43fcbcd,
+        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0c29a11d2c864b7982765b5340eed0e, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/SyndicateHardsuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/SyndicateHardsuit.prefab
@@ -17,6 +17,21 @@ PrefabInstance:
       propertyPath: m_TagString
       value: Clothing
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialName
+      value: blood-red hardsuit
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialDescription
+      value: An advanced hardsuit with built in energy shielding.
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: isEVACapable
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3530414307939662948, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -71,16 +86,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
-        type: 3}
-      propertyPath: initialName
-      value: blood-red hardsuit
-      objectReference: {fileID: 0}
-    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
-        type: 3}
-      propertyPath: initialDescription
-      value: An advanced hardsuit with built in energy shielding.
       objectReference: {fileID: 0}
     - target: {fileID: 3564244148772557028, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
@@ -156,8 +161,13 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: ab60e98a1ba74e24cbccb1290fbc6e92,
+      objectReference: {fileID: 11400000, guid: 96b702926e8fa6348a8964fd996b1761,
         type: 2}
+    - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: hideClothingFlags
+      value: 13
+      objectReference: {fileID: 0}
     - target: {fileID: 3611036598041473612, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Player/Resources/Player_V3(uNet).prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Player/Resources/Player_V3(uNet).prefab
@@ -795,7 +795,7 @@ Transform:
   - {fileID: 4304794156734570639}
   - {fileID: 4962232741225816}
   - {fileID: 4113773884394540}
-  - {fileID: 3952844223850906092}
+  - {fileID: 7860658775317605838}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1008,7 +1008,6 @@ MonoBehaviour:
   syncInterval: 0.1
   diagonalMovement: 1
   allowInput: 1
-  buckledObject: 4294967295
   moveList: 05000000060000000700000008000000
   pna: {fileID: 0}
   RunSpeed: 6
@@ -1122,6 +1121,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   registerTile: {fileID: 0}
+  floorDecal: {fileID: 0}
   isInitiallyNotPushable: 0
   pushPullSound: 
   soundDelayTime: 0
@@ -1191,6 +1191,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &6017414943583453005
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2322,7 +2325,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -902452607
   m_SortingLayer: 15
-  m_SortingOrder: 8
+  m_SortingOrder: 12
   m_Sprite: {fileID: 21300104, guid: fd3f3905eab5416c91b8df3b18a1e1e0, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -4939,6 +4942,12 @@ PrefabInstance:
       propertyPath: m_Name
       value: Light2D
       objectReference: {fileID: 0}
+    - target: {fileID: 114445607401685236, guid: e2b1333de46384f95876864de1911fff,
+        type: 3}
+      propertyPath: Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 7d4ab37af9168d243a3eead2ef5b5758,
+        type: 3}
     - target: {fileID: 4676201352523112, guid: e2b1333de46384f95876864de1911fff, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0.008
@@ -4983,22 +4992,16 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 23824325930050846, guid: e2b1333de46384f95876864de1911fff,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 33937463476659220, guid: e2b1333de46384f95876864de1911fff,
         type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 114445607401685236, guid: e2b1333de46384f95876864de1911fff,
+    - target: {fileID: 23824325930050846, guid: e2b1333de46384f95876864de1911fff,
         type: 3}
-      propertyPath: Sprite
+      propertyPath: m_Materials.Array.data[0]
       value: 
-      objectReference: {fileID: 21300000, guid: 7d4ab37af9168d243a3eead2ef5b5758,
-        type: 3}
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e2b1333de46384f95876864de1911fff, type: 3}
 --- !u!114 &4196149980577959187 stripped
@@ -5032,85 +5035,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4102488425209486}
     m_Modifications:
-    - target: {fileID: 1165960983247551198, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+    - target: {fileID: 8239968386569427463, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
         type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1165960983247551198, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1165960983247551198, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1165960983247551198, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1165960983247551198, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1165960983247551198, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3681712926237386885, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3681712926237386885, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3681712926237386885, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3681712926237386885, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5781423884290289158, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5781423884290289158, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5781423884290289158, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5781423884290289158, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5781423884290289158, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5781423884290289158, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
+      propertyPath: m_Name
+      value: ChatCanvas
       objectReference: {fileID: 0}
     - target: {fileID: 6615217630540879312, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
         type: 3}
@@ -5142,10 +5070,35 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6646321096472486983, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+    - target: {fileID: 1165960983247551198, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
         type: 3}
-      propertyPath: m_FontData.m_Alignment
-      value: 4
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1165960983247551198, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1165960983247551198, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1165960983247551198, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1165960983247551198, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1165960983247551198, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6868749942529127699, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
         type: 3}
@@ -5157,14 +5110,64 @@ PrefabInstance:
       propertyPath: bubbleOpacityNormal
       value: 0.7
       objectReference: {fileID: 0}
-    - target: {fileID: 8239968386569427463, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+    - target: {fileID: 5781423884290289158, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
         type: 3}
-      propertyPath: m_Name
-      value: ChatCanvas
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781423884290289158, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781423884290289158, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781423884290289158, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781423884290289158, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781423884290289158, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3681712926237386885, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3681712926237386885, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3681712926237386885, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3681712926237386885, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6646321096472486983, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
+        type: 3}
+      propertyPath: m_FontData.m_Alignment
+      value: 4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fe2ac855b478c5c4cb6e7df2634f28d3, type: 3}
---- !u!224 &3952844223850906092 stripped
+--- !u!224 &7860658775317605838 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6615217630540879312, guid: fe2ac855b478c5c4cb6e7df2634f28d3,
     type: 3}

--- a/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
+++ b/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
@@ -27,7 +27,7 @@ public class ClothingV2 : MonoBehaviour
 
 	[Tooltip("Determine when a piece of clothing hides another")]
 	[SerializeField, EnumFlag]
-	private ClothingHideFlags hideFlags;
+	private ClothingHideFlags hideClothingFlags;
 
 	private Dictionary<ClothingVariantType, int> variantStore = new Dictionary<ClothingVariantType, int>();
 	private List<int> variantList;
@@ -59,7 +59,7 @@ public class ClothingV2 : MonoBehaviour
 	/// <summary>
 	/// Determine when a piece of clothing hides another
 	/// </summary>
-	public ClothingHideFlags HideFlags => hideFlags;
+	public ClothingHideFlags HideClothingFlags => hideClothingFlags;
 
 
 	private SpriteDataHandler spriteDataHandler;
@@ -204,7 +204,7 @@ public enum ClothingHideFlags
 {
 	HIDE_NONE = 0,
 	HIDE_GLOVES =  1,
-	HIDE_SUITSTORAGE = 2,
+	HIDE_SUITSTORAGE = 2, // Not implemented
 	HIDE_JUMPSUIT = 4,
 	HIDE_SHOES = 8,
 	HIDE_MASK = 16,

--- a/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
+++ b/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
@@ -11,7 +11,6 @@ using Mirror;
 /// </summary>
 public class ClothingV2 : MonoBehaviour
 {
-
 	//TODO: This can probably be migrated to this component rather than using a separate SO, since
 	//there's probably no situation where we'd want to re-use the same cloth data on more than one item.
 	[Tooltip("Clothing data describing the various sprites for this clothing.")]
@@ -25,6 +24,10 @@ public class ClothingV2 : MonoBehaviour
 	[Tooltip("Type of variant to use of the clothing data.")]
 	[SerializeField]
 	private ClothingVariantType variantType;
+
+	[Tooltip("Determine when a piece of clothing hides another")]
+	[SerializeField, EnumFlag]
+	private ClothingHideFlags hideFlags;
 
 	private Dictionary<ClothingVariantType, int> variantStore = new Dictionary<ClothingVariantType, int>();
 	private List<int> variantList;
@@ -185,4 +188,26 @@ public enum ClothingVariantType
 	Default = 0,
 	Tucked = 1,
 	Skirt = 2
+}
+
+/// <summary>
+/// Bit flags which determine when a piece of clothing hides another. 
+/// IE a helmet hiding glasses.
+/// </summary>
+[Flags]
+public enum ClothingHideFlags
+{
+	HIDE_NONE = 0,
+	HIDE_GLOVES =  1,
+	HIDE_SUITSTORAGE = 2,
+	HIDE_JUMPSUIT = 4,
+	HIDE_SHOES = 8,
+	HIDE_MASK = 16,
+	HIDE_EARS = 32,
+	HIDE_EYES = 64,
+	HIDE_FACE = 128,
+	HIDE_HAIR = 256,
+	HIDE_FACIALHAIR = 512,
+	HIDE_NECK = 1024,
+	HIDE_ALL = ~0
 }

--- a/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
+++ b/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
@@ -56,6 +56,11 @@ public class ClothingV2 : MonoBehaviour
 	/// </summary>
 	public SpriteDataHandler SpriteDataHandler => spriteDataHandler;
 
+	/// <summary>
+	/// Determine when a piece of clothing hides another
+	/// </summary>
+	public ClothingHideFlags HideFlags => hideFlags;
+
 
 	private SpriteDataHandler spriteDataHandler;
 	private SpriteHandler inventoryIcon;

--- a/UnityProject/Assets/Scripts/Editor/Inspector/EnumFlagAttributePropertyDrawer.cs
+++ b/UnityProject/Assets/Scripts/Editor/Inspector/EnumFlagAttributePropertyDrawer.cs
@@ -1,0 +1,25 @@
+using System;
+using UnityEngine;
+using UnityEditor;
+
+/// <summary>
+/// Custom drawer for enum flags
+/// For more details, see https://docs.unity3d.com/ScriptReference/EditorGUILayout.EnumFlagsField.html
+/// </summary>
+[CustomPropertyDrawer(typeof(EnumFlagAttribute))]
+class EnumFlagAttributePropertyDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        label = EditorGUI.BeginProperty(position, label, property);
+
+        var oldValue = (Enum)fieldInfo.GetValue(property.serializedObject.targetObject);
+        var newValue = EditorGUI.EnumFlagsField(position, label, oldValue);
+        if (!newValue.Equals(oldValue))
+        {
+            property.intValue = (int)Convert.ChangeType(newValue, fieldInfo.FieldType);
+        }
+
+        EditorGUI.EndProperty();
+    }
+}

--- a/UnityProject/Assets/Scripts/Editor/Inspector/EnumFlagAttributePropertyDrawer.cs.meta
+++ b/UnityProject/Assets/Scripts/Editor/Inspector/EnumFlagAttributePropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7df0d6b5931274fda933de6e2e85e531
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -78,6 +78,8 @@ public class PlayerSprites : MonoBehaviour
 		foreach (ClothingItem c in GetComponentsInChildren<ClothingItem>())
 		{
 			clothes[c.name] = c;
+			// add listner in case clothing was changed
+			c.OnClothingEquiped += OnClothingEquipped;
 		}
 
 		SetupBodySprites();
@@ -366,6 +368,12 @@ public class PlayerSprites : MonoBehaviour
 	public bool HasClothingItem(NamedSlot? namedSlot)
 	{
 		return characterSprites.FirstOrDefault(ci => ci.Slot == namedSlot) != null;
+	}
+
+
+	private void OnClothingEquipped(ClothingV2 clothing, bool isEquiped)
+	{
+		Logger.Log($"Clothing {clothing} was equipped {isEquiped}!", Category.Inventory);
 	}
 }
 

--- a/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSprites.cs
@@ -44,6 +44,12 @@ public class PlayerSprites : MonoBehaviour
 	private PlayerHealth playerHealth;
 	private PlayerSync playerSync;
 
+	private ClothingHideFlags hideClothingFlags = ClothingHideFlags.HIDE_NONE;
+	/// <summary>
+	/// Define which piece of clothing are hidden (not rendering) right now
+	/// </summary>
+	public ClothingHideFlags HideClothingFlags => hideClothingFlags;
+
 	[Tooltip("Muzzle flash, should be on a child of the player gameobject")]
 	public LightSprite muzzleFlash;
 
@@ -373,8 +379,52 @@ public class PlayerSprites : MonoBehaviour
 
 	private void OnClothingEquipped(ClothingV2 clothing, bool isEquiped)
 	{
-		Logger.Log($"Clothing {clothing} was equipped {isEquiped}!", Category.Inventory);
+		//Logger.Log($"Clothing {clothing} was equipped {isEquiped}!", Category.Inventory);
+
+		// if new clothes equiped, add new hide flags
+		if (isEquiped)
+			hideClothingFlags |= clothing.HideClothingFlags;
+		// if player get off old clothes, we need to remove old flags
+		else
+			hideClothingFlags ^= clothing.HideClothingFlags;
+
+		// Update hide flags
+		ValidateHideFlags();
 	}
+
+	private void ValidateHideFlags()
+	{
+		// Need to check all flags with their gameobject names...
+		// TODO: it should be done much easier
+		ValidateHideFlag(ClothingHideFlags.HIDE_GLOVES, "hands");
+		ValidateHideFlag(ClothingHideFlags.HIDE_JUMPSUIT, "uniform");
+		ValidateHideFlag(ClothingHideFlags.HIDE_SHOES, "feet");
+		ValidateHideFlag(ClothingHideFlags.HIDE_MASK, "mask");
+		ValidateHideFlag(ClothingHideFlags.HIDE_EARS, "ear");
+		ValidateHideFlag(ClothingHideFlags.HIDE_EYES, "eyes");
+		ValidateHideFlag(ClothingHideFlags.HIDE_FACE, "face");
+		ValidateHideFlag(ClothingHideFlags.HIDE_HAIR, "Hair");
+		ValidateHideFlag(ClothingHideFlags.HIDE_FACIALHAIR, "beard");
+		ValidateHideFlag(ClothingHideFlags.HIDE_NECK, "neck");
+
+		// TODO: Not implemented yet?
+		//ValidateHideFlag(ClothingHideFlags.HIDE_SUITSTORAGE, "suit_storage");
+	}
+
+	private void ValidateHideFlag(ClothingHideFlags hideFlag, string name)
+	{
+		// Check if dictionary has entry about such clothing item name
+		if (!clothes.ContainsKey(name))
+		{
+			Logger.LogError($"Can't find {name} clothingItem linked to {hideFlag}");
+			return;
+		}
+
+		// Enable or disable based on hide flag
+		var isVisible = !hideClothingFlags.HasFlag(hideFlag);
+		clothes[name].gameObject.SetActive(isVisible);
+	}
+
 }
 
 public enum ClothingSprite

--- a/UnityProject/Assets/Scripts/Util/EnumFlagAttribute.cs
+++ b/UnityProject/Assets/Scripts/Util/EnumFlagAttribute.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+/// <summary>
+/// Display multi-select popup for Flags enum correctly.
+/// Keep in mind, all flags should be power of two to work corectly
+/// </summary>
+public class EnumFlagAttribute : PropertyAttribute
+{
+}

--- a/UnityProject/Assets/Scripts/Util/EnumFlagAttribute.cs.meta
+++ b/UnityProject/Assets/Scripts/Util/EnumFlagAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: accf4270f991743ef8f4ee56847bc716
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Fixes #1752 - now hardsuits hide hair, facial hair, shoes, gloves.
Also fixed syndi hardsuit (was previously linked to mining hardsuit sprites)
Also, facial hair sorting order is higher than outwear now.

### Notes:
This PR implements **ClothingHideFlags** [based on /tg/ .dm code](https://github.com/tgstation/tgstation/blob/5481515dff73d67f1d1a60b4a6fd3883d034c456/code/__DEFINES/inventory.dm#L51). It's a bit flag which determine when a piece of clothing hides another. 
This PR also add custom inspector attribute **EnumFlagAttribute**. It allows edit bitflags like an LayerMask.

![lighting](https://user-images.githubusercontent.com/6161335/73104176-d985ce00-3f06-11ea-8b70-f1f9131ac49f.gif)

