### PR TITLE
Fixed minor typos in engines and assistant description.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_E.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_E.prefab
@@ -122,7 +122,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58b822814682f460baa30059c4fd7f42, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Message: Touching hidrogen engines with your bare hands, really?
+  Message: Touching hydrogen engines with your bare hands, really?
 --- !u!114 &114380035635842018
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -218,10 +218,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
-  localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 1568471834
 --- !u!114 &2122850763136765348
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_W.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_W.prefab
@@ -202,7 +202,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58b822814682f460baa30059c4fd7f42, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Message: Touching hidrogen engines with your bare hands, really?
+  Message: Touching hydrogen engines with your bare hands, really?
 --- !u!114 &114297752066753362
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -298,10 +298,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
-  localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 378549142
 --- !u!114 &2380196287676553691
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_center.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_center.prefab
@@ -122,7 +122,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58b822814682f460baa30059c4fd7f42, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Message: Touching hidrogen engines with your bare hands, really?
+  Message: Touching hydrogen engines with your bare hands, really?
 --- !u!114 &114394273069994774
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -218,10 +218,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
-  localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 726241801
 --- !u!114 &4273586469488225513
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/ScriptableObjects/Occupations/Assistant.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Occupations/Assistant.asset
@@ -32,7 +32,7 @@ MonoBehaviour:
     chat channel if you have any questions about how to play.
 
 
-    Not sure what do so? Offer your help on the radio, or ask the Head of Personnel
+    Not sure what to do? Offer your help on the radio, or ask the Head of Personnel
     for a job.
 
 


### PR DESCRIPTION
This PR fixes two minor typos, one of which was introduced in https://github.com/unitystation/unitystation/pull/3157. Wish I could have noticed them before today's rebuild!

Asssistant description: "Not sure what **do so**?" --> "Not sure what **to do**?

Engine interact message: **hidrogen** --> **hydrogen**

That's it! 🎉

