### PR TITLE
Prevents dead or unconscious people from removing handcuffs.

### DIFF
--- a/UnityProject/Assets/Scripts/Clothing/RestraintOverlay.cs
+++ b/UnityProject/Assets/Scripts/Clothing/RestraintOverlay.cs
@@ -98,9 +98,11 @@ public class RestraintOverlay : ClothingItem
 
 	bool CanUncuff()
 	{
-		if (!thisPlayerScript.playerHealth.serverPlayerConscious ||
+		PlayerHealth playerHealth = thisPlayerScript.playerHealth;
+		if (playerHealth.ConsciousState == ConsciousState.DEAD ||
+			playerHealth.ConsciousState == ConsciousState.UNCONSCIOUS ||
 		    thisPlayerScript.registerTile.IsSlippingServer ||
-		    healthCache != thisPlayerScript.playerHealth.OverallHealth ||
+		    healthCache != playerHealth.OverallHealth ||
 		    positionCache != thisPlayerScript.registerTile.LocalPositionServer)
 		{
 			return false;

--- a/UnityProject/Assets/Scripts/Clothing/RestraintOverlay.cs
+++ b/UnityProject/Assets/Scripts/Clothing/RestraintOverlay.cs
@@ -99,10 +99,12 @@ public class RestraintOverlay : ClothingItem
 	bool CanUncuff()
 	{
 		PlayerHealth playerHealth = thisPlayerScript.playerHealth;
-		if (playerHealth.ConsciousState == ConsciousState.DEAD ||
+		
+		if (playerHealth == null ||
+			playerHealth.ConsciousState == ConsciousState.DEAD ||
 			playerHealth.ConsciousState == ConsciousState.UNCONSCIOUS ||
-		    thisPlayerScript.registerTile.IsSlippingServer ||
-		    healthCache != playerHealth.OverallHealth ||
+			playerHealth.OverallHealth != healthCache ||
+			thisPlayerScript.registerTile.IsSlippingServer ||
 		    positionCache != thisPlayerScript.registerTile.LocalPositionServer)
 		{
 			return false;


### PR DESCRIPTION
### Purpose
Fixes #2993

### Notes:
Problem was caused by a reference to `PlayerHealth.serverPlayerConscious` which doesn't seem to actually do anything.
