### PR TITLE
Give CE his unique belt and HoS his unique beret

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ChiefEngineerPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ChiefEngineerPopulator.asset
@@ -25,7 +25,7 @@ MonoBehaviour:
   - NamedSlot: 12
     Prefab: {fileID: 835768756810601639, guid: e3f1e3ca1346b4530930972e42524982, type: 3}
   - NamedSlot: 1
-    Prefab: {fileID: 1387665324668345695, guid: 371b9c216382844659c05791957b28c8,
+    Prefab: {fileID: 1993060742229998770, guid: 1616ac23693dc4adf88af91d3ea84856,
       type: 3}
   - NamedSlot: 10
     Prefab: {fileID: 4188245363048309518, guid: 9ece9b1c0b01fa46ab120b1b423b1739,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/DetectivePopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/DetectivePopulator.asset
@@ -31,7 +31,7 @@ MonoBehaviour:
     Prefab: {fileID: 7636118406116123594, guid: 5dd96f5e685214da19f65b06f2463aa2,
       type: 3}
   - NamedSlot: 0
-    Prefab: {fileID: 3921521694364753778, guid: cc01ce86e44f441a0a39be6164acd40e,
+    Prefab: {fileID: 3921521694364753778, guid: 02d871d46281a42d1820f9b47a8124c6,
       type: 3}
   - NamedSlot: 10
     Prefab: {fileID: 4188245363048309518, guid: 1a291489c8aa9da8598c8026ac53f935,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/HeadOfSecurityPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/HeadOfSecurityPopulator.asset
@@ -19,13 +19,13 @@ MonoBehaviour:
     Prefab: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73,
       type: 3}
   - NamedSlot: 2
-    Prefab: {fileID: 7636118406116123594, guid: 9445628fd16314b7388c7086f5fd2f26,
+    Prefab: {fileID: 7636118406116123594, guid: 8a05cb3da796e42e89e13a0963de6953,
       type: 3}
   - NamedSlot: 3
     Prefab: {fileID: 7106618204054676533, guid: eaeac5365190b4842bedb2b846ff15da,
       type: 3}
   - NamedSlot: 0
-    Prefab: {fileID: 3921521694364753778, guid: 02d871d46281a42d1820f9b47a8124c6,
+    Prefab: {fileID: 3921521694364753778, guid: cc01ce86e44f441a0a39be6164acd40e,
       type: 3}
   - NamedSlot: 6
     Prefab: {fileID: 3011710637427380133, guid: d2a5503a9764c49ed9a7b1a5c4e4c547,


### PR DESCRIPTION
### Purpose
Adds Chief Engineer's unique toolbelt variant to his populator
Adds Head of Security's unique beret to his populator and gives him the leather jacket instead of the trenchcoat to match the beret
Changes the Detective's leather jacket to a trenchcoat to match his hat, because his previous fashion sense was horrid
