### PR TITLE
Fixed test runner crash caused by ProjectVersion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,9 @@ jobs:
           license="${license//$'\n'/'%0A'}"
           license="${license//$'\r'/'%0D'}"
           echo "::set-env name=UNITY_LICENSE::$license"
+      # Delete unity version file (test runner will crash otherwise)
+      - name: Delete ProjectVersion.txt
+        run: sudo rm ./${{ matrix.projectPath }}/ProjectSettings/ProjectVersion.txt        
       # Run tests - only edit mode supported
       - name: Run tests
         uses: webbertakken/unity-test-runner@v1.5


### PR DESCRIPTION
### Purpose
Fixed test runner crash caused by #3268 PR.

### Notes:
Before this PR unity editor was adding some useless unity packages and works fine:
```  
com.unity.purchasing@2.0.6
com.unity.ads@2.0.8
com.unity.collab-proxy@1.2.16
```
After the explicit stated version it skips this step and raise compilation errors:
```
...
Required property 'name' not set (Packages/com.unity.collab-proxy/Editor/Unity.CollabProxy.Editor.asmdef)
 
(Filename:  Line: 0)

Required property 'name' not set (Packages/com.unity.collab-proxy/Tests/Editor/Unity.CollabProxy.EditorTests.asmdef)
 ...
```

The solution is simple: add new workflow step to delete ProjectVersion on a unity test worker. It's local change only and won't affect git or buids.
