### PR TITLE
Fixed #2909 (Latency letting players go over job limits)

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/Windows (Put all window UI's in here).prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/Windows (Put all window UI's in here).prefab
@@ -900,6 +900,83 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Starting in...
+--- !u!1 &6966413391240333405
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1825598347150382488}
+  - component: {fileID: 3832769593240119352}
+  - component: {fileID: 7583201979419768367}
+  m_Layer: 5
+  m_Name: WaitText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1825598347150382488
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6966413391240333405}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8530562246598747092}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 580, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3832769593240119352
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6966413391240333405}
+  m_CullTransparentMesh: 0
+--- !u!114 &7583201979419768367
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6966413391240333405}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.8235294, g: 0.94158214, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 16
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 185
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Please wait, checking if job is available...
 --- !u!1 &7517261535306248244
 GameObject:
   m_ObjectHideFlags: 0
@@ -1307,6 +1384,7 @@ RectTransform:
   - {fileID: 8530307510083584306}
   - {fileID: 8530153244358295158}
   - {fileID: 8530584791395837062}
+  - {fileID: 1825598347150382488}
   m_Father: {fileID: 8530432162611861968}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1422,10 +1500,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   buttonPrefab: {fileID: 6841219424616931615, guid: f911aba3224cf47bcb38ce2c82b53c19,
     type: 3}
-  hasPickedAJob: 0
-  isUpToDate: 0
   screen_Jobs: {fileID: 8465448598027235102}
-  title: {fileID: 8424752959952509960}
+  waitMessage: {fileID: 6966413391240333405}
+  waitForSpawnTimerMax: 4.5
 --- !u!1 &8465122399017204840
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -157,11 +157,20 @@ public class JoinedViewer : NetworkBehaviour
 	}
 
 	/// <summary>
-	/// At the moment players can choose their jobs on round start:
+	/// Used for requesting a job at round start.
+	/// Assigns the occupation to the player and spawns them on the station.
+	/// Fails if no more slots for that occupation are available.
 	/// </summary>
 	[Command]
 	public void CmdRequestJob(JobType jobType, CharacterSettings characterSettings)
 	{
+		int slotsTaken = GameManager.Instance.GetOccupationsCount(jobType);
+		int slotsMax = GameManager.Instance.GetOccupationMaxCount(jobType);
+		if (slotsTaken >= slotsMax)
+		{
+			return;
+		}
+
 		var spawnRequest =
 			PlayerSpawnRequest.RequestOccupation(this, GameManager.Instance.GetRandomFreeOccupation(jobType), characterSettings);
 		//regardless of their chosen occupation, they might spawn as an antag instead.

--- a/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
+++ b/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
@@ -66,17 +66,18 @@ public class GUI_PlayerJobs : MonoBehaviour
 	/// </summary>
 	private void Update()
 	{
+		if (PlayerManager.HasSpawned)
+		{
+			// Job selection is finished, close the window.
+			waitForSpawnTimer = 0;
+			SoundManager.SongTracker.Stop();
+			gameObject.SetActive(false);
+			waitMessage.SetActive(false);
+			screen_Jobs.SetActive(true);
+		}
+
 		if (waitForSpawnTimer > 0)
 		{
-			if (PlayerManager.HasSpawned)
-			{
-				// Job selection is finished, close the window.
-				SoundManager.SongTracker.Stop();
-				gameObject.SetActive(false);
-				waitMessage.SetActive(false);
-				screen_Jobs.SetActive(true);
-			}
-
 			waitForSpawnTimer -= Mathf.Max(0, Time.deltaTime);
 			if (waitForSpawnTimer <= 0)
 			{

--- a/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
+++ b/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
@@ -3,11 +3,25 @@ using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
 
+/// <summary>
+/// Manages the UI buttons for letting the player choose their desired job.
+/// </summary>
 public class GUI_PlayerJobs : MonoBehaviour
 {
 	public GameObject buttonPrefab;
 	private CustomNetworkManager networkManager;
-	public GameObject screen_Jobs;
+
+	/// <summary>
+	/// The gameobject displaying the various job selection buttons.
+	/// </summary>
+	public GameObject screen_Jobs = null;
+
+	/// <summary>
+	/// A gameobject that is shown after job selection when the player is waiting to spawn.
+	/// </summary>
+	[SerializeField]
+	[Tooltip("Number of seconds to wait after selecting a job. If the player does not spawn within that time the job selection re-opens.")]
+	private GameObject waitMessage = null;
 
 	/// <summary>
 	/// After the player selects a job this timer will be used to keep track of how long they've waited.
@@ -36,6 +50,8 @@ public class GUI_PlayerJobs : MonoBehaviour
 		}
 		SoundManager.Play("Click01");
 		screen_Jobs.SetActive(false);
+		waitMessage.SetActive(true);
+
 		PlayerManager.LocalViewerScript.CmdRequestJob(preference, PlayerManager.CurrentCharacterSettings);
 		waitForSpawnTimer = waitForSpawnTimerMax;
 	}
@@ -57,6 +73,8 @@ public class GUI_PlayerJobs : MonoBehaviour
 				// Job selection is finished, close the window.
 				SoundManager.SongTracker.Stop();
 				gameObject.SetActive(false);
+				waitMessage.SetActive(false);
+				screen_Jobs.SetActive(true);
 			}
 
 			waitForSpawnTimer -= Mathf.Max(0, Time.deltaTime);
@@ -65,6 +83,7 @@ public class GUI_PlayerJobs : MonoBehaviour
 				// Job selection failed, re-open it.
 				SoundManager.Play("Click01");
 				screen_Jobs.SetActive(true);
+				waitMessage.SetActive(false);
 			}
 		}
 	}


### PR DESCRIPTION
![BigReadyIvorybilledwoodpecker-small](https://user-images.githubusercontent.com/9169275/74569826-9f46a400-4f7b-11ea-8f9e-04d874a6cb5c.gif)
*This is what players now see when they failed to spawn for any reason (like their job already being taken).*
*Screenshot is slightly outdated. The wait time is shorter and the player is shown a message:
"Please wait, checking job availability..."*
*Thanks to Necromunger for the feedback.*
### Purpose
* Fixes #2909 : Players could go over job limit when they select their role at the same moment (depending on latency). For example: More than 1 captain could spawn. This is now fixed.

### Notes:
* This PR introduces a serverside check which prevents the player from being spawned if their selected job is no longer available.
* The job select UI now (partially) hides itself when a job is selected. It then waits for ~~6~~ 4.5 seconds, awaiting the player's spawn.
  * If the player spawns then the UI is fully hidden.
  * If the timer runs out then it is assumed that the player did not spawn. The job menu is then fully revealed again. 
  * The length of the timer (~~6~~ 4.5 seconds) is probably much longer than necessary, but should ensure that jobs do not exeed their slot limit. We might want to shorten the timer in case players get confused, or add something to the UI.

### Self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] The PR has been tested in multiplayer
  - With 1 server and 2 clients both trying to get the same role and failing. 1200ms latency
  - With 1 server and 1 user both forced to select the same job (by keeping job buttons always on). ~0ms latency.
- [x] The PR has been tested with round restarts. 
  - It's important the the UI shows up again! In my tests this never happened, but I'm concerned about it.
