### PR TITLE
Add staging server auto-deploy.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,5 +146,27 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           context: Docker
-          #buildargs: BUILD_NUMBER=${{github.run_number}}
-          # tags: "latest,$GITHUB_RUN_NUMBER"
+  
+  Staging:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    needs: Imaging
+    name: Deploy to Staging
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: webfactory/ssh-agent@v0.2.0
+      with:
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+    - name: Deploy to remote
+      env:
+        DOCKER_HOST: ${{ format('ssh://{0}', secrets.SSH_USER) }}
+        SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+      run: |
+        echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+        chmod 644 ~/.ssh/known_hosts
+        sudo curl -L "https://github.com/docker/compose/releases/download/1.25.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+        sudo chmod +x /usr/local/bin/docker-compose
+        cd Docker
+        docker-compose pull
+        docker-compose up -d --remove-orphans
+

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     ports:
       - 6666:7777
     volumes:
-      - /etc/unitystation/admin:/UnityStation_Data/StreamingAssets/admin
+      - /etc/UnityStation/admin:/UnityStation_Data/StreamingAssets/admin


### PR DESCRIPTION
### Purpose
Automatically deploys build from the develop branch to a staging server.

### Notes
It uses port 6666 because it is currently on GER02 which already uses 7777.
It also does not currently appear on the server list due to lacking credentials.
RCON is not forwarded to any port.

Currently, if any new update is pushed it simply tears down the server with the older version.
To connect to the server you have to manually download the client from the same build.

### Testing
Download the built client from my repository (so build number is correct) and connect to
`94.130.57.141:6666`