### PR TITLE
Prevent music playing on startup when it should be muted

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -111,14 +111,7 @@ public class SoundManager : MonoBehaviour
 		//Mute Music Preference
 		if (PlayerPrefs.HasKey(PlayerPrefKeys.MuteMusic))
 		{
-			if (PlayerPrefs.GetInt(PlayerPrefKeys.MuteMusic) == 0)
-			{
-				isMusicMute = true;
-			}
-			else
-			{
-				isMusicMute = false;
-			}
+			isMusicMute = PlayerPrefs.GetInt(PlayerPrefKeys.MuteMusic) == 0;
 		}
 
 		//Ambient Volume Preference

--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -108,6 +108,19 @@ public class SoundManager : MonoBehaviour
 
 	private void Init()
 	{
+		//Mute Music Preference
+		if (PlayerPrefs.HasKey(PlayerPrefKeys.MuteMusic))
+		{
+			if (PlayerPrefs.GetInt(PlayerPrefKeys.MuteMusic) == 0)
+			{
+				isMusicMute = true;
+			}
+			else
+			{
+				isMusicMute = false;
+			}
+		}
+
 		//Ambient Volume Preference
 		if (PlayerPrefs.HasKey(PlayerPrefKeys.AmbientVolumeKey))
 		{


### PR DESCRIPTION
### Purpose
Prevents music playing on the loading screen when you start the game if you have muted it in the lobby.
Fixes #2919