### PR TITLE
Fixes #3129 Updated WoodFloorTile with ItemCost value.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/PlaceableTiles/WoodFloorTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/PlaceableTiles/WoodFloorTile.prefab
@@ -72,6 +72,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f,
         type: 2}
+    - target: {fileID: 3004788566835106784, guid: a435d5d64bc4b48baa27fecfcab9e111,
+        type: 3}
+      propertyPath: waysToPlace.Array.data[0].itemCost
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5209370598559660201, guid: a435d5d64bc4b48baa27fecfcab9e111,
         type: 3}
       propertyPath: initialName


### PR DESCRIPTION
### Purpose

This pull addresses the last part of #3129 , most existing prefabs addressed already.

Adds an ItemCost value of 1 to the PlacableTile script.

### Please make sure you have followed the self checks below before submitting a PR:

- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor