### PR TITLE
Fixed atmos not resetting state on round restart

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
@@ -44,6 +44,7 @@ namespace Atmospherics
 		public void ClearUpdateList()
 		{
 			nodes.Clear();
+			updateList = new UniqueQueue<MetaDataNode>();
 		}
 
 		public void Run()

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosThread.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosThread.cs
@@ -5,6 +5,7 @@ using Tilemaps.Behaviours.Meta;
 using UnityEngine;
 using System.Diagnostics;
 using System;
+using UnityEngine.Profiling;
 
 public static class AtmosThread
 {
@@ -18,9 +19,12 @@ public static class AtmosThread
 
 	private static AtmosSimulation simulation;
 
+	private static CustomSampler sampler;
+
 	static AtmosThread()
 	{
 		simulation = new AtmosSimulation();
+		sampler = CustomSampler.Create("AtmosphericsStep");
 	}
 
 	public static void ClearAllNodes()
@@ -74,13 +78,16 @@ public static class AtmosThread
 
 	private static void Run()
 	{
+		Profiler.BeginThreadProfiling("Unitystation", "Atmospherics");
 		while (running)
 		{
 			if (!simulation.IsIdle)
 			{
+				sampler.Begin();
 				StopWatch.Restart();
 				RunStep();
 				StopWatch.Stop();
+				sampler.End();
 				if (StopWatch.ElapsedMilliseconds < MillieSecondDelay)
 				{
 					Thread.Sleep(MillieSecondDelay - (int)StopWatch.ElapsedMilliseconds);
@@ -94,6 +101,7 @@ public static class AtmosThread
 				}
 			}
 		}
+		Profiler.EndThreadProfiling();
 	}
 
 


### PR DESCRIPTION
Atmos thread takes roughly 1ms (on my machine) and would add another 1ms for each round restart. This results in roughly 4ms after 3 restarts as seen in bottom right below:

![image](https://user-images.githubusercontent.com/1729718/74079127-59498780-4a33-11ea-87e0-b983a3a27068.png)

Fixed by clearing updateList on round restart.

Also added profiling for the atmos thread.

Does not conflict with #2952 