### PR TITLE
Allows walking over animal corpses

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/SimpleAnimal/SimpleAnimal.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/SimpleAnimal/SimpleAnimal.cs
@@ -13,6 +13,13 @@ public class SimpleAnimal : LivingHealthBehaviour
 
 	public SpriteRenderer spriteRend;
 
+	public RegisterObject registerObject;
+
+	void Awake()
+	{
+		registerObject = GetComponent<RegisterObject>();
+	}
+
 	public override void OnStartClient()
 	{
 		base.OnStartClient();
@@ -34,13 +41,32 @@ public class SimpleAnimal : LivingHealthBehaviour
 	private void SetAliveState(bool oldState, bool state)
 	{
 		deadState = state;
+		registerObject.Passable = state;
 		if (state)
 		{
 			spriteRend.sprite = deadSprite;
+			SetToBodyLayer();
 		}
 		else
 		{
 			spriteRend.sprite = aliveSprite;
+			SetToNPCLayer();
 		}
+	}
+
+	/// <summary>
+	/// Set the sprite renderer to bodies when the mob has died
+	/// </summary>
+	public void SetToBodyLayer()
+	{
+		spriteRend.sortingLayerName = "Bodies";
+	}
+
+	/// <summary>
+	/// Set the mobs sprite renderer to NPC layer
+	/// </summary>
+	public void SetToNPCLayer()
+	{
+		spriteRend.sortingLayerName = "NPCs";
 	}
 }


### PR DESCRIPTION
### Purpose
When an animal dies, moves its sprite renderer to the `"Bodies"` sorting layer and sets is passability to be true.

When an animal ceases to be dead, moves sprite renderer back to `"NPCs"` sorting layer and sets passability to be false.
Fixes #2341