### PR TITLE
Fix for building metal rods, missing trashbags

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjects/Construction/BuildList/MetalConstructionList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Construction/BuildList/MetalConstructionList.asset
@@ -78,7 +78,7 @@ MonoBehaviour:
     spawnAmount: 4
     onePerTile: 0
   - name: Metal Rods x2
-    prefab: {fileID: 4386653123902480855, guid: 2a170fdb7187e38459de34c4d2b131ad,
+    prefab: {fileID: 4519819786599941225, guid: 2a170fdb7187e38459de34c4d2b131ad,
       type: 3}
     cost: 1
     buildTime: 5

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Items/Belt/JanitorToolbetFullPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Items/Belt/JanitorToolbetFullPopulator.asset
@@ -17,6 +17,6 @@ MonoBehaviour:
   - {fileID: 2419386692754613975, guid: 72539a60f847bd248bec932a82058e0b, type: 3}
   - {fileID: 2419386692754613975, guid: 72539a60f847bd248bec932a82058e0b, type: 3}
   - {fileID: 2419386692754613975, guid: e632378292aa9a645bf4a8745061e44d, type: 3}
-  - {fileID: 359432221073519209, guid: 4dddcb74ff9a3ee4ca69bc6d757dca03, type: 3}
+  - {fileID: 1726396646920325504, guid: 4dddcb74ff9a3ee4ca69bc6d757dca03, type: 3}
   - {fileID: 2419386692754613975, guid: 6603caafe8df84b4da1c797343cdf8c6, type: 3}
   MergeMode: 0

--- a/UnityProject/Assets/Resources/ScriptableObjects/SpawnableLists/Closets/Janitor.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/SpawnableLists/Closets/Janitor.asset
@@ -21,4 +21,4 @@ MonoBehaviour:
   - {fileID: 2419386692754613975, guid: 6603caafe8df84b4da1c797343cdf8c6, type: 3}
   - {fileID: 2419386692754613975, guid: 6603caafe8df84b4da1c797343cdf8c6, type: 3}
   - {fileID: 2419386692754613975, guid: 72539a60f847bd248bec932a82058e0b, type: 3}
-  - {fileID: 359432221073519209, guid: 4dddcb74ff9a3ee4ca69bc6d757dca03, type: 3}
+  - {fileID: 1726396646920325504, guid: 4dddcb74ff9a3ee4ca69bc6d757dca03, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/SpawnableLists/Resources/Rods.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/SpawnableLists/Resources/Rods.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: Rods
   m_EditorClassIdentifier: 
   contents:
-  - {fileID: 4386653123902480855, guid: 2a170fdb7187e38459de34c4d2b131ad, type: 3}
+  - {fileID: 4519819786599941225, guid: 2a170fdb7187e38459de34c4d2b131ad, type: 3}


### PR DESCRIPTION
### Purpose
Fixes being unable to build metal rods
Puts trash bags back in janitor lockers, janitor toolbelt populator

### Notes:
Previously broken by prefab IDs changing and .asset files losing their reference to them as a result.

Janitor belts cannot currently accept any janitor items (SpaceCleaner, Mop, TrashBag, Wet floor sign) as they are not whitelisted in Assets/Resources/ScriptableObjects/Inventory/Structure/Belts/JanitorBeltCapacity.asset
Additionally TrashBag is set to be Initial Size Large, so it wont currently fit in the Medium capacity belt even when whitelisted.
As a result both purchased and starter Janitor belts remain empty at this time. (related issue #2378)