### PR TITLE
Fix NukeOps and Game Mode System Improvements

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -399,17 +399,20 @@ namespace IngameDebugConsole
 				PlayerManager.LocalPlayerScript.registerTile.ServerSlip( true );
 			}
 		}
-		[ConsoleMethod("spawn-antag", "Spawns a random antag. Server only command")]
-		public static void SpawnAntag()
-		{
-			if (CustomNetworkManager.Instance._isServer == false)
-			{
-				Logger.LogError("Can only execute command from server.", Category.DebugConsole);
-				return;
-			}
-
-			Antagonists.AntagManager.Instance.CreateAntag();
-		}
+		// TODO: Removing this capability at the moment because some antags require an actual spawn (such as
+		// syndicate. and can't just be assigned an antag after they've already spawned. If there really is
+		// an actual need to be able to do this it will require refactoring GameMode system to support late reassignment.
+		// [ConsoleMethod("spawn-antag", "Spawns a random antag. Server only command")]
+		// public static void SpawnAntag()
+		// {
+		// 	if (CustomNetworkManager.Instance._isServer == false)
+		// 	{
+		// 		Logger.LogError("Can only execute command from server.", Category.DebugConsole);
+		// 		return;
+		// 	}
+		//
+		// 	Antagonists.AntagManager.Instance.CreateAntag();
+		// }
 		[ConsoleMethod("antag-status", "Shows status of all antag objectives. Server only command")]
 		public static void ShowAntagObjectives()
 		{

--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -74,6 +74,23 @@ namespace IngameDebugConsole
 			Logger.Log("Triggered round restart from DebugConsole.", Category.DebugConsole);
 			GameManager.Instance.RestartRound();
 		}
+
+#if UNITY_EDITOR
+		[MenuItem("Networking/End round")]
+#endif
+		[ConsoleMethod("end-round", "ends the round, triggering normal round end logic, letting people see their greentext. Server only cmd.")]
+		public static void RunEndRound()
+		{
+			if (CustomNetworkManager.Instance._isServer == false)
+			{
+				Logger.LogError("Can only execute command from server.", Category.DebugConsole);
+				return;
+			}
+
+			Logger.Log("Triggered round restart from DebugConsole.", Category.DebugConsole);
+			GameManager.Instance.RoundEnd();
+		}
+
 #if UNITY_EDITOR
 		[MenuItem("Networking/Start now")]
 #endif
@@ -413,7 +430,7 @@ namespace IngameDebugConsole
 		//
 		// 	Antagonists.AntagManager.Instance.CreateAntag();
 		// }
-		[ConsoleMethod("antag-status", "Shows status of all antag objectives. Server only command")]
+		[ConsoleMethod("antag-status", "System wide message, reports the status of all antag objectives to ALL players. Server only command")]
 		public static void ShowAntagObjectives()
 		{
 			if (CustomNetworkManager.Instance._isServer == false)
@@ -423,6 +440,18 @@ namespace IngameDebugConsole
 			}
 
 			Antagonists.AntagManager.Instance.ShowAntagStatusReport();
+		}
+
+		[ConsoleMethod("antag-remind", "Remind all antags of their own objectives. Server only command")]
+		public static void RemindAntagObjectives()
+		{
+			if (CustomNetworkManager.Instance._isServer == false)
+			{
+				Logger.LogError("Can only execute command from server.", Category.DebugConsole);
+				return;
+			}
+
+			Antagonists.AntagManager.Instance.RemindAntags();
 		}
 
 #if UNITY_EDITOR

--- a/UnityProject/Assets/Scripts/Antagonists/AntagManager.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/AntagManager.cs
@@ -83,8 +83,8 @@ namespace Antagonists
 			// Generate objectives for this antag
 			List<Objective> objectives = AntagData.GenerateObjectives(connectedPlayer.Script, chosenAntag);
 			// Set the antag
-			connectedPlayer.Script.mind.SetAntag(chosenAntag);
 			var spawnedAntag = SpawnedAntag.Create(chosenAntag, connectedPlayer.Script.mind, objectives);
+			connectedPlayer.Script.mind.SetAntag(spawnedAntag);
 			ActiveAntags.Add(spawnedAntag);
 			Logger.Log($"Created new antag. Made {connectedPlayer.Name} a {chosenAntag.AntagName} with objectives:\n{spawnedAntag.GetObjectivesForLog()}", Category.Antags);
 		}

--- a/UnityProject/Assets/Scripts/Antagonists/AntagManager.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/AntagManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -89,6 +90,18 @@ namespace Antagonists
 			Logger.Log($"Created new antag. Made {connectedPlayer.Name} a {chosenAntag.AntagName} with objectives:\n{spawnedAntag.GetObjectivesForLog()}", Category.Antags);
 		}
 
+
+		/// <summary>
+		/// Remind all antagonists of their objectives.
+		/// </summary>
+		public void RemindAntags()
+		{
+			foreach (var activeAntag in ActiveAntags)
+			{
+				activeAntag.Owner?.ShowObjectives();
+			}
+		}
+
 		/// <summary>
 		/// Show the end of round antag status report with their objectives, grouped by antag type.
 		/// </summary>
@@ -126,5 +139,6 @@ namespace Antagonists
 			TargetedPlayers.Clear();
 			TargetedItems.Clear();
 		}
+
 	}
 }

--- a/UnityProject/Assets/Scripts/Antagonists/Antagonist.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Antagonist.cs
@@ -5,15 +5,10 @@ using System.Text;
 namespace Antagonists
 {
 	/// <summary>
-	/// Contains all information about an antagonist including objectives
+	/// Defines an antagonist.
 	/// </summary>
-	public class Antagonist : ScriptableObject
+	public abstract class Antagonist : ScriptableObject
 	{
-		/// <summary>
-		/// The player controlling this antag
-		/// </summary>
-		public Mind Owner { get; set; }
-
 		/// <summary>
 		/// The name of the antagonist type
 		/// </summary>
@@ -48,71 +43,15 @@ namespace Antagonists
 		/// <summary>
 		/// The core objectives only this type of antagonist can get
 		/// </summary>
-		public List<Objective> CoreObjectives => coreObjectives;
+		public IEnumerable<Objective> CoreObjectives => coreObjectives;
 
 		/// <summary>
-		/// The objectives this antag currently has
+		/// Server only. Spawn the joined viewer as the indicated antag, includes creating their player object
+		/// and transferring them to it.
 		/// </summary>
-		protected List<Objective> CurrentObjectives = new List<Objective>();
+		/// <param name="spawnRequest">player's requested spawn</param>
+		/// <returns>gameobject of the spawned antag that he player is now in control of</returns>
+		public abstract GameObject ServerSpawn(PlayerSpawnRequest spawnRequest);
 
-		/// <summary>
-		///	Give this antag an objective
-		/// </summary>
-		public void GiveObjective(Objective objective)
-		{
-			CurrentObjectives.Add(objective);
-		}
-
-		/// <summary>
-		/// Give this antag multiple objectives at once
-		/// </summary>
-		public void GiveObjectives(List<Objective> objectives)
-		{
-			CurrentObjectives.AddRange(objectives);
-		}
-
-		/// <summary>
-		/// Returns a string with just the objectives for logging
-		/// </summary>
-		public string GetObjectivesForLog()
-		{
-			StringBuilder objSB = new StringBuilder(200);
-			for (int i = 0; i < CurrentObjectives.Count; i++)
-			{
-				objSB.AppendLine($"{i+1}. {CurrentObjectives[i].Description}");
-			}
-			return objSB.ToString();
-		}
-
-		/// <summary>
-		/// Returns a string with the current objectives for this antag which will be shown to the player
-		/// </summary>
-		public string GetObjectivesForPlayer()
-		{
-			StringBuilder objSB = new StringBuilder($"</i><size=26>You are a <b>{antagName}</b>!</size>\n", 200);
-			objSB.AppendLine("Your objectives are:");
-			for (int i = 0; i < CurrentObjectives.Count; i++)
-			{
-				objSB.AppendLine($"{i+1}. {CurrentObjectives[i].Description}");
-			}
-			// Adding back italic tag so rich text doesn't break
-			objSB.AppendLine("<i>");
-			return objSB.ToString();
-		}
-
-		/// <summary>
-		/// Returns a string with the status of all objectives for this antag
-		/// </summary>
-		public string GetObjectiveStatus()
-		{
-			StringBuilder objSB = new StringBuilder($"<b>{Owner.body.playerName}</b>\n", 200);
-			objSB.AppendLine("Their objectives were:");
-			for (int i = 0; i < CurrentObjectives.Count; i++)
-			{
-				objSB.Append($"{i+1}. {CurrentObjectives[i].Description}: ");
-				objSB.AppendLine(CurrentObjectives[i].IsComplete() ? "<color=green><b>Completed</b></color>" : "<color=red><b>Failed</b></color>");
-			}
-			return objSB.ToString();
-		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Antagonists/Antags/NuclearOperative.asset
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/NuclearOperative.asset
@@ -18,3 +18,5 @@ MonoBehaviour:
   needsEscapeObjective: 0
   coreObjectives:
   - {fileID: 11400000, guid: 1a15330eccadc7044b35b5a49a4154b4, type: 2}
+  nuclearOperativeOccupation: {fileID: 11400000, guid: 2b5314e7e17be4700b025e39af217ff2,
+    type: 2}

--- a/UnityProject/Assets/Scripts/Antagonists/Antags/NuclearOperative.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/NuclearOperative.cs
@@ -6,7 +6,29 @@ namespace Antagonists
 	[CreateAssetMenu(menuName="ScriptableObjects/Antagonist/NuclearOperative")]
 	public class NuclearOperative : Antagonist
 	{
+
+		[Tooltip("Occupation that nuclear operatives should spawn as.")]
+		[SerializeField]
+		private Occupation nuclearOperativeOccupation;
+
 		// add any NuclearOperative specific logic here
+		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
+		{
+			//spawn as a nuke op regardless of the requested occupation
+			var newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest.JoinedViewer, nuclearOperativeOccupation,
+				spawnRequest.CharacterSettings);
+
+			//send the code:
+			//Check to see if there is a nuke and communicate the nuke code:
+			Nuke nuke = Object.FindObjectOfType<Nuke>();
+			if (nuke != null)
+			{
+				UpdateChatMessage.Send(newPlayer, ChatChannel.Syndicate, ChatModifier.None,
+					"We have intercepted the code for the nuclear weapon: " + nuke.NukeCode);
+			}
+
+			return newPlayer;
+		}
 	}
 
 }

--- a/UnityProject/Assets/Scripts/Antagonists/Antags/Traitor.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/Traitor.cs
@@ -6,7 +6,10 @@ namespace Antagonists
 	[CreateAssetMenu(menuName="ScriptableObjects/Antagonist/Traitor")]
 	public class Traitor : Antagonist
 	{
-		// add any traitor specific logic here
+		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
+		{
+			// spawn them normally, with their preferred occupation
+			return PlayerSpawn.ServerSpawnPlayer(spawnRequest);
+		}
 	}
-
 }

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/Steal.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/Steal.cs
@@ -80,7 +80,14 @@ namespace Antagonists
 				// TODO find better way to determine item types (ScriptableObjects/item IDs could work but would need to refactor all items)
 				if (slot.ItemObject != null && slot.ItemObject.GetComponent<ItemAttributesV2>()?.InitialName == ItemName)
 				{
-					count++;
+					if (slot.ItemObject.TryGetComponent<Stackable>(out var stackable))
+					{
+						count += stackable.Amount;
+					}
+					else
+					{
+						count++;
+					}
 				}
 			}
 			// Check if the count is higher than the specified amount

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/TriggerNuke.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/TriggerNuke.cs
@@ -24,6 +24,7 @@ namespace Antagonists
 			{
 				UpdateChatMessage.Send(Owner.body.gameObject, ChatChannel.Syndicate, ChatModifier.None,
 					"We have intercepted the code for the nuclear weapon: " + NukeTarget.NukeCode);
+				description += ". Intercepted nuke code is " + NukeTarget.NukeCode;
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Antagonists/SpawnedAntag.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/SpawnedAntag.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Antagonists
+{
+	/// <summary>
+	/// Represents an antag that has been spawned into the game. Used so that Antagonist SO can remain
+	/// immutable and server merely as the definition of a particular kind of antag and this
+	/// can server as an actual INSTANCE of that antag in a given round.
+	/// </summary>
+	public class SpawnedAntag
+	{
+
+		/// <summary>
+		/// Antagonist this player spawned as.
+		/// </summary>
+		public readonly Antagonist Antagonist;
+
+		/// <summary>
+		/// Player controlling this antag.
+		/// </summary>
+		public readonly Mind Owner;
+
+		/// <summary>
+		/// The objectives this antag has been given
+		/// </summary>
+		public IEnumerable<Objective> Objectives;
+
+		private SpawnedAntag(Antagonist antagonist, Mind owner, IEnumerable<Objective> objectives)
+		{
+			Antagonist = antagonist;
+			Owner = owner;
+			Objectives = objectives;
+		}
+
+		/// <summary>
+		/// Create a spawned antag of the indicated antag type for the indicated mind with the given objectives.
+		/// </summary>
+		/// <param name="antagonist"></param>
+		/// <param name="owner"></param>
+		/// <param name="objectives"></param>
+		/// <returns></returns>
+		public static SpawnedAntag Create(Antagonist antagonist, Mind owner, IEnumerable<Objective> objectives)
+		{
+			return new SpawnedAntag(antagonist, owner, objectives);
+		}
+
+
+		/// <summary>
+		/// Returns a string with just the objectives for logging
+		/// </summary>
+		public string GetObjectivesForLog()
+		{
+			StringBuilder objSB = new StringBuilder(200);
+			var objectiveList = Objectives.ToList();
+			for (int i = 0; i < objectiveList.Count; i++)
+			{
+				objSB.AppendLine($"{i+1}. {objectiveList[i].Description}");
+			}
+			return objSB.ToString();
+		}
+
+		/// <summary>
+		/// Returns a string with the current objectives for this antag which will be shown to the player
+		/// </summary>
+		public string GetObjectivesForPlayer()
+		{
+			StringBuilder objSB = new StringBuilder($"</i><size=26>You are a <b>{Antagonist.AntagName}</b>!</size>\n", 200);
+			var objectiveList = Objectives.ToList();
+			objSB.AppendLine("Your objectives are:");
+			for (int i = 0; i < objectiveList.Count; i++)
+			{
+				objSB.AppendLine($"{i+1}. {objectiveList[i].Description}");
+			}
+			// Adding back italic tag so rich text doesn't break
+			objSB.AppendLine("<i>");
+			return objSB.ToString();
+		}
+
+		/// <summary>
+		/// Returns a string with the status of all objectives for this antag
+		/// </summary>
+		public string GetObjectiveStatus()
+		{
+			StringBuilder objSB = new StringBuilder($"<b>{Owner.body.playerName}</b>\n", 200);
+			var objectiveList = Objectives.ToList();
+			objSB.AppendLine("Their objectives were:");
+			for (int i = 0; i < objectiveList.Count; i++)
+			{
+				objSB.Append($"{i+1}. {objectiveList[i].Description}: ");
+				objSB.AppendLine(objectiveList[i].IsComplete() ? "<color=green><b>Completed</b></color>" : "<color=red><b>Failed</b></color>");
+			}
+			return objSB.ToString();
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Antagonists/SpawnedAntag.cs.meta
+++ b/UnityProject/Assets/Scripts/Antagonists/SpawnedAntag.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7e0fcbb58b2b4bc693b660c94ea99c28
+timeCreated: 1580183715

--- a/UnityProject/Assets/Scripts/GameModes/Extended.cs
+++ b/UnityProject/Assets/Scripts/GameModes/Extended.cs
@@ -8,6 +8,13 @@ public class Extended : GameMode
 	/// Set up the station for the game mode
 	/// </summary>
 	public override void SetupRound() {}
+
+	protected override bool ShouldSpawnAntag(PlayerSpawnRequest spawnRequest)
+	{
+		//no antags
+		return false;
+	}
+
 	/// <summary>
 	/// Begin the round
 	/// </summary>
@@ -18,5 +25,4 @@ public class Extended : GameMode
 	}
 	public override void CheckEndCondition() {}
 	public override void EndRound() {}
-	public override void TrySpawnAntag() {}
 }

--- a/UnityProject/Assets/Scripts/GameModes/Extended.cs
+++ b/UnityProject/Assets/Scripts/GameModes/Extended.cs
@@ -18,5 +18,5 @@ public class Extended : GameMode
 	}
 	public override void CheckEndCondition() {}
 	public override void EndRound() {}
-	public override void CheckAntags() {}
+	public override void TrySpawnAntag() {}
 }

--- a/UnityProject/Assets/Scripts/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/GameModes/GameMode.cs
@@ -63,21 +63,44 @@ public abstract class GameMode : ScriptableObject
 	public abstract void SetupRound();
 
 	/// <summary>
-	/// Check if more antags are needed. Should be defined by each game mode.
+	/// Checks if the conditions are met to spawn an antag, and spawns them
+	/// as the antag if so, spawning them as an actual player and transferring them into the body
+	/// (meaning there's no need to call PlayerSpawn.ServerSpawnPlayer). Does nothing
+	/// if the conditions are not met to spawn this viewer as an antag.
 	/// </summary>
-	public abstract void CheckAntags();
+	/// <param name="spawnRequest">spawn requested by the player</param>
+	/// <returns>true if the viewer was spawned as an antag.</returns>
+	public void TrySpawnAntag(PlayerSpawnRequest spawnRequest)
+	{
+		if (ShouldSpawnAntag(spawnRequest))
+		{
+			SpawnAntag(spawnRequest);
+		}
+	}
 
 	/// <summary>
-	/// Defines how to spawn an antag for this game mode.
-	/// Defaults to picking a random antag from the possible antags list.
+	/// Check if the joined viewer should be spawned as an antag (prior to actually
+	/// spawning them).
 	/// </summary>
-	public virtual void SpawnAntag(ConnectedPlayer player = null)
+	/// <param name="spawnRequest">player's spawn request, which should be used to determine
+	/// if they should spawn as an antag</param>
+	/// <returns>true if an antag should be spawned.</returns>
+	protected abstract bool ShouldSpawnAntag(PlayerSpawnRequest spawnRequest);
+
+	/// <summary>
+	/// Spawn the player requesting the spawn as an antag, includes creating their player object
+	/// and transferring them to it. This is used as an alternative
+	/// to PlayerSpawn.ServerSpawnPlayer when an antag should be spawned.
+	///
+	/// Defaults to picking a random antag from the possible antags list and
+	/// spawning them as per the antag-specific spawn logic.
+	/// </summary>
+	protected void SpawnAntag(PlayerSpawnRequest playerSpawnRequest)
 	{
 		if (PossibleAntags.Count > 0)
 		{
-		int randIndex = Random.Range(0, PossibleAntags.Count);
-		Antagonist gmAntag = Instantiate(PossibleAntags[randIndex]);
-		AntagManager.Instance.CreateAntag(gmAntag, player);
+			int randIndex = Random.Range(0, PossibleAntags.Count);
+			AntagManager.Instance.ServerSpawnAntag(PossibleAntags[randIndex], playerSpawnRequest);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/GameModes/GameMode.cs
@@ -70,12 +70,15 @@ public abstract class GameMode : ScriptableObject
 	/// </summary>
 	/// <param name="spawnRequest">spawn requested by the player</param>
 	/// <returns>true if the viewer was spawned as an antag.</returns>
-	public void TrySpawnAntag(PlayerSpawnRequest spawnRequest)
+	public bool TrySpawnAntag(PlayerSpawnRequest spawnRequest)
 	{
 		if (ShouldSpawnAntag(spawnRequest))
 		{
 			SpawnAntag(spawnRequest);
+			return true;
 		}
+
+		return false;
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/GameModes/GameModeData.asset
+++ b/UnityProject/Assets/Scripts/GameModes/GameModeData.asset
@@ -14,4 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   GameModes:
   - {fileID: 11400000, guid: a07c32cfb5b43954c908ca8910ad76e5, type: 2}
+  - {fileID: 11400000, guid: 05fce6636cea92c45b994911665cde8e, type: 2}
+  - {fileID: 11400000, guid: 52f8f627d68d9974a9d2376f6a9a2e61, type: 2}
   DefaultGameMode: {fileID: 11400000, guid: a07c32cfb5b43954c908ca8910ad76e5, type: 2}

--- a/UnityProject/Assets/Scripts/GameModes/NukeOps.asset
+++ b/UnityProject/Assets/Scripts/GameModes/NukeOps.asset
@@ -20,3 +20,4 @@ MonoBehaviour:
   MinAntags: 1
   PossibleAntags:
   - {fileID: 11400000, guid: 4bc36e6d8aa946c4081073eabc2472eb, type: 2}
+  nukeOpsRatio: 0.2

--- a/UnityProject/Assets/Scripts/GameModes/NukeOps.cs
+++ b/UnityProject/Assets/Scripts/GameModes/NukeOps.cs
@@ -5,6 +5,13 @@ using Antagonists;
 [CreateAssetMenu(menuName="ScriptableObjects/GameModes/NukeOps")]
 public class NukeOps : GameMode
 {
+	[Tooltip("Ratio of nuke ops to player count. A value of 0.2 means there would be " +
+	         "2 nuke ops when there are 10 players.")]
+	[Range(0,1)]
+	[SerializeField]
+	private float nukeOpsRatio;
+
+
 	/// <summary>
 	/// Set up the station for the game mode
 	/// </summary>
@@ -18,11 +25,10 @@ public class NukeOps : GameMode
 	public override void StartRound()
 	{
 		Logger.Log("Starting NukeOps round!", Category.GameMode);
-		// TODO remove once random antag allocation is done
-		UpdateUIMessage.Send(ControlDisplays.Screens.TeamSelect);
+		base.StartRound();
 	}
 
-	public override void CheckAntags()
+	public override void TrySpawnAntag()
 	{
 		List<ConnectedPlayer> shouldBeAntags = PlayerList.Instance.NonAntagPlayers.FindAll( p => p.Script.mind.occupation.JobType == JobType.SYNDICATE);
 		foreach (var player in shouldBeAntags)

--- a/UnityProject/Assets/Scripts/GameModes/NukeOps.cs
+++ b/UnityProject/Assets/Scripts/GameModes/NukeOps.cs
@@ -31,12 +31,12 @@ public class NukeOps : GameMode
 
 	protected override bool ShouldSpawnAntag(PlayerSpawnRequest spawnRequest)
 	{
-		//spawn only if there is not yet any syndicate ops or
+		//spawn only if there is not yet any syndicate ops (and at least one other player) or
 		//the ratio is too low
 		var existingNukeOps = PlayerList.Instance.AntagPlayers.Count;
-		var existingPlayers = PlayerList.Instance.AllPlayers.Count;
-		if (existingNukeOps == 0 ||
-		    existingNukeOps < Math.Floor(existingPlayers * nukeOpsRatio)) return true;
+		var inGamePlayers = PlayerList.Instance.InGamePlayers.Count;
+		if ((inGamePlayers > 0 && existingNukeOps == 0) ||
+		    existingNukeOps < Math.Floor(inGamePlayers * nukeOpsRatio)) return true;
 
 		return false;
 	}

--- a/UnityProject/Assets/Scripts/GameModes/NukeOps.cs
+++ b/UnityProject/Assets/Scripts/GameModes/NukeOps.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Antagonists;
@@ -28,12 +29,15 @@ public class NukeOps : GameMode
 		base.StartRound();
 	}
 
-	public override void TrySpawnAntag()
+	protected override bool ShouldSpawnAntag(PlayerSpawnRequest spawnRequest)
 	{
-		List<ConnectedPlayer> shouldBeAntags = PlayerList.Instance.NonAntagPlayers.FindAll( p => p.Script.mind.occupation.JobType == JobType.SYNDICATE);
-		foreach (var player in shouldBeAntags)
-		{
-			SpawnAntag(player);
-		}
+		//spawn only if there is not yet any syndicate ops or
+		//the ratio is too low
+		var existingNukeOps = PlayerList.Instance.AntagPlayers.Count;
+		var existingPlayers = PlayerList.Instance.AllPlayers.Count;
+		if (existingNukeOps == 0 ||
+		    existingNukeOps < Math.Floor(existingPlayers * nukeOpsRatio)) return true;
+
+		return false;
 	}
 }

--- a/UnityProject/Assets/Scripts/GameModes/Traitor.cs
+++ b/UnityProject/Assets/Scripts/GameModes/Traitor.cs
@@ -35,14 +35,8 @@ public class Traitor : GameMode
 
 	// }
 
-	/// <summary>
-	/// Check if more antags are needed. Should be defined by each game mode.
-	/// </summary>
-	public override void CheckAntags()
+	protected override bool ShouldSpawnAntag(PlayerSpawnRequest spawnRequest)
 	{
-		if ((AntagManager.Instance.AntagCount == 0) && PlayerList.Instance.InGamePlayers.Count > 1)
-		{
-			SpawnAntag();
-		}
+		return AntagManager.Instance.AntagCount == 0 && PlayerList.Instance.InGamePlayers.Count > 0;
 	}
 }

--- a/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
@@ -11,37 +11,28 @@ public static class PlayerSpawn
 {
 	/// <summary>
 	/// Server-side only. For use when a player has only joined (as a JoinedViewer) and
-	/// is not in control of any mobs. Spawns the player with the specified occupation / settings
-	/// and transfers the viewer to control the new player.
+	/// is not in control of any mobs. Spawns the joined viewer as the indicated occupation and transfers control to it.
+	/// Note that this doesn't take into account game mode or antags, it just spawns whatever is requested.
 	/// </summary>
-	/// <param name="forViewer">viewer who should control the player</param>
+	/// <param name="joinedViewer">viewer who should control the player</param>
 	/// <param name="occupation">occupation to spawn as</param>
 	/// <param name="characterSettings">settings to use for the character</param>
-	/// <returns></returns>
-	public static void ServerSpawnPlayer(JoinedViewer forViewer, Occupation occupation, CharacterSettings characterSettings)
+	/// <returns>the game object of the spawned player</returns>
+	public static GameObject ServerSpawnPlayer(JoinedViewer joinedViewer, Occupation occupation, CharacterSettings characterSettings)
 	{
-		NetworkConnection conn = forViewer.connectionToClient;
+		NetworkConnection conn = joinedViewer.connectionToClient;
+
 		var newPlayer = ServerSpawnInternal(conn, occupation, characterSettings, null);
 		if (newPlayer)
 		{
-			if (occupation.JobType == JobType.SYNDICATE)
-			{
-				//Check to see if there is a nuke and communicate the nuke code:
-				Nuke nuke = Object.FindObjectOfType<Nuke>();
-				if (nuke != null)
-				{
-					UpdateChatMessage.Send(newPlayer, ChatChannel.Syndicate, ChatModifier.None,
-						"We have intercepted the code for the nuclear weapon: " + nuke.NukeCode);
-				}
-			}
-
-			GameManager.Instance.CheckAntags();
-
-			if (occupation.JobType != JobType.SYNDICATE && occupation.JobType != JobType.AI)
+			if (occupation.JobType != JobType.SYNDICATE &&
+			    occupation.JobType != JobType.AI)
 			{
 				SecurityRecordsManager.Instance.AddRecord(newPlayer.GetComponent<PlayerScript>(), occupation.JobType);
 			}
 		}
+
+		return newPlayer;
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
@@ -35,6 +35,20 @@ public static class PlayerSpawn
 		return newPlayer;
 	}
 
+
+	/// <summary>
+	/// Server-side only. For use when a player has only joined (as a JoinedViewer) and
+	/// is not in control of any mobs. Spawns the joined viewer as the indicated occupation and transfers control to it.
+	/// Note that this doesn't take into account game mode or antags, it just spawns whatever is requested.
+	/// </summary>
+	/// <param name="spawnRequest">details of the requested spawn</param>
+	/// <returns>the game object of the spawned player</returns>
+	public static GameObject ServerSpawnPlayer(PlayerSpawnRequest spawnRequest)
+	{
+		return ServerSpawnPlayer(spawnRequest.JoinedViewer, spawnRequest.RequestedOccupation,
+			spawnRequest.CharacterSettings);
+	}
+
 	/// <summary>
 	/// For use when player is connected and dead.
 	/// Respawns the mind's character and transfers their control to it.
@@ -412,8 +426,4 @@ public static class PlayerSpawn
 
 		return spawnPoints.Count == 0 ? null : spawnPoints.PickRandom().transform;
 	}
-
-
-
-
 }

--- a/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawnRequest.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawnRequest.cs
@@ -1,0 +1,41 @@
+
+/// <summary>
+/// A viewer's request to spawn into the game as a new player. Doesn't necessarily guarantee they will actually
+/// spawn with what they requested, depending on game mode!
+/// </summary>
+public class PlayerSpawnRequest
+{
+
+	/// <summary>
+	/// Occupation requested to spawn as (won't necessarily be what they get if they
+	/// end up spawning as an antag)
+	/// </summary>
+	public readonly Occupation RequestedOccupation;
+
+	/// <summary>
+	/// JoinedViewer component of the player attempting to spawn.
+	/// </summary>
+	public readonly JoinedViewer JoinedViewer;
+
+	/// <summary>
+	/// Character settings the viewer is attempting to spawn with.
+	/// </summary>
+	public readonly CharacterSettings CharacterSettings;
+
+	private PlayerSpawnRequest(Occupation requestedOccupation, JoinedViewer joinedViewer, CharacterSettings characterSettings)
+	{
+		RequestedOccupation = requestedOccupation;
+		JoinedViewer = joinedViewer;
+		CharacterSettings = characterSettings;
+	}
+
+	/// <summary>
+	/// Create a new player spawn info indicating a request to spawn with the
+	/// selected occupation and settings.
+	/// </summary>
+	/// <returns></returns>
+	public static PlayerSpawnRequest RequestOccupation(JoinedViewer requestedBy, Occupation requestedOccupation, CharacterSettings characterSettings)
+	{
+		return new PlayerSpawnRequest(requestedOccupation, requestedBy, characterSettings);
+	}
+}

--- a/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawnRequest.cs.meta
+++ b/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawnRequest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2fff371fe21a4bfd849beb1a32c6a5a8
+timeCreated: 1580182082

--- a/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
@@ -96,10 +96,16 @@ public partial class GameManager
 	}
 
 	/// <summary>
-	/// Check the player count and see if new antags are needed
+	/// Checks if the conditions are met to spawn an antag, and spawns them
+	/// as the antag if so, spawning them as an actual player and transferring them into the body
+	/// (meaning there's no need to call PlayerSpawn.ServerSpawnPlayer). Does nothing
+	/// if the conditions are not met to spawn this viewer as an antag.
+	///
 	/// </summary>
-	public void CheckAntags()
+	/// <param name="spawnRequest">spawn requested by the player</param>
+	/// <returns>true if the player was spawned as an antag.</returns>
+	public bool TrySpawnAntag(PlayerSpawnRequest spawnRequest)
 	{
-		GameMode.CheckAntags();
+		return GameMode.TrySpawnAntag(spawnRequest);
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -162,8 +162,13 @@ public class JoinedViewer : NetworkBehaviour
 	[Command]
 	public void CmdRequestJob(JobType jobType, CharacterSettings characterSettings)
 	{
-		PlayerSpawn.ServerSpawnPlayer(this, GameManager.Instance.GetRandomFreeOccupation(jobType),
-			characterSettings);
+		var spawnRequest =
+			PlayerSpawnRequest.RequestOccupation(this, GameManager.Instance.GetRandomFreeOccupation(jobType), characterSettings);
+		//regardless of their chosen occupation, they might spawn as an antag instead.
+		//If they do, bypass the normal spawn logic.
+		if (GameManager.Instance.TrySpawnAntag(spawnRequest)) return;
+
+		PlayerSpawn.ServerSpawnPlayer(spawnRequest.JoinedViewer, spawnRequest.RequestedOccupation, characterSettings);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -12,7 +12,7 @@ public class Mind
 	public Occupation occupation;
 	public PlayerScript ghost;
 	public PlayerScript body;
-	private Antagonist Antag;
+	private SpawnedAntag Antag;
 	public bool IsAntag => Antag !=null;
 	public bool IsGhosting;
 	public bool DenyCloning;
@@ -44,12 +44,11 @@ public class Mind
 	}
 
 	/// <summary>
-	/// Make this mind a specific antag type
+	/// Make this mind a specific spawned antag
 	/// </summary>
-	public void SetAntag(Antagonist newAntag)
+	public void SetAntag(SpawnedAntag newAntag)
 	{
 		Antag = newAntag;
-		Antag.Owner = this;
 		ShowObjectives();
 	}
 


### PR DESCRIPTION
### Purpose
Fixes #2649 , players will be spawned as nuke ops regardless of their occupation choice if there is a need for more to be spawned.

- Refactors game mode system to support custom spawning logic based on game mode, rather than requiring the antag to spawn as a normal player and THEN assigning them to an antag role.
- NukeOps game mode has configurable nuke ops ratio, currently set at 0.2 (2 nuke ops when there's 10 players). Currently the 2nd player to join will always spawn as a nuke op regardless of player count.
- Adds antag-remind server command to remind antags of their objectives without broadcasting it to the entire server.
- Adds nuke code to the TriggerNuke objective so nukies can be reminded of the code if for some reason they forget.
- Fixes bug where Steal objective didn't properly count stackables

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
