### PR TITLE
Aliases for chat commands and new sing command

### DIFF
--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -370,15 +370,15 @@ public partial class Chat
 
 		foreach (char c in m)
 		{
-			var current = c;
+			char current = c;
 			if(Random.Range(1,6) == 1)
 			{
 				current = char.ToUpper(c);
 			}
-			song = song + current;
+			song += current;
 		}
 
-		song = song + " ♫";
+		song += " ♫";
 
 		return song;
 	}

--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -102,7 +102,7 @@ public partial class Chat
 			chatModifiers |= ChatModifier.Sing;
 		}
 		// Sing alias
-		else if (message.StartsWith("/s"))
+		else if (message.StartsWith("/s" ))
 		{
 			message = message.Substring(3);
 			chatModifiers |= ChatModifier.Sing;

--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -96,18 +96,14 @@ public partial class Chat
 			chatModifiers |= ChatModifier.Whisper;
 		}
 		// Sing
-		else if (sentByPlayer.Script.mind != null &&
-				sentByPlayer.Script.mind.occupation != null &&
-				message.StartsWith("%"))
+		else if (message.StartsWith("%"))
 		{
 			message = message.Substring(1);
 			message = Sing(message);
 			chatModifiers |= ChatModifier.Sing;
 		}
 		// Sing alias
-		else if (sentByPlayer.Script.mind != null &&
-				sentByPlayer.Script.mind.occupation != null &&
-				message.StartsWith("/s "))
+		else if (message.StartsWith("/s "))
 		{
 			message = message.Substring(3);
 			message = Sing(message);

--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -96,15 +96,21 @@ public partial class Chat
 			chatModifiers |= ChatModifier.Whisper;
 		}
 		// Sing
-		else if (message.StartsWith("%"))
+		else if (sentByPlayer.Script.mind != null &&
+				sentByPlayer.Script.mind.occupation != null &&
+				message.StartsWith("%"))
 		{
 			message = message.Substring(1);
+			message = Sing(message);
 			chatModifiers |= ChatModifier.Sing;
 		}
 		// Sing alias
-		else if (message.StartsWith("/s " ))
+		else if (sentByPlayer.Script.mind != null &&
+				sentByPlayer.Script.mind.occupation != null &&
+				message.StartsWith("/s "))
 		{
 			message = message.Substring(3);
+			message = Sing(message);
 			chatModifiers |= ChatModifier.Sing;
 		}
 		// Involuntaly whisper due to not being fully concious
@@ -141,7 +147,6 @@ public partial class Chat
 			}
 			chatModifiers |= ChatModifier.Clown;
 		}
-
 		// TODO None of the followinger modifiers are currently in use.
 		// They have been commented out to prevent compile warnings.
 
@@ -256,7 +261,7 @@ public partial class Chat
 		else if ((modifiers & ChatModifier.Sing) == ChatModifier.Sing)
 		{
 			verb = "sings,";
-			message = Sing(message);
+			message += " ♫" ;
 		}
 		else if ((modifiers & ChatModifier.Yell) == ChatModifier.Yell)
 		{
@@ -377,8 +382,6 @@ public partial class Chat
 			}
 			song += current;
 		}
-
-		song += " ♫";
 
 		return song;
 	}

--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -72,7 +72,13 @@ public partial class Chat
 		}
 
 		// Emote
-		if (message.StartsWith("/me "))
+		if (message.StartsWith("*"))
+		{
+			message = message.Substring(1);
+			chatModifiers |= ChatModifier.Emote;
+		}
+		// Emote alias
+		else if (message.StartsWith("/me "))
 		{
 			message = message.Substring(4);
 			chatModifiers |= ChatModifier.Emote;
@@ -82,6 +88,24 @@ public partial class Chat
 		{
 			message = message.Substring(1);
 			chatModifiers |= ChatModifier.Whisper;
+		}
+		// Whisper alias
+		else if (message.StartsWith("/w "))
+		{
+			message = message.Substring(3);
+			chatModifiers |= ChatModifier.Whisper;
+		}
+		// Sing
+		else if (message.StartsWith("%"))
+		{
+			message = message.Substring(1);
+			chatModifiers |= ChatModifier.Sing;
+		}
+		// Sing alias
+		else if (message.StartsWith("/s"))
+		{
+			message = message.Substring(3);
+			chatModifiers |= ChatModifier.Sing;
 		}
 		// Involuntaly whisper due to not being fully concious
 		else if (playerConsciousState == ConsciousState.BARELY_CONSCIOUS)
@@ -229,6 +253,11 @@ public partial class Chat
 			verb = "whispers,";
 			message = $"<i>{message}</i>";
 		}
+		else if ((modifiers & ChatModifier.Sing) == ChatModifier.Sing)
+		{
+			verb = "sings,";
+			message = Sing(message);
+		}
 		else if ((modifiers & ChatModifier.Yell) == ChatModifier.Yell)
 		{
 			verb = "yells,";
@@ -333,6 +362,25 @@ public partial class Chat
 			stutter = x;
 		}
 		return stutter;
+	}
+
+	private static string Sing(string m)
+	{
+		string song = "";
+
+		foreach (char c in m)
+		{
+			var current = c;
+			if(Random.Range(1,6) == 1)
+			{
+				current = char.ToUpper(c);
+			}
+			song = song + current;
+		}
+
+		song = song + " ♫";
+
+		return song;
 	}
 
 	private static string AddMsgColor(ChatChannel channel, string message)

--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -102,7 +102,7 @@ public partial class Chat
 			chatModifiers |= ChatModifier.Sing;
 		}
 		// Sing alias
-		else if (message.StartsWith("/s" ))
+		else if (message.StartsWith("/s " ))
 		{
 			message = message.Substring(3);
 			chatModifiers |= ChatModifier.Sing;

--- a/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
@@ -47,12 +47,12 @@ public enum ChatModifier
 	Mute 	= 1 << 2, // Dead, unconcious or naturally mute
 	Hiss 	= 1 << 3,
 	Clown 	= 1 << 4, // Having the clown occupation
-	Whisper = 1 << 5, // Message starts with "#"
+	Whisper = 1 << 5, // Message starts with "#" or "/w"
 	Yell    = 1 << 6, // Message is in capital letters
-	Emote   = 1 << 7, // Message starts with "/me"
+	Emote   = 1 << 7, // Message starts with "/me" or "*"
 	Exclaim = 1 << 8, // Message ends with a "!"
 	Question= 1 << 9, // Message ends with a "?"
-	Sing = 1 << 10
+	Sing = 1 << 10 // Message starts with "/s" or "%"
 }
 
 public class ChatEvent

--- a/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEvent.cs
@@ -51,7 +51,8 @@ public enum ChatModifier
 	Yell    = 1 << 6, // Message is in capital letters
 	Emote   = 1 << 7, // Message starts with "/me"
 	Exclaim = 1 << 8, // Message ends with a "!"
-	Question= 1 << 9 // Message ends with a "?"
+	Question= 1 << 9, // Message ends with a "?"
+	Sing = 1 << 10
 }
 
 public class ChatEvent

--- a/UnityProject/Assets/Scripts/UI/PlayerChatBubble/PlayerChatBubble.cs
+++ b/UnityProject/Assets/Scripts/UI/PlayerChatBubble/PlayerChatBubble.cs
@@ -282,6 +282,10 @@ public class PlayerChatBubble : MonoBehaviour
 			// TODO Differentiate emoting from whispering (e.g. dotted line around text)
 
 		}
+		else if((modifiers & ChatModifier.Sing) == ChatModifier.Sing)
+		{
+			msg = Sing(msg);
+		}
 		else if ((modifiers & ChatModifier.Yell) == ChatModifier.Yell)
 		{
 			bubbleSize = bubbleSizeCaps * screenHeightMultiplier;
@@ -350,5 +354,27 @@ public class PlayerChatBubble : MonoBehaviour
 		}
 
 		return PlayerPrefs.GetInt(PlayerPrefKeys.ChatBubbleKey) == 1;
+	}
+
+	/// <summary>
+	/// Same modifier as in Chat.Process.cs
+	/// </summary>
+	private static string Sing(string m)
+	{
+		string song = "";
+
+		foreach (char c in m)
+		{
+			var current = c;
+			if(Random.Range(1,6) == 1)
+			{
+				current = char.ToUpper(c);
+			}
+			song = song + current;
+		}
+
+		song = song + " ♫";
+
+		return song;
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/PlayerChatBubble/PlayerChatBubble.cs
+++ b/UnityProject/Assets/Scripts/UI/PlayerChatBubble/PlayerChatBubble.cs
@@ -284,7 +284,8 @@ public class PlayerChatBubble : MonoBehaviour
 		}
 		else if((modifiers & ChatModifier.Sing) == ChatModifier.Sing)
 		{
-			msg = Sing(msg);
+			bubbleSize = bubbleSizeCaps * screenHeightMultiplier;
+			bubbleText.fontStyle = FontStyles.Italic;
 		}
 		else if ((modifiers & ChatModifier.Yell) == ChatModifier.Yell)
 		{
@@ -354,27 +355,5 @@ public class PlayerChatBubble : MonoBehaviour
 		}
 
 		return PlayerPrefs.GetInt(PlayerPrefKeys.ChatBubbleKey) == 1;
-	}
-
-	/// <summary>
-	/// Same modifier as in Chat.Process.cs
-	/// </summary>
-	private static string Sing(string m)
-	{
-		string song = "";
-
-		foreach (char c in m)
-		{
-			var current = c;
-			if(Random.Range(1,6) == 1)
-			{
-				current = char.ToUpper(c);
-			}
-			song = song + current;
-		}
-
-		song = song + " ♫";
-
-		return song;
 	}
 }


### PR DESCRIPTION
### Purpose
Talking about PR's nobody asked for, this one will implement "*emote" as an alias for "/me emote", also "/w text" for whispering and a new chat command; "/s text" for singing.

![GIF 23-02-2020 1-30-59](https://user-images.githubusercontent.com/43683714/75104221-3b5c5500-55e5-11ea-9f36-ecf35f64e19f.gif)

### Notes:
- I honestly don't remember how singing worked on TG. Right now each character has a chance to be capitalized.
- As you can see in the GIF, chat bubble is not displaying ♫ character. No idea how to fix it.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
