### PR TITLE
Bug fixes for AlertUI when involving death. Also removes "(clone)" from spawned object names

### DIFF
--- a/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
+++ b/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
@@ -408,7 +408,7 @@ public class InteractableStorage : MonoBehaviour, IClientInteractable<HandActiva
 	// Client only method
 	public void OnInventoryMoveClient(ClientInventoryMove info)
 	{
-		if (CustomNetworkManager.Instance._isServer)
+		if (CustomNetworkManager.Instance._isServer && GameData.IsHeadlessServer)
 			return;
 
 		if (canClickPickup)

--- a/UnityProject/Assets/Scripts/Lifecycle/Spawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/Spawn.cs
@@ -430,6 +430,7 @@ public static class Spawn
 		else
 		{
 			tempObject = Object.Instantiate(prefab, pos, destination.Parent.rotation * destination.LocalRotation, destination.Parent);
+			tempObject.name = prefab.name;
 
 			tempObject.GetComponent<CustomNetTransform>()?.ReInitServerState();
 

--- a/UnityProject/Assets/Scripts/UI/AlertUI.cs
+++ b/UnityProject/Assets/Scripts/UI/AlertUI.cs
@@ -16,6 +16,8 @@ public class AlertUI : MonoBehaviour
 
 	public GameObject cuffed;
 	public GameObject pickupMode;
+	
+	bool shouldHideAllButtons = false;
 
 	private Action onClickBuckled;
 
@@ -45,16 +47,45 @@ public class AlertUI : MonoBehaviour
 	private void OnEnable()
 	{
 		EventManager.AddHandler(EVENT.RoundEnded, OnRoundEnd);
+		EventManager.AddHandler(EVENT.PlayerDied, OnPlayerDie);
+		EventManager.AddHandler(EVENT.PlayerSpawned, OnPlayerSpawn);
 	}
 
 	private void OnDisable()
 	{
 		EventManager.RemoveHandler(EVENT.RoundEnded, OnRoundEnd);
+		EventManager.RemoveHandler(EVENT.PlayerDied, OnPlayerDie);
+		EventManager.RemoveHandler(EVENT.PlayerSpawned, OnPlayerSpawn);
+	}
+
+	/* hides alerts to be visible when player dies */
+	void OnPlayerDie()
+	{
+		shouldHideAllButtons = true;
+
+		buckled.SetActive(false);
+		cuffed.SetActive(false);
+		pickupMode.SetActive(false);
+	}
+
+	/* allows alerts to be visible when player spawns/respawns */
+	void OnPlayerSpawn()
+	{
+		shouldHideAllButtons = false;
+
+		buckled.SetActive(PlayerManager.LocalPlayerScript.playerMove.IsBuckled);
+
+		cuffed.SetActive(PlayerManager.LocalPlayerScript.playerMove.IsCuffed);
+
+		// TODO: check if player spawns with something where pickupMode should be shown
+		pickupMode.SetActive(false);
 	}
 
 	public void OnRoundEnd()
 	{
 		onClickBuckled = null;
+		shouldHideAllButtons = false;
+
 		buckled.SetActive(false);
 		cuffed.SetActive(false);
 		pickupMode.SetActive(false);
@@ -68,11 +99,13 @@ public class AlertUI : MonoBehaviour
 	/// <param name="onClick">if show=true, callback to invoke when the alert is clicked</param>
 	public void ToggleAlertBuckled(bool show, Action onClick)
 	{
-		buckled.SetActive(show);
 		if (show)
 		{
 			this.onClickBuckled = onClick;
 		}
+
+		if (!shouldHideAllButtons)
+			buckled.SetActive(show);
 	}
 
 	/// <summary>
@@ -81,7 +114,8 @@ public class AlertUI : MonoBehaviour
 	/// <param name="show"></param>
 	public void ToggleAlertCuffed(bool show)
 	{
-		cuffed.SetActive(show);
+		if (!shouldHideAllButtons)
+			cuffed.SetActive(show);
 	}
 
 	/// <summary>
@@ -90,7 +124,8 @@ public class AlertUI : MonoBehaviour
 	/// <param name="show"></param>
 	public void ToggleAlertPickupMode(bool show)
 	{
-		pickupMode.SetActive(show);
+		if (!shouldHideAllButtons)
+			pickupMode.SetActive(show);
 	}
 
 }


### PR DESCRIPTION
### Purpose
Prevents "(clone)" from appearing in names of spawned objects
Hides uncuff/unbuckle/switch pickup modes button when player dies.
hides uncuff/unbuckle button for respawned players unless they are spawned cuffed or buckled (?)

makes interactable storage icon show on listen server's ui

Fixes #3039
Fixes #2692 