### PR TITLE
Re-fix ore redemption machine not refining sand to glass

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Mining/Ore Redemption Machine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Mining/Ore Redemption Machine.prefab
@@ -35,7 +35,7 @@ MonoBehaviour:
     Material: {fileID: 6254655335276451647, guid: fdfebca06b77ef64898a68e1df0d3e9a,
       type: 3}
   - Trait: {fileID: 11400000, guid: 6097f8423a1b255468e2285de46bc3d3, type: 2}
-    Material: {fileID: 6201122676745363040, guid: ea07289ba72453444a4ff1202b47a57d,
+    Material: {fileID: 5680136605834777345, guid: ea07289ba72453444a4ff1202b47a57d,
       type: 3}
 --- !u!114 &7207538277679673550
 MonoBehaviour:


### PR DESCRIPTION
# Pull Request Template

### Purpose
PR #3139 was broken by https://github.com/unitystation/unitystation/commit/3cad75bb14bce5db5900c293e8b5c5c1e1e80a79 so I'm making a followup to #3151 to also fix this again.

### Please make sure you have followed the self checks below before submitting a PR:

- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.

