### PR TITLE
MORE Vending Items and Ghost speed

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_16.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_16.prefab
@@ -126,6 +126,10 @@ MonoBehaviour:
     Stock: 5
   - Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
     Stock: 5
+  - Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
+    Stock: 5
+  - Item: {fileID: 6532193109441330816, guid: 6366d9ab2983aa44aa585fd0f7557e17, type: 3}
+    Stock: 5
   HullColor: {r: 0.7294118, g: 0.06666667, b: 0.23529413, a: 1}
   EjectObjects: 0
   EjectDirection: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_185.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_185.prefab
@@ -124,6 +124,10 @@ MonoBehaviour:
   VendorContent:
   - Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
     Stock: 5
+  - Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
+    Stock: 2
+  - Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
+    Stock: 2
   HullColor: {r: 0.25882354, g: 0.25882354, b: 0.25882354, a: 1}
   EjectObjects: 1
   EjectDirection: 2

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_24.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_24.prefab
@@ -120,7 +120,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8ed381a72f1e344bb8020dc181414b43, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  VendorContent: []
+  VendorContent:
+  - Item: {fileID: 8582594776399167655, guid: f23b37dbf83885c4aabb3240de1c5b19, type: 3}
+    Stock: 1
+  - Item: {fileID: 742292832060491855, guid: 7bfcc39ce2266f54581ac24597ce0434, type: 3}
+    Stock: 2
+  - Item: {fileID: 8594439505056330043, guid: 838a4732b2dece64497d074b7a700be6, type: 3}
+    Stock: 20
+  - Item: {fileID: 5260985750374485318, guid: 36e3533550bd8a943ad05db76b83fdd3, type: 3}
+    Stock: 1
   HullColor: {r: 0.40784314, g: 0.41568628, b: 0.36862746, a: 1}
   EjectObjects: 0
   EjectDirection: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_24.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_24.prefab
@@ -33,7 +33,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1825784958154784}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 47, y: 36, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -121,12 +121,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   VendorContent:
+  - Item: {fileID: 8594439505056330043, guid: 838a4732b2dece64497d074b7a700be6, type: 3}
+    Stock: 20
   - Item: {fileID: 8582594776399167655, guid: f23b37dbf83885c4aabb3240de1c5b19, type: 3}
     Stock: 1
   - Item: {fileID: 742292832060491855, guid: 7bfcc39ce2266f54581ac24597ce0434, type: 3}
     Stock: 2
-  - Item: {fileID: 8594439505056330043, guid: 838a4732b2dece64497d074b7a700be6, type: 3}
-    Stock: 20
   - Item: {fileID: 5260985750374485318, guid: 36e3533550bd8a943ad05db76b83fdd3, type: 3}
     Stock: 1
   HullColor: {r: 0.40784314, g: 0.41568628, b: 0.36862746, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Player/Resources/Ghost.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Player/Resources/Ghost.prefab
@@ -151,8 +151,8 @@ MonoBehaviour:
   allowInput: 1
   moveList: 05000000060000000700000008000000
   pna: {fileID: 0}
-  RunSpeed: 10
-  WalkSpeed: 10
+  RunSpeed: 30
+  WalkSpeed: 30
   CrawlSpeed: 0.8
   PushFallSpeed: 10
 --- !u!114 &2038932850302980570
@@ -279,7 +279,7 @@ MonoBehaviour:
   serverOnly: 0
   localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 1586761048
+  m_SceneId: 0
 --- !u!114 &8224268276445300722
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Player/Resources/Ghost.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Player/Resources/Ghost.prefab
@@ -151,8 +151,8 @@ MonoBehaviour:
   allowInput: 1
   moveList: 05000000060000000700000008000000
   pna: {fileID: 0}
-  RunSpeed: 30
-  WalkSpeed: 30
+  RunSpeed: 10
+  WalkSpeed: 10
   CrawlSpeed: 0.8
   PushFallSpeed: 10
 --- !u!114 &2038932850302980570


### PR DESCRIPTION
# MORE Vending Items and Ghost speed

### Purpose
Grants Nukies the ability to vend 1 emag which will let them disable safeties on shuttles.
Adds more food to vending machines
Increases Ghost SPEED
Fixes #2951 
Fixes #2923 

### Notes:
All relevant info is above

### Please make sure you have followed the self checks below before submitting a PR:

- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor

