### PR TITLE
made plasma from plasma canisters colder so it won't catch on fire

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/PlasmaCanister.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Canisters/PlasmaCanister.prefab
@@ -36,6 +36,11 @@ PrefabInstance:
       propertyPath: ReleasePressure
       value: 300
       objectReference: {fileID: 0}
+    - target: {fileID: 114104253718565984, guid: e9620f26b24f33c4cbe56a85ae95865d,
+        type: 3}
+      propertyPath: Temperature
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 114271548548165924, guid: e9620f26b24f33c4cbe56a85ae95865d,
         type: 3}
       propertyPath: PrimaryUITint.r


### PR DESCRIPTION
### what this do?
made plasma from plasma canisters colder so it won't catch on fire, and A lot of players are complaining about people who rush atmospherics to get the plasma ccanisters to burn everything down
### why you do this?
so it won't catch on fire
### what have you changed?
 plasma canisters
### what you tested?
editor