### PR TITLE
Update manager refactor

### DIFF
--- a/UnityProject/Assets/Scripts/Botany/hydroponics tray/HydroponicsTray.cs
+++ b/UnityProject/Assets/Scripts/Botany/hydroponics tray/HydroponicsTray.cs
@@ -49,7 +49,7 @@ public class HydroponicsTray : NetworkBehaviour, IInteractable<HandApply>
 	public override void OnStartServer()
 	{
 		EnsureInit();
-		UpdateManager.Instance.Add(ServerUpdate);
+		UpdateManager.Add(CallbackType.UPDATE, ServerUpdate);
 		IsServer = true;
 		if (isSoilPile)
 		{
@@ -79,7 +79,7 @@ public class HydroponicsTray : NetworkBehaviour, IInteractable<HandApply>
 	{
 		if (IsServer)
 		{
-			UpdateManager.Instance.Remove(ServerUpdate);
+			UpdateManager.Remove(CallbackType.UPDATE, ServerUpdate);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Health/BloodHealth/BloodSystem.cs
+++ b/UnityProject/Assets/Scripts/Health/BloodHealth/BloodSystem.cs
@@ -57,13 +57,12 @@ public class BloodSystem : MonoBehaviour
 
 	void OnEnable()
 	{
-		UpdateManager.Instance.Add(UpdateMe);
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 
 	void OnDisable()
 	{
-		if (UpdateManager.Instance != null)
-			UpdateManager.Instance.Remove(UpdateMe);
+		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 	}
 
 	//Initial setting for blood type. Server only

--- a/UnityProject/Assets/Scripts/Health/BloodHealth/MetabolismSystem.cs
+++ b/UnityProject/Assets/Scripts/Health/BloodHealth/MetabolismSystem.cs
@@ -110,13 +110,12 @@ public class MetabolismSystem : NetworkBehaviour
 
 	void OnEnable()
 	{
-		UpdateManager.Instance.Add(UpdateMe);
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		effects = new List<MetabolismEffect>();
 	}
 	void OnDisable()
 	{
-		if (UpdateManager.Instance != null)
-			UpdateManager.Instance.Remove(UpdateMe);
+		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 	}
 
 	void UpdateMe()

--- a/UnityProject/Assets/Scripts/Health/BrainHealth/BrainSystem.cs
+++ b/UnityProject/Assets/Scripts/Health/BrainHealth/BrainSystem.cs
@@ -61,13 +61,12 @@ public class BrainSystem : MonoBehaviour //Do not turn into NetBehaviour
 
 	void OnEnable()
 	{
-		UpdateManager.Instance.Add(UpdateMe);
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 
 	void OnDisable()
 	{
-		if (UpdateManager.Instance != null)
-			UpdateManager.Instance.Remove(UpdateMe);
+		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 	}
 
 	// Controlled via UpdateManager

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -143,13 +143,12 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 
 	void OnEnable()
 	{
-		UpdateManager.Instance.Add(UpdateMe);
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 
 	void OnDisable()
 	{
-		if (UpdateManager.Instance != null)
-			UpdateManager.Instance.Remove(UpdateMe);
+		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 	}
 
 	/// Add any missing systems:

--- a/UnityProject/Assets/Scripts/Health/RespiratoryHealth/RespiratorySystem.cs
+++ b/UnityProject/Assets/Scripts/Health/RespiratoryHealth/RespiratorySystem.cs
@@ -45,15 +45,12 @@ public class RespiratorySystem : MonoBehaviour //Do not turn into NetBehaviour
 
 	void OnEnable()
 	{
-		UpdateManager.Instance.Add(UpdateMe);
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 
 	void OnDisable()
 	{
-		if (UpdateManager.Instance != null)
-		{
-			UpdateManager.Instance.Remove(UpdateMe);
-		}
+		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 	}
 
 	//Handle by UpdateManager

--- a/UnityProject/Assets/Scripts/Items/Others/SolidPlasma.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/SolidPlasma.cs
@@ -18,7 +18,7 @@ public class SolidPlasma : NetworkBehaviour
 		{
 			burningPlasma = true;
 			burnSpeed = _burnSpeed;
-			UpdateManager.Instance.Add(UpdateMe);
+			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 		}
 		else
 		{
@@ -30,17 +30,14 @@ public class SolidPlasma : NetworkBehaviour
 	public void StopBurningPlasma()
 	{
 		burningPlasma = false;
-		if (UpdateManager.Instance != null)
-		{
-			UpdateManager.Instance.Remove(UpdateMe);
-		}
+		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 	}
 
 	void OnDisable()
 	{
 		if (burningPlasma)
 		{
-			UpdateManager.Instance.Remove(UpdateMe);
+			UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 		}
 	}
 
@@ -54,10 +51,7 @@ public class SolidPlasma : NetworkBehaviour
 			{
 				burningPlasma = false;
 				fuelExhausted.Invoke();
-				if (UpdateManager.Instance != null)
-				{
-					UpdateManager.Instance.Remove(UpdateMe);
-				}
+				UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Managers/UpdateManager/ManagedNetworkBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Managers/UpdateManager/ManagedNetworkBehaviour.cs
@@ -2,20 +2,18 @@
 
 public class ManagedNetworkBehaviour : NetworkBehaviour
 {
-//    protected virtual void Awake()
-//    {
-//        UpdateManager.Instance.regularUpdate.Add(this);
-//    }
+	protected bool IsUpdating;
+
 	protected virtual void OnEnable()
 	{
-		UpdateManager.Instance.Add(this);
+		UpdateManager.Add(this);
+		IsUpdating = true;
 	}
 
 	protected virtual void OnDisable()
 	{
-		if (UpdateManager.Instance != null) {
-			UpdateManager.Instance.Remove(this);
-		}
+		UpdateManager.Remove(this);
+		IsUpdating = false;
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
-using UnityEngine.SceneManagement;
 using System;
+using System.Collections.Generic;
+using UnityEngine.Profiling;
 
 /// <summary>
 ///     Handles the update methods for in game objects
@@ -9,100 +10,196 @@ using System;
 /// </summary>
 public class UpdateManager : MonoBehaviour
 {
-	private static UpdateManager updateManager;
+	private Dictionary<CallbackType, CallbackCollection> collections;
 
-	private event Action UpdateMe;
-	private event Action FixedUpdateMe;
-	private event Action LateUpdateMe;
-	private event Action UpdateAction;
+    public static bool IsInitialized { get { return instance != null; } }
+	private static UpdateManager instance;
 
-	public static UpdateManager Instance
+	private class NamedAction
 	{
-		get
+		public Action Action;
+		public string Name;
+		public bool WaitingForRemove;
+	}
+
+	private class CallbackCollection
+	{
+		// Double collection: List for fast iteration, dictionary for O(1) removal.
+		// Trading memory for cpu perf.
+
+		public readonly List<NamedAction> ActionList = new List<NamedAction>(128);
+		public readonly Dictionary<Action, NamedAction> ActionDictionary = new Dictionary<Action, NamedAction>(128);
+	}
+
+	public static void Add(CallbackType type, Action action)
+	{
+		instance.AddCallbackInternal(type, action);
+	}
+
+	public static void Add(ManagedNetworkBehaviour networkBehaviour)
+	{
+		instance.AddCallbackInternal(CallbackType.UPDATE, networkBehaviour.UpdateMe);
+		instance.AddCallbackInternal(CallbackType.FIXED_UPDATE, networkBehaviour.FixedUpdateMe);
+		instance.AddCallbackInternal(CallbackType.LATE_UPDATE, networkBehaviour.LateUpdateMe);
+	}
+
+	public static void Remove(CallbackType type, Action action)
+	{
+		var callbackCollection = instance.collections[type];
+
+		instance.RemoveCallbackInternal(callbackCollection, action);
+	}
+
+	public static void Remove(ManagedNetworkBehaviour networkBehaviour)
+	{
+		Remove(CallbackType.UPDATE, networkBehaviour.UpdateMe);
+		Remove(CallbackType.FIXED_UPDATE, networkBehaviour.FixedUpdateMe);
+		Remove(CallbackType.LATE_UPDATE, networkBehaviour.LateUpdateMe);
+	}
+
+	private void ProcessCallbacks(CallbackCollection collection)
+	{
+		List<NamedAction> callbackList = collection.ActionList;
+
+		// Iterate backwards so we can remove at O(1) while still iterating the rest.
+		int startCount = callbackList.Count;
+		int count = startCount;
+		for (int i = count - 1; i >= 0; --i)
 		{
-			if (updateManager == null)
+			NamedAction namedAction = callbackList[i];
+			Action callback = namedAction.Action;
+
+			if (namedAction.WaitingForRemove)
 			{
-				updateManager = FindObjectOfType<UpdateManager>();
+				// When removing from a list, everything else will shift to fill in the gaps.
+				// To avoid this, we swap this item to the back of the list.
+				// At the end of iteration, we remove the items marked for removal from the back (can be multiple) so no other memory has to shift.
+				NamedAction last = callbackList[count - 1];
+				callbackList[count - 1] = namedAction;
+				callbackList[i] = last;
+				count--;
+				continue;
 			}
-			return updateManager;
+
+#if UNITY_EDITOR
+			Profiler.BeginSample(namedAction.Name);
+			try
+			{
+				callback?.Invoke();
+			}
+			catch (Exception e)
+			{
+				// Catch the exception so it does not break flow of all callbacks
+				// But still log it to Unity console so we know something happened
+				Debug.LogException(e);
+
+				// Get rid of it.
+				RemoveCallbackInternal(collection, callback);
+			}
+			Profiler.EndSample();
+#else
+			callback?.Invoke();
+#endif
 		}
+
+		callbackList.RemoveRange(count, startCount - count);
 	}
 
-	public void Add(ManagedNetworkBehaviour updatable)
+	private void AddCallbackInternal(CallbackType type, Action action)
 	{
-		if (updatable.GetType().GetMethod(nameof(ManagedNetworkBehaviour.UpdateMe))?.DeclaringType == updatable.GetType())
-		{ //Avoiding duplicates:
-			UpdateMe -= updatable.UpdateMe;
-			UpdateMe += updatable.UpdateMe;
-		}
+		NamedAction namedAction = new NamedAction();
 
-		if (updatable.GetType().GetMethod(nameof(ManagedNetworkBehaviour.FixedUpdateMe))?.DeclaringType == updatable.GetType())
+		// Give that shit a name so we can refer to it in profiler.
+#if UNITY_EDITOR
+		namedAction.Name = action.Target != null ?
+			action.Target.GetType().ToString() + "." + action.Method.ToString() :
+			action.Method.ToString();
+#endif
+		namedAction.Action = action;
+
+        CallbackCollection callbackCollection = collections[type];
+
+		// Check if it's already been added, should never be the case so avoiding the overhead in build.
+#if UNITY_EDITOR
+		if (callbackCollection.ActionDictionary.ContainsKey(action))
 		{
-			FixedUpdateMe -= updatable.FixedUpdateMe;
-			FixedUpdateMe += updatable.FixedUpdateMe;
+			Debug.LogErrorFormat("Failed to add callback '{0}' to CallbackEvent '{1}' because it is already added.", namedAction.Name, type.ToString());
+			return;
 		}
+#endif
 
-		if (updatable.GetType().GetMethod(nameof(ManagedNetworkBehaviour.LateUpdateMe))?.DeclaringType == updatable.GetType())
+		callbackCollection.ActionList.Add(namedAction);
+		callbackCollection.ActionDictionary.Add(action, namedAction);
+	}
+
+	private void RemoveCallbackInternal(CallbackCollection collection, Action callback)
+	{
+		NamedAction namedAction;
+		if (collection.ActionDictionary.TryGetValue(callback, out namedAction))
 		{
-			LateUpdateMe -= updatable.LateUpdateMe;
-			LateUpdateMe += updatable.LateUpdateMe;
+			namedAction.WaitingForRemove = true;
+			collection.ActionDictionary.Remove(callback);
 		}
 	}
 
-	public void Add(Action updatable)
+	private void Awake()
 	{
-		UpdateAction -= updatable;
-		UpdateAction += updatable;
-	}
+		if (instance != null)
+		{
+			Destroy(gameObject);
+			return;
+		}
 
-	public void Remove(ManagedNetworkBehaviour updatable)
-	{
-		UpdateMe -= updatable.UpdateMe;
-		FixedUpdateMe -= updatable.FixedUpdateMe;
-		LateUpdateMe -= updatable.LateUpdateMe;
-	}
+		collections = new Dictionary<CallbackType, CallbackCollection>(3, new CallbackTypeComparer());
+		foreach (CallbackType callbackType in Enum.GetValues(typeof(CallbackType)))
+		{
+			collections.Add(callbackType, new CallbackCollection());
+		}
 
-	public void Remove(Action updatable)
-	{
-		UpdateAction -= updatable;
-	}
-
-	private void OnEnable()
-	{
-		SceneManager.activeSceneChanged += SceneChanged;
-	}
-
-	private void OnDisable()
-	{
-		SceneManager.activeSceneChanged -= SceneChanged;
-	}
-
-	private void SceneChanged(Scene prevScene, Scene newScene)
-	{
-		Reset();
-	}
-
-	private void Reset()
-	{
-		UpdateMe = null;
-		FixedUpdateMe = null;
-		LateUpdateMe = null;
-		UpdateAction = null;
+		instance = this;
 	}
 
 	private void Update()
 	{
-		UpdateMe?.Invoke();
-		UpdateAction?.Invoke();
+		ProcessCallbacks(collections[CallbackType.UPDATE]);
 	}
 
 	private void FixedUpdate()
 	{
-		FixedUpdateMe?.Invoke();
+		ProcessCallbacks(collections[CallbackType.FIXED_UPDATE]);
 	}
 
 	private void LateUpdate()
 	{
-		LateUpdateMe?.Invoke();
+		ProcessCallbacks(collections[CallbackType.LATE_UPDATE]);
+	}
+
+	private void OnDestroy()
+	{
+		if (instance == this)
+			instance = null;
+	}
+}
+
+public enum CallbackType : byte
+{
+	UPDATE,
+	FIXED_UPDATE,
+	LATE_UPDATE
+}
+
+/// <summary>
+/// Used to prevent garbage from boxing when comparing enums.
+/// </summary>
+public struct CallbackTypeComparer : IEqualityComparer<CallbackType>
+{
+	public bool Equals(CallbackType x, CallbackType y)
+	{
+		return x == y;
+	}
+
+	public int GetHashCode(CallbackType obj)
+	{
+		return (int)obj;
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
@@ -15,6 +15,9 @@ public class UpdateManager : MonoBehaviour
     public static bool IsInitialized { get { return instance != null; } }
 	private static UpdateManager instance;
 
+	// TODO: Obsolete, remove when no longer used.
+	public static UpdateManager Instance { get { return instance; } }
+
 	private class NamedAction
 	{
 		public Action Action;
@@ -34,6 +37,18 @@ public class UpdateManager : MonoBehaviour
 	public static void Add(CallbackType type, Action action)
 	{
 		instance.AddCallbackInternal(type, action);
+	}
+
+	[Obsolete("This will be removed in the future. Use UpdateManager.Add(CallbackType, Action) instead.")]
+	public void Add(Action updatable)
+	{
+		Add(CallbackType.UPDATE, updatable);
+	}
+
+	[Obsolete("This will be removed in the future. Use UpdateManager.Remove(CallbackType, Action) instead.")]
+	public void Remove(Action updatable)
+	{
+		Add(CallbackType.UPDATE, updatable);
 	}
 
 	public static void Add(ManagedNetworkBehaviour networkBehaviour)

--- a/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs.meta
+++ b/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs.meta
@@ -1,9 +1,10 @@
 fileFormatVersion: 2
 guid: 5becb0357443a41449a1dc06b7b68eae
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -50
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
@@ -80,7 +80,7 @@ public class MobAI : MonoBehaviour, IServerDespawn
 
 		if (CustomNetworkManager.Instance._isServer)
 		{
-			UpdateManager.Instance.Add(UpdateMe);
+			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 			health.applyDamageEvent += OnAttackReceived;
 			isServer = true;
 			AIStartServer();
@@ -91,7 +91,7 @@ public class MobAI : MonoBehaviour, IServerDespawn
 	{
 		if (isServer)
 		{
-			UpdateManager.Instance.Remove(UpdateMe);
+			UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 			health.applyDamageEvent += OnAttackReceived;
 		}
 	}

--- a/UnityProject/Assets/Scripts/NPC/AI/MobAgent.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAgent.cs
@@ -63,7 +63,7 @@ public class MobAgent : Agent
 		//only needed for starting via a map scene through the editor:
 		if (CustomNetworkManager.Instance == null) return;
 
-		UpdateManager.Instance.Add(UpdateMe);
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 
 		if (CustomNetworkManager.Instance._isServer)
 		{
@@ -82,7 +82,7 @@ public class MobAgent : Agent
 		{
 			cnt.OnTileReached().RemoveListener(OnTileReached);
 		}
-		UpdateManager.Instance.Remove(UpdateMe);
+		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 	}
 
 	protected virtual void OnTileReached(Vector3Int tilePos)

--- a/UnityProject/Assets/Scripts/Objects/UprightSprites.cs
+++ b/UnityProject/Assets/Scripts/Objects/UprightSprites.cs
@@ -62,17 +62,18 @@ public class UprightSprites : MonoBehaviour, IClientLifecycle, IMatrixRotation
 
 	public void OnDespawnClient(ClientDespawnInfo info)
 	{
-		UpdateManager.Instance.Remove(SetSpritesUpright);
+		UpdateManager.Remove(CallbackType.UPDATE, SetSpritesUpright);
 	}
 
 	//makes sure it's removed from update manager at end of round since currently updatemanager is not
 	//reset on round end.
 	private void OnDisable()
 	{
-		if (UpdateManager.Instance)
-		{
-			UpdateManager.Instance.Remove(SetSpritesUpright);
-		}
+		// Make sure we're in play mode if running in editor.
+#if UNITY_EDITOR
+		if (Application.isPlaying)
+#endif
+			UpdateManager.Remove(CallbackType.UPDATE, SetSpritesUpright);
 	}
 
 	private void SetSpritesUpright()
@@ -97,7 +98,7 @@ public class UprightSprites : MonoBehaviour, IClientLifecycle, IMatrixRotation
 			{
 				if (spriteMatrixRotationBehavior == SpriteMatrixRotationBehavior.RemainUpright)
 				{
-					UpdateManager.Instance.Add(SetSpritesUpright);
+					UpdateManager.Add(CallbackType.UPDATE, SetSpritesUpright);
 				}
 			}
 			else if (rotationInfo.IsEnding)
@@ -105,7 +106,7 @@ public class UprightSprites : MonoBehaviour, IClientLifecycle, IMatrixRotation
 				if (spriteMatrixRotationBehavior == SpriteMatrixRotationBehavior.RemainUpright)
 				{
 					//stop reorienting to face upright
-					UpdateManager.Instance.Remove(SetSpritesUpright);
+					UpdateManager.Remove(CallbackType.UPDATE, SetSpritesUpright);
 				}
 
 				SetSpritesUpright();

--- a/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandler.cs
@@ -128,7 +128,7 @@ public class SpriteHandler : MonoBehaviour
 		}
 		if (!isAnimation)
 		{
-			UpdateManager.Instance.Remove(UpdateMe);
+			UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 			spriteRenderer.sprite = null;
 		}
 	}
@@ -189,12 +189,12 @@ public class SpriteHandler : MonoBehaviour
 		//UpdateManager.Instance.Remove(UpdateMe);
 		if (turnOn && !isAnimation)
 		{
-			UpdateManager.Instance.Add(UpdateMe);
+			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 			isAnimation = true;
 		}
 		else if (!turnOn && isAnimation)
 		{
-			UpdateManager.Instance.Remove(UpdateMe);
+			UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 			isAnimation = false;
 		}
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Meter.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Pipenets/Meter.cs
@@ -73,7 +73,7 @@ public class Meter : NetworkBehaviour, ICheckedInteractable<HandApply>
 					SoundManager.PlayNetworkedAtPos("Wrench", registerTile.WorldPositionServer, 1f);
 					pipe = foundPipe;
 					ToggleAnchored(true);
-					UpdateManager.Instance.Add(UpdateMe);
+					UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 					UpdateMe();
 					break;
 				}
@@ -85,7 +85,7 @@ public class Meter : NetworkBehaviour, ICheckedInteractable<HandApply>
 	{
 		ToggleAnchored(false);
 		spriteSync = 0;
-		UpdateManager.Instance.Remove(UpdateMe);
+		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 	}
 
 	void ToggleAnchored(bool value)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -36,15 +36,12 @@ public class MetaDataSystem : SubsystemBehaviour
 
 	void OnEnable()
 	{
-		UpdateManager.Instance.Add(UpdateMe);
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 
 	void OnDisable()
 	{
-		if (UpdateManager.Instance != null)
-		{
-			UpdateManager.Instance.Remove(UpdateMe);
-		}
+		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 	}
 
 	public override void Initialize()

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -521,7 +521,7 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 		if (crossMatrixRelationships == null)
 		{
 			crossMatrixRelationships = new List<BaseSpatialRelationship>();
-			UpdateManager.Instance.Add(UpdatePollCrossMatrixRelationships);
+			UpdateManager.Add(CallbackType.UPDATE, UpdatePollCrossMatrixRelationships);
 		}
 		crossMatrixRelationships.Add(toAdd);
 	}
@@ -546,7 +546,7 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 		crossMatrixRelationships.Remove(toRemove);
 		if (crossMatrixRelationships.Count == 0)
 		{
-			UpdateManager.Instance.Remove(UpdatePollCrossMatrixRelationships);
+			UpdateManager.Remove(CallbackType.UPDATE, UpdatePollCrossMatrixRelationships);
 			crossMatrixRelationships = null;
 		}
 	}

--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
@@ -84,14 +84,19 @@ public partial class CustomNetTransform : ManagedNetworkBehaviour, IPushable, IR
 		get { return motionState; }
 		set
 		{
-			if ( motionState == value || UpdateManager.Instance == null )
+			if ( motionState == value || !UpdateManager.IsInitialized )
 			{
 				return;
 			}
 
 			if ( value == MotionStateEnum.Moving )
 			{
-				base.OnEnable();
+				StopCoroutine(limboHandle);
+
+				// In the case we become Still and then Moving again in one second, we're still updating because freeze timer hasn't finished yet.
+				// Checking here if timer has passed yet (so we're no longer updating), if we are still updating we don't have to call OnEnable again.
+				if (!IsUpdating)
+					base.OnEnable();
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/UI/PlayerHealthUI.cs
+++ b/UnityProject/Assets/Scripts/UI/PlayerHealthUI.cs
@@ -27,15 +27,12 @@ public class PlayerHealthUI : MonoBehaviour
 
 	private void OnEnable()
 	{
-		UpdateManager.Instance.Add(UpdateMe);
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 
 	private void OnDisable()
 	{
-		if (UpdateManager.Instance != null)
-		{
-			UpdateManager.Instance.Remove(UpdateMe);
-		}
+		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 	}
 
 	private void DisableAll()

--- a/UnityProject/Assets/Scripts/UI/UI_HeartMonitor.cs
+++ b/UnityProject/Assets/Scripts/UI/UI_HeartMonitor.cs
@@ -36,16 +36,13 @@ public class UI_HeartMonitor : TooltipMonoBehaviour
 	private void OnEnable()
 	{
 		SceneManager.activeSceneChanged += OnSceneChange;
-		UpdateManager.Instance.Add(UpdateMe);
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 
 	private void OnDisable()
 	{
 		SceneManager.activeSceneChanged -= OnSceneChange;
-		if (UpdateManager.Instance != null)
-		{
-			UpdateManager.Instance.Remove(UpdateMe);
-		}
+		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 	}
 
 	private void OnSceneChange(Scene prev, Scene next)

--- a/UnityProject/Assets/Scripts/UI/UI_OxygenAlert.cs
+++ b/UnityProject/Assets/Scripts/UI/UI_OxygenAlert.cs
@@ -23,15 +23,12 @@ public class UI_OxygenAlert : TooltipMonoBehaviour
 
 	private void OnEnable()
 	{
-		UpdateManager.Instance.Add(UpdateMe);
+		UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
 	}
 
 	private void OnDisable()
 	{
-		if (UpdateManager.Instance != null)
-		{
-			UpdateManager.Instance.Remove(UpdateMe);
-		}
+		UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
 		ResetImg();
 	}
 


### PR DESCRIPTION
Updated the update manager. The main objective of this PR is to add profiling functionality to the update manager so we can actually see where frame time is going. Before this PR only "UpdateManager.Update()" shows up in profiler, but now the individual methods are visible.
Sorry about the text, the text in this PR is probably longer than the code I changed, I just wanted to be thorough.

**Refactor**
* UpdateManager add/remove is now faster, but uses slightly more memory.
* UpdateManager methods now show up properly in profiler with where it's being called from. Excluded from build to prevent overhead.
* Now catches exceptions. Excluded from build to prevent overhead, even though the performance impact is very small (less than 10% of what one iteration costs). One exception in updatemanager flow will still break entire build, but in editor keeps working. We might want to extend this to builds as well, but that is up for debate.
* Moved priority in the script execution order so it will always execute (and be available) before everything else. This is now an assumption you can make rather than having it be random wether updates before or after.

**Fixes**
* Updated existing calls to add/remove to use new static method.
* Removed calls and reflection that were used in case user did not unsubscribe/tried to double subscribe, user now needs to always unsubscribe properly. This revealed the following issues that were fixed:
* Fixed invalid remove that happened during UprightSprites during editor (non-playmode) time.
* Fixed duplicate add that happened when waking up CustomNetTransform before sleep timer had completed.

**Changes**
UpdateManager.Instance.Add(Action) has been changed to UpdateManager.Add(CallbackType, Action). This is to make it easier for the user (as in programmer), because they should not have to think about instances. Same for Remove.
Old methods were left functional and marked obsolete to prevent breaking code that people are currently working on.

**Benchmarks**
**Updating 10k calls**
Before commit: 0.25ms
After commit: 0.25ms
After commit, profiling enabled: ~2ms

**Adding 10k**
Before commit: 1000+ ms, 383.9 mb gc alloc
After commit: 12.87ms, 2.9 mb gc alloc
After commit, profiling enabled: 108ms, 12.1 mb gc alloc

**Removing 10k**
Before commit: 1000+ ms, 383.9 mb gc alloc
After commit: 16.80ms, 2.1 mb gc alloc
After commit, profiling enabled: 20ms, 2.1 mb gc alloc

I don't want to spam this entire issue with screenshots, but here's the last 3:
![image](https://user-images.githubusercontent.com/1729718/74614272-cd142000-5116-11ea-9987-86a3811b8e41.png)
![image](https://user-images.githubusercontent.com/1729718/74614276-d9987880-5116-11ea-960f-38356f60e298.png)
![image](https://user-images.githubusercontent.com/1729718/74614275-d604f180-5116-11ea-87ab-112729524523.png)

**Conclusion**
Updating is the same performance in build. Adding/removing is a lot faster. Profiling reduces performance. I think the overhead on profiling is acceptable because now we can optimize what's actually in the update loop by seeing what takes the most time, and it is excluded from build.