### PR TITLE
UpdateManager now uses try catch in build also

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
@@ -96,7 +96,6 @@ public class UpdateManager : MonoBehaviour
 				continue;
 			}
 
-#if UNITY_EDITOR
 			Profiler.BeginSample(namedAction.Name);
 			try
 			{
@@ -112,9 +111,6 @@ public class UpdateManager : MonoBehaviour
 				RemoveCallbackInternal(collection, callback);
 			}
 			Profiler.EndSample();
-#else
-			callback?.Invoke();
-#endif
 		}
 
 		callbackList.RemoveRange(count, startCount - count);


### PR DESCRIPTION
After further consideration, one nullref should not break entire game. Also, after one exception that specific update will be removed from the loop to prevent infinite spam.

This also serves as a hotfix for current servers breaking from a nullref in UprightSprites.SetSpritesUpright()