### PR TITLE
Increases accuracy of NutritionLevel and fixed some things

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Bureaucracy/HandLabeler.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Bureaucracy/HandLabeler.prefab
@@ -6,7 +6,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8518059871006131007}
+  m_GameObject: {fileID: 8517905270553474336}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7d55bb27d7729e44190487b1ada01adc, type: 3}
@@ -122,7 +122,7 @@ PrefabInstance:
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialSize
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -131,7 +131,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
---- !u!1 &8518059871006131007 stripped
+--- !u!1 &8517905270553474336 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298,
     type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/Food.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/Food.prefab
@@ -15,8 +15,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   leavings: {fileID: 0}
-  healAmount: 10
-  healHungerAmount: 10
+  NutrientsHealAmount: 50
 --- !u!1001 &1130340699969248113
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/4no raisins.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/4no raisins.prefab
@@ -16,7 +16,7 @@ PrefabInstance:
     - target: {fileID: 658621036961164916, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}
       propertyPath: NutritionLevel
-      value: 8
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Anti Steak.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Anti Steak.prefab
@@ -91,7 +91,7 @@ PrefabInstance:
     - target: {fileID: 8511698057709975335, guid: f5b3ac01c1928bf4ab03433000e00ca2,
         type: 3}
       propertyPath: NutrientsHealAmount
-      value: -25
+      value: -50
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f5b3ac01c1928bf4ab03433000e00ca2, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Anti Steak.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Anti Steak.prefab
@@ -78,6 +78,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 6640758129479907135, guid: f5b3ac01c1928bf4ab03433000e00ca2,
+        type: 3}
+      propertyPath: NutritionLevel
+      value: -100
+      objectReference: {fileID: 0}
     - target: {fileID: 6650296790158201314, guid: f5b3ac01c1928bf4ab03433000e00ca2,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Beef Jerky.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Beef Jerky.prefab
@@ -26,7 +26,7 @@ PrefabInstance:
     - target: {fileID: 658621036961164916, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}
       propertyPath: NutritionLevel
-      value: 10
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Cooked Cutlet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Cooked Cutlet.prefab
@@ -27,7 +27,7 @@ PrefabInstance:
     - target: {fileID: 658621036961164916, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}
       propertyPath: NutritionLevel
-      value: 25
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Donut.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Donut.prefab
@@ -7,6 +7,48 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 658621036961164916, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: healAmount
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 658621036961164916, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: NutrientsHealAmount
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: initialName
+      value: Donut
+      objectReference: {fileID: 0}
+    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: initialDescription
+      value: Goes great with robust coffee.
+      objectReference: {fileID: 0}
+    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: initialTraits.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 7b9f470d9aa5545ce87447d3cd3d61ce,
+        type: 2}
+    - target: {fileID: 963106870793376919, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 2559a51d68bb91e408b9f2e92bdfe1a7,
+        type: 3}
+    - target: {fileID: 1024679538077702783, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 1129366686127204299, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}
       propertyPath: m_Name
@@ -66,43 +108,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: initialName
-      value: Donut
-      objectReference: {fileID: 0}
-    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: initialDescription
-      value: Goes great with robust coffee.
-      objectReference: {fileID: 0}
-    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: initialTraits.Array.data[0]
-      value: 
-      objectReference: {fileID: 11400000, guid: 7b9f470d9aa5545ce87447d3cd3d61ce,
-        type: 2}
-    - target: {fileID: 1024679538077702783, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 963106870793376919, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 2559a51d68bb91e408b9f2e92bdfe1a7,
-        type: 3}
-    - target: {fileID: 658621036961164916, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: healAmount
-      value: 30
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9e24daf3783555e42b00f94e49d98357, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Donut.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Donut.prefab
@@ -17,6 +17,11 @@ PrefabInstance:
       propertyPath: NutrientsHealAmount
       value: 40
       objectReference: {fileID: 0}
+    - target: {fileID: 658621036961164916, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: NutritionLevel
+      value: 40
+      objectReference: {fileID: 0}
     - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}
       propertyPath: initialTraits.Array.size

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Meat Cutlet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Meat Cutlet.prefab
@@ -6,7 +6,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6128081887975287799}
+  m_GameObject: {fileID: 6532193109441330816}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e7c30ca55ffa4467a421abf7a832a6a1, type: 3}
@@ -23,7 +23,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6128081887975287799}
+  m_GameObject: {fileID: 6532193109441330816}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a4ad9570c5ec4b1e995fad54bc897280, type: 3}
@@ -38,6 +38,27 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: initialName
+      value: Meat Cutlet
+      objectReference: {fileID: 0}
+    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: initialDescription
+      value: Slices of meat.
+      objectReference: {fileID: 0}
+    - target: {fileID: 963106870793376919, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: d58ef77f538a66348bddf1289b2d2c1f,
+        type: 3}
+    - target: {fileID: 1024679538077702783, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 1129366686127204299, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}
       propertyPath: m_Name
@@ -98,31 +119,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1024679538077702783, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: initialName
-      value: Meat Cutlet
-      objectReference: {fileID: 0}
-    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: initialDescription
-      value: Slices of meat.
-      objectReference: {fileID: 0}
-    - target: {fileID: 963106870793376919, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: d58ef77f538a66348bddf1289b2d2c1f,
-        type: 3}
     m_RemovedComponents:
     - {fileID: 658621036961164916, guid: 9e24daf3783555e42b00f94e49d98357, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 9e24daf3783555e42b00f94e49d98357, type: 3}
---- !u!1 &6128081887975287799 stripped
+--- !u!1 &6532193109441330816 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1129366686127204299, guid: 9e24daf3783555e42b00f94e49d98357,
     type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Meat Steak.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Meat Steak.prefab
@@ -21,7 +21,7 @@ PrefabInstance:
     - target: {fileID: 658621036961164916, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}
       propertyPath: NutritionLevel
-      value: 40
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Meat.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Meat.prefab
@@ -21,6 +21,27 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: initialName
+      value: Meat
+      objectReference: {fileID: 0}
+    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: initialDescription
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 963106870793376919, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: cc952f9d9946cac4d8c48b3ba3e42c72,
+        type: 3}
+    - target: {fileID: 1024679538077702783, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 1129366686127204299, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}
       propertyPath: m_Name
@@ -81,27 +102,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: initialName
-      value: Meat
-      objectReference: {fileID: 0}
-    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: initialDescription
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1024679538077702783, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 963106870793376919, guid: 9e24daf3783555e42b00f94e49d98357,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: cc952f9d9946cac4d8c48b3ba3e42c72,
-        type: 3}
     m_RemovedComponents:
     - {fileID: 658621036961164916, guid: 9e24daf3783555e42b00f94e49d98357, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 9e24daf3783555e42b00f94e49d98357, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/CraftingManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/CraftingManager.prefab
@@ -72,7 +72,7 @@ MonoBehaviour:
       Ingredients:
       - amount: 1
         ingredientName: Meat
-      Output: {fileID: 6128081887975287799, guid: f06058cd7ca4b944aa68f64125386e28,
+      Output: {fileID: 6532193109441330816, guid: dcb198c42e70def43a450ef925a6b4b5,
         type: 3}
   techweb: {fileID: 8028218387555133124}
   designs: {fileID: 8028062986537714290}

--- a/UnityProject/Assets/Scripts/Health/BloodHealth/MetabolismSystem.cs
+++ b/UnityProject/Assets/Scripts/Health/BloodHealth/MetabolismSystem.cs
@@ -42,12 +42,17 @@ public enum MetabolismDuration
 /// </summary>
 public class MetabolismSystem : NetworkBehaviour
 {
-	public static int MAX_NUTRITION_LEVEL = 200;
+	public static int NUTRITION_LEVEL_MAX = 500;
+	public static int NUTRITION_LEVEL_STUFFED = 450;
+	public static int NUTRITION_LEVEL_NORMAL = 300;
+	public static int NUTRITION_LEVEL_HUNGRY = 200;
+	public static int NUTRITION_LEVEL_MALNOURISHED = 100;
+	public static int NUTRITION_LEVEL_STARVING = 0;
 
 	//TODO: Maybe make this dependent on the heart rate?
 	[SerializeField]
 	[Tooltip("How often a metabolism tick occurs (in seconds)")]
-	private float metabolismRate = 10f;
+	private float metabolismRate = 5f;
 
 	//TODO: Actually use this
 	//[SerializeField]
@@ -56,7 +61,7 @@ public class MetabolismSystem : NetworkBehaviour
 
 	public int NutritionLevel => nutritionLevel;
 
-	private int nutritionLevel = 150;
+	private int nutritionLevel = 400;
 	public HungerState HungerState
 	{
 		get
@@ -95,7 +100,7 @@ public class MetabolismSystem : NetworkBehaviour
 	/// <summary>
 	/// How much hunger is applied per metabolism tick
 	/// </summary>
-	public int HungerRate { get; set; } = 1;
+	public int HungerRate { get; set; } = 2;
 
 	private BloodSystem bloodSystem;
 	private PlayerMove playerMove;
@@ -147,17 +152,17 @@ public class MetabolismSystem : NetworkBehaviour
 					effects[i] = e;
 				}
 
-				nutritionLevel = Mathf.Clamp(nutritionLevel, 0, MAX_NUTRITION_LEVEL);
+				nutritionLevel = Mathf.Clamp(nutritionLevel, 0, NUTRITION_LEVEL_MAX);
 
 				HungerState oldState = this.HungerState;
 
-				if (nutritionLevel > 150) //TODO: Make character nauseous when he's too full
+				if (nutritionLevel > NUTRITION_LEVEL_STUFFED) //TODO: Make character nauseous when he's too full
 					HungerState = HungerState.Full;
-				else if (nutritionLevel > 75)
+				else if (nutritionLevel > NUTRITION_LEVEL_NORMAL)
 					HungerState = HungerState.Normal;
-				else if (nutritionLevel > 25)
+				else if (nutritionLevel > NUTRITION_LEVEL_HUNGRY)
 					HungerState = HungerState.Hungry;
-				else if (nutritionLevel > 0)
+				else if (nutritionLevel > NUTRITION_LEVEL_MALNOURISHED)
 					HungerState = HungerState.Malnourished;
 				else
 					HungerState = HungerState.Starving;

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
@@ -20,9 +20,6 @@ public class HandLabeler : NetworkBehaviour, ICheckedInteractable<HandApply>, IC
 
 	public void OnInputReceived(string input)
 	{
-		if (labelAmount == 0) return;
-
-		Chat.AddExamineMsgToClient("You set the " + this.gameObject.Item().InitialName.ToLower() + "s text to '" + input + "'.");
 		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRequestItemLabel(gameObject, input);
 		StartCoroutine(WaitToAllowInput());
 	}
@@ -50,14 +47,6 @@ public class HandLabeler : NetworkBehaviour, ICheckedInteractable<HandApply>, IC
 
 		if (interaction.HandObject != gameObject) return false;
 
-		if (currentLabel.Trim().Length == 0)
-		{
-			if (side == NetworkSide.Client)
-				Chat.AddExamineMsgToClient("You haven't set a text yet.");
-
-			return false;
-		}
-
 		return true;
 	}
 
@@ -65,7 +54,13 @@ public class HandLabeler : NetworkBehaviour, ICheckedInteractable<HandApply>, IC
 	{
 		if(labelAmount == 0)
 		{
-			Chat.AddExamineMsg(interaction.Performer, "No labels left!");
+			Chat.AddExamineMsgFromServer(interaction.Performer, "No labels left!");
+			return;
+		}
+
+		if (currentLabel.Trim().Length == 0)
+		{
+			Chat.AddExamineMsgFromServer(interaction.Performer, "You haven't set a text yet.");
 			return;
 		}
 

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/HandLabeler.cs
@@ -20,8 +20,8 @@ public class HandLabeler : NetworkBehaviour, ICheckedInteractable<HandApply>, IC
 
 	public void OnInputReceived(string input)
 	{
-		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRequestItemLabel(gameObject, input);
 		StartCoroutine(WaitToAllowInput());
+		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRequestItemLabel(gameObject, input);
 	}
 
 	IEnumerator WaitToAllowInput()

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -521,6 +521,12 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	[Command]
 	public void CmdRequestItemLabel(GameObject handLabeler, string label)
 	{
+		//if (!Validations.CanApply(playerScript, handLabeler, NetworkSide.Server)) return;
+
+		ItemStorage itemStorage = gameObject.GetComponent<ItemStorage>();
+		if (itemStorage.GetActiveHandSlot().Item.gameObject != handLabeler) return;
+
+		Chat.AddExamineMsgFromServer(gameObject, "You set the " + handLabeler.Item().InitialName.ToLower() + "s text to '" + label + "'.");
 		handLabeler.GetComponent<HandLabeler>().SetLabel(label);
 	}
 

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -521,10 +521,10 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	[Command]
 	public void CmdRequestItemLabel(GameObject handLabeler, string label)
 	{
-		//if (!Validations.CanApply(playerScript, handLabeler, NetworkSide.Server)) return;
-
 		ItemStorage itemStorage = gameObject.GetComponent<ItemStorage>();
-		if (itemStorage.GetActiveHandSlot().Item.gameObject != handLabeler) return;
+		Pickupable handItem = itemStorage.GetActiveHandSlot().Item;
+		if (handItem == null) return;
+		if (handItem.gameObject != handLabeler) return;
 
 		Chat.AddExamineMsgFromServer(gameObject, "You set the " + handLabeler.Item().InitialName.ToLower() + "s text to '" + label + "'.");
 		handLabeler.GetComponent<HandLabeler>().SetLabel(label);

--- a/UnityProject/Assets/Scripts/Weapons/Meleeable.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Meleeable.cs
@@ -8,9 +8,6 @@ using UnityEngine;
 public class Meleeable : MonoBehaviour, IPredictedCheckedInteractable<PositionalHandApply>
 {
 	[SerializeField]
-	private ItemTrait butcherKnifeTrait;
-
-	[SerializeField]
 	private static readonly StandardProgressActionConfig ProgressConfig
 	= new StandardProgressActionConfig(StandardProgressActionType.Restrain);
 
@@ -114,7 +111,7 @@ public class Meleeable : MonoBehaviour, IPredictedCheckedInteractable<Positional
 			//butcher check
 			GameObject victim = interaction.TargetObject;
 			var healthComponent = victim.GetComponent<LivingHealthBehaviour>();
-			if (healthComponent && healthComponent.allowKnifeHarvest && healthComponent.IsDead && Validations.HasItemTrait(interaction.HandObject, butcherKnifeTrait) && interaction.Intent == Intent.Harm)
+			if (healthComponent && healthComponent.allowKnifeHarvest && healthComponent.IsDead && Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Knife) && interaction.Intent == Intent.Harm)
 			{
 				GameObject performer = interaction.Performer;
 


### PR DESCRIPTION
### Purpose
Makes one unit of NutritionLevel smaller, making hunger easier to fine tune via HungerRate.
Maximum NutritionLevel is now 500 (up from 200). HungerStates and NutritionLevels of food were scaled up similarly.

Also adds a security check to HandLabeler (fixes #2875 ) and removes butcherKnife from Meleeable script since its now included in CommonTraits.