### PR TITLE
Removed file extension from build directory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,14 +6,14 @@ on:
     - develop
     - master
     paths:
-    - 'Tools/**'
+    - 'Tools/UnityLicense.ulf'
     - 'UnityProject/**'
   pull_request:
     branches:
     - develop
     - master
     paths:
-    - 'Tools/**'
+    - 'Tools/UnityLicense.ulf'
     - 'UnityProject/**'
 
 jobs:

--- a/UnityProject/Assets/Scripts/Editor/BuildServer.cs
+++ b/UnityProject/Assets/Scripts/Editor/BuildServer.cs
@@ -167,11 +167,13 @@ static class BuildScript
 
 		var buildTarget = options["buildTarget"];
 		var buildPath = options["customBuildPath"];
-		var buildName = options["customBuildName"];
+		// TODO: fix Unity Builder Action to use customBuildName
+		// var buildName = options["customBuildName"];
 
 		// Gather values from project
 		var scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(s => s.path).ToArray();
-		var locationPathName = $"{buildPath}/{buildName}{GetFileExtension(buildTarget)}";
+		// var locationPathName = $"{buildPath}/{buildName}{GetFileExtension(buildTarget)}";
+		var locationPathName = buildPath;
 		var target = (BuildTarget) Enum.Parse(typeof(BuildTarget), buildTarget);
 
 		// Define BuildPlayer Options


### PR DESCRIPTION
### Purpose
Removes the file names from the build directories, and changes the build trigger path to only include UnityLicense in the Tools directory.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
