### PR TITLE
Made T key default to local instead of the last channels used

### DIFF
--- a/UnityProject/Assets/Scripts/Input System/KeyboardInputManager.cs
+++ b/UnityProject/Assets/Scripts/Input System/KeyboardInputManager.cs
@@ -82,7 +82,7 @@ public class KeyboardInputManager : MonoBehaviour
 	public static bool IsMovementPressed(KeyEventType keyEventType = KeyEventType.Down)
 	{
 		if (UIManager.IsInputFocus) return false;
-		
+
 		return Instance.CheckKeyAction(KeyAction.MoveUp,   keyEventType) || Instance.CheckKeyAction(KeyAction.MoveDown,  keyEventType) ||
 		       Instance.CheckKeyAction(KeyAction.MoveLeft, keyEventType) || Instance.CheckKeyAction(KeyAction.MoveRight, keyEventType);
 	}
@@ -165,7 +165,7 @@ public class KeyboardInputManager : MonoBehaviour
 		{ KeyAction.IntentHarm, 	() => { UIManager.Intent.SetIntent(Intent.Harm); }},
 
 		// Chat
-		{ KeyAction.ChatLocal,		() => { ChatUI.Instance.OpenChatWindow(); }},
+		{ KeyAction.ChatLocal,		() => { ChatUI.Instance.OpenChatWindow(ChatChannel.Local); }},
 		{ KeyAction.ChatRadio,		() => { ChatUI.Instance.OpenChatWindow(ChatChannel.Common); }},
 		{ KeyAction.ChatOOC,		() => { ChatUI.Instance.OpenChatWindow(ChatChannel.OOC); }},
 


### PR DESCRIPTION
### Purpose
To make sure you don't accidentally shout woody's got wood into the wrong channel.

Partially fixes #2654

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
