### PR TITLE
Hop console log out now spits out ID. Decreased zoom increment

### DIFF
--- a/UnityProject/Assets/Scripts/UI/CameraZoomHandler.cs
+++ b/UnityProject/Assets/Scripts/UI/CameraZoomHandler.cs
@@ -40,7 +40,7 @@ public class CameraZoomHandler : MonoBehaviour
 	/// <summary>
 	/// Increment at which zoom changes when using Increase / DecreaseZoomLevel().
 	/// </summary>
-	private readonly int zoomIncrement = 2;
+	private readonly int zoomIncrement = 1;
 
     void Update()
     {

--- a/UnityProject/Assets/Scripts/UI/IdConsole/GUI_IDConsole.cs
+++ b/UnityProject/Assets/Scripts/UI/IdConsole/GUI_IDConsole.cs
@@ -214,6 +214,7 @@ public class GUI_IDConsole : NetTab
 		console.LoggedIn = false;
 		pageSwitcher.SetActivePage(loginPage);
 		ServerUpdateLoginCardName();
+		ServerRemoveAccessCard();
 	}
 
 	public void CloseTab()


### PR DESCRIPTION
If you click log out on hop console it will now shoot out your ID
I also decreased zoom increment so it did not jump to high zoom quickly (as per tester request)
