### PR TITLE
Makes hit icons obey palletting

### DIFF
--- a/UnityProject/Assets/Scripts/Player/HitIcon.cs
+++ b/UnityProject/Assets/Scripts/Player/HitIcon.cs
@@ -21,22 +21,27 @@ public class HitIcon : MonoBehaviour
 	/// </summary>
 	/// <param name="dir">direction of the animation in world space</param>
 	/// <param name="sprite">sprite to show</param>
-	public void ShowHitIcon(Vector2 dir, Sprite sprite)
+	public void ShowHitIcon(Vector2 dir, SpriteRenderer sourceSpriteRenderer)
 	{
 		if (isFading)
 		{
 			return;
 		}
+	
 
 		Vector3 lerpFromWorld = transform.position + (Vector3)(dir * 0.75f);
 		Vector3 lerpToWorld = transform.position + (Vector3)(dir);
 		Vector3 lerpFromLocal = transform.parent.InverseTransformPoint(lerpFromWorld);
 		Vector3 lerpToLocal = transform.parent.InverseTransformPoint(lerpToWorld);
+		MaterialPropertyBlock pb = new MaterialPropertyBlock();
+		sourceSpriteRenderer.GetPropertyBlock(pb);
 
 		lerpFrom = lerpFromLocal;
 		lerpTo = lerpToLocal;
 		isFading = true;
-		spriteRenderer.sprite = sprite;
+		spriteRenderer.sprite = sourceSpriteRenderer.sprite;
+		spriteRenderer.SetPropertyBlock(pb);
+		
 
 		if (gameObject.activeInHierarchy)
 		{

--- a/UnityProject/Assets/Scripts/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Weapons/WeaponNetworkActions.cs
@@ -18,7 +18,7 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 	private float lerpProgress;
 
 	//Lerp parameters
-	private Sprite lerpSprite;
+	private SpriteRenderer spriteRendererSource; // need renderer for shader configuration
 
 	private Vector3 lerpTo;
 	private PlayerMove playerMove;
@@ -31,7 +31,7 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 		spritesObj = transform.Find("Sprites").gameObject;
 		playerMove = GetComponent<PlayerMove>();
 		playerScript = GetComponent<PlayerScript>();
-		lerpSprite = null;
+		spriteRendererSource = null;
 	}
 
 	[Command]
@@ -197,15 +197,14 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 			return;
 		}
 
-		if (weapon && lerpSprite == null)
+		if (weapon && spriteRendererSource == null)
 		{
-			SpriteRenderer spriteRenderer = weapon.GetComponentInChildren<SpriteRenderer>();
-			lerpSprite = spriteRenderer.sprite;
+			spriteRendererSource = weapon.GetComponentInChildren<SpriteRenderer>();
 		}
 
-		if (lerpSprite != null)
+		if (spriteRendererSource != null)
 		{
-			playerScript.hitIcon.ShowHitIcon(stabDir, lerpSprite);
+			playerScript.hitIcon.ShowHitIcon(stabDir, spriteRendererSource);
 		}
 
 		Vector3 lerpFromWorld = spritesObj.transform.position;
@@ -272,6 +271,6 @@ public class WeaponNetworkActions : ManagedNetworkBehaviour
 		lerpProgress = 0f;
 		lerping = false;
 		isForLerpBack = false;
-		lerpSprite = null;
+		spriteRendererSource = null;
 	}
 }


### PR DESCRIPTION
### Purpose
Makes sprite that indicate hits with an item use the palette of the item being hit with

### Notes
Hit icons get a Property Block from the weapon being used, which applies the palette (or lack of palette) appropriately.