### PR TITLE
Fix issue Comms Consoles now print out empty Centcomm reports #2783

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Bureaucracy/Resources/Paper.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Bureaucracy/Resources/Paper.prefab
@@ -36,6 +36,20 @@ MonoBehaviour:
   NetTabType: 13
   originalName: 
   customName: 
+--- !u!114 &6974843602557491631
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8734328976324889014}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b7da862871064b7b95b5a52335c790a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetTabType: 4
+  paper: {fileID: 585395312865148023}
 --- !u!1001 &8733893691203122444
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -46,37 +60,6 @@ PrefabInstance:
     - target: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_Name
       value: Paper
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: initialName
-      value: Paper
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: initialDescription
-      value: A piece of paper
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: initialTraits.Array.data[0]
-      value: 
-      objectReference: {fileID: 11400000, guid: 24632eaec5a984a9f95155bf676a95bc,
-        type: 2}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: throwSpeed
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: throwRange
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalPosition.x
@@ -133,6 +116,37 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 66064101faf2cf84d8db3ffd022fd141,
         type: 3}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialName
+      value: Paper
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialDescription
+      value: A piece of paper
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 24632eaec5a984a9f95155bf676a95bc,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: throwSpeed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: throwRange
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
 --- !u!1 &8734328976324889014 stripped

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/CraftingManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/CraftingManager.prefab
@@ -52,7 +52,8 @@ MonoBehaviour:
       Ingredients:
       - amount: 1
         ingredientName: Meat
-      Output: {fileID: 1110193000772614, guid: 6bee1f6e9832bf940a50f7cfe3788b0f, type: 3}
+      Output: {fileID: 6532193109441330816, guid: f5b3ac01c1928bf4ab03433000e00ca2,
+        type: 3}
   techweb: {fileID: 8028218387555133124}
   designs: {fileID: 8028062986537714290}
 --- !u!114 &8028218387555133124


### PR DESCRIPTION
InteractablePaper component was removed (accidentally?) from the Paper prefab.  That caused the interraction to find another Interactable component: Renameable instead.

I put the Interactable Paper component back with better priority than Renameable.

Fix issue Comms Consoles now print out empty Centcomm reports #2783