### PR TITLE
Updated DoorSwitchEditor to set the scene as dirty.

### DIFF
--- a/UnityProject/Assets/Scripts/Editor/Inspector/DoorSwitchEditor.cs
+++ b/UnityProject/Assets/Scripts/Editor/Inspector/DoorSwitchEditor.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
 using UnityEngine;
 using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
 
 [CustomEditor(typeof(DoorSwitch))]
 public class DoorSwitchEditor : Editor
@@ -68,6 +70,8 @@ public class DoorSwitchEditor : Editor
 				if (doorController != null)
 					ToggleDoorController(doorSwitch, doorController);
 			}
+
+			EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
 		}
 
 		//return selection to switch


### PR DESCRIPTION
### Purpose

Fixed DoorSwitchEditor script not saving changes by setting scene to be dirty.

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] Any new / changed components follow the [Component Development Checklist]
