### PR TITLE
More Shift-click features + a gun fix

### DIFF
--- a/UnityProject/Assets/Scripts/Construction/ComputerFrame.cs
+++ b/UnityProject/Assets/Scripts/Construction/ComputerFrame.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 /// <summary>
 /// Main component for computer construction (ComputerFrame).
 /// </summary>
-public class ComputerFrame : MonoBehaviour, ICheckedInteractable<HandApply>
+public class ComputerFrame : MonoBehaviour, ICheckedInteractable<HandApply>, IExaminable
 {
 
 	[SerializeField] private StatefulState initialState;
@@ -225,6 +225,52 @@ public class ComputerFrame : MonoBehaviour, ICheckedInteractable<HandApply>
 				stateful.ServerChangeState(cablesAddedState);
 			}
 		}
+
+		
+	}
+
+	public string Examine(Vector3 worldPos)
+	{
+		string msg = "";
+		if (CurrentState == initialState)
+		{
+			if (objectBehaviour.IsPushable)
+			{
+				msg = "Use a wrench to secure the frame to the floor, or a welder to deconstruct it.";
+			}
+				
+			else
+			{
+				msg = "Use a wrench to unfasten the frame from the floor.";
+				if (circuitBoardSlot.IsEmpty)
+				{
+					msg += " A circuit board must be added to continue.";
+				}
+					
+				if (circuitBoardSlot.IsOccupied)
+				{
+					msg += " Use a screwdriver to screw in the circuitboard, or a crowbar to remove it.";
+				}
+			}
+		}
+
+		if (CurrentState == circuitScrewedState)
+		{
+			msg = " Add five wires must be added to continue construction. Use a screwdriver to unfasten the circuitboard.";
+		}
+
+
+		if (CurrentState == cablesAddedState)
+		{
+			msg = "Add two glass sheets to mount the glass panel. Use a wirecutter to remove cables.";
+		}
+		
+		if (CurrentState == glassAddedState)
+		{
+			msg = "Connect the monitor with a screwdriver to finish construction. Use a crowbar to remove glass panel.";
+		}
+
+	return msg;
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Equipment/Equipment.cs
@@ -144,7 +144,7 @@ public class Equipment : NetworkBehaviour, IExaminable
 			}
 		}
 	
-	public String Examine()
+	public string Examine(Vector3 worldPos)
 	{
 		// Collect clothing + ID info.
 		string msg = "This is " + GetComponent<PlayerScript>().visibleName + ".";

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -762,7 +762,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	/// so logic generating examine text can be completely separate from examine 
 	/// request or netmessage processing.
 	/// </summary>
-	public string Examine()
+	public string Examine(Vector3 worldPos)
 	{
 		var healthFraction = OverallHealth/maxHealth;
 		var healthString  = "";

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -241,7 +241,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 		}
 	}
 
-	public string Examine()
+	public string Examine(Vector3 worldPos)
 	{
 		string str = "";
 		if (integrity < 0.9f*initialIntegrity)

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/Interfaces/IExaminable.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/Interfaces/IExaminable.cs
@@ -1,14 +1,10 @@
+using UnityEngine;
+using System.Runtime.InteropServices;
 
 /// <summary>
 /// Indicates an Examinable Component -- Deets are coming later.
 /// </summary>
 public interface IExaminable
 {
-	/// <summary>
-	/// Describeme!
-	/// </summary>
-	/// <param name=""></param>
-	/// <returns>.</returns>
-	
-    string Examine();
+	string Examine(Vector3 worldPos = default(Vector3));
 }

--- a/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
@@ -490,7 +490,7 @@ public class MouseInputController : MonoBehaviour
 		
 		// TODO Prepare and send requestexaminemessage
 		// todo:  check if netid = 0.
-		RequestExamineMessage.Send(clickedObject.GetComponent<NetworkIdentity>().netId);
+		RequestExamineMessage.Send(clickedObject.GetComponent<NetworkIdentity>().netId, MouseWorldPosition);
 	}
 
 	private bool CheckAltClick()

--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -136,14 +136,11 @@ public class Attributes : NetworkBehaviour, IRightClickable, IServerSpawn, IExam
 
 	private void OnExamine()
 	{
-		if (!string.IsNullOrEmpty(initialDescription))
-		{
-			Chat.AddExamineMsgToClient(initialDescription);
-		}
+		RequestExamineMessage.Send(GetComponent<NetworkIdentity>().netId);
 	}
 
 	// Initial implementation of shift examine behaviour
-	public string Examine()
+	public string Examine(Vector3 worldPos)
 	{
 		string displayName = "<error>";
 		if (string.IsNullOrWhiteSpace(articleName))

--- a/UnityProject/Assets/Scripts/Items/EncryptionKey.cs
+++ b/UnityProject/Assets/Scripts/Items/EncryptionKey.cs
@@ -272,7 +272,7 @@ public class EncryptionKey : NetworkBehaviour
 
 	#endregion
 
-	public void OnExamine()
+	public void onExamine(Vector3 worldPos)
 	{
 		Chat.AddExamineMsgToClient(ExamineTexts[Type]);
 	}

--- a/UnityProject/Assets/Scripts/Items/IDCard.cs
+++ b/UnityProject/Assets/Scripts/Items/IDCard.cs
@@ -218,7 +218,7 @@ public class IDCard : NetworkBehaviour, IServerInventoryMove, IServerSpawn, IExa
 	// When examine is triggered by the server on a player gameobj (by a shift click from another player)
 	// the target's Equipment component returns ID info based on presence of ID card in "viewable" slot (id and hands). 
 	// When ID card itself is examined, it should return full text.
-	public string Examine()
+	public string Examine(Vector3 worldPos)
 	{
 		return "This is the ID card of " + registeredName + ", station " + JobType + ".";
 	}

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestExamineMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestExamineMessage.cs
@@ -17,7 +17,7 @@ public class RequestExamineMessage : ClientMessage
 	//members
 	// netid of target
 	public uint examineTarget;
-
+	public Vector3 mousePosition;
 	static RequestExamineMessage()
 	{
 		//constructor
@@ -48,7 +48,8 @@ public class RequestExamineMessage : ClientMessage
 		for (int i = 0; i < examinables.Count(); i++) 
 		{
 			examinable = examinables[i];
-			msg += $"{examinable.Examine()}";
+
+			msg += $"{examinable.Examine(mousePosition)}";
 
 			if (i != examinables.Count() - 1)
 			{
@@ -66,6 +67,17 @@ public class RequestExamineMessage : ClientMessage
 		var msg = new RequestExamineMessage()
 		{
 			examineTarget = targetNetId
+		};
+		msg.Send();
+	}
+
+	public static void Send(uint targetNetId, Vector3 mousePos)
+	{
+		// TODO: Log something?
+		var msg = new RequestExamineMessage()
+		{
+			examineTarget = targetNetId,
+			mousePosition = mousePos
 		};
 		msg.Send();
 	}

--- a/UnityProject/Assets/Scripts/Objects/Construction/Girder.cs
+++ b/UnityProject/Assets/Scripts/Objects/Construction/Girder.cs
@@ -5,7 +5,7 @@ using Mirror;
 /// <summary>
 /// The main girder component
 /// </summary>
-public class Girder : NetworkBehaviour, ICheckedInteractable<HandApply>, IServerSpawn
+public class Girder : NetworkBehaviour, ICheckedInteractable<HandApply>, IServerSpawn, IExaminable
 {
 	private TileChangeManager tileChangeManager;
 
@@ -155,6 +155,12 @@ public class Girder : NetworkBehaviour, ICheckedInteractable<HandApply>, IServer
 				Chat.AddExamineMsg(interaction.Performer, "You must unsecure it first.");
 			}
 		}
+	}
+
+	public string Examine(Vector3 worldPos)
+	{
+		return (objectBehaviour.IsPushable?"Use a wrench to secure to the floor, or a screwdriver to disassemble it."
+				:"Apply metal sheets to finalize the plating, or plasteel to reinforce the structure. Use a wrench to unsecure the girder.");
 	}
 
 	[Server]

--- a/UnityProject/Assets/Scripts/Objects/Construction/ReinforcedGirder.cs
+++ b/UnityProject/Assets/Scripts/Objects/Construction/ReinforcedGirder.cs
@@ -5,7 +5,7 @@ using Mirror;
 /// <summary>
 /// The main reinforced girder component
 /// </summary>
-public class ReinforcedGirder : NetworkBehaviour, ICheckedInteractable<HandApply>, IServerSpawn
+public class ReinforcedGirder : NetworkBehaviour, ICheckedInteractable<HandApply>, IServerSpawn, IExaminable
 {
 	private TileChangeManager tileChangeManager;
 
@@ -108,6 +108,13 @@ public class ReinforcedGirder : NetworkBehaviour, ICheckedInteractable<HandApply
 					});
 			}
 		}
+	}
+
+	public string Examine(Vector3 worldPos)
+	{
+		return (strutsUnsecured?"Secure support struts with a screwdriver, or remove the inner grille with a wirecutter."
+				:"Add Plasteel to finalize the reinforced wall, or use a screwdriver to unsecure the support struts.");
+
 	}
 
 	[Server]

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -9,7 +9,7 @@ using UnityEngine.Tilemaps;
 ///
 /// Also provides various utility methods for working with tiles.
 /// </summary>
-public class InteractableTiles : NetworkBehaviour, IClientInteractable<PositionalHandApply>
+public class InteractableTiles : NetworkBehaviour, IClientInteractable<PositionalHandApply>, IExaminable
 {
 	private MetaTileMap metaTileMap;
 	private Matrix matrix;
@@ -132,6 +132,12 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 		}
 	}
 
+	public string Examine(Vector3 pos)
+	{
+		// Get Tile at position
+		LayerTile tile = LayerTileAt(pos);
+		return "A " + tile.DisplayName;
+	}
 
 	public bool Interact(PositionalHandApply interaction)
 	{

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSwap.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSwap.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using Mirror;
 
 public class UI_ItemSwap : TooltipMonoBehaviour, IPointerClickHandler, IDropHandler,
 	IPointerEnterHandler, IPointerExitHandler, IDragHandler, IEndDragHandler
@@ -26,6 +27,13 @@ public class UI_ItemSwap : TooltipMonoBehaviour, IPointerClickHandler, IDropHand
 
 	public void OnClick()
 	{
+		//If shift is pressed, don't check anything, just send Examine on contained item if any.
+		if (KeyboardInputManager.IsShiftPressed() && itemSlot.Item != null)
+		{
+			RequestExamineMessage.Send(itemSlot.Item.GetComponent<NetworkIdentity>().netId);
+			return; 
+		}
+
 		SoundManager.Play("Click01");
 		//if there is an item in this slot, try interacting.
 		if (itemSlot.Item != null)

--- a/UnityProject/Assets/Scripts/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Gun.cs
@@ -292,7 +292,7 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 		return false;
 	}
 
-	public string  Examine()
+	public string  Examine(Vector3 pos)
 	{
 		return WeaponType + " - Fires " + ammoType + " ammunition (" + (CurrentMagazine != null?(CurrentMagazine.ServerAmmoRemains.ToString() + " rounds loaded in magazine"):"It's empty!") + ")";
 	}

--- a/UnityProject/Assets/Scripts/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Gun.cs
@@ -504,7 +504,6 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 		{
 			//this is our gun so we need to update our predictions
 			FireCountDown += 1.0 / FireRate;
-			CurrentMagazine.ExpendAmmo();
 			//add additional recoil after shooting for the next round
 			AppendRecoil();
 
@@ -520,6 +519,9 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 			}
 			Camera2DFollow.followControl.Recoil(-finalDirection, CameraRecoilConfig);
 		}
+
+		//call ExpendAmmo outside of previous check, or it won't run serverside and state will desync.
+		CurrentMagazine.ExpendAmmo();
 
 		//display the effects of the shot
 

--- a/UnityProject/Assets/Scripts/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Gun.cs
@@ -10,7 +10,7 @@ using UnityEngine.Serialization;
 [RequireComponent(typeof(Pickupable))]
 [RequireComponent(typeof(ItemStorage))]
 public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IClientInteractable<HandActivate>,
-	 IClientInteractable<InventoryApply>, IServerInventoryMove, IServerSpawn
+	 IClientInteractable<InventoryApply>, IServerInventoryMove, IServerSpawn, IExaminable
 {
 	//constants for calculating screen shake due to recoil
 	private static readonly float MAX_PROJECTILE_VELOCITY = 48f;
@@ -292,6 +292,10 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 		return false;
 	}
 
+	public string  Examine()
+	{
+		return WeaponType + " - Fires " + ammoType + " ammunition (" + (CurrentMagazine != null?(CurrentMagazine.ServerAmmoRemains.ToString() + " rounds loaded in magazine"):"It's empty!") + ")";
+	}
 
 	#endregion
 

--- a/UnityProject/Assets/Scripts/Weapons/MagazineBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/MagazineBehaviour.cs
@@ -5,7 +5,7 @@ using Mirror;
 /// Tracks the ammo in a magazine. Note that if you are referencing the ammo count stored in this
 /// behavior, server and client ammo counts are stored separately but can be synced with SyncClientAmmoRemainsWithServer().
 /// </summary>
-public class MagazineBehaviour : NetworkBehaviour, IServerSpawn
+public class MagazineBehaviour : NetworkBehaviour, IServerSpawn, IExaminable
 {
 	/*
 	We keep track of 2 ammo counts. The server's ammo count is authoritative, but when ammo is being
@@ -146,6 +146,11 @@ public class MagazineBehaviour : NetworkBehaviour, IServerSpawn
 	{
 		Logger.LogTraceFormat("rng {0}, serverAmmo {1} clientAmmo {2}", Category.Firearms, currentRNG, serverAmmoRemains, clientAmmoRemains);
 		return currentRNG;
+	}
+
+	public String Examine()
+	{
+		return "Accepts " + ammoType + " rounds (" + (ServerAmmoRemains > 0?(ServerAmmoRemains.ToString() + " left"):"empty") + ")";
 	}
 }
 

--- a/UnityProject/Assets/Scripts/Weapons/MagazineBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/MagazineBehaviour.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Mirror;
+using UnityEngine;
 
 /// <summary>
 /// Tracks the ammo in a magazine. Note that if you are referencing the ammo count stored in this
@@ -37,7 +38,7 @@ public class MagazineBehaviour : NetworkBehaviour, IServerSpawn, IExaminable
 	/// RNG whose seed is based on the netID of the magazine and which provides a random value based
 	/// on how much ammo the magazine has left.
 	/// </summary>
-	private Random magSyncedRNG;
+	private System.Random magSyncedRNG;
 
 	private double currentRNG;
 
@@ -71,7 +72,7 @@ public class MagazineBehaviour : NetworkBehaviour, IServerSpawn, IExaminable
 	/// </summary>
 	public void SyncPredictionWithServer()
 	{
-		magSyncedRNG = new Random(GetComponent<NetworkIdentity>().netId.GetHashCode());
+		magSyncedRNG = new System.Random(GetComponent<NetworkIdentity>().netId.GetHashCode());
 		currentRNG = magSyncedRNG.NextDouble();
 		//fast forward RNG based on how many shots are spent
 		var shots = magazineSize - serverAmmoRemains;
@@ -148,7 +149,7 @@ public class MagazineBehaviour : NetworkBehaviour, IServerSpawn, IExaminable
 		return currentRNG;
 	}
 
-	public String Examine()
+	public String Examine(Vector3 pos)
 	{
 		return "Accepts " + ammoType + " rounds (" + (ServerAmmoRemains > 0?(ServerAmmoRemains.ToString() + " left"):"empty") + ")";
 	}


### PR DESCRIPTION
# Pull Request Template

### Purpose
Fixes #2340 
Partial solution to #3271 - submitting as i'll have to take a few days off and i'd like these changes to be merged before too much stuff changes.

Possibly addresses #2679 - While testing examine on weapons and mags, i noticed serverAmmoRemains and clientAmmoRemains variables in magazine weren't updating properly. Gun code had a problem that meant that firing a gun would do everything right except decrease Serverside ammo count. Moved one call outside a particular clientside check to fix, tested with client, behaviour should now be correct.

For shiftclick:
- Makes items in inventory/ui examinable
- Adds functionality for in-progress construction to provide feedback as per #2340 (reinf wall and computer construction)
- Initial tile based examine implementation - returns DisplayName of Layertiles under cursor
- Add Examine() to guns and mags to show ammo used, ammocount, etc
- inclusion of right click items logic to streamline examine behavior
- refactor existing OnExamine behaviours to be compatible

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.

