### PR TITLE
Fixed having no hub config stopping rcon config from running.

### DIFF
--- a/UnityProject/Assets/Scripts/Database/ServerData.ServerStatus.cs
+++ b/UnityProject/Assets/Scripts/Database/ServerData.ServerStatus.cs
@@ -74,7 +74,6 @@ namespace DatabaseAPI
 	        if (string.IsNullOrEmpty(config.HubUser) || string.IsNullOrEmpty(config.HubPass))
 	        {
 		        Logger.Log("Invalid Hub creds found, aborting HUB connection", Category.DatabaseAPI);
-		        config = null;
 		        yield break;
 	        }
 

--- a/UnityProject/Assets/Scripts/Database/ServerData.cs
+++ b/UnityProject/Assets/Scripts/Database/ServerData.cs
@@ -96,8 +96,10 @@ namespace DatabaseAPI
 		void Update()
 		{
 			if (config != null)
-			{
-				MonitorServerStatus();
+				if (!string.IsNullOrEmpty(config.HubUser))
+				{
+					MonitorServerStatus();
+				}
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Database/ServerData.cs
+++ b/UnityProject/Assets/Scripts/Database/ServerData.cs
@@ -96,6 +96,7 @@ namespace DatabaseAPI
 		void Update()
 		{
 			if (config != null)
+			{
 				if (!string.IsNullOrEmpty(config.HubUser))
 				{
 					MonitorServerStatus();

--- a/UnityProject/Assets/Scripts/Database/ServerData.cs
+++ b/UnityProject/Assets/Scripts/Database/ServerData.cs
@@ -97,7 +97,7 @@ namespace DatabaseAPI
 		{
 			if (config != null)
 			{
-				if (!string.IsNullOrEmpty(config.HubUser))
+				if (!string.IsNullOrEmpty(config.HubUser) && !string.IsNullOrEmpty(config.HubPass))
 				{
 					MonitorServerStatus();
 				}


### PR DESCRIPTION
# Pull Request Template

### Purpose
Fixes #2884 
If you didn't have hub credentials set in the config but you had rcon set up you it would just skip the code to look at the rcon config.

### Notes:
Without HubUser set in the config, the hub communication loop code will not run.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
