### PR TITLE
Welderable glass shards, Construction list for Glass Sheets

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/glass sheet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/glass sheet.prefab
@@ -17,7 +17,22 @@ MonoBehaviour:
     placeableOn: 5
     placeableOnlyOnTile: {fileID: 11400000, guid: 3975642db6c52ed4fa2086247abc1f28,
       type: 2}
-    itemCost: 1
+    itemCost: 4
+  placeTime: 2
+  placeSound: GlassHit
+--- !u!114 &-2579858806210337748
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5680136605834777345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30e3ac583a1e4eddb2808ce1a2fc3b37, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  buildList: {fileID: 11400000, guid: ca111255596f713468225a5b1fb4ad31, type: 2}
 --- !u!1001 &6201122676745358930
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -25,87 +40,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: stacksWith.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: stacksWith.Array.data[0]
-      value: 
-      objectReference: {fileID: 5680136605834777345}
-    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 1791647728409730387, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: m_Name
       value: glass sheet
       objectReference: {fileID: 0}
-    - target: {fileID: 1821991397738242279, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1886097303314001423, guid: c3138c3e8a46444199668b85070b1a39,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 18cd7fb17fa20c346bc0bd71a2b07f9b,
-        type: 3}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: itemSprites.InventoryIcon.Sprites.Array.size
@@ -249,6 +188,82 @@ PrefabInstance:
       propertyPath: initialDescription
       value: HOLY SHEET! That is a lot of glass.
       objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821991397738242279, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stacksWith.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: stacksWith.Array.data[0]
+      value: 
+      objectReference: {fileID: 5680136605834777345}
+    - target: {fileID: 1886097303314001423, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 18cd7fb17fa20c346bc0bd71a2b07f9b,
+        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c3138c3e8a46444199668b85070b1a39, type: 3}
 --- !u!1 &5680136605834777345 stripped

--- a/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/GlassShard.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/construction/Materials/Resources/GlassShard.prefab
@@ -31,6 +31,21 @@ MonoBehaviour:
   - {fileID: 21300000, guid: 40b0aa452345ccc4c9ecae14031d3063, type: 3}
   - {fileID: 21300000, guid: 01beb265568f12a4c874f2da6617fb05, type: 3}
   spriteIndex: 0
+--- !u!114 &7942108884443502463
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2265521501557685915}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5c02b9d5ca346d489af1023e8f6923b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TraitRequired: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
+  TransformTo: {fileID: 5680136605834777345, guid: ea07289ba72453444a4ff1202b47a57d,
+    type: 3}
 --- !u!1001 &2266199196745466401
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -91,16 +106,10 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 40b0aa452345ccc4c9ecae14031d3063,
-        type: 3}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -196,6 +205,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 5beae98557a654ea6acad86c309950af,
         type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: eca72cf10c773424ab1605cf913b19a1,
+        type: 2}
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 40b0aa452345ccc4c9ecae14031d3063,
+        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
 --- !u!1 &2265521501557685915 stripped

--- a/UnityProject/Assets/Resources/ScriptableObjects/Construction/BuildList/GlassConstructionList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Construction/BuildList/GlassConstructionList.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba38351aa03f427e90c2f6010b4c1b05, type: 3}
+  m_Name: GlassConstructionList
+  m_EditorClassIdentifier: 
+  entries:
+  - name: WhiteServiceDoor
+    prefab: {fileID: 1000013430947772, guid: 37b07457c4df4dc29163cbf5f441b9ed, type: 3}
+    cost: 6
+    buildTime: 6
+    spawnAmount: 1
+    onePerTile: 1
+  - name: WinDoor
+    prefab: {fileID: 1797280918088156, guid: aec802ad975d3418d9b782880452b7bf, type: 3}
+    cost: 4
+    buildTime: 6
+    spawnAmount: 1
+    onePerTile: 1

--- a/UnityProject/Assets/Resources/ScriptableObjects/Construction/BuildList/GlassConstructionList.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Construction/BuildList/GlassConstructionList.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ca111255596f713468225a5b1fb4ad31
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/CommonTraitsSingleton.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/CommonTraitsSingleton.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: CommonTraitsSingleton
   m_EditorClassIdentifier: 
   ReagentContainer: {fileID: 11400000, guid: 175ef43f5edbe4b76b865068ed381c58, type: 2}
-  CanisterFillable: {fileID: 11400000, guid: 985f3296ea5ef9e48998b22a38a14617, type: 2}
+  CanisterFillable: {fileID: 0}
   Gun: {fileID: 11400000, guid: 0ed64735be8ec47f99cd4c93bce388ac, type: 2}
   Food: {fileID: 11400000, guid: fe7314825ebf744c3b651ca76d282adc, type: 2}
   Mask: {fileID: 11400000, guid: 3858899698cc1425f86b8b93032ca57d, type: 2}
@@ -35,5 +35,7 @@ MonoBehaviour:
   PlasteelSheet: {fileID: 11400000, guid: debdeac43ef6b474f934cecc7f43a273, type: 2}
   Cable: {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764, type: 2}
   Welder: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
-  Shovel: {fileID: 11400000, guid: 35ecd7ae92ffc9f4d9e62613c2ad8cf8, type: 2}
+  Shovel: {fileID: 0}
   Knife: {fileID: 11400000, guid: 5beae98557a654ea6acad86c309950af, type: 2}
+  Transforamble: {fileID: 11400000, guid: eca72cf10c773424ab1605cf913b19a1, type: 2}
+  CanTransfrom: {fileID: 11400000, guid: 6ce59236613b88941a75d2d450cf5a85, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/Transformable.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/Transformable.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: Transformable
+  m_EditorClassIdentifier: 
+  traitDescription: Describe me!

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/Transformable.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/Transformable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eca72cf10c773424ab1605cf913b19a1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Others/TransformableItem.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/TransformableItem.cs
@@ -19,7 +19,19 @@ public class TransformableItem : MonoBehaviour , IPredictedCheckedInteractable<H
 		if (Validations.HasItemTrait(ObjectInHand, CommonTraits.Instance.Welder) && !Validations.HasUsedActiveWelder(interaction)) return false;
 		return true;
 	}
+	public void ClientPredictInteraction(HandApply interaction)
+	{
+	}
 
+	//this is invoked on the server when client requests an interaction
+	//but the server's WillInteract method returns false. So the server may need to tell
+	// the client their prediction is wrong, depending on how client prediction works for this
+	// interaction.
+	public void ServerRollbackClient(HandApply interaction)
+	{
+		//Server should send the client a message or invoke a ClientRpc telling it to
+		//undo its prediction or reset its state to sync with the server
+	}
 
 	[Tooltip("Choose an item to spawn.")]
 	[SerializeField]

--- a/UnityProject/Assets/Scripts/Items/Others/TransformableItem.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/TransformableItem.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TransformableItem : MonoBehaviour , IPredictedCheckedInteractable<HandApply>
+{
+	// Start is called before the first frame update
+	//this method is invoked on the client side before informing the server of the interaction.
+	//If it returns false, no message is sent.
+	//If it returns true, the message is sent to the server. Then this is invoked on the server side, and if 
+	//it returns true, the server finally performs the interaction.
+	//We don't NEED to implement this method, but by implementing it we can cut down on the amount of messages
+	//sent to the server.
+	[Tooltip("Choose an item to spawn.")]
+	[SerializeField]
+	private ItemTrait TraitRequired;
+	public bool WillInteract(HandApply interaction, NetworkSide side)
+	{
+		//the Default method defines the "default" behavior for when a HandApply should occur, which currently
+		//checks if the player is conscious and standing next to the thing they are clicking.
+		GameObject ObjectInHand = interaction.HandObject;
+		if (!DefaultWillInteract.Default(interaction, side)) return false;
+
+		//we only want this interaction to happen when a lit welder is used
+		//interaction.HandObject.GetComponent<Welder>()
+		if(!Validations.HasItemTrait(ObjectInHand, TraitRequired)) return false;
+		//ObjectInHand.GetComponents<IInteractable<HandActivate>>();
+		if (Validations.HasItemTrait(ObjectInHand, CommonTraits.Instance.Welder) && !Validations.HasUsedActiveWelder(interaction)) return false;
+		return true;
+	}
+
+	//this is invoked when WillInteract returns true on the client side.
+	//We can implement this to add client prediction logic to make the game feel more responsive.
+	public void ClientPredictInteraction(HandApply interaction)
+	{
+		//display an explosion effect on this client that has no effect on their actual health
+		
+	}
+
+	//this is invoked on the server when client requests an interaction
+	//but the server's WillInteract method returns false. So the server may need to tell
+	// the client their prediction is wrong, depending on how client prediction works for this
+	// interaction.
+	public void ServerRollbackClient(HandApply interaction)
+	{
+		//Server should send the client a message or invoke a ClientRpc telling it to
+		//undo its prediction or reset its state to sync with the server
+		
+	}
+
+	[Tooltip("Choose an item to spawn.")]
+	[SerializeField]
+	private GameObject TransformTo;
+	//invoked when the server recieves the interaction request and WIllinteract returns true
+	public void ServerPerformInteraction(HandApply interaction)
+	{
+		//Server-side trigger the explosion and inform all clients of it
+		ItemAttributesV2 attr = interaction.TargetObject.GetComponent<ItemAttributesV2>();
+		if(attr.HasTrait(CommonTraits.Instance.Transforamble))
+		{
+			//interaction.TargetObject.transform.position
+			Spawn.ServerPrefab(TransformTo, interaction.TargetObject.RegisterTile().WorldPositionServer);
+			Despawn.ServerSingle(interaction.TargetObject);
+		}
+		
+}
+}

--- a/UnityProject/Assets/Scripts/Items/Others/TransformableItem.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/TransformableItem.cs
@@ -4,49 +4,22 @@ using UnityEngine;
 
 public class TransformableItem : MonoBehaviour , IPredictedCheckedInteractable<HandApply>
 {
-	// Start is called before the first frame update
-	//this method is invoked on the client side before informing the server of the interaction.
-	//If it returns false, no message is sent.
-	//If it returns true, the message is sent to the server. Then this is invoked on the server side, and if 
-	//it returns true, the server finally performs the interaction.
-	//We don't NEED to implement this method, but by implementing it we can cut down on the amount of messages
-	//sent to the server.
+	
 	[Tooltip("Choose an item to spawn.")]
 	[SerializeField]
 	private ItemTrait TraitRequired;
 	public bool WillInteract(HandApply interaction, NetworkSide side)
 	{
-		//the Default method defines the "default" behavior for when a HandApply should occur, which currently
-		//checks if the player is conscious and standing next to the thing they are clicking.
+		
 		GameObject ObjectInHand = interaction.HandObject;
 		if (!DefaultWillInteract.Default(interaction, side)) return false;
 
-		//we only want this interaction to happen when a lit welder is used
-		//interaction.HandObject.GetComponent<Welder>()
 		if(!Validations.HasItemTrait(ObjectInHand, TraitRequired)) return false;
-		//ObjectInHand.GetComponents<IInteractable<HandActivate>>();
+
 		if (Validations.HasItemTrait(ObjectInHand, CommonTraits.Instance.Welder) && !Validations.HasUsedActiveWelder(interaction)) return false;
 		return true;
 	}
 
-	//this is invoked when WillInteract returns true on the client side.
-	//We can implement this to add client prediction logic to make the game feel more responsive.
-	public void ClientPredictInteraction(HandApply interaction)
-	{
-		//display an explosion effect on this client that has no effect on their actual health
-		
-	}
-
-	//this is invoked on the server when client requests an interaction
-	//but the server's WillInteract method returns false. So the server may need to tell
-	// the client their prediction is wrong, depending on how client prediction works for this
-	// interaction.
-	public void ServerRollbackClient(HandApply interaction)
-	{
-		//Server should send the client a message or invoke a ClientRpc telling it to
-		//undo its prediction or reset its state to sync with the server
-		
-	}
 
 	[Tooltip("Choose an item to spawn.")]
 	[SerializeField]
@@ -54,11 +27,10 @@ public class TransformableItem : MonoBehaviour , IPredictedCheckedInteractable<H
 	//invoked when the server recieves the interaction request and WIllinteract returns true
 	public void ServerPerformInteraction(HandApply interaction)
 	{
-		//Server-side trigger the explosion and inform all clients of it
 		ItemAttributesV2 attr = interaction.TargetObject.GetComponent<ItemAttributesV2>();
 		if(attr.HasTrait(CommonTraits.Instance.Transforamble))
 		{
-			//interaction.TargetObject.transform.position
+
 			Spawn.ServerPrefab(TransformTo, interaction.TargetObject.RegisterTile().WorldPositionServer);
 			Despawn.ServerSingle(interaction.TargetObject);
 		}

--- a/UnityProject/Assets/Scripts/Items/Others/TransformableItem.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Others/TransformableItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5c02b9d5ca346d489af1023e8f6923b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
+++ b/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
@@ -34,4 +34,5 @@ public class CommonTraits : SingletonScriptableObject<CommonTraits>
 	public ItemTrait Welder;
 	public ItemTrait Shovel;
 	public ItemTrait Knife;
+	public ItemTrait Transforamble;
 }


### PR DESCRIPTION
# Pull Request Template

### Purpose
Makes glass a bit more usefull.

### Notes:
Glass shard now can be weldered and transformed into glass sheet. 1 glass shard = 1 glass sheet.
Glass sheets allow youto cunstruct a WhiteServiceDoor and a WinDoor.
By breaking a window 2-4 glass shards drop, placing glass sheets on a grill now takes time and costs 4 glass sheets.


### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
