### PR TITLE
Reduce nesting in CI build output.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
     paths:
     - 'Tools/**'
     - 'UnityProject/**'
+    - '.github/workflows/main.yml'
   pull_request:
     branches:
     - develop
@@ -15,6 +16,7 @@ on:
     paths:
     - 'Tools/**'
     - 'UnityProject/**'
+    - '.github/workflows/main.yml'
 
 jobs:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,5 +109,5 @@ jobs:
       - name: Upload Build
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ matrix.targetPlatform }} Build
-          path: build
+          name: ${{ matrix.targetPlatform }}
+          path: build/${{ matrix.targetPlatform }}


### PR DESCRIPTION
### Purpose
_This should make the build output less confusing and easier to use._<br>

### Notes:
_The space in the output zip was difficult to work with and the output had an unnecessary folder level._
