### PR TITLE
Fixed welds disappearing upon highlighting of welded doors.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/AirLock.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/AirLock.prefab
@@ -10,8 +10,8 @@ GameObject:
   m_Component:
   - component: {fileID: 4000012887992874}
   - component: {fileID: 61000013173726114}
-  - component: {fileID: 114247149050027938}
   - component: {fileID: 114232321497863980}
+  - component: {fileID: 114247149050027938}
   - component: {fileID: 114990158330489740}
   - component: {fileID: 114298626141523242}
   - component: {fileID: 114897681876509866}
@@ -42,7 +42,7 @@ Transform:
   m_Children:
   - {fileID: 4183345251610980}
   - {fileID: 4000013698625186}
-  - {fileID: 7322139021859764651}
+  - {fileID: 6889267071701964348}
   - {fileID: 4300014015526388}
   - {fileID: 4390488788653686}
   m_Father: {fileID: 0}
@@ -74,21 +74,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!114 &114247149050027938
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000011462531918}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  butcherKnifeTrait: {fileID: 0}
-  butcherTime: 2
-  butcherSound: BladeSlice
 --- !u!114 &114232321497863980
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -110,7 +95,7 @@ MonoBehaviour:
   DoorCoverSpriteOffset: 49
   DoorLightSpriteOffset: 0
   DoorSpriteOffset: 2
-  weldOverlay: {fileID: 2943727638702044015}
+  weldOverlay: {fileID: 5137714821279777868}
   weldSprite: {fileID: 21300000, guid: a02b4f763fa778d4ba5c9664ee50c42c, type: 3}
   doorType: 13
   damageOnClose: 0
@@ -124,6 +109,21 @@ MonoBehaviour:
   openSFX: {fileID: 82346760648337948}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114247149050027938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000011462531918}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114990158330489740
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1108,7 +1108,7 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
---- !u!1 &1318257543714340145
+--- !u!1 &7509354565332168853
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1116,8 +1116,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7322139021859764651}
-  - component: {fileID: 2943727638702044015}
+  - component: {fileID: 6889267071701964348}
+  - component: {fileID: 5137714821279777868}
   m_Layer: 18
   m_Name: overlay_Weld
   m_TagString: Untagged
@@ -1125,13 +1125,13 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7322139021859764651
+--- !u!4 &6889267071701964348
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1318257543714340145}
+  m_GameObject: {fileID: 7509354565332168853}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -1139,13 +1139,13 @@ Transform:
   m_Father: {fileID: 4000012887992874}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &2943727638702044015
+--- !u!212 &5137714821279777868
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1318257543714340145}
+  m_GameObject: {fileID: 7509354565332168853}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -1174,8 +1174,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/AtmosDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/AtmosDoor.prefab
@@ -466,8 +466,8 @@ GameObject:
   m_Component:
   - component: {fileID: 4172947130070054}
   - component: {fileID: 61963350373266860}
-  - component: {fileID: 114199714939546294}
   - component: {fileID: 114201876269245600}
+  - component: {fileID: 114199714939546294}
   - component: {fileID: 114955538477622776}
   - component: {fileID: 114796983354351306}
   - component: {fileID: 114984589981480830}
@@ -530,21 +530,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!114 &114199714939546294
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1457523303891292}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  butcherKnifeTrait: {fileID: 0}
-  butcherTime: 2
-  butcherSound: BladeSlice
 --- !u!114 &114201876269245600
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -580,6 +565,21 @@ MonoBehaviour:
   openSFX: {fileID: 82155393946766332}
   openingDirection: 0
   spriteRenderer: {fileID: 0}
+--- !u!114 &114199714939546294
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1457523303891292}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  butcherKnifeTrait: {fileID: 0}
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &114955538477622776
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1114,7 +1114,7 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8090978763268200091}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
@@ -1142,8 +1142,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/CommandDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/CommandDoor.prefab
@@ -1114,7 +1114,7 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3057472279261103098}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
@@ -1142,8 +1142,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/EngineeringDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/EngineeringDoor.prefab
@@ -486,7 +486,7 @@ Transform:
   m_Children:
   - {fileID: 4019579189306820}
   - {fileID: 4010010888124160}
-  - {fileID: 1669957232966711968}
+  - {fileID: 4105027822359820395}
   - {fileID: 4311678113025566}
   - {fileID: 4994825646226282}
   m_Father: {fileID: 0}
@@ -539,7 +539,7 @@ MonoBehaviour:
   DoorCoverSpriteOffset: 17
   DoorLightSpriteOffset: 0
   DoorSpriteOffset: 2
-  weldOverlay: {fileID: 7977941249359571854}
+  weldOverlay: {fileID: 1409498888672740618}
   weldSprite: {fileID: 21300000, guid: cf9154a43b6ccbf4a8bb5d9e0315133b, type: 3}
   doorType: 2
   damageOnClose: 0
@@ -1076,7 +1076,7 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
---- !u!1 &8889840724110402672
+--- !u!1 &5649966785046828897
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1084,8 +1084,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1669957232966711968}
-  - component: {fileID: 7977941249359571854}
+  - component: {fileID: 4105027822359820395}
+  - component: {fileID: 1409498888672740618}
   m_Layer: 17
   m_Name: overlay_Weld
   m_TagString: Untagged
@@ -1093,13 +1093,13 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1669957232966711968
+--- !u!4 &4105027822359820395
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8889840724110402672}
+  m_GameObject: {fileID: 5649966785046828897}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -1107,13 +1107,13 @@ Transform:
   m_Father: {fileID: 4033324952160438}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &7977941249359571854
+--- !u!212 &1409498888672740618
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8889840724110402672}
+  m_GameObject: {fileID: 5649966785046828897}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -1142,8 +1142,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MaintDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MaintDoor.prefab
@@ -1114,7 +1114,7 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3573900715524212567}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
@@ -1142,8 +1142,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MedBayDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MedBayDoor.prefab
@@ -1142,8 +1142,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MiningDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MiningDoor.prefab
@@ -1114,7 +1114,7 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 876652298075455179}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
@@ -1142,8 +1142,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/PublicDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/PublicDoor.prefab
@@ -68,7 +68,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1883797623
   m_SortingLayer: 13
-  m_SortingOrder: 11
+  m_SortingOrder: 12
   m_Sprite: {fileID: 21300198, guid: 5186da76a90ba4cfa9ca3f8229798e76, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -1212,9 +1212,9 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
-  m_SortingOrder: 12
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
+  m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/ResearchDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/ResearchDoor.prefab
@@ -1114,7 +1114,7 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8782801490122980267}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
@@ -1142,8 +1142,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/ScienceDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/ScienceDoor.prefab
@@ -1114,7 +1114,7 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8998420787615636406}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
@@ -1142,8 +1142,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/SecDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/SecDoor.prefab
@@ -1142,8 +1142,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/SpaceshipDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/SpaceshipDoor.prefab
@@ -1076,7 +1076,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3509748171234952956}
   - component: {fileID: 50397795418674704}
-  m_Layer: 17
+  m_Layer: 18
   m_Name: overlay_Weld
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1132,8 +1132,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/Virology.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/Virology.prefab
@@ -1142,8 +1142,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/WhiteServiceDoor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/WhiteServiceDoor.prefab
@@ -724,7 +724,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1883797623
   m_SortingLayer: 13
-  m_SortingOrder: 11
+  m_SortingOrder: 12
   m_Sprite: {fileID: 21300126, guid: aa62bd6401d4c406b8c477866454a587, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -1178,9 +1178,9 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -1883797623
-  m_SortingLayer: 13
-  m_SortingOrder: 12
+  m_SortingLayerID: -1825689229
+  m_SortingLayer: 17
+  m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0


### PR DESCRIPTION
### Purpose
Door-welds no longer visually disappear while highlighting.

### Notes:
Windowed doors may be highlighted in a slightly different fashion (always outer edge, sometimes inner windows) depending on order of cycling the door and welding it.
The problems stemmed from the sprite layers for the welds not being activated by default and layer changes of the door.
The interactions with the layer changes should possibly be investigated again, though things seem to be working for now.

### Please make sure you have followed the self checks below before submitting a PR:

[X] Code is sufficiently commented [No new code]
[X] Code is indented with tabs and not spaces [No new code]
[X] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b> [The prefabs contained the errors and were therefore all replaced]
[X] The PR does not bring up any new compile errors
[X] The PR has been tested in editor
[X] Any new files are named using PascalCase (to avoid issues on case sensitive file systems) [No new files]
[X] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist) [Only prefabs changed]
[X] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants) [Only prefabs changed]
[X] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable) [local]
[X] The PR has been tested with round restarts.
[X] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
