### PR TITLE
Small Chat system improvements

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -517,7 +517,7 @@ namespace IngameDebugConsole
 					Chat.AddChatMsgToChat(ConnectedPlayer.Invalid, DateTime.Now.ToFileTimeUtc().ToString(), ChatChannel.OOC);
 					break;
 				default:
-					Chat.AddLocalMsgToChat(DateTime.Now.ToFileTimeUtc().ToString(), new Vector2(Random.value*100,Random.value*100));
+					Chat.AddLocalMsgToChat(DateTime.Now.ToFileTimeUtc().ToString(), new Vector2(Random.value*100,Random.value*100), null);
 					break;
 			}
 

--- a/UnityProject/Assets/Scripts/Botany/hydroponics tray/HydroponicsTray.cs
+++ b/UnityProject/Assets/Scripts/Botany/hydroponics tray/HydroponicsTray.cs
@@ -338,7 +338,7 @@ public class HydroponicsTray : NetworkBehaviour, IInteractable<HandApply>
 		plantSyncStage = newStage;
 		if (plantData == null)
 		{
-			Logger.Log("BOD PLZ FIX BOTANY PLANT DATA IS NULL!");
+			//FIXME: BOD PLZ FIX BOTANY PLANT DATA IS NULL!
 			return;
 		}
 		switch (plantSyncStage)
@@ -405,7 +405,7 @@ public class HydroponicsTray : NetworkBehaviour, IInteractable<HandApply>
 
 		if (plantData == null)
 		{
-			Logger.Log("BOD PLZ FIX BOTANY PLANT DATA IS NULL!");
+			//FIXME "BOD PLZ FIX BOTANY PLANT DATA IS NULL!"
 			return;
 		}
 		switch (plantSyncStage)

--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -359,7 +359,7 @@ public partial class Chat
 			{
 				while (messageQueue.TryDequeue(out var msg))
 				{
-					AddLocalMsgToChat(msg.Message + postfix, msg.WorldPosition);
+					AddLocalMsgToChat(msg.Message + postfix, msg.WorldPosition, null);
 				}
 				continue;
 			}
@@ -367,8 +367,9 @@ public partial class Chat
 			//Combined message at average position
 			stringBuilder.Clear();
 
-			int averageX = 0;
-			int averageY = 0;
+//			int averageX = 0;
+//			int averageY = 0;
+			Vector2Int lastPos = Vector2Int.zero;
 			int count = 1;
 
 			while (messageQueue.TryDequeue(out DestroyChatMessage msg))
@@ -378,12 +379,14 @@ public partial class Chat
 					stringBuilder.Append(", ");
 				}
 				stringBuilder.Append(msg.Message);
-				averageX += msg.WorldPosition.x;
-				averageY += msg.WorldPosition.y;
+//				averageX += msg.WorldPosition.x;
+//				averageY += msg.WorldPosition.y;
+				lastPos = msg.WorldPosition;
 				count++;
 			}
 
-			AddLocalMsgToChat(stringBuilder.Append(postfix).ToString(), new Vector2Int(averageX / count, averageY / count));
+//			AddLocalMsgToChat(stringBuilder.Append(postfix).ToString(), new Vector2Int(averageX / count, averageY / count));
+			AddLocalMsgToChat(stringBuilder.Append(postfix).ToString(), lastPos, null);
 		}
 	}
 
@@ -523,7 +526,7 @@ public partial class Chat
 		if (string.IsNullOrEmpty(playerInput))
 			return new ParsedChatInput(playerInput, playerInput, ChatChannel.None);
 
-		// all extracted channels from special chars 
+		// all extracted channels from special chars
 		ChatChannel extractedChanel = ChatChannel.None;
 		// how many special chars we need to delete
 		int specialCharCount = 0;

--- a/UnityProject/Assets/Scripts/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.cs
@@ -336,7 +336,8 @@ public partial class Chat : MonoBehaviour
 		{
 			channels = ChatChannel.Combat,
 			message = message,
-			position = victim.WorldPosServer()
+			position = victim.WorldPosServer(),
+			originator = victim
 		});
 	}
 
@@ -369,7 +370,7 @@ public partial class Chat : MonoBehaviour
 	/// </summary>
 	/// <param name="message">The message to show in the chat stream</param>
 	/// <param name="worldPos">The position of the local message</param>
-	public static void AddLocalMsgToChat(string message, Vector2 worldPos)
+	public static void AddLocalMsgToChat(string message, Vector2 worldPos, GameObject originator)
 	{
 		if (!IsServer()) return;
 		Instance.TryStopCoroutine(ref composeMessageHandle);
@@ -378,7 +379,8 @@ public partial class Chat : MonoBehaviour
 		{
 			channels = ChatChannel.Local,
 			message = message,
-			position = worldPos
+			position = worldPos,
+			originator = originator
 		});
 	}
 

--- a/UnityProject/Assets/Scripts/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatRelay.cs
@@ -58,6 +58,7 @@ public class ChatRelay : NetworkBehaviour
 	private void PropagateChatToClients(ChatEvent chatEvent)
 	{
 		List<ConnectedPlayer> players;
+
 		if (chatEvent.matrix != MatrixInfo.Invalid)
 		{
 			//get players only on provided matrix
@@ -65,12 +66,28 @@ public class ChatRelay : NetworkBehaviour
 		}
 		else
 		{
-			players = PlayerList.Instance.AllPlayers;
+			//Try get the matrix first:
+			if (chatEvent.originator != null)
+			{
+				var regiTile = chatEvent.originator.GetComponent<RegisterTile>();
+				if (regiTile != null)
+				{
+					players = PlayerList.Instance.GetPlayersOnMatrix(MatrixManager.Get(regiTile.Matrix));
+				}
+				else
+				{
+					players = PlayerList.Instance.AllPlayers;
+				}
+			}
+			else
+			{
+				players = PlayerList.Instance.AllPlayers;
+			}
 		}
 
 		//Local chat range checks:
-		if (chatEvent.channels == ChatChannel.Local || chatEvent.channels == ChatChannel.Combat
-													|| chatEvent.channels == ChatChannel.Action)
+		if (chatEvent.channels.HasFlag(ChatChannel.Local) || chatEvent.channels.HasFlag(ChatChannel.Combat)
+													|| chatEvent.channels.HasFlag(ChatChannel.Action))
 		{
 			for (int i = 0; i < players.Count; i++)
 			{
@@ -140,6 +157,7 @@ public class ChatRelay : NetworkBehaviour
 				{
 					UpdateChatMessage.Send(players[i].GameObject, channels, chatEvent.modifiers, chatEvent.message, chatEvent.messageOthers,
 						chatEvent.originator, chatEvent.speaker);
+
 					continue;
 				}
 			}

--- a/UnityProject/Assets/Scripts/Chemistry/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/Chemistry/ReagentContainer.cs
@@ -382,7 +382,7 @@ public class ReagentContainer : Container, IRightClickable, IServerSpawn,
 		}
 		else
 		{
-			Chat.AddLocalMsgToChat($"{gameObject.ExpensiveName()}'s contents spill all over the floor!",(Vector3)worldPos);
+			Chat.AddLocalMsgToChat($"{gameObject.ExpensiveName()}'s contents spill all over the floor!",(Vector3)worldPos, gameObject);
 		}
 
 		var spilledReagents = TakeReagents(AmountOfReagents(Contents));

--- a/UnityProject/Assets/Scripts/Health/Living/HumanHealth/PlayerHealth.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/HumanHealth/PlayerHealth.cs
@@ -103,7 +103,7 @@ public class PlayerHealth : LivingHealthBehaviour
 					descriptor = "their";
 				}
 
-				Chat.AddLocalMsgToChat($"<b>{playerName}</b> seizes up and falls limp, {descriptor} eyes dead and lifeless...", (Vector3)registerPlayer.WorldPositionServer);
+				Chat.AddLocalMsgToChat($"<b>{playerName}</b> seizes up and falls limp, {descriptor} eyes dead and lifeless...", (Vector3)registerPlayer.WorldPositionServer, gameObject);
 			}
 
 			PlayerDeathMessage.Send(gameObject);

--- a/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
@@ -504,7 +504,7 @@ public class MouseInputController : MonoBehaviour
 					Logger.LogFormat($"Forcefully updated atmos at worldPos {position}/ localPos {localPos} of {matrix.Name}");
 				});
 
-				Chat.AddLocalMsgToChat("Ping "+DateTime.Now.ToFileTimeUtc(), (Vector3) position );
+				Chat.AddLocalMsgToChat("Ping "+DateTime.Now.ToFileTimeUtc(), (Vector3) position, PlayerManager.LocalPlayer );
 			}
 			return true;
 		}

--- a/UnityProject/Assets/Scripts/Objects/Posters/PosterBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Objects/Posters/PosterBehaviour.cs
@@ -133,7 +133,7 @@ public class PosterBehaviour : NetworkBehaviour, ICheckedInteractable<HandApply>
 		}
 
 		Chat.AddLocalMsgToChat(interaction.Performer.ExpensiveName() +
-		                       " rips the poster in a single, decisive motion!", pos);
+		                       " rips the poster in a single, decisive motion!", pos, gameObject);
 		SoundManager.PlayNetworkedAtPos("PosterRipped", pos);
 
 		SyncPosterType(posterVariant, Posters.Ripped);

--- a/UnityProject/Assets/Scripts/UI/Canister/GUI_Canister.cs
+++ b/UnityProject/Assets/Scripts/UI/Canister/GUI_Canister.cs
@@ -330,7 +330,7 @@ public class GUI_Canister : NetTab
 		if (isOpen)
 		{
 			Chat.AddLocalMsgToChat($"Canister releasing at {container.ReleasePressure}",
-				container.transform.position);
+				container.transform.position, container?.gameObject);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/UI/GUI_Vendor.cs
+++ b/UnityProject/Assets/Scripts/UI/GUI_Vendor.cs
@@ -169,7 +169,7 @@ public class GUI_Vendor : NetTab
 
 	private void SendToChat(string messageToSend)
 	{
-		Chat.AddLocalMsgToChat(messageToSend, vendor.transform.position);
+		Chat.AddLocalMsgToChat(messageToSend, vendor.transform.position, vendor?.gameObject);
 	}
 
 	private IEnumerator VendorInputCoolDown()


### PR DESCRIPTION
- Made sure matrix info was present when determining the initial player pool to send too.
- Changed the condition for determining which chat channels exist in the physics2d culling part
- Removed the averaging of the group local message world positions and just set it as the last position of the last local message

This won't solve local chat problems but it might help us reduce the noise to find the real cause