### PR TITLE
TTS now triggers more reliably. Chat modifiers disabled when OOC.

### DIFF
--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -58,7 +58,7 @@ public partial class Chat
 		{
 			return (message, chatModifiers);
 		}
-		
+
 		if (sentByPlayer.Script.playerHealth != null)
 		{
 			playerConsciousState = sentByPlayer.Script.playerHealth.ConsciousState;
@@ -253,9 +253,9 @@ public partial class Chat
 		}
 
 		return AddMsgColor(channels,
-			$"{chan}<b>{speaker}</b> {verb}"	// [cmd] Username says,
-			+ "  "                              // Two thin spaces. This triggers Text-to-Speech.
-			+ "\"" + message + "\"");			// "This text will be spoken by TTS!"
+			$"{chan}<b>{speaker}</b> {verb}"    // [cmd] Username says,
+			+ "  "                              // Two hair spaces. This triggers Text-to-Speech.
+			+ "\"" + message + "\"");           // "This text will be spoken by TTS!"
 	}
 
 	private static string StripTags(string input)
@@ -418,11 +418,11 @@ public partial class Chat
 		{
 			var getOrigin = NetworkIdentity.spawned[originator];
 			if (channels == ChatChannel.Local || channels == ChatChannel.Combat
-			                                  || channels == ChatChannel.Action)
+											  || channels == ChatChannel.Action)
 			{
 				LayerMask layerMask = LayerMask.GetMask("Walls", "Door Closed");
 				if (Vector2.Distance(getOrigin.transform.position,
-					    PlayerManager.LocalPlayer.transform.position) > 14f)
+						PlayerManager.LocalPlayer.transform.position) > 14f)
 				{
 					return true;
 				}

--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -252,7 +252,10 @@ public partial class Chat
 			chan = "";
 		}
 
-		return AddMsgColor(channels, $"{chan}<b>{speaker}</b> {verb} " + "\"" + message + "\"");
+		return AddMsgColor(channels,
+			$"{chan}<b>{speaker}</b> {verb}"	// [cmd] Username says,
+			+ "  "                              // Two thin spaces. This triggers Text-to-Speech.
+			+ "\"" + message + "\"");			// "This text will be spoken by TTS!"
 	}
 
 	private static string StripTags(string input)

--- a/UnityProject/Assets/Scripts/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.cs
@@ -53,11 +53,14 @@ public partial class Chat : MonoBehaviour
 		var player = sentByPlayer.Script;
 
 		// The exact words that leave the player's mouth (or that are narrated). Already includes HONKs, stutters, etc.
-		(string message, ChatModifier chatModifiers) processedMessage = ProcessMessage(sentByPlayer, message);
+		// This step is skipped when speaking in the OOC channel.
+		(string message, ChatModifier chatModifiers) processedMessage = (string.Empty, ChatModifier.None); // Placeholder values
+		bool isOOC = channels.HasFlag(ChatChannel.OOC);
+		if (!isOOC) processedMessage = ProcessMessage(sentByPlayer, message);
 
 		var chatEvent = new ChatEvent
 		{
-			message = processedMessage.message,
+			message = isOOC ? message : processedMessage.message,
 			modifiers = (player == null) ? ChatModifier.None : processedMessage.chatModifiers,
 			speaker = (player == null) ? sentByPlayer.Username : player.name,
 			position = ((player == null) ? Vector2.zero : (Vector2)player.gameObject.transform.position),

--- a/UnityProject/Assets/Scripts/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatRelay.cs
@@ -18,11 +18,10 @@ public class ChatRelay : NetworkBehaviour
 	public List<ChatEvent> ChatLog { get; } = new List<ChatEvent>();
 
 	/// <summary>
-	/// The character indicating that the following text is speech.
-	/// Currently the comma indicates speech.
-	/// For example: Player says, "ALL CLOWNS MUST SUFFER"
+	/// The char indicating that the following text is speech.
+	/// For example: Player says, [Character goes here]"ALL CLOWNS MUST SUFFER"
 	/// </summary>
-	private char saysChar = ',';
+	private char saysChar = ' '; // This is U+200A, a hair space.
 
 	private void Awake()
 	{
@@ -193,8 +192,8 @@ public class ChatRelay : NetworkBehaviour
 
 	/// <summary>
 	/// Sends a message to TTS to vocalize.
-	/// Only messages that are spoken by player characters are currently vocalized.
-	/// Messages must contain at least one letter from the alphabet.
+	/// They are required to contain the saysChar.
+	/// Messages must also contain at least one letter from the alphabet.
 	/// </summary>
 	/// <param name="message">The message to try to vocalize.</param>
 	private void trySendingTTS(string message)

--- a/UnityProject/Assets/Scripts/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatRelay.cs
@@ -204,7 +204,7 @@ public class ChatRelay : NetworkBehaviour
 			int saysCharIndex = message.IndexOf(saysChar);
 			if (saysCharIndex != -1)
 			{
-				string messageAfterSaysChar = message.Substring(message.IndexOf(saysChar)+1);
+				string messageAfterSaysChar = message.Substring(message.IndexOf(saysChar) + 1);
 				if (messageAfterSaysChar.Length > 0 && messageAfterSaysChar.Any(char.IsLetter))
 				{
 					MaryTTS.Instance.Synthesize(messageAfterSaysChar);


### PR DESCRIPTION
![2020-01-31_21-36-41](https://user-images.githubusercontent.com/9169275/73573404-9631df00-4473-11ea-9cde-d67dbe7908b7.png)
### Purpose:
* Fixes https://github.com/unitystation/unitystation/issues/2736
* Fixes https://github.com/unitystation/unitystation/issues/2791

### Notes:
* OOC speech was processed the same way as regular messages. This meant that clowns HONKed even in the OOC channel. A check is now in place to prevent this.
* TTS was previously triggered by the colon or the comma symbol. However, some messages which are not supposed to be processed (e. g. interact messages, death messages, etc.) also contained these symbols. The TTS symbol was changed to a hair space (U+200A) which is much less likely to occur in non-TTS messages.
  * If players abuse hair spaces to trigger TTS we could start filtering all hair spaces from player input.

### Self checks

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
