### PR TITLE
Attempt at fixing #2728. Removed unused code in PlayerScript.cs

### DIFF
--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -81,6 +81,11 @@ public partial class Chat
 
 		var verb = "says,";
 
+		if ((modifiers & ChatModifier.Mute) == ChatModifier.Mute)
+		{
+			return "";
+		}
+
 		if ((modifiers & ChatModifier.Whisper) == ChatModifier.Whisper)
 		{
 			verb = "whispers,";

--- a/UnityProject/Assets/Scripts/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.cs
@@ -136,7 +136,7 @@ public partial class Chat : MonoBehaviour
 		if (playerConsciousState == ConsciousState.UNCONSCIOUS || playerConsciousState == ConsciousState.DEAD)
 		{
 			// Only the Mute modifier matters if the player cannot speak. We can skip everything else.
-			return ("", ChatModifier.Mute);
+			return (message, ChatModifier.Mute);
 		}
 
 		// Emote

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -291,35 +291,6 @@ public class PlayerScript : ManagedNetworkBehaviour, IMatrixRotation
 		return transmitChannels | receiveChannels;
 	}
 
-	public ChatModifier GetCurrentChatModifiers()
-	{
-		ChatModifier modifiers = ChatModifier.None;
-		if (IsGhost)
-		{
-			return ChatModifier.None;
-		}
-		if (playerHealth.IsCrit)
-		{
-			return ChatModifier.Mute;
-		}
-		if (playerHealth.IsSoftCrit)
-		{
-			modifiers |= ChatModifier.Whisper;
-		}
-
-		//TODO add missing modifiers
-		//TODO add if for being drunk
-		//ChatModifier modifiers = ChatModifier.Drunk;
-
-		if (mind.occupation.JobType == JobType.CLOWN)
-		{
-			modifiers |= ChatModifier.Clown;
-
-		}
-
-		return modifiers;
-	}
-
 	//Tooltips inspector bar
 	public void OnHoverStart()
 	{

--- a/UnityProject/Assets/Scripts/UI/PlayerChatBubble/PlayerChatBubble.cs
+++ b/UnityProject/Assets/Scripts/UI/PlayerChatBubble/PlayerChatBubble.cs
@@ -178,6 +178,12 @@ public class PlayerChatBubble : MonoBehaviour
 
 	private void AddChatBubbleMsg(string msg, ChatChannel channel, ChatModifier chatModifier)
 	{
+		// Cancel right away if the player cannot speak.
+		if ((chatModifier & ChatModifier.Mute) == ChatModifier.Mute)
+		{
+			return;
+		}
+
 		if (msg.Length > maxMessageLength)
 		{
 			while (msg.Length > maxMessageLength)


### PR DESCRIPTION

![2020-01-26_01-28-59](https://user-images.githubusercontent.com/9169275/73129064-a5c8a800-3fdb-11ea-8288-3cc102e43827.png)
### Purpose
* Fixes https://github.com/unitystation/unitystation/issues/2728 (OOC chat breaking when dead)
* Removes some unused code

### Notes:
The reason the OOC chat broke was because chat messages were completely emptied ("") when a player has the "mute" modifier. However, this modifier is not important when talking on certain channels, such as the OOC or ghost channel.

This bug was introduced when I reworked how chat messages are processed. https://github.com/unitystation/unitystation/pull/2708

I've restored how the chat log reacts to mute players. It *should* work like it did before.

Chat bubbles now ignore the messages of mute players.

### Checks:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor


No extensive multiplayer tests were performed. Additional fixes will be required if one of these things occur:
* Mute players being able to talk on certain channels
* Dead players still not being able to talk OOC
