### PR TITLE
Fast equip inventory fixes

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/Emergency Oxygen Tank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/Emergency Oxygen Tank.prefab
@@ -65,6 +65,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 3c067c15f69684f9bb99b801202069b3,
         type: 2}
+    - target: {fileID: 520041481196620939, guid: cbf90b2e22f389941aaf3912f2b607ee,
+        type: 3}
+      propertyPath: initialTraits.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 3c067c15f69684f9bb99b801202069b3,
+        type: 2}
     - target: {fileID: 21992246282985053, guid: cbf90b2e22f389941aaf3912f2b607ee,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/GasContainer.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/GasContainer.prefab
@@ -34,41 +34,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: GasContainer
       objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: initialName
-      value: A Tank
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: initialDescription
-      value: A tank of Someting?
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: initialSize
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: hitDamage
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: throwDamage
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: throwSpeed
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: throwRange
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -118,6 +83,58 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialName
+      value: A Tank
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialDescription
+      value: A tank of Someting?
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialSize
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: hitDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: throwDamage
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: throwSpeed
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: throwRange
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: b05bab692e98c487eb4996a0614d143d,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ed946b910c993490a8fc6dbcce8d23e2,
+        type: 2}
     - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/BestSlotForTraitSingleton.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/BestSlotForTraitSingleton.asset
@@ -30,7 +30,7 @@ MonoBehaviour:
   - Trait: {fileID: 11400000, guid: 499c5f7e8067145d3b31ba4b21a2fa74, type: 2}
     Slot: 15
   - Trait: {fileID: 11400000, guid: 3858899698cc1425f86b8b93032ca57d, type: 2}
-    Slot: 4
+    Slot: 5
   - Trait: {fileID: 11400000, guid: 03d313a9668074d24b7a143b70a86327, type: 2}
     Slot: 13
   - Trait: {fileID: 11400000, guid: 9dd6c830eadb94ceb8578c8ac94dde66, type: 2}
@@ -45,3 +45,5 @@ MonoBehaviour:
     Slot: 16
   - Trait: {fileID: 0}
     Slot: 17
+  - Trait: {fileID: 11400000, guid: ed946b910c993490a8fc6dbcce8d23e2, type: 2}
+    Slot: 18

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/EquipSlot/Suit Storage.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/EquipSlot/Suit Storage.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: Suit Storage
+  m_EditorClassIdentifier: 
+  traitDescription: Items with this trait can be equipped in a suit storage like big
+    gas tank.

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/EquipSlot/Suit Storage.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/EquipSlot/Suit Storage.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed946b910c993490a8fc6dbcce8d23e2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Traits/BestSlotForTrait.cs
+++ b/UnityProject/Assets/Scripts/Items/Traits/BestSlotForTrait.cs
@@ -28,6 +28,15 @@ public class BestSlotForTrait : SingletonScriptableObject<BestSlotForTrait>
 	[ArrayElementTitle("Trait", "Any")]
 	[SerializeField] private List<TraitSlotMapping> BestSlots;
 
+
+	/// <summary>
+	/// This Named Slots can't be best slots. GetBestSlot will ignore them
+	/// </summary>
+	private static NamedSlot[] BlackListSlots = new NamedSlot[]{
+		NamedSlot.leftHand,
+		NamedSlot.rightHand
+	};
+
 	/// <summary>
 	/// Returns the slot in storage which is the best fit for the item.
 	/// The BestSlots list will be scanned through in order. Returns the
@@ -69,7 +78,15 @@ public class BestSlotForTrait : SingletonScriptableObject<BestSlotForTrait>
 		Logger.LogTraceFormat("Item {0} did not fit in any BestSlots, thus will" +
 		                      " be placed in first available slot.", Category.Inventory, toCheck);
 
-		return storage.GetItemSlots().FirstOrDefault(slot =>
+		// Get all slots
+		var allSlots = storage.GetItemSlots();
+
+		// Filter blaclisted named slots
+		var allowedSlots = allSlots.Where((slot) => !slot.NamedSlot.HasValue ||
+		(slot.NamedSlot.HasValue && !BlackListSlots.Contains(slot.NamedSlot.Value))).ToArray();
+
+		// Select first avaliable
+		return allowedSlots.FirstOrDefault(slot =>
 			(!mustHaveUISlot || slot.LocalUISlot != null) &&
 			Validations.CanFit(slot, toCheck, side));
 	}

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
@@ -142,7 +142,12 @@ public class Hands : MonoBehaviour
 		//This checks which UI slot the item can be equiped to and swaps it there
 		//Try to equip the item into the appropriate slot
 		var bestSlot = BestSlotForTrait.Instance.GetBestSlot(CurrentSlot.Item, PlayerManager.LocalPlayerScript.ItemStorage);
-		if (bestSlot == null) return;
+		if (bestSlot == null)
+		{
+			Chat.AddExamineMsg(PlayerManager.LocalPlayerScript.gameObject, "There is no available slot for that");
+			return;
+		}
+
 		SwapItem(bestSlot.LocalUISlot);
 	}
 


### PR DESCRIPTION
### Purpose
Fixes #2563. Now oxygen tank can be properly equipped on suit storage slot.
Also gas masks are equipped in mask slot by pressing E button.
Fixed bug when item starts swap hands when there is no available best slot.
Add client-only message when there are no available slot. 

### Notes:
Also can't replicate #1860. 
Because #2248 you can wear big oxygen tank with any suit.
