### PR TITLE
Collision atmos

### DIFF
--- a/UnityProject/Assets/Scripts/Editor/Matrix/Utils/GizmoUtils.cs
+++ b/UnityProject/Assets/Scripts/Editor/Matrix/Utils/GizmoUtils.cs
@@ -103,6 +103,21 @@ public static class GizmoUtils
 		Gizmos.DrawWireCube(position + (local ? HalfOne: Vector3.zero), Vector3.one * size);
 	}
 
+	public static void DrawRay(Vector3 pos, Vector3 direction, bool local=true)
+	{
+		if (direction == Vector3.zero)
+		{
+			return;
+		}
+
+		if ( local )
+		{
+			pos += HalfOne;
+		}
+
+		Gizmos.DrawRay(pos, direction);
+	}
+
 	public static void DrawArrow(Vector3 pos, Vector3 direction, bool local=true, float arrowHeadLength = 0.25f, float arrowHeadAngle = 20.0f)
 	{
 		if (direction == Vector3.zero)

--- a/UnityProject/Assets/Scripts/Editor/Matrix/Views/MetaDataView.cs
+++ b/UnityProject/Assets/Scripts/Editor/Matrix/Views/MetaDataView.cs
@@ -131,6 +131,22 @@ public class MetaDataView : BasicView
 				GizmoUtils.DrawText($"{neighborCount}", p, false);
 			}
 		}
+
+		public override void DrawGizmo(MetaDataLayer source, Vector3Int position)
+		{
+			MetaDataNode node = source.Get(position, false);
+			foreach (MetaDataNode neighbor in node.Neighbors)
+			{
+				if (neighbor != null)
+				{
+					Vector3 p2 = LocalToWorld(neighbor.ReactionManager, neighbor.Position);
+
+					p2 = WorldToLocal(source, p2);
+
+					GizmoUtils.DrawRay(position, p2 - position);
+				}
+			}
+		}
 	}
 
 	private class PressureCheck : Check<MetaDataLayer>
@@ -305,8 +321,13 @@ public class MetaDataView : BasicView
 		}
 	}
 
-	private static Vector3 LocalToWorld(Component source, Vector3Int position)
+	private static Vector3 LocalToWorld(Component source, Vector3 position)
 	{
 		return MatrixManager.LocalToWorld(position, MatrixManager.Get(source.GetComponent<Matrix>()));
+	}
+
+	private static Vector3 WorldToLocal(Component source, Vector3 position)
+	{
+		return MatrixManager.WorldToLocal(position, MatrixManager.Get(source.GetComponent<Matrix>()));
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -81,7 +81,7 @@ public class MetaDataSystem : SubsystemBehaviour
 		else
 		{
 			node.Type = NodeType.Occupied;
-			if ( matrix.GetFirst<RegisterDoor>(localPosition, true) )
+			if (matrix.GetFirst<RegisterDoor>(localPosition, true))
 			{
 				node.IsClosedAirlock = true;
 			}
@@ -105,7 +105,7 @@ public class MetaDataSystem : SubsystemBehaviour
 			MetaDataNode node = metaDataLayer.Get(position);
 			node.Type = NodeType.Occupied;
 
-			if ( matrix.GetFirst<RegisterDoor>(position, true) )
+			if (matrix.GetFirst<RegisterDoor>(position, true))
 			{
 				node.IsClosedAirlock = true;
 			}
@@ -202,23 +202,26 @@ public class MetaDataSystem : SubsystemBehaviour
 					externalNodes[node] = node;
 				}
 
-				Vector3 neighborWorldPosition = MatrixManager.LocalToWorldInt(neighbor, MatrixManager.Get(matrix.Id));
-
-				if (!MatrixManager.IsSpaceAt(neighborWorldPosition.RoundToInt(), true))
+				if (!node.IsSpace)
 				{
-					MatrixInfo matrixInfo = MatrixManager.AtPoint(neighborWorldPosition.RoundToInt(), true);
+					Vector3 neighborWorldPosition = MatrixManager.LocalToWorldInt(neighbor, MatrixManager.Get(matrix.Id));
 
-					if (matrixInfo.MetaTileMap != metaTileMap)
+					if (!MatrixManager.IsSpaceAt(neighborWorldPosition.RoundToInt(), true))
 					{
-						Vector3Int neighborlocalPosition = MatrixManager.WorldToLocalInt(neighborWorldPosition, matrixInfo);
-						Vector3Int nodeLocalPosition = MatrixManager.WorldToLocalInt(nodeWorldPosition, matrixInfo);
+						MatrixInfo matrixInfo = MatrixManager.AtPoint(neighborWorldPosition.RoundToInt(), true);
 
-						if (matrixInfo.MetaTileMap.IsAtmosPassableAt(nodeLocalPosition, neighborlocalPosition, true))
+						if (matrixInfo.MetaTileMap != metaTileMap)
 						{
-							node.AddNeighbor(matrixInfo.MetaDataLayer.Get(neighborlocalPosition));
-						}
+							Vector3Int neighborlocalPosition = MatrixManager.WorldToLocalInt(neighborWorldPosition, matrixInfo);
+							Vector3Int nodeLocalPosition = MatrixManager.WorldToLocalInt(nodeWorldPosition, matrixInfo);
 
-						continue;
+							if (matrixInfo.MetaTileMap.IsAtmosPassableAt(nodeLocalPosition, neighborlocalPosition, true))
+							{
+								node.AddNeighbor(matrixInfo.MetaDataLayer.Get(neighborlocalPosition));
+							}
+
+							continue;
+						}
 					}
 				}
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -10,10 +10,12 @@ using UnityEngine;
 /// </summary>
 public class MetaDataSystem : SubsystemBehaviour
 {
+	// Set higher priority to ensure that it is executed before other systems
 	public override int Priority => 100;
 
 	/// <summary>
 	/// Nodes which exist in space next to room tiles of the matrix.
+	/// These are regularly checked for tiles from other matrices, i.e. they build the bridge to other matrices
 	/// </summary>
 	private ConcurrentDictionary<MetaDataNode, MetaDataNode> externalNodes;
 
@@ -23,8 +25,6 @@ public class MetaDataSystem : SubsystemBehaviour
 	private Matrix matrix;
 
 	private int roomCounter = 0;
-
-	// Set higher priority to ensure that it is executed before other systems
 
 	public override void Awake()
 	{
@@ -69,6 +69,9 @@ public class MetaDataSystem : SubsystemBehaviour
 		MetaUtils.RemoveFromNeighbors(node);
 		externalNodes.TryRemove(node, out MetaDataNode nothing);
 
+		node.IsClosedAirlock = false;
+
+		// If the node is atmos passable (i.e. space or room), we need to setup its neighbors again, otherwise it's occupied and does need a neighbor check
 		if (metaTileMap.IsAtmosPassableAt(localPosition, true))
 		{
 			node.ClearNeighbors();
@@ -76,7 +79,6 @@ public class MetaDataSystem : SubsystemBehaviour
 			node.Type = metaTileMap.IsSpaceAt(localPosition, true) ? NodeType.Space : NodeType.Room;
 			SetupNeighbors(node);
 			MetaUtils.AddToNeighbors(node);
-			node.IsClosedAirlock = false;
 		}
 		else
 		{
@@ -127,6 +129,7 @@ public class MetaDataSystem : SubsystemBehaviour
 
 		var isSpace = false;
 
+		// breadth-first search of the connected tiles that are not occupied
 		while (!freePositions.IsEmpty)
 		{
 			if (freePositions.TryDequeue(out Vector3Int position))
@@ -141,6 +144,8 @@ public class MetaDataSystem : SubsystemBehaviour
 					{
 						Vector3Int worldPosition = MatrixManager.LocalToWorldInt(neighbor, MatrixManager.Get(matrix.Id));
 
+						// If matrix manager says, the neighboring positions is space, the whole room is connected to space.
+						// Otherwise there is another matrix, blocking off the connection to space.
 						if (MatrixManager.IsSpaceAt(worldPosition, true))
 						{
 							isSpace = true;
@@ -148,6 +153,8 @@ public class MetaDataSystem : SubsystemBehaviour
 					}
 					else if (metaTileMap.IsAtmosPassableAt(position, neighbor, true))
 					{
+						// if neighbor position is not yet a room in the meta data layer and not in the room positions list,
+						// add it to the positions that need be checked
 						if (!roomPositions.Contains(neighbor) && !metaDataLayer.IsRoomAt(neighbor))
 						{
 							freePositions.Enqueue(neighbor);
@@ -164,15 +171,18 @@ public class MetaDataSystem : SubsystemBehaviour
 
 	private void AssignType(IEnumerable<Vector3Int> positions, NodeType nodeType)
 	{
+		// Bulk assign type to nodes at given positions
 		foreach (Vector3Int position in positions)
 		{
 			MetaDataNode node = metaDataLayer.Get(position);
 
 			node.Type = nodeType;
 
+			// assign room number, if type is room
 			node.RoomNumber = nodeType == NodeType.Room ? roomCounter : -1;
 		}
 
+		// increase room counter, so next room will get a new number
 		if (nodeType == NodeType.Room)
 		{
 			roomCounter++;
@@ -191,41 +201,50 @@ public class MetaDataSystem : SubsystemBehaviour
 	{
 		Vector3 nodeWorldPosition = MatrixManager.LocalToWorldInt(node.Position, MatrixManager.Get(matrix.Id));
 
+		// Look in every direction for neighboring tiles.
 		foreach (Vector3Int dir in MetaUtils.Directions)
 		{
 			Vector3Int neighbor = dir + node.Position;
 
 			if (metaTileMap.IsSpaceAt(neighbor, true))
 			{
+				// if current node is a room, but the neighboring is a space tile, this node needs to be checked regularly for changes by other matrices
 				if (node.IsRoom && !externalNodes.ContainsKey(node))
 				{
 					externalNodes[node] = node;
 				}
 
+				// If the node is not space, check other matrices if it has a tile next to this node.
 				if (!node.IsSpace)
 				{
 					Vector3 neighborWorldPosition = MatrixManager.LocalToWorldInt(neighbor, MatrixManager.Get(matrix.Id));
 
+					// if matrixManager says, it's not space at the neighboring position, there must be a matrix with a non-space tile
 					if (!MatrixManager.IsSpaceAt(neighborWorldPosition.RoundToInt(), true))
 					{
 						MatrixInfo matrixInfo = MatrixManager.AtPoint(neighborWorldPosition.RoundToInt(), true);
 
+						// ignore tilemap of current node
 						if (matrixInfo.MetaTileMap != metaTileMap)
 						{
+							// Check if atmos can pass to the neighboring position
 							Vector3Int neighborlocalPosition = MatrixManager.WorldToLocalInt(neighborWorldPosition, matrixInfo);
 							Vector3Int nodeLocalPosition = MatrixManager.WorldToLocalInt(nodeWorldPosition, matrixInfo);
 
 							if (matrixInfo.MetaTileMap.IsAtmosPassableAt(nodeLocalPosition, neighborlocalPosition, true))
 							{
+								// add node of other matrix to the neighbors of the current node
 								node.AddNeighbor(matrixInfo.MetaDataLayer.Get(neighborlocalPosition));
 							}
 
+							// skip other checks for neighboring tile on local tilemap, to prevent the space tile to be added as a neighbor
 							continue;
 						}
 					}
 				}
 			}
 
+			// If neighboring tile on local tilemap is atmos passable, add it as a neighbor
 			if (metaTileMap.IsAtmosPassableAt(node.Position, neighbor, true))
 			{
 				MetaDataNode neighborNode = metaDataLayer.Get(neighbor);


### PR DESCRIPTION
### Purpose
Fixes #2291, where crashing shuttles and then created space tiles wouldnt be updated properly.
Problem was how the neighbors of a node were chosen.
Previously, if a neighboring tile was space, there was a check if there is a neighboring matrix and if there is a tile.
Now, this check doesn't trigger anymore, when the current tile is also space, thus choosing the proper neighboring tiles.

Extended the matrix check for neighboring nodes to draw a white line between two neighboring nodes.

### Notes:
Multiplayer test wasn't done, since the fix doesn't touch anything network-related.
