### PR TITLE
Fixes Asteroid Spawn and Doesnt affect Asteroid spawning distance.

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -130,8 +130,9 @@ public partial class GameManager : MonoBehaviour
 	{
 		if (SceneManager.GetActiveScene().name == "BoxStationV1")
 		{
-			minDistanceBetweenSpaceBodies = 300f;
+			minDistanceBetweenSpaceBodies = 200f;
 		}
+		//Change this for larger maps to avoid asteroid spawning on station.
 		else
 		{
 			minDistanceBetweenSpaceBodies = 200f;


### PR DESCRIPTION
Offsets box station to avoid having to move asteroids further away.
Changes distance from 300 back to 200.

![image](https://user-images.githubusercontent.com/56727168/75111274-ded25780-562f-11ea-8fa9-d7a3a431ad85.png)

CodeKalias Fix:

Quick and dirty fix
Unparent Station from BoxStation,
move BoxStation to -200,40,0
Put Station back as child of BoxStation
Default 200 min distance should be fine

Minor side affects include a bias to spawn asteroids SE of the station, since the code is somewhat setup to expect your station at 0,0