### PR TITLE
Fixed Dev builds. Removed windoor from bridge

### DIFF
--- a/UnityProject/Assets/Scenes/OBSOLETE/OutpostStationOld.unity.meta
+++ b/UnityProject/Assets/Scenes/OBSOLETE/OutpostStationOld.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7b01d3afcfb67481e8398b72f2e21fa5
+guid: 1acff2f0b883a9c42bd84f8d573b9a28
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/UnityProject/Assets/Scenes/OutpostStation.unity.meta
+++ b/UnityProject/Assets/Scenes/OutpostStation.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7b01d3afcfb67481e8398b72f2e21fa5
+guid: 55ee576d5b067ad44823fc3b4edc6c42
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs
@@ -96,7 +96,6 @@ public class UpdateManager : MonoBehaviour
 				continue;
 			}
 
-			Profiler.BeginSample(namedAction.Name);
 			try
 			{
 				callback?.Invoke();
@@ -110,7 +109,6 @@ public class UpdateManager : MonoBehaviour
 				// Get rid of it.
 				RemoveCallbackInternal(collection, callback);
 			}
-			Profiler.EndSample();
 		}
 
 		callbackList.RemoveRange(count, startCount - count);

--- a/UnityProject/ProjectSettings/EditorBuildSettings.asset
+++ b/UnityProject/ProjectSettings/EditorBuildSettings.asset
@@ -25,7 +25,10 @@ EditorBuildSettings:
     guid: e540262a5e4484c578775515f5c48bc3
   - enabled: 1
     path: Assets/Scenes/OutpostStation.unity
-    guid: 7b01d3afcfb67481e8398b72f2e21fa5
+    guid: 55ee576d5b067ad44823fc3b4edc6c42
+  - enabled: 0
+    path: 
+    guid: 00000000000000000000000000000000
   - enabled: 0
     path: 
     guid: 00000000000000000000000000000000
@@ -39,6 +42,6 @@ EditorBuildSettings:
     path: 
     guid: 00000000000000000000000000000000
   - enabled: 0
-    path: Assets/Scenes/OutpostStation02.unity
-    guid: 646278ba0dcbda5418c8bb4fa6ce0b8e
+    path: 
+    guid: 00000000000000000000000000000000
   m_configObjects: {}


### PR DESCRIPTION
The Profile Samplers in UpdateManager prevented the game from moving between Lobbuy -> Outpostation scenes. It would just crash the build. So I removed them.

Also removed faulty windoor in bridge
