### PR TITLE
Added Glass as the output for Sand

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Mining/Ore Redemption Machine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Mining/Ore Redemption Machine.prefab
@@ -1,32 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &7207538277679673550
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7537901516811143965}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Sprites:
-  - Texture: {fileID: 2800000, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
-    Sprites:
-    - {fileID: 21300000, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
-    - {fileID: 21300002, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
-    - {fileID: 21300004, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
-    - {fileID: 21300006, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
-    - {fileID: 21300008, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
-    - {fileID: 21300010, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
-    - {fileID: 21300012, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
-    - {fileID: 21300014, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
-    EquippedData: {fileID: 4900000, guid: cbe20f1541f640d408cb8185d77f9f95, type: 3}
-  spriteIndex: 0
-  variantIndex: 0
-  SetSpriteOnStartUp: 1
 --- !u!114 &1892107992577685649
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -62,8 +35,35 @@ MonoBehaviour:
     Material: {fileID: 6254655335276451647, guid: fdfebca06b77ef64898a68e1df0d3e9a,
       type: 3}
   - Trait: {fileID: 11400000, guid: 6097f8423a1b255468e2285de46bc3d3, type: 2}
-    Material: {fileID: 5680136605834777345, guid: ea07289ba72453444a4ff1202b47a57d,
+    Material: {fileID: 6201122676745363040, guid: ea07289ba72453444a4ff1202b47a57d,
       type: 3}
+--- !u!114 &7207538277679673550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7537901516811143965}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Sprites:
+  - Texture: {fileID: 2800000, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
+    Sprites:
+    - {fileID: 21300000, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
+    - {fileID: 21300002, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
+    - {fileID: 21300004, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
+    - {fileID: 21300006, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
+    - {fileID: 21300008, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
+    - {fileID: 21300010, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
+    - {fileID: 21300012, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
+    - {fileID: 21300014, guid: 7cd232d70698e2d4b856d70b22d3f223, type: 3}
+    EquippedData: {fileID: 4900000, guid: cbe20f1541f640d408cb8185d77f9f95, type: 3}
+  spriteIndex: 0
+  variantIndex: 0
+  SetSpriteOnStartUp: 1
 --- !u!1001 &2473681083921268590
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Purpose
Glass was a missing option when smelting in the Ore Redemption Machine
@hecksadecimal for pointing me to the fix location was looking on the items themselves

##Notes
Should the item themselves know their transformation?

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
