### PR TITLE
Add 2019.2.19f1 version file

### DIFF
--- a/UnityProject/ProjectSettings/ProjectVersion.txt
+++ b/UnityProject/ProjectSettings/ProjectVersion.txt
@@ -1,0 +1,2 @@
+m_EditorVersion: 2019.2.19f1
+m_EditorVersionWithRevision: 2019.2.19f1 (929ab4d01772)


### PR DESCRIPTION
### Purpose
This should let unity hub automatically install the right version, and gets rid of the warning when opening the project for the first time.

This should stop people getting confused and using the wrong version of unity.

Note: this doesn't touch the .gitignore to stop people accidentally updating the unity version.