### PR TITLE
Allow Cargo shuttle to arrive ignoring broken orders

### DIFF
--- a/UnityProject/Assets/Scripts/Shuttles/CargoShuttle.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/CargoShuttle.cs
@@ -152,7 +152,13 @@ public class CargoShuttle : MonoBehaviour
 			for (int i = 0; i < order.Items.Count; i++)
 			{
 				var orderedItem = Spawn.ServerPrefab(order.Items[i], pos).GameObject;
-				if (orderedItem != null && orderedItem.TryGetComponent<ObjectBehaviour>(out var objectBehaviour))
+				if (orderedItem == null)
+				{
+					Logger.Log($"Can't add ordered item to create because it doesn't have a GameObject", Category.ItemSpawn);
+					continue;
+
+				}
+				else if (orderedItem.TryGetComponent<ObjectBehaviour>(out var objectBehaviour))
 				{
 					//ensure it is added to crate
 					closetControl.ServerAddInternalItem(objectBehaviour);

--- a/UnityProject/Assets/Scripts/Shuttles/CargoShuttle.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/CargoShuttle.cs
@@ -154,6 +154,7 @@ public class CargoShuttle : MonoBehaviour
 				var orderedItem = Spawn.ServerPrefab(order.Items[i], pos).GameObject;
 				if (orderedItem == null)
 				{
+					//let the shuttle still be able to complete the order empty otherwise it will be stuck permantly
 					Logger.Log($"Can't add ordered item to create because it doesn't have a GameObject", Category.ItemSpawn);
 					continue;
 


### PR DESCRIPTION
### Purpose
Added a check to ignore an improperly entered item with an ItemSpawn log instead of a Warning log allowing shuttle orders to complete.
Fixes  #3098

### Notes:

Should there be checks earlier on to not display a invalid order in the terminal?

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- The PR has been tested with round restarts.

