### PR TITLE
Patting out players who are on fire (new interaction)

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Player/Resources/Player_V3(uNet).prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Player/Resources/Player_V3(uNet).prefab
@@ -729,6 +729,7 @@ GameObject:
   - component: {fileID: 114279031792796038}
   - component: {fileID: 441872716838640463}
   - component: {fileID: 4171332437423579703}
+  - component: {fileID: -2023535518380200052}
   m_Layer: 8
   m_Name: Player_V3(uNet)
   m_TagString: Untagged
@@ -1278,7 +1279,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 4024605270
+  m_SceneId: 0
 --- !u!114 &441872716838640463
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1307,6 +1308,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 859b05c4e8c945cf932ff3427e9102df, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &-2023535518380200052
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1133514949248654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14a61d8455306ba4a8bc340ee1699eda, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1147423205297840

--- a/UnityProject/Assets/Scripts/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.cs
@@ -256,20 +256,7 @@ public partial class Chat : MonoBehaviour
 			victimName = "yourself";
 			if (player != null)
 			{
-				if (player.Script.characterSettings.Gender == Gender.Female)
-				{
-					victimNameOthers = "herself";
-				}
-
-				if (player.Script.characterSettings.Gender == Gender.Male)
-				{
-					victimNameOthers = "himself";
-				}
-
-				if (player.Script.characterSettings.Gender == Gender.Neuter)
-				{
-					victimNameOthers = "itself";
-				}
+				victimNameOthers = player.Script.characterSettings.ReflexivePronoun();
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/Health/CPRable.cs
+++ b/UnityProject/Assets/Scripts/Health/CPRable.cs
@@ -13,16 +13,18 @@ public class CPRable : MonoBehaviour, IClientInteractable<PositionalHandApply>
 
 		// Is the target in range for CPR? Is the target unconscious? Is the intent set to help? Is the target a player?
 		// Is the performer's hand empty? Is the performer not stunned/downed? Is the performer conscious to perform the interaction?
-		// Is the performer interacting with itself?
+		// Is the performer interacting with itself? Is neither player on fire?
 		if (!PlayerManager.LocalPlayerScript.IsInReach(interaction.WorldPositionTarget, false) ||
-		    targetPlayerHealth.ConsciousState == ConsciousState.CONSCIOUS ||
-		    targetPlayerHealth.ConsciousState == ConsciousState.DEAD ||
-		    UIManager.CurrentIntent != Intent.Help ||
-		    !targetPlayerHealth ||
-		    interaction.HandObject != null ||
-		    performerRegisterPlayer.IsLayingDown ||
-		    performerPlayerHealth.ConsciousState != ConsciousState.CONSCIOUS ||
-		    interaction.Performer == interaction.TargetObject)
+			targetPlayerHealth.ConsciousState == ConsciousState.CONSCIOUS ||
+			targetPlayerHealth.ConsciousState == ConsciousState.DEAD ||
+			UIManager.CurrentIntent != Intent.Help ||
+			!targetPlayerHealth ||
+			interaction.HandObject != null ||
+			performerRegisterPlayer.IsLayingDown ||
+			performerPlayerHealth.ConsciousState != ConsciousState.CONSCIOUS ||
+			interaction.Performer == interaction.TargetObject ||
+			interaction.TargetObject.GetComponent<LivingHealthBehaviour>().FireStacks > 0 ||
+			interaction.Performer.GetComponent<LivingHealthBehaviour>().FireStacks > 0)
 		{
 			return false;
 		}

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -98,7 +98,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	//how on fire we are, sames as tg fire_stacks. 0 = not on fire.
 	//It's called "stacks" but it's really just a floating point value that
 	//can go up or down based on possible sources of being on fire. Max seems to be 20 in tg.
-	[SyncVar(hook=nameof(SyncFireStacks))]
+	[SyncVar(hook = nameof(SyncFireStacks))]
 	private float fireStacks;
 
 	/// <summary>
@@ -231,9 +231,19 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 		SyncFireStacks(0);
 	}
 
-	public void SyncFireStacks(float newValue)
+	/// <summary>
+	/// Sets the serverside fireStacks of a LivingHealthBehaviour to a new value.
+	/// </summary>
+	/// <param name="newValue">The new value, clamped to values 0 and above.</param>
+	[Server]
+	public void ServerSetFireStacks(float newValue)
 	{
-		this.fireStacks = Math.Max(0,newValue);
+		this.fireStacks = Math.Max(0, newValue);
+	}
+
+	private void SyncFireStacks(float newValue)
+	{
+		this.fireStacks = Math.Max(0, newValue);
 		OnClientFireStacksChange.Invoke(this.fireStacks);
 	}
 
@@ -241,7 +251,8 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	/// PUBLIC FUNCTIONS: HEAL AND DAMAGE:
 	/// ---------------------------
 
-	private BodyPartBehaviour GetBodyPart(float amount, DamageType damageType, BodyPartType bodyPartAim = BodyPartType.Chest){
+	private BodyPartBehaviour GetBodyPart(float amount, DamageType damageType, BodyPartType bodyPartAim = BodyPartType.Chest)
+	{
 		if (amount <= 0 || IsDead)
 		{
 			return null;
@@ -323,10 +334,10 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	/// <param name="attackType">type of attack that is causing the damage</param>
 	/// <param name="damageType">The Type of Damage</param>
 	[Server]
-	public void ApplyDamageToBodypart( GameObject damagedBy, float damage,
-		AttackType attackType, DamageType damageType )
+	public void ApplyDamageToBodypart(GameObject damagedBy, float damage,
+		AttackType attackType, DamageType damageType)
 	{
-		ApplyDamageToBodypart( damagedBy, damage, attackType, damageType, BodyPartType.Chest.Randomize( 0 ) );
+		ApplyDamageToBodypart(damagedBy, damage, attackType, damageType, BodyPartType.Chest.Randomize(0));
 	}
 
 	/// <summary>
@@ -341,17 +352,17 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	public virtual void ApplyDamageToBodypart(GameObject damagedBy, float damage,
 		AttackType attackType, DamageType damageType, BodyPartType bodyPartAim)
 	{
-		if ( IsDead )
+		if (IsDead)
 		{
 			afterDeathDamage += damage;
-			if ( afterDeathDamage >= GIB_THRESHOLD )
+			if (afterDeathDamage >= GIB_THRESHOLD)
 			{
 				Harvest();//Gib() instead when fancy gibs are in
 			}
 		}
 
 		BodyPartBehaviour bodyPartBehaviour = GetBodyPart(damage, damageType, bodyPartAim);
-		if(bodyPartBehaviour == null)
+		if (bodyPartBehaviour == null)
 		{
 			return;
 		}
@@ -368,7 +379,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 
 		if (attackType == AttackType.Fire)
 		{
-			SyncFireStacks(fireStacks+1);
+			SyncFireStacks(fireStacks + 1);
 		}
 
 		//For special effects spawning like blood:
@@ -427,7 +438,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 					//TODO: Burn clothes (see species.dm handle_fire)
 					ApplyDamageToBodypart(null, fireStacks * DAMAGE_PER_FIRE_STACK, AttackType.Internal, DamageType.Burn);
 					//gradually deplete fire stacks
-					SyncFireStacks(fireStacks-0.1f);
+					SyncFireStacks(fireStacks - 0.1f);
 					//instantly stop burning if there's no oxygen at this location
 					MetaDataNode node = registerTile.Matrix.MetaDataLayer.Get(registerTile.LocalPositionClient);
 					if (node.GasMix.GetMoles(Gas.Oxygen) < 1)
@@ -581,7 +592,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	{
 		if (ConsciousState != ConsciousState.CONSCIOUS && bloodSystem.OxygenDamage < HealthThreshold.OxygenPassOut && OverallHealth > HealthThreshold.SoftCrit)
 		{
-			Logger.LogFormat( "{0}, back on your feet!", Category.Health, gameObject.name );
+			Logger.LogFormat("{0}, back on your feet!", Category.Health, gameObject.name);
 			Uncrit();
 			return;
 		}

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -231,7 +231,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 		SyncFireStacks(0);
 	}
 
-	private void SyncFireStacks(float newValue)
+	public void SyncFireStacks(float newValue)
 	{
 		this.fireStacks = Math.Max(0,newValue);
 		OnClientFireStacksChange.Invoke(this.fireStacks);

--- a/UnityProject/Assets/Scripts/Player/ExtinguishByHand.cs
+++ b/UnityProject/Assets/Scripts/Player/ExtinguishByHand.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+/// <summary>
+/// Allows an object to be patted when on fire.
+/// </summary>
+public class ExtinguishByHand : MonoBehaviour, IClientInteractable<PositionalHandApply>
+{
+	public bool Interact(PositionalHandApply interaction)
+	{
+		var targetPlayerHealth = interaction.TargetObject.GetComponent<PlayerHealth>();
+		var performerPlayerHealth = interaction.Performer.GetComponent<PlayerHealth>();
+		var performerRegisterPlayer = interaction.Performer.GetComponent<RegisterPlayer>();
+
+		// Is the target in range for a pat? Is the performer's intent set to help?
+		// Is the performer's hand empty? Is the performer not stunned/downed? Is the performer conscious to perform the interaction?
+		if (!PlayerManager.LocalPlayerScript.IsInReach(interaction.WorldPositionTarget, false) ||
+		    UIManager.CurrentIntent != Intent.Help ||
+		    interaction.HandObject != null ||
+		    performerPlayerHealth.ConsciousState != ConsciousState.CONSCIOUS ||
+		    performerRegisterPlayer.IsLayingDown)
+		{
+			return false;
+		}
+
+		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRequestPatFire(PlayerManager.LocalPlayerScript.playerName,
+			gameObject);
+		return true;
+	}
+}

--- a/UnityProject/Assets/Scripts/Player/ExtinguishByHand.cs
+++ b/UnityProject/Assets/Scripts/Player/ExtinguishByHand.cs
@@ -14,10 +14,10 @@ public class ExtinguishByHand : MonoBehaviour, IClientInteractable<PositionalHan
 		// Is the target in range for a pat? Is the performer's intent set to help?
 		// Is the performer's hand empty? Is the performer not stunned/downed? Is the performer conscious to perform the interaction?
 		if (!PlayerManager.LocalPlayerScript.IsInReach(interaction.WorldPositionTarget, false) ||
-		    UIManager.CurrentIntent != Intent.Help ||
-		    interaction.HandObject != null ||
-		    performerPlayerHealth.ConsciousState != ConsciousState.CONSCIOUS ||
-		    performerRegisterPlayer.IsLayingDown)
+			UIManager.CurrentIntent != Intent.Help ||
+			interaction.HandObject != null ||
+			performerPlayerHealth.ConsciousState != ConsciousState.CONSCIOUS ||
+			performerRegisterPlayer.IsLayingDown)
 		{
 			return false;
 		}

--- a/UnityProject/Assets/Scripts/Player/ExtinguishByHand.cs
+++ b/UnityProject/Assets/Scripts/Player/ExtinguishByHand.cs
@@ -3,27 +3,42 @@ using UnityEngine;
 /// <summary>
 /// Allows an object to be patted when on fire.
 /// </summary>
-public class ExtinguishByHand : MonoBehaviour, IClientInteractable<PositionalHandApply>
+public class ExtinguishByHand : MonoBehaviour, ICheckedInteractable<HandApply>
 {
-	public bool Interact(PositionalHandApply interaction)
+	/// <summary>
+	/// Fire stacks removed when patting fires (on other people)
+	/// </summary>
+	private readonly float patFireStacksRemoved = 999f;
+
+	/// <summary>
+	/// Fire stacks removed when patting fires (on yourself
+	/// </summary>
+	private readonly float patFireStacksRemovedSelf = 999f;
+
+	public bool WillInteract(HandApply interaction, NetworkSide side)
 	{
-		var targetPlayerHealth = interaction.TargetObject.GetComponent<PlayerHealth>();
+		if (!DefaultWillInteract.Default(interaction, side)) return false;
+
+		// Can be done with an empty hand and only to LHBs
+		if (interaction.HandObject != null) return false;
+		if (!Validations.HasComponent<LivingHealthBehaviour>(interaction.TargetObject)) return false;
+
+		return true;
+	}
+
+	public void ServerPerformInteraction(HandApply interaction)
+	{
 		var performerPlayerHealth = interaction.Performer.GetComponent<PlayerHealth>();
 		var performerRegisterPlayer = interaction.Performer.GetComponent<RegisterPlayer>();
 
-		// Is the target in range for a pat? Is the performer's intent set to help?
-		// Is the performer's hand empty? Is the performer not stunned/downed? Is the performer conscious to perform the interaction?
-		if (!PlayerManager.LocalPlayerScript.IsInReach(interaction.WorldPositionTarget, false) ||
-			UIManager.CurrentIntent != Intent.Help ||
+		if (UIManager.CurrentIntent != Intent.Help ||
 			interaction.HandObject != null ||
 			performerPlayerHealth.ConsciousState != ConsciousState.CONSCIOUS ||
 			performerRegisterPlayer.IsLayingDown)
 		{
-			return false;
+			return;
 		}
-
-		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRequestPatFire(PlayerManager.LocalPlayerScript.playerName,
-			gameObject);
-		return true;
+		float fireStacksToRemove = interaction.Performer == interaction.TargetObject ? patFireStacksRemovedSelf : patFireStacksRemoved;
+		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRequestPatFire(interaction.TargetObject, fireStacksToRemove);
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/ExtinguishByHand.cs.meta
+++ b/UnityProject/Assets/Scripts/Player/ExtinguishByHand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14a61d8455306ba4a8bc340ee1699eda
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Lobby/CharacterCustomization.cs
@@ -767,6 +767,25 @@ public class CharacterSettings
 				return "their";
 		}
 	}
+
+	/// <summary>
+	/// Returns a reflexive pronous (i.e. "herself) based on the character's gender.
+	/// </summary>
+	/// <returns></returns>
+	public string ReflexivePronoun()
+	{
+		switch (Gender)
+		{
+			case Gender.Male:
+				return "himself";
+			case Gender.Female:
+				return "herself";
+			case Gender.Neuter:
+				return "itself";
+			default:
+				return "themselves";
+		}
+	}
 }
 
 public enum Gender


### PR DESCRIPTION

![2020-02-02_14-57-50](https://user-images.githubusercontent.com/9169275/73609431-d4dbac80-45cd-11ea-854c-f3273dbed31a.png)
![2020-02-02_14-47-48](https://user-images.githubusercontent.com/9169275/73609433-d6a57000-45cd-11ea-8132-f9ae3cd12504.png)

### Purpose
* Previously there was not much a player could to about being on fire. https://github.com/unitystation/unitystation/issues/2660 requested resisting fires.
* This PR lets players extinguish the flames on other players by patting them. Players can also pat out themselves (which is less effective).

### Notes:
* Patting out players is a new interaction.
* CPR can no longer be performed if the patient is on fire. (They will be patted instead)
* Patting decreases the fire stacks on that player. Patting other players is more effective than patting yourself. The number may need to be tweaked in case patting out fires is too easy.
* Added a function for getting a player's reflexing pronoun ("herself", "himself," ...)
* Made the function for changing fire stacks public. (Or is there another method..?)
* Players can still give each other fiery hugs - but only when the person performing the hug is the one on fire. (Sorry @chairbender !)
* Did a tiny bit of autoformatting.

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] The PR has been tested in multiplayer (**Editor only**)
