### PR TITLE
Adds test for missing component in asset references.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/BentPipe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/BentPipe.prefab
@@ -99,7 +99,6 @@ GameObject:
   - component: {fileID: 114185907784239616}
   - component: {fileID: 114612731264727302}
   - component: {fileID: 1739955761982081149}
-  - component: {fileID: 114253643887694602}
   - component: {fileID: -753721034424592532}
   - component: {fileID: -8786115220826574288}
   - component: {fileID: -2427645337683300516}
@@ -209,9 +208,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  registerTile: {fileID: 0}
-  objectBehaviour: {fileID: 0}
-  nodes: []
   direction: 3
   anchored: 0
   volume: 70
@@ -234,7 +230,6 @@ MonoBehaviour:
   - {fileID: 21300172, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
   - {fileID: 21300174, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
-  spriteSync: 0
 --- !u!114 &5640039996929275955
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -338,18 +333,6 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
---- !u!114 &114253643887694602
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &-753721034424592532
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -362,10 +345,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
-  localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 1453164084
 --- !u!114 &-8786115220826574288
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -396,6 +378,19 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  itemSprites:
+    LeftHand:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
+    RightHand:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
+    InventoryIcon:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
 --- !u!114 &-2427645337683300516
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Connector.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Connector.prefab
@@ -99,7 +99,6 @@ GameObject:
   - component: {fileID: 114185907784239616}
   - component: {fileID: 114643104810596728}
   - component: {fileID: 7444202956614922778}
-  - component: {fileID: 114933713635356078}
   - component: {fileID: 1479264743170500274}
   - component: {fileID: -3465280134105671477}
   - component: {fileID: 6334083418781041707}
@@ -322,28 +321,6 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
---- !u!114 &114933713635356078
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Infos:
-    SpriteAndData:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
-    spriteIndex: 0
-    VariantIndex: 0
-    AID: 0
-    Serialized: []
-  spriteList: []
 --- !u!114 &1479264743170500274
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -356,10 +333,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
-  localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 0
 --- !u!114 &-3465280134105671477
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -390,6 +366,19 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  itemSprites:
+    LeftHand:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
+    RightHand:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
+    InventoryIcon:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
 --- !u!114 &6334083418781041707
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/FourWayManifold.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/FourWayManifold.prefab
@@ -99,7 +99,6 @@ GameObject:
   - component: {fileID: 114185907784239616}
   - component: {fileID: 114665036458884384}
   - component: {fileID: 8413143254154855439}
-  - component: {fileID: 114629543756366832}
   - component: {fileID: -7664889531177341902}
   - component: {fileID: 2033547086399081926}
   - component: {fileID: -1437310941191989404}
@@ -213,9 +212,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  registerTile: {fileID: 0}
-  objectBehaviour: {fileID: 0}
-  nodes: []
   direction: 3
   anchored: 0
   volume: 70
@@ -223,7 +219,6 @@ MonoBehaviour:
   - {fileID: 21300132, guid: b17c2d8fde0016741b3ddae80bb61948, type: 3}
   - {fileID: 21300038, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
-  spriteSync: 0
   connectionSprite:
   - {fileID: 21300056, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   - {fileID: 21300058, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
@@ -338,18 +333,6 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
---- !u!114 &114629543756366832
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &-7664889531177341902
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -362,10 +345,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
-  localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 736993030
 --- !u!114 &2033547086399081926
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -396,6 +378,19 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  itemSprites:
+    LeftHand:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
+    RightHand:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
+    InventoryIcon:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
 --- !u!114 &-1437310941191989404
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Manifold.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Manifold.prefab
@@ -99,7 +99,6 @@ GameObject:
   - component: {fileID: 114450221674697092}
   - component: {fileID: 114481024304208226}
   - component: {fileID: 5591104723912208015}
-  - component: {fileID: 114288942117177720}
   - component: {fileID: -1280114811554306276}
   - component: {fileID: -461505412488338308}
   - component: {fileID: -6790079540501293182}
@@ -196,9 +195,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  registerTile: {fileID: 0}
-  objectBehaviour: {fileID: 0}
-  nodes: []
   direction: 3
   anchored: 0
   volume: 70
@@ -209,7 +205,6 @@ MonoBehaviour:
   - {fileID: 21300036, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   - {fileID: 21300034, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   spriteRenderer: {fileID: 212588640390319518}
-  spriteSync: 0
   connectionSprite:
   - {fileID: 21300056, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
   - {fileID: 21300058, guid: 56cc0708b88c34536828cc7262a07808, type: 3}
@@ -341,18 +336,6 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
---- !u!114 &114288942117177720
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &-1280114811554306276
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -365,10 +348,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
-  localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 475751778
 --- !u!114 &-461505412488338308
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -399,6 +381,19 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  itemSprites:
+    LeftHand:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
+    RightHand:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
+    InventoryIcon:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
 --- !u!114 &-6790079540501293182
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Meter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Meter.prefab
@@ -18,7 +18,6 @@ GameObject:
   - component: {fileID: 114185907784239616}
   - component: {fileID: 114405250905390060}
   - component: {fileID: 7564706497059525126}
-  - component: {fileID: 114557966116762654}
   - component: {fileID: 7284841258646247885}
   - component: {fileID: -3683827223415588112}
   - component: {fileID: 5317582979494515227}
@@ -228,18 +227,6 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
---- !u!114 &114557966116762654
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &7284841258646247885
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -252,10 +239,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
-  localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 824319096
 --- !u!114 &-3683827223415588112
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -286,6 +272,19 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  itemSprites:
+    LeftHand:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
+    RightHand:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
+    InventoryIcon:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
 --- !u!114 &5317582979494515227
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Pipe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Pipe.prefab
@@ -19,7 +19,6 @@ GameObject:
   - component: {fileID: 114185907784239616}
   - component: {fileID: 114405250905390060}
   - component: {fileID: 7564706497059525126}
-  - component: {fileID: 114655540776166054}
   - component: {fileID: 9181656149164435648}
   - component: {fileID: -6026534052110882755}
   - component: {fileID: 8750409313360246655}
@@ -129,9 +128,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  registerTile: {fileID: 0}
-  objectBehaviour: {fileID: 0}
-  nodes: []
   direction: 0
   anchored: 0
   volume: 70
@@ -146,7 +142,6 @@ MonoBehaviour:
   - {fileID: 21300160, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
   - {fileID: 21300164, guid: 7c4fb2dfd69292045b1a3300b683390a, type: 3}
   spriteRenderer: {fileID: 1047382295693061733}
-  spriteSync: 0
 --- !u!114 &5640039996929275955
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,18 +245,6 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
---- !u!114 &114655540776166054
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1645856876941636}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 73fef738c78305541bcd6c7e3abca116, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &9181656149164435648
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -274,10 +257,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
-  localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 878681949
 --- !u!114 &-6026534052110882755
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -308,6 +290,19 @@ MonoBehaviour:
   canConnectToTank: 0
   isEVACapable: 0
   attackVerbs: []
+  itemSprites:
+    LeftHand:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
+    RightHand:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
+    InventoryIcon:
+      Texture: {fileID: 0}
+      Sprites: []
+      EquippedData: {fileID: 0}
 --- !u!114 &8750409313360246655
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Editor/Tools/SearchandDestroy.cs
+++ b/UnityProject/Assets/Scripts/Editor/Tools/SearchandDestroy.cs
@@ -191,7 +191,7 @@ public class SearchAndDestroy : EditorWindow
 		List<string> result = new List<string>();
 		foreach (string s in temp)
 		{
-			if (s.Contains(".prefab"))
+			if (s.EndsWith(".prefab") && s.StartsWith("Assets/"))
 			{
 				result.Add(s);
 			}

--- a/UnityProject/Assets/Tests/Asset.meta
+++ b/UnityProject/Assets/Tests/Asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec9ea14083d4d2849bfe265d8c0c00b3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Tests/Asset/MissingAssetReferences.cs
+++ b/UnityProject/Assets/Tests/Asset/MissingAssetReferences.cs
@@ -1,0 +1,48 @@
+﻿
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEditor;
+using System.Linq;
+
+namespace Tests
+{
+	public class MissingAssetReferences 
+	{
+		[Test]
+		public void TestAllChannelsTag()
+		{
+			List<string> listResult = new List<string>();
+			string[] allPrefabs = SearchAndDestroy.GetAllPrefabs();
+			foreach (string prefab in allPrefabs)
+			{
+				Object o = AssetDatabase.LoadMainAssetAtPath(prefab);
+				GameObject go;
+				try
+				{
+					go = (GameObject)o;
+					Component[] components = go.GetComponentsInChildren<Component>(true);
+					foreach (Component c in components)
+					{
+						if (c == null)
+						{
+							listResult.Add(prefab);
+						}
+					}
+				}
+				catch
+				{
+					Logger.LogFormat("For some reason, prefab {0} won't cast to GameObject", Category.UI, prefab);
+				}
+			}
+
+			foreach (string s in listResult)
+			{
+				Debug.LogFormat("Missing reference found in prefab {0}", s);
+			}
+
+			Assert.IsEmpty(listResult, "Missing references found: {0}", listResult.Aggregate((i, j) => i + "," + j));
+		}
+	}
+}

--- a/UnityProject/Assets/Tests/Asset/MissingAssetReferences.cs.meta
+++ b/UnityProject/Assets/Tests/Asset/MissingAssetReferences.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cf58b8e02c915c4cbedc47958ee589c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Tests/Tests.asmdef
+++ b/UnityProject/Assets/Tests/Tests.asmdef
@@ -3,19 +3,23 @@
     "references": [
         "Assets",
         "Mirror",
-        "Mirror.Components"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "Mirror.Components",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Editor"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
-    "autoReferenced": true,
-    "defineConstraints": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": []
 }


### PR DESCRIPTION
Also, changes asset finder to only care if it starts with "Assets/" and ends with ".asset"

### Purpose
Addresses (Maybe fixes) #2851

### Notes
There are some missing components in unitystation/unitystation@6a71c84e996767df99d8656912d9e5f8208591cb that this test (correctly) fails on. I don't know how best to fix them~