### PR TITLE
Fix Re-logging breaks player sprites for all equipment. #2647

### DIFF
--- a/UnityProject/Assets/Scripts/Items/ClothingItem.cs
+++ b/UnityProject/Assets/Scripts/Items/ClothingItem.cs
@@ -93,8 +93,6 @@ public class ClothingItem : MonoBehaviour
 		UpdateReferenceOffset();
 		if (Item == null)
 		{
-			GameObjectReference = null; // Remove the item from equipment
-
 			if (spriteHandler != null) //need to remove
 			{
 				spriteHandler.spriteData = null;
@@ -109,6 +107,7 @@ public class ClothingItem : MonoBehaviour
 					OnClothingEquiped?.Invoke(unequippedClothing, false);
 			}
 
+			GameObjectReference = null; // Remove the item from equipment
 		}
 
 		if (Item != null)

--- a/UnityProject/Assets/Scripts/Items/ClothingItem.cs
+++ b/UnityProject/Assets/Scripts/Items/ClothingItem.cs
@@ -93,6 +93,8 @@ public class ClothingItem : MonoBehaviour
 		UpdateReferenceOffset();
 		if (Item == null)
 		{
+			GameObjectReference = null; // Remove the item from equipment
+
 			if (spriteHandler != null) //need to remove
 			{
 				spriteHandler.spriteData = null;
@@ -111,7 +113,8 @@ public class ClothingItem : MonoBehaviour
 
 		if (Item != null)
 		{
-			GameObjectReference = Item;
+			GameObjectReference = Item; // Add item to equipment
+
 			if (InHands)
 			{
 				var ItemAttributesV2 = Item.GetComponent<ItemAttributesV2>();


### PR DESCRIPTION
Clothing items were never removed from equipment slots, they were merely hidden, making them reappearing when you re-logging.  Even if you dropped them on the floor!
