### PR TITLE
Stable atmos fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
@@ -482,8 +482,7 @@ public class MouseInputController : MonoBehaviour
 		{
 			//Check for items on the clicked position, and display them in the Item List Tab, if they're in reach
 			//and not FOV occluded
-			Vector3 position = MouseWorldPosition;
-			position.z = 0f;
+			Vector3Int position = MouseWorldPosition.CutToInt();
 			if (!lightingSystem.enabled || lightingSystem.IsScreenPointVisible(CommonInput.mousePosition))
 			{
 				if (PlayerManager.LocalPlayerScript.IsInReach(position, false))
@@ -499,6 +498,14 @@ public class MouseInputController : MonoBehaviour
 			}
 
 			UIManager.SetToolTip = $"clicked position: {Vector3Int.RoundToInt(position)}";
+			if (CustomNetworkManager.IsServer)
+			{
+				MatrixManager.ForMatrixAt(position, true, (matrix, localPos) =>
+				{
+					matrix.SubsystemManager.UpdateAt(localPos);
+					Logger.LogFormat($"Forcefully updated atmos at worldPos {position}/ localPos {localPos} of {matrix.Name}");
+				});
+			}
 			return true;
 		}
 		return false;

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
@@ -5,6 +5,7 @@ using Mirror;
 /// Struct that helps identify matrices
 public struct MatrixInfo
 {
+	public string Name => Matrix.gameObject.name;
 	public int Id;
 	public Matrix Matrix;
 	public MetaTileMap MetaTileMap;

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -876,6 +876,19 @@ public partial class MatrixManager : MonoBehaviour
 
 		return AtPoint( position.Value.RoundToInt(), isServer ).ObjectParent;
 	}
+
+	/// <summary>
+	/// Do something to matrix using its local position if you only know world position
+	/// ..and don't need the reference afterwards
+	/// </summary>
+	/// <param name="worldPos"></param>
+	/// <param name="isServer"></param>
+	/// <param name="matrixAction"></param>
+	public static void ForMatrixAt(Vector3Int worldPos, bool isServer, Action<MatrixInfo, Vector3Int> matrixAction)
+	{
+		var matrixAtPoint = AtPoint(worldPos, isServer);
+		matrixAction.Invoke(matrixAtPoint, WorldToLocalInt(worldPos, matrixAtPoint));
+	}
 }
 
 /// <summary>

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
@@ -55,29 +55,27 @@ namespace Atmospherics
 
 		private void Update(MetaDataNode node)
 		{
-			nodes.Clear();
-
-			if (!node.IsClosedAirlock)
-			{ //Gases are frozen within closed airlocks
-				nodes.Add(node);
+			//Gases are frozen within closed airlocks or walls
+			if ( node.IsOccupied || node.IsClosedAirlock )
+			{
+				return;
 			}
+
+			nodes.Clear();
+			nodes.Add(node);
 
 			node.AddNeighborsToList(ref nodes);
 
 			bool isPressureChanged = AtmosUtils.IsPressureChanged(node, out var windDirection, out var windForce);
-
-			if (node.IsOccupied || node.IsSpace || isPressureChanged)
+			if (isPressureChanged)
 			{
-				if (isPressureChanged)
-				{
-					node.ReactionManager.AddWindEvent(node, windDirection, windForce); //fixme: ass backwards
-				}
+				node.ReactionManager.AddWindEvent( node, windDirection, windForce );
 				Equalize();
+			}
 
-				for (int i = 1; i < nodes.Count; i++)
-				{
-					updateList.Enqueue(nodes[i]);
-				}
+			for (int i = 1; i < nodes.Count; i++)
+			{
+				updateList.Enqueue(nodes[i]);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
@@ -12,7 +12,7 @@ public class AtmosSystem : SubsystemBehaviour
 		{
 			MetaDataNode node = metaDataLayer.Get(position, false);
 
-			node.GasMix = new GasMix( (node.IsRoom||node.IsClosedAirlock) ? GasMixes.Air : GasMixes.Space );
+			node.GasMix = new GasMix( (node.IsRoom||node.IsOccupied) ? GasMixes.Air : GasMixes.Space );
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -243,7 +243,7 @@ namespace Atmospherics
 
 		public override string ToString()
 		{
-			return $"{Pressure} kPA, {Temperature} K, {Moles} mol, {Volume * 1000} L";
+			return $"{Pressure} kPA, {Temperature} K, {Moles} mol, {Volume}m^3 ";
 		}
 
 		private void Recalculate()

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -189,7 +189,7 @@ public class ReactionManager : MonoBehaviour
 			Logger.LogError("Hotspot position key was not found in the hotspots dictionary", Category.Atmos);
 			return;
 		}
-		
+
 		var exposure = FireExposure.FromMetaDataNode(hotspots[hotspotPosition], hotspotWorldPosition.To2Int(), atLocalPosition.To2Int(), atWorldPosition.To2Int());
 		if (isSideExposure)
 		{
@@ -248,7 +248,6 @@ public class ReactionManager : MonoBehaviour
 			node.WindForce = pressureDifference;
 			node.WindDirection = windDirection;
 			winds.Enqueue( node );
-			Logger.LogTraceFormat( LogAddingWindyNode, Category.Atmos, node.Position.To2Int(), windDirection, pressureDifference );
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SubsystemManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SubsystemManager.cs
@@ -39,6 +39,9 @@ public class SubsystemManager : NetworkBehaviour
 			return;
 		}
 
+		//ensuring no metadata tiles are created at non-zero Z
+		position.z = 0;
+
 		for (int i = 0; i < systems.Count; i++)
 		{
 			systems[i].UpdateAt(position);


### PR DESCRIPTION
### Purpose
Fills walls with air; ensures there are no MetaDataNodes created at non-zero Z
Fixes #1856 
Fixes #2610 

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
