### PR TITLE
Fixes "Unknown" tooltip when hovering people

### DIFF
--- a/UnityProject/Assets/Scripts/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Equipment/Equipment.cs
@@ -133,26 +133,21 @@ public class Equipment : NetworkBehaviour, IExaminable
 	public String GetIdentityFromID()
 		{
 			IDCard card = ItemSlot.GetNamed(itemStorage,NamedSlot.id)?.Item?.GetComponent<IDCard>();
-			
+			//Logger.Log("ID Card: " + (card != null ? card.ToString() : "null"));
 			if (card != null)
 			{
 				return card.RegisteredName + " " + (card.Occupation ? $" ({ card.Occupation.DisplayName })" : "");
 			}
 			else
 			{
-				return "Unknown";
+				return "";
 			}
 		}
 	
-	public void OnHoverStart()
-	{
-		UIManager.SetToolTip = GetIdentityFromID();
-	}
-
 	public String Examine()
 	{
 		// Collect clothing + ID info.
-		string msg = "This is " + GetIdentityFromID() + ".";
+		string msg = "This is " + GetComponent<PlayerScript>().visibleName + ".";
 
 		// TODO: LOOP over items
 		// msg += blah;

--- a/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
@@ -483,7 +483,6 @@ public class MouseInputController : MonoBehaviour
 	/// Fires if shift is pressed on click, initiates examine. Assumes inanimate object, but upgrades to checking health if living, and id if target has 
 	/// storage and an ID card in-slot.
 	/// </summary>
-	/// <returns>false if no shiftclick, true if something was examined (for future chatbox related events, or gui)</returns>
 	private void CheckShiftClick()
 	{
 		// Get clickedObject from mousepos

--- a/UnityProject/Assets/Scripts/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Inventory/Pickupable.cs
@@ -79,6 +79,9 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 			//clear previous slot appearance
 			PlayerAppearanceMessage.SendToAll(info.FromPlayer.gameObject,
 				(int)info.FromSlot.NamedSlot.GetValueOrDefault(NamedSlot.none), null);
+
+			//ask target playerscript to update shown name.
+			info.FromPlayer.GetComponent<PlayerScript>().RefreshVisibleName();
 		}
 
 		if (info.ToPlayer != null &&
@@ -87,6 +90,9 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 			//change appearance based on new item
 			PlayerAppearanceMessage.SendToAll(info.ToPlayer.gameObject,
 				(int)info.ToSlot.NamedSlot.GetValueOrDefault(NamedSlot.none), info.MovedObject.gameObject);
+
+			//ask target playerscript to update shown name.
+			info.ToPlayer.GetComponent<PlayerScript>().RefreshVisibleName();
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -314,7 +314,7 @@ public class PlayerScript : ManagedNetworkBehaviour, IMatrixRotation
 	{
 		// TODO: Check inventory for head/mask items that hide face - atm just check you are not wearing a mask.
 		// needs helmet/hideface trait to be added and checked for. This way, we start with a "face name" our characters might know...
-		if (ItemSlot.GetNamed(ItemStorage,NamedSlot.mask).IsEmpty)
+		if (ItemSlot.GetNamed(ItemStorage, NamedSlot.mask).IsEmpty)
 		{
 			SyncVisibleName(playerName, playerName);
 		}

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -18,6 +18,7 @@ public class PlayerScript : ManagedNetworkBehaviour, IMatrixRotation
 
 	[SyncVar(hook = nameof(SyncPlayerName))] public string playerName = " ";
 
+	[SyncVar(hook = nameof(SyncVisibleName))] public string visibleName = " ";
 	public PlayerNetworkActions playerNetworkActions { get; set; }
 
 	public WeaponNetworkActions weaponNetworkActions { get; set; }
@@ -302,10 +303,40 @@ public class PlayerScript : ManagedNetworkBehaviour, IMatrixRotation
 		return transmitChannels | receiveChannels;
 	}
 
+	//Syncvisiblename
+	public void SyncVisibleName(string oldValue, string value)
+	{
+		visibleName = value;
+	}
+
+	//Update visible name.
+	public void RefreshVisibleName()
+	{
+		// TODO: Check inventory for head/mask items that hide face - atm just check you are not wearing a mask.
+		// needs helmet/hideface trait to be added and checked for. This way, we start with a "face name" our characters might know...
+		if (ItemSlot.GetNamed(ItemStorage,NamedSlot.mask).IsEmpty)
+		{
+			SyncVisibleName(playerName, playerName);
+		}
+		else
+		{
+			SyncVisibleName("Unknown", "Unknown");
+		}
+		
+		// ...but if ID card is in belt slot, override with ID card data.
+		string idname = Equipment.GetIdentityFromID();
+		if (!String.Equals(idname, ""))
+		{
+			SyncVisibleName(idname, idname);
+		}
+		
+		
+	}
+
 	//Tooltips inspector bar
 	public void OnHoverStart()
 	{
-		UIManager.SetToolTip = name;
+		UIManager.SetToolTip = visibleName;
 	}
 
 	public void OnHoverEnd()


### PR DESCRIPTION
# Pull Request Template

### Purpose
Corrects Shift click examine and tooltip/mouseover behaviour to correctly show name and job description. Pushing it before I implement other planned fixes cause I think it's a little bit urgent and annoying to have.

### Notes:
Currently the code checks if mask slot is empty; if so, it assumes people on the station can recognize faces, so examining or hovering over someone will tell you their name but not their role. If their ID card is equipped in the id slot, you'll also see their job. 
On the other hand, if their id is not showing and they're wearing a mask, they'll show up as Unknown.

In the near future I'm planning to expand the system by adding a trait for items that considers if they hide the face or not.

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
