### PR TITLE
Atmospheric GFX added for plasma

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -18,6 +18,10 @@ public class ReactionManager : MonoBehaviour
 
 	private Dictionary<Vector3Int, MetaDataNode> hotspots;
 	private UniqueQueue<MetaDataNode> winds;
+
+	private UniqueQueue<MetaDataNode> addFog; //List of tiles to add chemcial fx to
+	private UniqueQueue<MetaDataNode> removeFog; //List of tiles to remove the chemical fx from
+
 	private TilemapDamage[] tilemapDamages;
 
 	private float timePassed;
@@ -32,6 +36,10 @@ public class ReactionManager : MonoBehaviour
 
 		hotspots = new Dictionary<Vector3Int, MetaDataNode>();
 		winds = new UniqueQueue<MetaDataNode>();
+
+		addFog = new UniqueQueue<MetaDataNode>();
+		removeFog = new UniqueQueue<MetaDataNode>();
+
 		tilemapDamages = GetComponentsInChildren<TilemapDamage>();
 	}
 
@@ -114,6 +122,46 @@ public class ReactionManager : MonoBehaviour
 				else
 				{
 					RemoveHotspot(node);
+				}
+			}
+		}
+
+		//Here we check to see if chemical fog fx needs to be applied, and if so, add them. If not, we remove them
+		int addFogCount = addFog.Count;
+		if ( addFogCount > 0 )
+		{
+			for ( int i = 0; i < addFogCount; i++ )
+			{
+				if ( addFog.TryDequeue( out var addFogNode ) )
+				{
+					if( !hotspots.ContainsKey(addFogNode.Position) )  //Make sure the tile currently isn't on fire. If it is on fire, we don't want to overright the fire effect
+					{
+						tileChangeManager.UpdateTile(addFogNode.Position, TileType.Effects, "PlasmaAir");
+					}
+
+					else if( !removeFog.Contains(addFogNode) )  //If the tile is on fire, but there is still plasma on the tile, put this tile back into the queue so we can try again
+					{
+						addFog.Enqueue(addFogNode);
+					}
+				}
+			}
+		}
+
+		//Similar to above, but for removing chemical fog fx
+		int removeFogCount = removeFog.Count;
+		if ( removeFogCount > 0 )
+		{
+			for ( int i = 0; i < removeFogCount; i++ )
+			{
+				if ( removeFog.TryDequeue( out var removeFogNode ) )
+				{
+					if( !hotspots.ContainsKey(removeFogNode.Position) ) //Make sure the tile isn't on fire, as we don't want to delete fire effects here
+					{
+						tileChangeManager.RemoveTile(removeFogNode.Position, LayerType.Effects);
+					}
+
+					//If it's on fire, we don't need to do anything else, as the system managing fire will remove all effects from the tile
+					//after the fire burns out
 				}
 			}
 		}
@@ -249,5 +297,19 @@ public class ReactionManager : MonoBehaviour
 			node.WindDirection = windDirection;
 			winds.Enqueue( node );
 		}
+	}
+
+	//Add tile to add fog effect queue
+	//Being called by AtmosSimulation
+	public void AddFogEvent( MetaDataNode node)
+	{
+		addFog.Enqueue( node );
+	}
+
+	//Add tile to remove fog effect queue
+	//Being called by AtmosSimulation
+	public void RemoveFogEvent( MetaDataNode node)
+	{
+		removeFog.Enqueue( node );
 	}
 }

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/PlasmaAir.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Effects/PlasmaAir.asset
@@ -4,30 +4,57 @@
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1796e5cfb0bb4f9b81661d07e7794f1d, type: 3}
   m_Name: PlasmaAir
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 6
   TileType: 9
   RequiredTiles: []
-  AtmosPassable: 1
-  IsSealed: 0
-  PassableException:
-    m_keys: 
-    m_values: 
-  Passable: 1
+  WalkingSoundCategory: 0
+  atmosPassable: 1
+  isSealed: 0
+  oreCategory: 0
   MaxHealth: 0
   HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  passable: 1
+  mineable: 0
+  passableException:
+    m_keys: 
+    m_values: 
+  maxHealth: 0
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  armor:
+    Melee: 0
+    Bullet: 0
+    Laser: 0
+    Energy: 0
+    Bomb: 0
+    Rad: 0
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   Sprites:
-  - {fileID: 21300000, guid: bae6a830cacc41c2bf59b93993502c34, type: 3}
-  - {fileID: 21300002, guid: bae6a830cacc41c2bf59b93993502c34, type: 3}
-  - {fileID: 21300004, guid: bae6a830cacc41c2bf59b93993502c34, type: 3}
+  - {fileID: 21300000, guid: 835b8b57fad81c8488c8450d87805733, type: 3}
+  - {fileID: 21300002, guid: 835b8b57fad81c8488c8450d87805733, type: 3}
+  - {fileID: 21300004, guid: 835b8b57fad81c8488c8450d87805733, type: 3}
   AnimationSpeed: 2
   AnimationStartTime: 0
+  randomizeStartTime: 1


### PR DESCRIPTION
Adds atmospheric GFXs
A method in atmosSimulation enqueues nessecary changes in ReactionManager
ReactionManager sends them to TileChangeManager
TileChangeManager adds the effect layer onto the tile

# Pull Request Template

### Purpose
This PR fixes #2499 and adds a graphic effect on a tile when that tile's gasmix contains at least 0.4 mole of plasma (slightly less then the amount required to start a fire under standard atmospheric conditions)

AtmosSimulation has a list of all the tiles that have chemical fog showing on them. If AtmosSimulation is updating a tile's gasmix, it also checks to see if that gasmix meets the conditions to show fog. If it does, and that tile isn't in the aforementioned list, it adds the tile to the list, and adds the tile to a queue in ReactionManager (It does this because AtmosSimulation is on its own thread, and GFX need to be executed on the main thread)

ReactionManager, every update(), goes through the queue, and as long as a tile isn't on fire, calls TileChangeManager.UpdateTile to add the atmospheric effect.

The same process takes place in reverse for removing fx.

I also added a "PlasmaAir" effect to the TileMap resources folder, which uses the old /tg/ sprite for the plasma effect

### Notes:

No additional notes

### Please make sure you have followed the self checks below before submitting a PR:

[x] Code is sufficiently commented
[x] Code is indented with tabs and not spaces
[x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
[x] The PR does not bring up any new compile errors
[x] The PR has been tested in editor
[x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
[x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
[x] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
[x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
[x] The PR has been tested with round restarts.
[x] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
