### PR TITLE
Chat icon modifiers, fixed chat icon matrix rotation

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Player/Resources/Player_V3(uNet).prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Player/Resources/Player_V3(uNet).prefab
@@ -1934,7 +1934,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d845653319a64ba5a7817f7abd873f4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  exlaimSprite: {fileID: 21300000, guid: 3c54d977ea4ae8146b5ae55fb7e2e108, type: 3}
+  exclaimSprite: {fileID: 21300000, guid: 3c54d977ea4ae8146b5ae55fb7e2e108, type: 3}
   questionSprite: {fileID: 21300000, guid: 9a18b695db53b73488c31459c6c6915c, type: 3}
   talkSprite: {fileID: 21300000, guid: 40aefb2bf6760364ab60f17a2f9f57f1, type: 3}
 --- !u!1 &1308134912561008

--- a/UnityProject/Assets/Scripts/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.cs
@@ -162,6 +162,11 @@ public partial class Chat : MonoBehaviour
 		{
 			chatModifiers |= ChatModifier.Yell;
 		}
+		// Exclaim
+		else if (message.EndsWith("!"))
+		{
+			chatModifiers |= ChatModifier.Exclaim;
+		}
 
 		// Clown
 		if (sentByPlayer.Script.mind.occupation.JobType == JobType.CLOWN)

--- a/UnityProject/Assets/Scripts/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.cs
@@ -162,6 +162,11 @@ public partial class Chat : MonoBehaviour
 		{
 			chatModifiers |= ChatModifier.Yell;
 		}
+		// Question
+		else if (message.EndsWith("?"))
+		{
+			chatModifiers |= ChatModifier.Question;
+		}
 		// Exclaim
 		else if (message.EndsWith("!"))
 		{

--- a/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
@@ -39,7 +39,9 @@ public enum ChatChannel
 [Flags]
 public enum ChatModifier
 {
-	None 	= 0,
+	// The following comments are for easy reference. They may be out of date.
+	// See Chat.cs to see how a message's ChatModifier is determined.
+	None 	= 0,      // Default value
 	Drunk 	= 1 << 0,
 	Stutter = 1 << 1,
 	Mute 	= 1 << 2, // Dead, unconcious or naturally mute
@@ -48,7 +50,8 @@ public enum ChatModifier
 	Whisper = 1 << 5, // Message starts with "#"
 	Yell    = 1 << 6, // Message is in capital letters
 	Emote   = 1 << 7, // Message starts with "/me"
-	Exclaim = 1 << 8  // Message ends with a "!"
+	Exclaim = 1 << 8, // Message ends with a "!"
+	Question= 1 << 9 // Message ends with a "?"
 }
 
 public class ChatEvent

--- a/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
@@ -47,7 +47,8 @@ public enum ChatModifier
 	Clown 	= 1 << 4, // Having the clown occupation
 	Whisper = 1 << 5, // Message starts with "#"
 	Yell    = 1 << 6, // Message is in capital letters
-	Emote   = 1 << 7  // Message starts with "/me"
+	Emote   = 1 << 7, // Message starts with "/me"
+	Exclaim = 1 << 8  // Message ends with a "!"
 }
 
 public class ChatEvent

--- a/UnityProject/Assets/Scripts/Player/ChatIcon.cs
+++ b/UnityProject/Assets/Scripts/Player/ChatIcon.cs
@@ -31,6 +31,7 @@ public class ChatIcon : MonoBehaviour
 
 	/// <summary>
 	/// Turns on the talk icon and picks a suitable icon for the chat modifier.
+	/// Starts a coroutine to continue display the icon for a while.
 	/// </summary>
 	/// <param name="chatModifier">The player's chat modifier.</param>
 	public void TurnOnTalkIcon(ChatModifier chatModifier)
@@ -41,6 +42,9 @@ public class ChatIcon : MonoBehaviour
 				goto case ChatModifier.Exclaim;
 			case ChatModifier.Exclaim:
 				spriteRend.sprite = exclaimSprite;
+				break;
+			case ChatModifier.Question:
+				spriteRend.sprite = questionSprite;
 				break;
 			default:
 				spriteRend.sprite = talkSprite;

--- a/UnityProject/Assets/Scripts/Player/ChatIcon.cs
+++ b/UnityProject/Assets/Scripts/Player/ChatIcon.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 public class ChatIcon : MonoBehaviour
 {
-	public Sprite exlaimSprite;
+	public Sprite exclaimSprite;
 	public Sprite questionSprite;
 	private SpriteRenderer spriteRend;
 	public Sprite talkSprite;
@@ -17,11 +17,11 @@ public class ChatIcon : MonoBehaviour
 		spriteRend.enabled = false;
 	}
 
-	public void ToggleChatIcon(bool toggle)
+	public void ToggleChatIcon(bool toggle, ChatModifier chatModifier)
 	{
 		if (toggle)
 		{
-			TurnOnTalkIcon();
+			TurnOnTalkIcon(chatModifier);
 		}
 		else
 		{
@@ -29,10 +29,23 @@ public class ChatIcon : MonoBehaviour
 		}
 	}
 
-	//TODO needs work
-	public void TurnOnTalkIcon()
+	/// <summary>
+	/// Turns on the talk icon and picks a suitable icon for the chat modifier.
+	/// </summary>
+	/// <param name="chatModifier">The player's chat modifier.</param>
+	public void TurnOnTalkIcon(ChatModifier chatModifier)
 	{
-		spriteRend.sprite = talkSprite;
+		switch (chatModifier)
+		{
+			case ChatModifier.Yell:
+				goto case ChatModifier.Exclaim;
+			case ChatModifier.Exclaim:
+				spriteRend.sprite = exclaimSprite;
+				break;
+			default:
+				spriteRend.sprite = talkSprite;
+				break;
+		}
 		spriteRend.enabled = true;
 		if (coWaitToTurnOff != null)
 		{

--- a/UnityProject/Assets/Scripts/UI/PlayerChatBubble/PlayerChatBubble.cs
+++ b/UnityProject/Assets/Scripts/UI/PlayerChatBubble/PlayerChatBubble.cs
@@ -68,7 +68,7 @@ public class PlayerChatBubble : MonoBehaviour
 	[SerializeField]
 	private ChatIcon chatIcon;
 	[SerializeField]
-	private GameObject chatBubble;
+	private GameObject chatBubble = null;
 	[SerializeField]
 	private TextMeshProUGUI bubbleText;
 	[SerializeField]
@@ -85,11 +85,6 @@ public class PlayerChatBubble : MonoBehaviour
 	/// A cache for the cache bubble rect transform. For performance!
 	/// </summary>
 	private RectTransform chatBubbleRectTransform;
-
-	/// <summary>
-	/// The type of the current chat bubble.
-	/// </summary>
-	private BubbleType bubbleType = BubbleType.normal;
 
 	/// <summary>
 	/// Multiplies the elapse of display time per character left in the msgQueue (after the first element).
@@ -173,7 +168,7 @@ public class PlayerChatBubble : MonoBehaviour
 	{
 		if (!UseChatBubble())
 		{
-			chatIcon.ToggleChatIcon(toggle);
+			chatIcon.ToggleChatIcon(toggle, chatModifier);
 		}
 		else
 		{

--- a/UnityProject/Assets/Textures/interface/HUD/talk/talk_default1.png.meta
+++ b/UnityProject/Assets/Textures/interface/HUD/talk/talk_default1.png.meta
@@ -43,8 +43,8 @@ TextureImporter:
   spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 0
-  alignment: 0
-  spritePivot: {x: 0.5, y: 0.5}
+  alignment: 9
+  spritePivot: {x: 0.25, y: 0.16}
   spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1

--- a/UnityProject/Assets/Textures/interface/HUD/talk/talk_default2.png.meta
+++ b/UnityProject/Assets/Textures/interface/HUD/talk/talk_default2.png.meta
@@ -43,8 +43,8 @@ TextureImporter:
   spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 0
-  alignment: 0
-  spritePivot: {x: 0.5, y: 0.5}
+  alignment: 9
+  spritePivot: {x: 0.25, y: 0.16}
   spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1


### PR DESCRIPTION
![2020-01-25_21-36-49](https://user-images.githubusercontent.com/9169275/73127849-e79b2380-3fc6-11ea-80a4-28a83402dc25.gif)

### Purpose

* Chat icons now correctly rotate after rotating a shuttle ( Fixes https://github.com/unitystation/unitystation/issues/2735 , related https://github.com/unitystation/unitystation/issues/2569 )
  * This was accomplished by setting the position of chat icons on the player prefab to 0 and moving the sprite pivot instead.
* Added new question and exclaim chat modifiers.
* Chat icons now show some chat modifiers (question and exclaim)
* Fixed some chat-related editor warnings
### Notes:
* ~~The compile error in https://github.com/unitystation/unitystation/pull/2731 will have to be fixed before the project can be compiled.~~
* Adding more chat modifiers to chat icons seems an easy feature to implement.

### Self checks

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors 
- [x] The PR has been tested in editor
- [x] The PR has been tested on moving matrices
