### PR TITLE
Starting round as a Spectator Ghost

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/Windows (Put all window UI's in here).prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/Windows (Put all window UI's in here).prefab
@@ -1,5 +1,40 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &69544675715416013
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3295285530625747375}
+  m_Layer: 5
+  m_Name: Footer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3295285530625747375
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 69544675715416013}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8530562246598747092}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -360}
+  m_SizeDelta: {x: 603, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &229740723746823538
 GameObject:
   m_ObjectHideFlags: 0
@@ -930,7 +965,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8530562246598747092}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1383,6 +1418,7 @@ RectTransform:
   - {fileID: 8530864212418573692}
   - {fileID: 8530307510083584306}
   - {fileID: 8530153244358295158}
+  - {fileID: 3295285530625747375}
   - {fileID: 8530584791395837062}
   - {fileID: 1825598347150382488}
   - {fileID: 3429227472507289906}
@@ -1503,6 +1539,7 @@ MonoBehaviour:
     type: 3}
   screen_Jobs: {fileID: 8465448598027235102}
   jobInfo: {fileID: 983924974610874109}
+  footer: {fileID: 69544675715416013}
   waitMessage: {fileID: 6966413391240333405}
   waitForSpawnTimerMax: 6
 --- !u!1 &8465122399017204840
@@ -2126,7 +2163,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8530562246598747092}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -2208,8 +2245,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -57.8}
-  m_SizeDelta: {x: 600, y: 584.5}
+  m_AnchoredPosition: {x: 0, y: -35.3}
+  m_SizeDelta: {x: 600, y: 539.4}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &8423900532526398878
 MonoBehaviour:
@@ -2602,7 +2639,7 @@ PrefabInstance:
     - target: {fileID: 900480354902066348, guid: 6b542914667733642b0efffe6015068b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 900480354902066348, guid: 6b542914667733642b0efffe6015068b,
         type: 3}
@@ -2706,6 +2743,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b542914667733642b0efffe6015068b, type: 3}
+--- !u!224 &3429227472507289906 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 900480354902066348, guid: 6b542914667733642b0efffe6015068b,
+    type: 3}
+  m_PrefabInstance: {fileID: 2587377544402109854}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &983924974610874109 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3337075678619761507, guid: 6b542914667733642b0efffe6015068b,
@@ -2718,9 +2761,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d69ab76b2a02704cb275b3a9fbbb912, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &3429227472507289906 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 900480354902066348, guid: 6b542914667733642b0efffe6015068b,
-    type: 3}
-  m_PrefabInstance: {fileID: 2587377544402109854}
-  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
@@ -289,15 +289,15 @@ public static class PlayerSpawn
 		//Hard coding to assistant
 		Vector3Int spawnPosition = GetSpawnForJob(JobType.ASSISTANT).transform.position.CutToInt();
 
+		//Get spawn location 
 		var matrixInfo = MatrixManager.AtPoint(spawnPosition, true);
 		var parentNetId = matrixInfo.NetID;
 		var parentTransform = matrixInfo.Objects;
 		var newPlayer = Object.Instantiate(CustomNetworkManager.Instance.ghostPrefab, spawnPosition, parentTransform.rotation, parentTransform);
 		newPlayer.GetComponent<PlayerScript>().registerTile.ServerSetNetworkedMatrixNetID(parentNetId);
 
-		var newPlayerScript = newPlayer.GetComponent<PlayerScript>();
+		//Create the mind without a job refactor this to make it as a ghost mind 
 		Mind.Create(newPlayer);
-
 		ServerTransferPlayer(joinedViewer.connectionToClient, newPlayer, null, EVENT.GhostSpawned, PlayerManager.CurrentCharacterSettings);
 
 	}

--- a/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
@@ -26,7 +26,7 @@ public static class PlayerSpawn
 		if (newPlayer)
 		{
 			if (occupation.JobType != JobType.SYNDICATE &&
-			    occupation.JobType != JobType.AI)
+				occupation.JobType != JobType.AI)
 			{
 				SecurityRecordsManager.Instance.AddRecord(newPlayer.GetComponent<PlayerScript>(), occupation.JobType);
 			}
@@ -56,6 +56,9 @@ public static class PlayerSpawn
 	/// <param name="forMind"></param>
 	public static void ServerRespawnPlayer(Mind forMind)
 	{
+		if (forMind.IsSpectator)
+			return;
+
 		//get the settings from the mind
 		var occupation = forMind.occupation;
 		var oldBody = forMind.GetCurrentMob();
@@ -257,7 +260,7 @@ public static class PlayerSpawn
 			spawnPosition = spawnTransform.transform.position.CutToInt();
 		}
 
-		var matrixInfo = MatrixManager.AtPoint( spawnPosition, true );
+		var matrixInfo = MatrixManager.AtPoint(spawnPosition, true);
 		var parentNetId = matrixInfo.NetID;
 		var parentTransform = matrixInfo.Objects;
 
@@ -278,6 +281,26 @@ public static class PlayerSpawn
 		Spawn._ServerFireClientServerSpawnHooks(SpawnResult.Single(info, ghost));
 	}
 
+	/// <summary>
+	/// Spawns as a ghost for spectating the Round
+	/// </summary>
+	public static void ServerSpawnGhost(JoinedViewer joinedViewer)
+	{
+		//Hard coding to assistant
+		Vector3Int spawnPosition = GetSpawnForJob(JobType.ASSISTANT).transform.position.CutToInt();
+
+		var matrixInfo = MatrixManager.AtPoint(spawnPosition, true);
+		var parentNetId = matrixInfo.NetID;
+		var parentTransform = matrixInfo.Objects;
+		var newPlayer = Object.Instantiate(CustomNetworkManager.Instance.ghostPrefab, spawnPosition, parentTransform.rotation, parentTransform);
+		newPlayer.GetComponent<PlayerScript>().registerTile.ServerSetNetworkedMatrixNetID(parentNetId);
+
+		var newPlayerScript = newPlayer.GetComponent<PlayerScript>();
+		Mind.Create(newPlayer);
+
+		ServerTransferPlayer(joinedViewer.connectionToClient, newPlayer, null, EVENT.GhostSpawned, PlayerManager.CurrentCharacterSettings);
+
+	}
 
 	/// <summary>
 	/// Spawns an assistant dummy
@@ -312,7 +335,7 @@ public static class PlayerSpawn
 	{
 		//player is only spawned on server, we don't sync it to other players yet
 		var spawnPosition = spawnWorldPosition;
-		var matrixInfo = MatrixManager.AtPoint( spawnPosition, true );
+		var matrixInfo = MatrixManager.AtPoint(spawnPosition, true);
 		var parentNetId = matrixInfo.NetID;
 		var parentTransform = matrixInfo.Objects;
 
@@ -391,7 +414,7 @@ public static class PlayerSpawn
 			FollowCameraMessage.Send(newBody, playerObjectBehavior.parentContainer.gameObject);
 		}
 		bool newMob = false;
-		if(characterSettings != null)
+		if (characterSettings != null)
 		{
 			playerScript.characterSettings = characterSettings;
 			playerScript.playerName = characterSettings.Name;
@@ -404,7 +427,7 @@ public static class PlayerSpawn
 			newMob = true;
 		}
 		var healthStateMonitor = newBody.GetComponent<HealthStateMonitor>();
-		if(healthStateMonitor)
+		if (healthStateMonitor)
 		{
 			healthStateMonitor.ProcessClientUpdateRequest(newBody);
 		}

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -180,7 +180,7 @@ public class JoinedViewer : NetworkBehaviour
 		PlayerSpawn.ServerSpawnPlayer(spawnRequest.JoinedViewer, spawnRequest.RequestedOccupation, characterSettings);
 	}
 	/// <summary>
-	/// Calling to spactate a rowun
+	/// Command to spectate a round instead of spawning as a player
 	/// </summary>
 	/// <param name="jobType"></param>
 	/// <param name="characterSettings"></param>

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -179,6 +179,16 @@ public class JoinedViewer : NetworkBehaviour
 
 		PlayerSpawn.ServerSpawnPlayer(spawnRequest.JoinedViewer, spawnRequest.RequestedOccupation, characterSettings);
 	}
+	/// <summary>
+	/// Calling to spactate a rowun
+	/// </summary>
+	/// <param name="jobType"></param>
+	/// <param name="characterSettings"></param>
+	[Command]
+	public void CmdSpectacte()
+	{
+		PlayerSpawn.ServerSpawnGhost(this);
+	}
 
 	/// <summary>
 	/// Tells the client to start the countdown if it's already started

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -17,6 +17,7 @@ public class Mind
 	public bool IsGhosting;
 	public bool DenyCloning;
 	public int bodyMobID;
+	//Current way to check if it's not actually a ghost but a spectator, should set this not have it be the below.
 	public bool IsSpectator => occupation == null || body == null;
 
 	//use Create to create a mind.
@@ -45,6 +46,7 @@ public class Mind
 		var playerScript = player.GetComponent<PlayerScript>();
 		var mind = new Mind { };
 		playerScript.mind = mind;
+		//Forces you into ghosting, the IsGhosting field should make it so it never points to Body
 		mind.Ghosting(player);
 	}
 

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -31,10 +31,11 @@ public class Mind
 	/// <param name="occupation"></param>
 	public static void Create(GameObject player, Occupation occupation)
 	{
-		var mind = new Mind { occupation = occupation };
+		var mind = new Mind {occupation = occupation};
 		var playerScript = player.GetComponent<PlayerScript>();
 		mind.SetNewBody(playerScript);
 	}
+
 	/// <summary>
 	/// Create as a Ghost
 	/// </summary>

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -13,10 +13,11 @@ public class Mind
 	public PlayerScript ghost;
 	public PlayerScript body;
 	private SpawnedAntag Antag;
-	public bool IsAntag => Antag !=null;
+	public bool IsAntag => Antag != null;
 	public bool IsGhosting;
 	public bool DenyCloning;
 	public int bodyMobID;
+	public bool IsSpectator => occupation == null || body == null;
 
 	//use Create to create a mind.
 	private Mind()
@@ -30,9 +31,20 @@ public class Mind
 	/// <param name="occupation"></param>
 	public static void Create(GameObject player, Occupation occupation)
 	{
-		var mind = new Mind {occupation = occupation};
+		var mind = new Mind { occupation = occupation };
 		var playerScript = player.GetComponent<PlayerScript>();
 		mind.SetNewBody(playerScript);
+	}
+	/// <summary>
+	/// Create as a Ghost
+	/// </summary>
+	/// <param name="player"></param>
+	public static void Create(GameObject player)
+	{
+		var playerScript = player.GetComponent<PlayerScript>();
+		var mind = new Mind { };
+		playerScript.mind = mind;
+		mind.Ghosting(player);
 	}
 
 	public void SetNewBody(PlayerScript playerScript)
@@ -87,23 +99,24 @@ public class Mind
 
 	public bool ConfirmClone(int recordMobID)
 	{
-		if(bodyMobID != recordMobID){  //an old record might still exist even after several body swaps
+		if (bodyMobID != recordMobID)
+		{  //an old record might still exist even after several body swaps
 			return false;
 		}
-		if(DenyCloning)
+		if (DenyCloning)
 		{
 			return false;
 		}
 		var currentMob = GetCurrentMob();
-		if(!IsGhosting)
+		if (!IsGhosting)
 		{
 			var livingHealthBehaviour = currentMob.GetComponent<LivingHealthBehaviour>();
-			if(!livingHealthBehaviour.IsDead)
+			if (!livingHealthBehaviour.IsDead)
 			{
 				return false;
 			}
 		}
-		if(!IsOnline(currentMob))
+		if (!IsOnline(currentMob))
 		{
 			return false;
 		}

--- a/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
+++ b/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
@@ -39,7 +39,7 @@ public class GUI_PlayerJobs : MonoBehaviour
 	/// Number of seconds to wait after selecting a job. If the player does not spawn within that time the job selection re-opens.
 	/// </summary>
 	[SerializeField]
-	[Range(0,15)]
+	[Range(0, 15)]
 	[Tooltip("Number of seconds to wait after selecting a job. If the player does not spawn within that time the job selection re-opens.")]
 	private float waitForSpawnTimerMax = 6;
 
@@ -50,7 +50,7 @@ public class GUI_PlayerJobs : MonoBehaviour
 	/// <param name="preference">The job associated with the button.</param>
 	private void BtnOk(JobType preference)
 	{
-		if(waitForSpawnTimer > 0)
+		if (waitForSpawnTimer > 0)
 		{
 			return; // Disallowing picking a job while another job has been selected.
 		}
@@ -150,6 +150,20 @@ public class GUI_PlayerJobs : MonoBehaviour
 
 			occupationGO.SetActive(true);
 		}
+		//Ghost stuff
+		if (true)
+		{
+			GameObject occupationGO = Instantiate(buttonPrefab, screen_Jobs.transform);
+
+			occupationGO.GetComponent<Image>().color = Color.white;
+			occupationGO.GetComponentInChildren<Text>().text = "Spectator";
+			occupationGO.transform.localScale = new Vector3(1.0f, 1.0f, 1.0f);
+			occupationGO.GetComponent<Button>().onClick.AddListener(() => { PlayerManager.LocalViewerScript.CmdSpectacte(); });
+
+
+
+		}
+
 		screen_Jobs.SetActive(true);
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
+++ b/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
@@ -21,6 +21,10 @@ public class GUI_PlayerJobs : MonoBehaviour
 	/// The window showing information about a job.
 	/// </summary>
 	public GUI_JobInfo jobInfo = null;
+	/// <summary>
+	/// The gameobject to display the spectate button and others
+	/// </summary>
+	public GameObject footer = null;
 
 	/// <summary>
 	/// A gameobject that is shown after job selection when the player is waiting to spawn.
@@ -39,7 +43,7 @@ public class GUI_PlayerJobs : MonoBehaviour
 	/// Number of seconds to wait after selecting a job. If the player does not spawn within that time the job selection re-opens.
 	/// </summary>
 	[SerializeField]
-	[Range(0,15)]
+	[Range(0, 15)]
 	[Tooltip("Number of seconds to wait after selecting a job. If the player does not spawn within that time the job selection re-opens.")]
 	private float waitForSpawnTimerMax = 6;
 
@@ -50,12 +54,13 @@ public class GUI_PlayerJobs : MonoBehaviour
 	/// <param name="preference">The job associated with the button.</param>
 	private void BtnOk(JobType preference)
 	{
-		if(waitForSpawnTimer > 0)
+		if (waitForSpawnTimer > 0)
 		{
 			return; // Disallowing picking a job while another job has been selected.
 		}
 		SoundManager.Play("Click01");
 		screen_Jobs.SetActive(false);
+		footer.SetActive(false);
 		waitMessage.SetActive(true);
 
 		PlayerManager.LocalViewerScript.CmdRequestJob(preference, PlayerManager.CurrentCharacterSettings);
@@ -65,6 +70,9 @@ public class GUI_PlayerJobs : MonoBehaviour
 	void OnEnable()
 	{
 		screen_Jobs.SetActive(true);
+		SetFooter();
+		footer.SetActive(true);
+
 	}
 
 	/// <summary>
@@ -80,6 +88,7 @@ public class GUI_PlayerJobs : MonoBehaviour
 			gameObject.SetActive(false);
 			waitMessage.SetActive(false);
 			screen_Jobs.SetActive(true);
+			footer.SetActive(true);
 		}
 
 		if (waitForSpawnTimer > 0)
@@ -90,6 +99,7 @@ public class GUI_PlayerJobs : MonoBehaviour
 				// Job selection failed, re-open it.
 				SoundManager.Play("Click01");
 				screen_Jobs.SetActive(true);
+				footer.SetActive(true);
 				waitMessage.SetActive(false);
 			}
 		}
@@ -150,20 +160,19 @@ public class GUI_PlayerJobs : MonoBehaviour
 
 			occupationGO.SetActive(true);
 		}
-		//Ghost stuff
-		if (true)
-		{
-			GameObject occupationGO = Instantiate(buttonPrefab, screen_Jobs.transform);
 
-			occupationGO.GetComponent<Image>().color = Color.white;
-			occupationGO.GetComponentInChildren<Text>().text = "Spectator";
-			occupationGO.transform.localScale = new Vector3(1.0f, 1.0f, 1.0f);
-			occupationGO.GetComponent<Button>().onClick.AddListener(() => { PlayerManager.LocalViewerScript.CmdSpectacte(); });
-
-
-
-		}
 
 		screen_Jobs.SetActive(true);
+	}
+
+	public void SetFooter()
+	{
+		GameObject occupationGO = Instantiate(buttonPrefab, footer.transform);
+
+		occupationGO.GetComponent<Image>().color = Color.white;
+		occupationGO.GetComponentInChildren<Text>().text = "Spectate";
+		occupationGO.transform.localScale = new Vector3(1.0f, 1f, 1.0f);
+		occupationGO.GetComponent<Button>().onClick.AddListener(() => { PlayerManager.LocalViewerScript.CmdSpectacte(); });
+
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
+++ b/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
@@ -39,7 +39,7 @@ public class GUI_PlayerJobs : MonoBehaviour
 	/// Number of seconds to wait after selecting a job. If the player does not spawn within that time the job selection re-opens.
 	/// </summary>
 	[SerializeField]
-	[Range(0, 15)]
+	[Range(0,15)]
 	[Tooltip("Number of seconds to wait after selecting a job. If the player does not spawn within that time the job selection re-opens.")]
 	private float waitForSpawnTimerMax = 6;
 
@@ -50,7 +50,7 @@ public class GUI_PlayerJobs : MonoBehaviour
 	/// <param name="preference">The job associated with the button.</param>
 	private void BtnOk(JobType preference)
 	{
-		if (waitForSpawnTimer > 0)
+		if(waitForSpawnTimer > 0)
 		{
 			return; // Disallowing picking a job while another job has been selected.
 		}

--- a/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
+++ b/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
@@ -164,11 +164,12 @@ public class GUI_PlayerJobs : MonoBehaviour
 
 		screen_Jobs.SetActive(true);
 	}
-
+	/// <summary>
+	/// Code for loading the footer, currently only containing a spectate button
+	/// </summary>
 	public void SetFooter()
 	{
 		GameObject occupationGO = Instantiate(buttonPrefab, footer.transform);
-
 		occupationGO.GetComponent<Image>().color = Color.white;
 		occupationGO.GetComponentInChildren<Text>().text = "Spectate";
 		occupationGO.transform.localScale = new Vector3(1.0f, 1f, 1.0f);


### PR DESCRIPTION
### Purpose
Lets players start the round as a ghost instead of a crew member #2983 
Can be used by admins that feel guilty at spacing their bodies at the start of the round

### Notes:
I have concern on code in the future looking for the mind.body as it doesn't exist for a ghost, most of this is handled with the IsGhosting feature of the mind.

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.

