### PR TITLE
Automatic admin for editor

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/GameData.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/GameData.prefab
@@ -44,5 +44,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   offlineMode: 0
-  editorofflineMode: 1
+  editorAdmin: 1
   testServer: 0

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/GameData.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/GameData.prefab
@@ -44,4 +44,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   offlineMode: 0
+  editorofflineMode: 1
   testServer: 0

--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -26,11 +26,13 @@ public class GameData : MonoBehaviour
 	private bool offlineMode;
 
 
-	[Tooltip("Overrides offlineMode  If you are in the editor " +
-			 " Turn off if you want to test Authentication stuff/that type of thing" +
+	[Tooltip("Sets the editor to admin When starting game " +
 			 "Only works in the editor application")]
 	[SerializeField]
-	private bool editorofflineMode = true;
+	private bool editorAdmin = true;
+
+	[System.NonSerialized]
+	public bool Admin = false;
 	/// <summary>
 	/// Is offline mode enabled, allowing login skip / working without connection to server.?
 	/// Disabled always for release builds.
@@ -74,9 +76,9 @@ public class GameData : MonoBehaviour
 
 	private void Init()
 	{
-
+		Admin = !BuildPreferences.isForRelease && offlineMode;
 		#if UNITY_EDITOR
-				offlineMode = editorofflineMode;
+				Admin = editorAdmin;
 		#endif
 		var buildInfo = JsonUtility.FromJson<BuildInfo>(File.ReadAllText(Path.Combine(Application.streamingAssetsPath, "buildinfo.json")));
 		BuildNumber = buildInfo.BuildNumber;

--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -20,11 +20,17 @@ public class GameData : MonoBehaviour
 	private static GameData gameData;
 
 	[Tooltip("Only use this when offline or you can't reach the auth server! Allows the game to still work in that situation and " +
-	         " allows skipping login. Host player will also be given admin privs." +
-	         "Not supported in release builds.")]
+			 " allows skipping login. Host player will also be given admin privs." +
+			 "Not supported in release builds.")]
 	[SerializeField]
 	private bool offlineMode;
 
+
+	[Tooltip("Overrides offlineMode  If you are in the editor " +
+			 " Turn off if you want to test Authentication stuff/that type of thing" +
+			 "Only works in the editor application")]
+	[SerializeField]
+	private bool editorofflineMode = true;
 	/// <summary>
 	/// Is offline mode enabled, allowing login skip / working without connection to server.?
 	/// Disabled always for release builds.
@@ -68,6 +74,10 @@ public class GameData : MonoBehaviour
 
 	private void Init()
 	{
+
+		#if UNITY_EDITOR
+				offlineMode = editorofflineMode;
+		#endif
 		var buildInfo = JsonUtility.FromJson<BuildInfo>(File.ReadAllText(Path.Combine(Application.streamingAssetsPath, "buildinfo.json")));
 		BuildNumber = buildInfo.BuildNumber;
 		ForkName = buildInfo.ForkName;
@@ -253,10 +263,10 @@ public class GameData : MonoBehaviour
 		//Check if running in batchmode (headless server)
 		if (CheckHeadlessState())
 		{
-//			float calcFrameRate = 1f / Time.deltaTime;
-//			Application.targetFrameRate = (int) calcFrameRate;
-//			Logger.Log($"Starting server in HEADLESS mode. Target framerate is {Application.targetFrameRate}",
-//				Category.Server);
+			//			float calcFrameRate = 1f / Time.deltaTime;
+			//			Application.targetFrameRate = (int) calcFrameRate;
+			//			Logger.Log($"Starting server in HEADLESS mode. Target framerate is {Application.targetFrameRate}",
+			//				Category.Server);
 
 			Logger.Log($"FrameRate limiting has been disabled on Headless Server",
 				Category.Server);

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -221,7 +221,7 @@ public partial class PlayerList
 	public void CheckAdminState(ConnectedPlayer playerConn, string userid)
 	{
 		//full admin privs for local offline testing for host player
-		if (adminUsers.Contains(userid) || (GameData.Instance.OfflineMode && playerConn.GameObject == PlayerManager.LocalViewerScript.gameObject))
+		if (adminUsers.Contains(userid) || ((GameData.Instance.Admin) && playerConn.GameObject == PlayerManager.LocalViewerScript.gameObject))
 		{
 			//This is an admin, send admin notify to the users client
 			Logger.Log($"{playerConn.Username} logged in as Admin. " +


### PR DESCRIPTION
### what this do?
Automatic off-line mode for editor, can be turned off if needed in game data prefab
### why you do this?
so  you have admin tools when you need to on the editor and Don't make a prefab dirty

### what you tested?
Editor and builds

### Potential Issues?
Might cause login issues not to be shown on editor When in general use, so to test you can disable it in game data
