### PR TITLE
Allow Atmospheric analyzers in toolbelt

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Atmospheric analyser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Atmospheric analyser.prefab
@@ -23,11 +23,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Atmospheric analyser
       objectReference: {fileID: 0}
-    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -71,6 +66,22 @@ PrefabInstance:
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 8d87a9afc0ec08f4d9b246612c1040ab,
+        type: 3}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -155,12 +166,12 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.EquippedData
       value: 
       objectReference: {fileID: 4900000, guid: ec6854a61869009489a51ab42f43f97c, type: 3}
-    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: m_Sprite
+      propertyPath: initialTraits.Array.data[0]
       value: 
-      objectReference: {fileID: 21300000, guid: 8d87a9afc0ec08f4d9b246612c1040ab,
-        type: 3}
+      objectReference: {fileID: 11400000, guid: d4ee295561ea59d2ca19e09cfb0e0490,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
 --- !u!1 &8238071069653876758 stripped

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/Belts/ToolbeltCapacity.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/Belts/ToolbeltCapacity.asset
@@ -22,5 +22,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 5e02bb5046f5e49d99d448363a2cdf86, type: 2}
   - {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
   - {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764, type: 2}
+  - {fileID: 11400000, guid: d4ee295561ea59d2ca19e09cfb0e0490, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AtmosAnalyser.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AtmosAnalyser.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: AtmosAnalyser
+  m_EditorClassIdentifier: 
+  traitDescription: Items with this trait can be used to receive a detailed report
+    about the atmosphere around the user

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AtmosAnalyser.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AtmosAnalyser.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d4ee295561ea59d2ca19e09cfb0e0490
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
+++ b/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
@@ -34,5 +34,4 @@ public class CommonTraits : SingletonScriptableObject<CommonTraits>
 	public ItemTrait Welder;
 	public ItemTrait Shovel;
 	public ItemTrait Knife;
-	public ItemTrait AtmosAnalyser;
 }

--- a/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
+++ b/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
@@ -34,4 +34,5 @@ public class CommonTraits : SingletonScriptableObject<CommonTraits>
 	public ItemTrait Welder;
 	public ItemTrait Shovel;
 	public ItemTrait Knife;
+	public ItemTrait AtmosAnalyser;
 }


### PR DESCRIPTION
Allows storage of atmos analyzers in toolbelts

I added an itemtrait for the atmos analyzer to allow it to be whitelisted in toolbeltcapacity.asset, the second commit in this pr seems to have reordered the atmos analyzer prefab for whatever reason