### PR TITLE
Fixes the NRE from ghosts trying to use hand hotkeys.

### DIFF
--- a/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
@@ -37,6 +37,12 @@ public class ControlAction : MonoBehaviour
 
 		// if (!Validations.CanInteract(PlayerManager.LocalPlayerScript, NetworkSide.Client, allowCuffed: true)); Commented out because it does... nothing?
 		UI_ItemSlot currentSlot = UIManager.Hands.CurrentSlot;
+
+		if(PlayerManager.LocalPlayerScript.IsGhost) 
+		{
+			return;
+		}
+	
 		if (currentSlot.Item == null)
 		{
 			return;

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
@@ -113,6 +113,12 @@ public class Hands : MonoBehaviour
 	/// </summary>
 	public void Activate()
 	{
+
+		if(!isValidPlayer())
+		{
+			return;
+		}
+
 		// Is there an item in the active hand?
 		if (CurrentSlot.Item == null)
 		{


### PR DESCRIPTION
### Purpose
Fixes #2768.

### Notes:
Checks if a player is not a ghost when trying to drop an item using PlayerManager.LocalPlayerScript.IsGhost. Uses isValidPlayer method when trying to use an item.