### PR TITLE
Gave botany food prefab the edible component

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Botany/food.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Botany/food.prefab
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  spriteData:
+    isPaletteds: 
   Sprites: []
   spriteIndex: 0
   variantIndex: 0
@@ -91,8 +93,8 @@ MonoBehaviour:
   TraitWhitelist: []
   ReagentWhitelist: []
   TransferMode: 4
-  InitialTransferAmount: 20
   PossibleTransferAmounts: []
+  InitialTransferAmount: 20
 --- !u!114 &7234734607788621599
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -109,6 +111,22 @@ MonoBehaviour:
   backgroundColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   iconOverride: {fileID: 0}
   backgroundSprite: {fileID: 0}
+--- !u!114 &6259075970471028923
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4953422017611688559}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e06ddb12acf47158b8cccf9289fd75, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  leavings: {fileID: 0}
+  nutritionLevel: 5
 --- !u!1001 &4953256935291295445
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Food/Edible.cs
+++ b/UnityProject/Assets/Scripts/Food/Edible.cs
@@ -1,4 +1,4 @@
-﻿ quiusing System;
+﻿using System;
 using System.Collections;
 using UnityEngine;
 using Mirror;
@@ -31,10 +31,11 @@ public class Edible : NetworkBehaviour, IClientInteractable<HandActivate>, IClie
 	public void NPCTryEat()
 	{
 		SoundManager.PlayNetworkedAtPos("EatFood", transform.position);
-		if (leavings != null)
+		//Keeping this out allows food to be eaten and disappeared, change to despawn at some point.
+		/*if (leavings != null)
 		{
 			Spawn.ServerPrefab(leavings, transform.position, transform.parent);
-		}
+		}*/
 
 		GetComponent<CustomNetTransform>().DisappearFromWorldServer();
 	}

--- a/UnityProject/Assets/Scripts/Food/Edible.cs
+++ b/UnityProject/Assets/Scripts/Food/Edible.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿ quiusing System;
 using System.Collections;
 using UnityEngine;
 using Mirror;
@@ -31,11 +31,10 @@ public class Edible : NetworkBehaviour, IClientInteractable<HandActivate>, IClie
 	public void NPCTryEat()
 	{
 		SoundManager.PlayNetworkedAtPos("EatFood", transform.position);
-		//Keeping this out allows food to be eaten and disappeared, change to despawn at some point.
-		/*if (leavings != null)
+		if (leavings != null)
 		{
 			Spawn.ServerPrefab(leavings, transform.position, transform.parent);
-		}*/
+		}
 
 		GetComponent<CustomNetTransform>().DisappearFromWorldServer();
 	}

--- a/UnityProject/Assets/Scripts/Food/Edible.cs
+++ b/UnityProject/Assets/Scripts/Food/Edible.cs
@@ -31,11 +31,10 @@ public class Edible : NetworkBehaviour, IClientInteractable<HandActivate>, IClie
 	public void NPCTryEat()
 	{
 		SoundManager.PlayNetworkedAtPos("EatFood", transform.position);
-		//Keeping this out allows food to be eaten and disappeared, change to despawn at some point.
-		/*if (leavings != null)
+		if (leavings != null)
 		{
 			Spawn.ServerPrefab(leavings, transform.position, transform.parent);
-		}*/
+		}
 
 		GetComponent<CustomNetTransform>().DisappearFromWorldServer();
 	}


### PR DESCRIPTION
# Pull Request Template

### Purpose
This should now properly allow botany grown food to be edible

### Notes:
also reverted NPCTryEat() edit.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
