### PR TITLE
Render palettable sprites in right-click menu properly

### DIFF
--- a/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
+++ b/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
@@ -30,6 +30,9 @@ public class ClothingV2 : MonoBehaviour
 	[SerializeField, EnumFlag]
 	private ClothingHideFlags hideClothingFlags;
 
+	private ItemAttributesV2 myItem;
+	private Pickupable myPickupable;
+
 	private Dictionary<ClothingVariantType, int> variantStore = new Dictionary<ClothingVariantType, int>();
 	private List<int> variantList;
 	private SpriteData spriteInfo;
@@ -60,6 +63,8 @@ public class ClothingV2 : MonoBehaviour
 	private void Awake()
 	{
 		spriteHandlerController = GetComponent<SpriteHandlerController>();
+		myItem = GetComponent<ItemAttributesV2>();
+		myPickupable = GetComponent<Pickupable>();
 		TryInit();
 	}
 
@@ -68,7 +73,6 @@ public class ClothingV2 : MonoBehaviour
 	{
 		if (clothData is ClothingData clothingData)
 		{
-			var item = GetComponent<ItemAttributesV2>();
 			spriteInfo = SetUpSheetForClothingData(clothingData);
 			SetUpFromClothingData(clothingData.Base);
 
@@ -94,19 +98,16 @@ public class ClothingV2 : MonoBehaviour
 		}
 		else if (clothData is ContainerData containerData)
 		{
-			var Item = GetComponent<ItemAttributesV2>();
 			this.spriteInfo = SpriteFunctions.SetupSingleSprite(containerData.Sprites.Equipped);
 			SetUpFromClothingData(containerData.Sprites);
 		}
 		else if (clothData is BeltData beltData)
 		{
-			var Item = GetComponent<ItemAttributesV2>();
 			this.spriteInfo = SpriteFunctions.SetupSingleSprite(beltData.sprites.Equipped);
 			SetUpFromClothingData(beltData.sprites);
 		}
 		else if (clothData is HeadsetData headsetData)
 		{
-			var Item = GetComponent<ItemAttributesV2>();
 			var Headset = GetComponent<Headset>();
 			this.spriteInfo = SpriteFunctions.SetupSingleSprite(headsetData.Sprites.Equipped);
 			SetUpFromClothingData(headsetData.Sprites);
@@ -117,7 +118,7 @@ public class ClothingV2 : MonoBehaviour
 	private void SetUpFromClothingData(EquippedData equippedData)
 	{
 		var SpriteSOData = new ItemsSprites();
-		SpriteSOData.Palette = equippedData.Palette;
+		SpriteSOData.Palette = new List<Color>(equippedData.Palette);
 		SpriteSOData.LeftHand = (equippedData.InHandsLeft);
 		SpriteSOData.RightHand = (equippedData.InHandsRight);
 		SpriteSOData.InventoryIcon = (equippedData.ItemIcon);
@@ -126,6 +127,16 @@ public class ClothingV2 : MonoBehaviour
 		spriteHandlerController.SetSprites(SpriteSOData);
 	}
 
+
+	public void AssignPaletteToSprites(List<Color> palette)
+	{
+		if (myItem.ItemSprites.IsPaletted)
+		{
+			spriteHandlerController.SetPaletteOfCurrentSprite(palette);
+			clothingItem?.spriteHandler.SetPaletteOfCurrentSprite(palette);
+			myPickupable.SetPalette(palette);
+		}
+	}
 
 
 	private SpriteData SetUpSheetForClothingData(ClothingData clothingData)

--- a/UnityProject/Assets/Scripts/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Inventory/Pickupable.cs
@@ -283,4 +283,15 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 			CT.SetInHand(_ItemsSprites);
 		}
 	}
+
+	public void SetPalette(List<Color> palette)
+	{
+		if (itemSlot != null)
+		{
+			var equipment = itemSlot.Player.GetComponent<Equipment>();
+			if (equipment == null) return;
+			var CT = equipment.GetClothingItem(itemSlot.NamedSlot.Value);
+			CT.spriteHandler.SetPaletteOfCurrentSprite(palette);
+		}
+	}
 }

--- a/UnityProject/Assets/Scripts/Items/ClothingItem.cs
+++ b/UnityProject/Assets/Scripts/Items/ClothingItem.cs
@@ -142,6 +142,13 @@ public class ClothingItem : MonoBehaviour
 	public void RefreshFromClothing(ClothingV2 clothing)
 	{
 		spriteHandler.spriteData = clothing.SpriteInfo;
+
+		List<Color> palette = clothing.GetComponent<ItemAttributesV2>()?.ItemSprites?.Palette;
+		if (palette != null)
+		{
+			spriteHandler.SetPaletteOfCurrentSprite(palette);
+		}
+
 		spriteHandler.ChangeSprite(clothing.SpriteInfoState);
 		PushTexture();
 	}

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -279,4 +279,11 @@ public class ItemAttributesV2 : Attributes
 	{
 		itemSprites = newSprites;
 	}
+
+	[ContextMenu("Propagate Palette Changes")]
+	public void PropagatePaletteChanges()
+	{
+		ClothingV2 clothing = GetComponent<ClothingV2>();
+		if (clothing != null) clothing.AssignPaletteToSprites(this.ItemSprites.Palette);
+	}
 }

--- a/UnityProject/Assets/Scripts/Sprite Handler/ItemsSprites.cs
+++ b/UnityProject/Assets/Scripts/Sprite Handler/ItemsSprites.cs
@@ -10,7 +10,7 @@ public class ItemsSprites
 
 	public SpriteSheetAndData InventoryIcon = new SpriteSheetAndData();
 
-	public Color[] Palette = new Color[8];
+	public List<Color> Palette = new List<Color>(new Color[8]);
 	public bool IsPaletted = false;
 
 }

--- a/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandler.cs
@@ -86,24 +86,28 @@ public class SpriteHandler : MonoBehaviour
 
 	private bool isPaletted()
 	{
-		if (spriteData.isPaletteds.Count == 0)
+		if (spriteData == null || spriteData.isPaletteds == null || spriteData.isPaletteds.Count == 0)
 			return false;
-		if (spriteData.isPaletteds.Count == 1)
-			return spriteData.isPaletteds[0];
 		return spriteData.isPaletteds[spriteIndex];
 	}
 
 	private List<Color> getPaletteOrNull()
 	{
-		bool _isPaletted = isPaletted();
-
-		if (!_isPaletted)
+		if (!isPaletted())
 			return null;
 
-		if (spriteData.palettes.Count == 1)
-			return spriteData.palettes[0];
 
 		return spriteData.palettes[spriteIndex];
+	}
+
+	public void SetPaletteOfCurrentSprite(List<Color> newPalette)
+	{
+		if (isPaletted())
+		{
+			spriteData.palettes[spriteIndex] = newPalette;
+			PushTexture();
+		}
+
 	}
 
 

--- a/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandlerController.cs
+++ b/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandlerController.cs
@@ -82,4 +82,11 @@ public class SpriteHandlerController : NetworkBehaviour
 			spriteRenderer.sprite = newSprites.InventoryIcon.Data.ReturnFirstSprite();
 		}
 	}
+
+
+	public void SetPaletteOfCurrentSprite(List<Color> newPalette)
+	{
+		pickupable.RefreshUISlotImage();
+		spriteHandler.SetPaletteOfCurrentSprite(newPalette);
+	}
 }

--- a/UnityProject/Assets/Scripts/UI/Right click/Button.prefab
+++ b/UnityProject/Assets/Scripts/UI/Right click/Button.prefab
@@ -57,7 +57,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 2100000, guid: 15f015b12f2615240bab192aeaa9c18d, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
   m_OnCullStateChanged:

--- a/UnityProject/Assets/Scripts/UI/Right click/RadialButton.cs
+++ b/UnityProject/Assets/Scripts/UI/Right click/RadialButton.cs
@@ -10,6 +10,7 @@ public class RadialButton : MonoBehaviour, IPointerEnterHandler, IPointerExitHan
 {
 	[SerializeField] private Image circle;
 	[SerializeField] private Image icon;
+	private List<Color> palette;
 	[SerializeField] private Text title;
 	private RadialMenu menuControl;
 	private Color defaultColour;
@@ -19,6 +20,12 @@ public class RadialButton : MonoBehaviour, IPointerEnterHandler, IPointerExitHan
 	private bool isSelected;
 	private bool isTopLevel;
 	public List<RadialButton> childButtons = new List<RadialButton>();
+
+	private void Awake()
+	{
+		// unity doesn't support property blocks on ui renderers, so this is a workaround
+		icon.material = Instantiate(icon.material);
+	}
 
 	public void SetButton(Vector2 localPos, RadialMenu menuController, RightClickMenuItem menuItem, bool topLevel)
 	{
@@ -31,6 +38,17 @@ public class RadialButton : MonoBehaviour, IPointerEnterHandler, IPointerExitHan
 		action = menuItem.Action;
 
 		icon.sprite = menuItem.IconSprite;
+		palette = menuItem.palette;
+		if (palette != null)
+		{
+			icon.material.SetInt("_IsPaletted", 1);
+			icon.material.SetColorArray("_ColorPalette", menuItem.palette.ToArray());
+		}
+		else
+		{
+			icon.material.SetInt("_IsPaletted", 0);
+		}
+
 		if (menuItem.BackgroundSprite != null)
 		{
 			circle.sprite = menuItem.BackgroundSprite;

--- a/UnityProject/Assets/Scripts/UI/Right click/RightClickManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Right click/RightClickManager.cs
@@ -231,6 +231,18 @@ public class RightClickManager : MonoBehaviour
 		var label = forObject.name.Replace("(clone)","");
 		SpriteRenderer firstSprite = forObject.GetComponentInChildren<SpriteRenderer>();
 		Sprite sprite = null;
+
+		// check if is a paletted item
+		ItemAttributesV2 item = forObject.GetComponent<ItemAttributesV2>();
+		List<Color> palette = null;
+		if (item != null)
+		{
+			if (item.ItemSprites.IsPaletted)
+			{
+				palette = item.ItemSprites.Palette;
+			}
+		}
+
 		if (firstSprite != null)
 		{
 			sprite = firstSprite.sprite;
@@ -242,6 +254,6 @@ public class RightClickManager : MonoBehaviour
 			                        " on this object.", Category.UI, forObject.name);
 		}
 
-		return RightClickMenuItem.CreateObjectMenuItem(Color.gray, sprite, null, label, subMenus);
+		return RightClickMenuItem.CreateObjectMenuItem(Color.gray, sprite, null, label, subMenus, palette);
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Right click/RightClickMenuItem.cs
+++ b/UnityProject/Assets/Scripts/UI/Right click/RightClickMenuItem.cs
@@ -13,12 +13,13 @@ public class RightClickMenuItem
 	public readonly Sprite IconSprite;
 	public readonly Sprite BackgroundSprite;
 	public readonly string Label;
+	public readonly List<Color> palette;
 
 	public readonly List<RightClickMenuItem> SubMenus;
 	public readonly Action Action;
 
 
-	private RightClickMenuItem(Color backgroundColor, Sprite iconSprite, Sprite backgroundSprite, string label, List<RightClickMenuItem> subMenus, Action action)
+	private RightClickMenuItem(Color backgroundColor, Sprite iconSprite, Sprite backgroundSprite, string label, List<RightClickMenuItem> subMenus, Action action, List<Color> palette = null)
 	{
 		this.BackgroundColor = backgroundColor;
 		this.IconSprite = iconSprite;
@@ -26,6 +27,7 @@ public class RightClickMenuItem
 		this.Action = action;
 		this.SubMenus = subMenus;
 		this.BackgroundSprite = backgroundSprite;
+		this.palette = palette;
 	}
 
 	/// <summary>
@@ -36,9 +38,9 @@ public class RightClickMenuItem
 	/// <param name="backgroundSprite">background sprite of icon, can be null</param>
 	/// <param name="label">label to show</param>
 	/// <param name="action">action to invoke when it is clicked</param>
-	public static RightClickMenuItem CreateSubMenuItem(Color color, Sprite sprite, Sprite backgroundSprite, string label, Action action)
+	public static RightClickMenuItem CreateSubMenuItem(Color color, Sprite sprite, Sprite backgroundSprite, string label, Action action, List<Color> palette = null)
 	{
-		return new RightClickMenuItem(color, sprite, backgroundSprite, label, null, action);
+		return new RightClickMenuItem(color, sprite, backgroundSprite, label, null, action, palette);
 	}
 
 	/// <summary>
@@ -51,8 +53,8 @@ public class RightClickMenuItem
 	/// <param name="label">label to show</param>
 	/// <param name="subMenus">submenu items to show for this object</param>
 	public static RightClickMenuItem CreateObjectMenuItem(Color color, Sprite sprite, Sprite backgroundSprite, string label,
-		List<RightClickMenuItem> subMenus)
+		List<RightClickMenuItem> subMenus, List<Color> palette = null)
 	{
-		return new RightClickMenuItem(color, sprite, backgroundSprite,  label, subMenus, null);
+		return new RightClickMenuItem(color, sprite, backgroundSprite,  label, subMenus, null, palette);
 	}
 }

--- a/UnityProject/Assets/Shaders/Sprite Fov Masked.shader
+++ b/UnityProject/Assets/Shaders/Sprite Fov Masked.shader
@@ -73,14 +73,17 @@ Shader "Stencil/Unlit background masked" {
 		fixed4 textureSample = tex2D(_MainTex, i.texcoord);
 		fixed4 maskSample = tex2D(_ObjectFovMask, i.screencoord);
 
-		fixed4 final = textureSample * i.color;
+		fixed4 final;
 
-		
 		if (_IsPaletted)
 		{
 			int paletteIndexA = min(textureSample.r, 0.99) * 8;
 			int paletteIndexB = min(textureSample.g, 0.99) * 8;
 			final = lerp(_ColorPalette[paletteIndexA], _ColorPalette[paletteIndexB], textureSample.b) * i.color;
+		}
+		else
+		{
+			final = textureSample * i.color;
 		}
 		
 		float maskChennel = maskSample.g + maskSample.r;

--- a/UnityProject/Assets/Shaders/UIPalettable.shader
+++ b/UnityProject/Assets/Shaders/UIPalettable.shader
@@ -105,7 +105,7 @@ Shader "UI/Palettable UI"
 				{
 					half4 textureSample = tex2D(_MainTex, IN.texcoord);
 					
-					fixed4 final = (textureSample + _TextureSampleAdd) * IN.color;
+					fixed4 final;
 
 					if (_IsPaletted)
 					{
@@ -113,8 +113,12 @@ Shader "UI/Palettable UI"
 						int paletteIndexB = min(textureSample.g, 0.99) * 8;
 						final = lerp(_ColorPalette[paletteIndexA], _ColorPalette[paletteIndexB], textureSample.b) * IN.color;
 					}
+					else
+					{
+						final  = (textureSample + _TextureSampleAdd) * IN.color;
+					}
 
-					final.a = textureSample.a * IN.color;
+					final.a = textureSample.a * IN.color.a;
 
 					#ifdef UNITY_UI_CLIP_RECT
 					final.a *= UnityGet2DClipping(IN.worldPosition.xy, _ClipRect);


### PR DESCRIPTION
###Purpose 
Fixes palettable sprites not being rendered properly in right click menus
Fixes red/green UI ghosts of items based on UI slot compatibility rendering incorrectly

###Notes
Also, adds right-click context option to ItemAttributesV2 that applies changes to palette to related sprites and icons.

progress towards #2110