### PR TITLE
Fix Client breaking NRE when using edit field on Canister GUI #2826

### DIFF
--- a/UnityProject/Assets/Scripts/UI/InputFieldFocus.cs
+++ b/UnityProject/Assets/Scripts/UI/InputFieldFocus.cs
@@ -63,10 +63,13 @@ public class InputFieldFocus : InputField
 		DisableInput();
 	}
 
+	/// <summary>
+	/// This event is called when the input field is deselected.
+	/// </summary>
+	/// <param name="eventData">Data for the event</param>
 	public override void OnDeselect( BaseEventData eventData )
 	{
 		base.OnDeselect( eventData );
-		StartCoroutine(DelayedEnableInput());
 	}
 
 	public override void OnSubmit( BaseEventData eventData )


### PR DESCRIPTION
Client breaking NRE when using edit field on Canister GUI #2826

I don't see the need to enable an invisble output.