### PR TITLE
Fix of #3042 and closely related unreported bug (wrong item despawn on rack assembly from ground)

### DIFF
--- a/UnityProject/Assets/Scripts/Storage/RackParts.cs
+++ b/UnityProject/Assets/Scripts/Storage/RackParts.cs
@@ -67,7 +67,14 @@ public class RackParts : MonoBehaviour, ICheckedInteractable<PositionalHandApply
 			Spawn.ServerPrefab(rackPrefab, interaction.WorldPositionTarget.RoundToInt(),
 				interaction.Performer.transform.parent);
 			var handObj = interaction.HandObject;
-			Inventory.ServerDespawn(interaction.HandSlot);
+			if (handObj.GetInstanceID() == gameObject.GetInstanceID()) // the rack parts were assembled from the hands, despawn in inventory-fashion
+			{ // (note: instanceIDs used in case somebody starts assembling rack parts on the ground with rack parts in hand (which was not possible at the time this was written))
+				Inventory.ServerDespawn(interaction.HandSlot);
+			}
+			else // the rack parts were assembled from the ground, despawn in general fashion
+			{
+				Despawn.ServerSingle(gameObject);
+			}
 		}
 
 		var bar = StandardProgressAction.Create(ProgressConfig, ProgressComplete)


### PR DESCRIPTION
### Purpose
Assembling rack parts on the grounds now despawns those rack parts ( #3042 ) instead of despawning whatever was in your hand at the time (not reported before).

### Notes:
Assembling rack parts on the ground with rack parts in your hand will despawn the rack parts in your hand.
As far as I can tell, this is just caused by assembling-from-hand being prioritized over assembling-from-ground. Should these priorities be switched, the parts on the ground should be despawned instead.

### Performed Self-Checks:
- [X] Code is sufficiently commented
- [X] Code is indented with tabs and not spaces
- [X] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [X] The PR does not bring up any new compile errors
- [X] The PR has been tested in editor
- [X] Any new files are named using PascalCase (to avoid issues on case sensitive file systems) [No new files]
- [X] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [X] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [X] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable) [Locally]
- [X] The PR has been tested with round restarts. [In editor]