### PR TITLE
Various Bug fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -51,7 +51,12 @@ public partial class Chat
 	private static (string, ChatModifier) ProcessMessage(ConnectedPlayer sentByPlayer, string message)
 	{
 		ChatModifier chatModifiers = ChatModifier.None; // Modifier that will be returned in the end.
-		ConsciousState playerConsciousState = sentByPlayer.Script.playerHealth.ConsciousState;
+		ConsciousState playerConsciousState = ConsciousState.DEAD;
+		
+		if (sentByPlayer.Script.playerHealth != null)
+		{
+			playerConsciousState = sentByPlayer.Script.playerHealth.ConsciousState;
+		}
 
 		if (playerConsciousState == ConsciousState.UNCONSCIOUS || playerConsciousState == ConsciousState.DEAD)
 		{

--- a/UnityProject/Assets/Scripts/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.cs
@@ -1,11 +1,6 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using System;
-using System.Text;
 using Tilemaps.Behaviours.Meta;
-using System.Linq;
-using System.Text.RegularExpressions;
 
 /// <summary>
 /// The Chat API
@@ -112,117 +107,6 @@ public partial class Chat : MonoBehaviour
 				Instance.addChatLogServer.Invoke(chatEvent);
 			}
 		}
-	}
-
-	/// <summary>
-	/// Processes a message to be used in the chat log and chat bubbles.
-	/// 1. Detects which modifiers should be present in the messages.
-	///    - Some of the modifiers will come from the player being unconcious, being a clown, etc.
-	///    - Other modifiers are voluntary, such as shouting. They normally cannot override involuntary modifiers.
-	///    - Certain emotes override each other and will never be present at the same time.
-	///      - Emote overrides whispering, and whispering overrides yelling.
-	/// 2. Modifies the message to match the previously detected modifiers.
-	///    - Stutters, honks, drunkenness, etc. are directly applied to the message.
-	///    - The chat log and chat bubble may add minor changes to the text, such as narration ("Player says, ...").
-	/// </summary>
-	/// <param name="sendByPlayer">The player sending the message. Used for detecting conciousness and occupation.</param>
-	/// <param name="message">The chat message to process.</param>
-	/// <returns>A tuple of the processed chat message and the detected modifiers.</returns>
-	private static (string, ChatModifier) ProcessMessage(ConnectedPlayer sentByPlayer, string message)
-	{
-		ChatModifier chatModifiers = ChatModifier.None; // Modifier that will be returned in the end.
-		ConsciousState playerConsciousState = sentByPlayer.Script.playerHealth.ConsciousState;
-
-		if (playerConsciousState == ConsciousState.UNCONSCIOUS || playerConsciousState == ConsciousState.DEAD)
-		{
-			// Only the Mute modifier matters if the player cannot speak. We can skip everything else.
-			return (message, ChatModifier.Mute);
-		}
-
-		// Emote
-		if (message.StartsWith("/me "))
-		{
-			message = message.Substring(4);
-			chatModifiers |= ChatModifier.Emote;
-		}
-		// Whisper
-		else if (message.StartsWith("#"))
-		{
-			message = message.Substring(1);
-			chatModifiers |= ChatModifier.Whisper;
-		}
-		// Involuntaly whisper due to not being fully concious
-		else if (playerConsciousState == ConsciousState.BARELY_CONSCIOUS)
-		{
-			chatModifiers |= ChatModifier.Whisper;
-		}
-		// Yell
-		else if ((message == message.ToUpper(System.Globalization.CultureInfo.InvariantCulture) // Is it all caps?
-			&& message.Any(char.IsLetter)))// AND does it contain at least one letter?
-		{
-			chatModifiers |= ChatModifier.Yell;
-		}
-		// Question
-		else if (message.EndsWith("?"))
-		{
-			chatModifiers |= ChatModifier.Question;
-		}
-		// Exclaim
-		else if (message.EndsWith("!"))
-		{
-			chatModifiers |= ChatModifier.Exclaim;
-		}
-
-		// Clown
-		if (sentByPlayer.Script.mind.occupation.JobType == JobType.CLOWN)
-		{
-			int intensity = UnityEngine.Random.Range(1, 4);
-			for (int i = 0; i < intensity; i++)
-			{
-				message += " HONK!";
-			}
-			chatModifiers |= ChatModifier.Clown;
-		}
-
-		// TODO None of the followinger modifiers are currently in use.
-		// They have been commented out to prevent compile warnings.
-
-		// Stutter
-		//if (false) // TODO Currently players can not stutter.
-		//{
-		//	//Stuttering people randomly repeat beginnings of words
-		//	//Regex - find word boundary followed by non digit, non special symbol, non end of word letter. Basically find the start of words.
-		//	Regex rx = new Regex(@"(\b)+([^\d\W])\B");
-		//	message = rx.Replace(message, Stutter);
-		//	chatModifiers |= ChatModifier.Stutter;
-		//}
-		//
-		//// Hiss
-		//if (false) // TODO Currently players can never speak like a snek.
-		//{
-		//	Regex rx = new Regex("s+|S+");
-		//	message = rx.Replace(message, Hiss);
-		//	chatModifiers |= ChatModifier.Hiss;
-		//}
-		//
-		//// Drunk
-		//if (false) // TODO Currently players can not get drunk.
-		//{
-		//	//Regex - find 1 or more "s"
-		//	Regex rx = new Regex("s+|S+");
-		//	message = rx.Replace(message, Slur);
-		//	//Regex - find 1 or more whitespace
-		//	rx = new Regex(@"\s+");
-		//	message = rx.Replace(message, Hic);
-		//	//50% chance to ...hic!... at end of sentance
-		//	if (UnityEngine.Random.Range(1, 3) == 1)
-		//	{
-		//		message = message + " ...hic!...";
-		//	}
-		//	chatModifiers |= ChatModifier.Drunk;
-		//}
-
-		return (message, chatModifiers);
 	}
 
 	/// <summary>
@@ -451,17 +335,6 @@ public partial class Chat : MonoBehaviour
 		});
 	}
 
-	#region Destroy Message
-
-	private static Dictionary<string, UniqueQueue<DestroyChatMessage>> messageQueueDict = new Dictionary<string, UniqueQueue<DestroyChatMessage>>();
-	private static Coroutine composeMessageHandle;
-	private static StringBuilder stringBuilder = new StringBuilder();
-	private struct DestroyChatMessage
-	{
-		public string Message;
-		public Vector2Int WorldPosition;
-	}
-
 	/// <summary>
 	/// Allows grouping destruction messages into one if they happen in short period of time.
 	/// Average position is calculated in that case.
@@ -483,57 +356,6 @@ public partial class Chat : MonoBehaviour
 			Instance.StartCoroutine(Instance.ComposeDestroyMessage(), ref composeMessageHandle);
 		}
 	}
-
-
-
-	private IEnumerator ComposeDestroyMessage()
-	{
-		yield return WaitFor.Seconds(0.3f);
-
-		foreach (var postfix in messageQueueDict.Keys)
-		{
-			var messageQueue = messageQueueDict[postfix];
-
-			if (messageQueue.IsEmpty)
-			{
-				Instance.TryStopCoroutine(ref composeMessageHandle);
-				continue;
-			}
-
-			//Normal separate messages with precise location
-			if (messageQueue.Count <= 3)
-			{
-				while (messageQueue.TryDequeue(out var msg))
-				{
-					AddLocalMsgToChat(msg.Message + postfix, msg.WorldPosition);
-				}
-				continue;
-			}
-
-			//Combined message at average position
-			stringBuilder.Clear();
-
-			int averageX = 0;
-			int averageY = 0;
-			int count = 1;
-
-			while (messageQueue.TryDequeue(out DestroyChatMessage msg))
-			{
-				if (count > 1)
-				{
-					stringBuilder.Append(", ");
-				}
-				stringBuilder.Append(msg.Message);
-				averageX += msg.WorldPosition.x;
-				averageY += msg.WorldPosition.y;
-				count++;
-			}
-
-			AddLocalMsgToChat(stringBuilder.Append(postfix).ToString(), new Vector2Int(averageX / count, averageY / count));
-		}
-	}
-
-	#endregion
 
 	/// <summary>
 	/// For any other local messages that are not an Action or a Combat Action.
@@ -632,43 +454,5 @@ public partial class Chat : MonoBehaviour
 	{
 		AddExamineMsg(recipient, message,
 			CustomNetworkManager.IsServer ? NetworkSide.Server : NetworkSide.Client);
-	}
-
-	/// <summary>
-	/// This should only be called via UpdateChatMessage
-	/// on the client. Do not use for anything else!
-	/// </summary>
-	public static void ProcessUpdateChatMessage(uint recipient, uint originator, string message,
-		string messageOthers, ChatChannel channels, ChatModifier modifiers, string speaker)
-	{
-		//If there is a message in MessageOthers then determine
-		//if it should be the main message or not.
-		if (!string.IsNullOrEmpty(messageOthers))
-		{
-			//This is not the originator so use the messageOthers
-			if (recipient != originator)
-			{
-				message = messageOthers;
-			}
-		}
-
-		var msg = ProcessMessageFurther(message, speaker, channels, modifiers);
-		Instance.addChatLogClient.Invoke(msg, channels);
-	}
-
-	private static string InTheZone(BodyPartType hitZone)
-	{
-		return hitZone == BodyPartType.None ? "" : $" in the {hitZone.ToString().ToLower().Replace("_", " ")}";
-	}
-
-	private static bool IsServer()
-	{
-		if (!CustomNetworkManager.Instance._isServer)
-		{
-			Logger.LogError("A server only method was called on a client in chat.cs", Category.Chat);
-			return false;
-		}
-
-		return true;
 	}
 }

--- a/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
@@ -25,6 +25,12 @@ public class ChatEntry : MonoBehaviour
 	private Image stackCircle;
 	private int stackTimes = 1;
 	private string adminId;
+	private Vector3 localScaleCache;
+
+	void Awake()
+	{
+		localScaleCache = stackTimesObj.transform.localScale;
+	}
 
 	void OnEnable()
 	{
@@ -166,7 +172,6 @@ public class ChatEntry : MonoBehaviour
 	IEnumerator StackPumpAnim()
 	{
 		yield return WaitFor.EndOfFrame;
-		var localScaleCache = stackTimesObj.transform.localScale;
 		var targetScale = localScaleCache * 1.1f;
 		var progress = 0f;
 		while (progress < 1f)
@@ -183,6 +188,8 @@ public class ChatEntry : MonoBehaviour
 			stackTimesObj.transform.localScale = Vector3.Lerp(targetScale, localScaleCache, progress);
 			yield return WaitFor.EndOfFrame;
 		}
+
+		stackTimesObj.transform.localScale = localScaleCache;
 	}
 
 	//state = is mouse button down on the scroll bar handle

--- a/UnityProject/Assets/Scripts/Lifecycle/Spawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/Spawn.cs
@@ -247,11 +247,14 @@ public static class Spawn
 	/// <returns></returns>
 	private static SpawnResult Server(SpawnInfo info)
 	{
+		Debug.Log("1");
 		if (info == null)
 		{
+			Debug.Log("2");
 			Logger.LogError("Cannot spawn, info is null", Category.ItemSpawn);
 			return SpawnResult.Fail(info);
 		}
+		Debug.Log("3");
 		EnsureInit();
 		Logger.LogTraceFormat("Server spawning {0}", Category.ItemSpawn, info);
 

--- a/UnityProject/Assets/Scripts/Lifecycle/Spawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/Spawn.cs
@@ -247,14 +247,12 @@ public static class Spawn
 	/// <returns></returns>
 	private static SpawnResult Server(SpawnInfo info)
 	{
-		Debug.Log("1");
 		if (info == null)
 		{
-			Debug.Log("2");
 			Logger.LogError("Cannot spawn, info is null", Category.ItemSpawn);
 			return SpawnResult.Fail(info);
 		}
-		Debug.Log("3");
+
 		EnsureInit();
 		Logger.LogTraceFormat("Server spawning {0}", Category.ItemSpawn, info);
 

--- a/UnityProject/Assets/Scripts/Messages/Server/HealthMessages/HealthConsciousMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/HealthMessages/HealthConsciousMessage.cs
@@ -15,7 +15,16 @@ public class HealthConsciousMessage : ServerMessage
 	public override IEnumerator Process()
 	{
 		yield return WaitFor(EntityToUpdate);
-		NetworkObject.GetComponent<LivingHealthBehaviour>().UpdateClientConsciousState(ConsciousState);
+		var healthBehaviour = NetworkObject.GetComponent<LivingHealthBehaviour>();
+
+		if (healthBehaviour != null)
+		{
+			healthBehaviour.UpdateClientConsciousState(ConsciousState);
+		}
+		else
+		{
+			Logger.Log($"Living health behaviour not found for {NetworkObject.ExpensiveName()} skipping conscious state update", Category.Health);
+		}
 	}
 
 	public static HealthConsciousMessage Send(GameObject recipient, GameObject entityToUpdate, ConsciousState consciousState)

--- a/UnityProject/Assets/Scripts/Objects/Directional.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directional.cs
@@ -158,6 +158,9 @@ public class Directional : NetworkBehaviour, IMatrixRotation
 	    //note: doing it this way (internal TargetRpc passing serverDirection)
 	    //so we are guaranteed that the client has the correct
 	    //server direction when we force them to sync to it.
+	    if (target == null) return;
+	    if (target.connectionId == -1) return;
+
 	    TargetForceSyncDirection(target, serverDirection);
     }
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -82,11 +82,11 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 	/// </summary>
 	/// <param name="worldPos"></param>
 	/// <returns></returns>
-	public LayerTile LayerTileAt(Vector2 worldPos)
+	public LayerTile LayerTileAt(Vector2 worldPos, bool ignoreEffectsLayer = false)
 	{
 		Vector3Int pos = objectLayer.transform.InverseTransformPoint(worldPos).RoundToInt();
 
-		return metaTileMap.GetTile(pos);
+		return metaTileMap.GetTile(pos, ignoreEffectsLayer);
 	}
 
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -241,13 +241,15 @@ public class MetaTileMap : MonoBehaviour
 	/// <param name="cellPosition">cell position within the tilemap to get the tile of. NOT the same
 	/// as world position.</param>
 	/// <returns></returns>
-	public LayerTile GetTile(Vector3Int cellPosition)
+	public LayerTile GetTile(Vector3Int cellPosition, bool ignoreEffectsLayer = false)
 	{
 		for (var i = 0; i < LayersValues.Length; i++)
 		{
 			LayerTile tile = LayersValues[i].GetTile(cellPosition);
 			if (tile != null)
 			{
+				if (ignoreEffectsLayer && tile.LayerType == LayerType.Effects) continue;
+				
 				return tile;
 			}
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -518,7 +518,7 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 			SoundManager.PlayNetworkedAtPos("GrillHit", bulletHitTarget, 1f);
 
 			//Spawn rods:
-			if (Random.value < 0.4f)
+			if (Random.value < 0.7f)
 			{
 				SpawnRods(bulletHitTarget);
 			}
@@ -556,21 +556,20 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 	private void SpawnMetal(Vector3 pos)
 	{
 		Spawn.ServerPrefab("Metal", pos.CutToInt(), count: 1,
-			scatterRadius: Spawn.DefaultScatterRadius, cancelIfImpassable: true);
+			scatterRadius: Spawn.DefaultScatterRadius);
 	}
 	private void SpawnRods(Vector3 pos)
 	{
 		Spawn.ServerPrefab("Rods", pos.CutToInt(), count: 1,
-			scatterRadius: Spawn.DefaultScatterRadius, cancelIfImpassable: true);
+			scatterRadius: Spawn.DefaultScatterRadius);
 	}
 
 	private void SpawnGlassShards(Vector3 pos)
 	{
 		//Spawn 2-4 glass shards
-		var t = Spawn.ServerPrefab("GlassShard", pos, count: Random.Range(2, 4),
-			scatterRadius: Spawn.DefaultScatterRadius, cancelIfImpassable: true);
+		Spawn.ServerPrefab("GlassShard", pos, count: Random.Range(2, 4),
+			scatterRadius: Spawn.DefaultScatterRadius);
 
-		Debug.Log("IS SUCCESSFUL " + t.Successful);
 		//Play the breaking window sfx:
 		SoundManager.PlayNetworkedAtPos("GlassBreak0#", pos, 1f);
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -268,7 +268,7 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 		MetaDataNode data = metaDataLayer.Get(cellPos);
 
 		//look up layer tile so we can calculate damage
-		var layerTile = metaTileMap.GetTile(cellPos);
+		var layerTile = metaTileMap.GetTile(cellPos, true);
 		if (layerTile is BasicTile basicTile)
 		{
 			//TODO: Incorporate more resistance, not just indestructible
@@ -463,10 +463,10 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 	/// <param name="damage">The amount of damage the window received</param>
 	/// <param name="data">The data about the current state of this window</param>
 	/// <param name="cellPos">The position of the window tile</param>
-	/// <param name="bulletHitTarget">Where exactly the bullet hit</param>
+	/// <param name="hitPos">Where exactly the bullet hit</param>
 	/// <param name="attackType">The type of attack that did the damage</param>
 	/// <returns>The remaining damage to apply to the tile if the window is broken, 0 otherwise.</returns>
-	private float AddWindowDamage(float damage, MetaDataNode data, Vector3Int cellPos, Vector3 bulletHitTarget, AttackType attackType)
+	private float AddWindowDamage(float damage, MetaDataNode data, Vector3Int cellPos, Vector3 hitPos, AttackType attackType)
 	{
 		data.Damage += REINFORCED_WINDOW_ARMOR.GetDamage(damage, attackType);
 		if (data.Damage >= 20 && data.Damage < 50 && data.WindowDamage < WindowDamageLevel.Crack01)
@@ -493,10 +493,10 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 			tileChangeManager.RemoveTile(cellPos, LayerType.Windows);
 
 			//Spawn 3 glass shards with different sprites:
-			SpawnGlassShards(bulletHitTarget);
+			SpawnGlassShards(hitPos);
 
 			//Play the breaking window sfx:
-			SoundManager.PlayNetworkedAtPos("GlassBreak0#", bulletHitTarget, 1f);
+			SoundManager.PlayNetworkedAtPos("GlassBreak0#", hitPos, 1f);
 
 			data.WindowDamage = WindowDamageLevel.Broken;
 			return data.ResetDamage() - MAX_WINDOW_DAMAGE;
@@ -567,9 +567,10 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 	private void SpawnGlassShards(Vector3 pos)
 	{
 		//Spawn 2-4 glass shards
-		Spawn.ServerPrefab("GlassShard", pos, count: Random.Range(2, 4),
+		var t = Spawn.ServerPrefab("GlassShard", pos, count: Random.Range(2, 4),
 			scatterRadius: Spawn.DefaultScatterRadius, cancelIfImpassable: true);
 
+		Debug.Log("IS SUCCESSFUL " + t.Successful);
 		//Play the breaking window sfx:
 		SoundManager.PlayNetworkedAtPos("GlassBreak0#", pos, 1f);
 	}

--- a/UnityProject/Assets/Scripts/UI/Lobby/SongTracker.cs
+++ b/UnityProject/Assets/Scripts/UI/Lobby/SongTracker.cs
@@ -76,6 +76,7 @@ public class SongTracker : MonoBehaviour
 	{
 		trackName.gameObject.SetActive(isActive);
 		artist.gameObject.SetActive(isActive);
+		speakerImage.gameObject.SetActive(isActive);
 	}
 
 	public void ToggleMusicMute()

--- a/UnityProject/Assets/Scripts/Weapons/Meleeable.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Meleeable.cs
@@ -68,7 +68,7 @@ public class Meleeable : MonoBehaviour, IPredictedCheckedInteractable<Positional
 		//if attacking tiles, only some layers are allowed to be attacked
 		if (interactableTiles != null)
 		{
-			var tileAt = interactableTiles.LayerTileAt(interaction.WorldPositionTarget);
+			var tileAt = interactableTiles.LayerTileAt(interaction.WorldPositionTarget, true);
 
 			//Nothing there, could be space?
 			if (tileAt == null) return false;
@@ -99,7 +99,7 @@ public class Meleeable : MonoBehaviour, IPredictedCheckedInteractable<Positional
 		if (interactableTiles != null)
 		{
 			//attacking tiles
-			var tileAt = interactableTiles.LayerTileAt(interaction.WorldPositionTarget);
+			var tileAt = interactableTiles.LayerTileAt(interaction.WorldPositionTarget, true);
 			wna.ServerPerformMeleeAttack(gameObject, interaction.TargetVector, BodyPartType.None, tileAt.LayerType);
 		}
 		else

--- a/UnityProject/Assets/Scripts/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Weapons/WeaponNetworkActions.cs
@@ -122,6 +122,7 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 				.GetComponent<TilemapDamage>();
 			if (tileMapDamage != null)
 			{
+				attackSoundName = "";
 				var worldPos = (Vector2)transform.position + attackDirection;
 				attackedTile = tileChangeManager.InteractableTiles.LayerTileAt(worldPos, true);
 				tileMapDamage.DoMeleeDamage(worldPos,
@@ -169,7 +170,11 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 		//common logic to do if we hit something
 		if (didHit)
 		{
-			SoundManager.PlayNetworkedAtPos(attackSoundName, transform.position);
+			if (!string.IsNullOrEmpty(attackSoundName))
+			{
+				SoundManager.PlayNetworkedAtPos(attackSoundName, transform.position);
+			}
+
 			if (damage > 0)
 			{
 				Chat.AddAttackMsgToChat(gameObject, victim, damageZone, weapon, attackedTile: attackedTile);

--- a/UnityProject/Assets/Scripts/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Weapons/WeaponNetworkActions.cs
@@ -123,7 +123,7 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 			if (tileMapDamage != null)
 			{
 				var worldPos = (Vector2)transform.position + attackDirection;
-				attackedTile = tileChangeManager.InteractableTiles.LayerTileAt(worldPos);
+				attackedTile = tileChangeManager.InteractableTiles.LayerTileAt(worldPos, true);
 				tileMapDamage.DoMeleeDamage(worldPos,
 					gameObject, (int)damage);
 				didHit = true;


### PR DESCRIPTION
- Disables the lobby music button when not needed
- Fixed a bug where you could not melee attack a window with a crack in it
- Fixed missing glass shards on broken windows
- Fixed connection id error when sending directional updates to non player controlled bodies. Fixes #2749
- Catches and displays an error for missing LivingHealthBehaviour component in conscious state update message
- Fixes #2348 
- Cleans up chat.cs