### PR TITLE
Grill fix for v4039

### DIFF
--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/Grill in doors.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/Grill in doors.asset
@@ -11,8 +11,8 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: Grill in doors
-  m_EditorClassIdentifier: 
-  displayName: 
+  m_EditorClassIdentifier:
+  displayName:
   LayerType: 5
   TileType: 6
   RequiredTiles:
@@ -26,8 +26,8 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   passableException:
-    m_keys: 
-    m_values: 
+    m_keys:
+    m_values:
   maxHealth: 0
   healthStates: []
   resistances:
@@ -51,6 +51,6 @@ MonoBehaviour:
     Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 10228000f4d0b45ccbe54926e21b9cb0, type: 2}
-  spawnOnDeconstruct: {fileID: 0}
+  spawnOnDeconstruct: {fileID: 4519819786599941225, guid: 2a170fdb7187e38459de34c4d2b131ad,     type: 3}
   spawnAmountOnDeconstruct: 2
   sprite: {fileID: 21300000, guid: 10623b9787a8d384b8d9825b3337ea04, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/Grill.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/Grill.asset
@@ -11,8 +11,8 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: Grill
-  m_EditorClassIdentifier: 
-  displayName: 
+  m_EditorClassIdentifier:
+  displayName:
   LayerType: 5
   TileType: 6
   RequiredTiles:
@@ -26,8 +26,8 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   passableException:
-    m_keys: 
-    m_values: 
+    m_keys:
+    m_values:
   maxHealth: 0
   healthStates: []
   resistances:
@@ -51,6 +51,6 @@ MonoBehaviour:
     Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 10228000f4d0b45ccbe54926e21b9cb0, type: 2}
-  spawnOnDeconstruct: {fileID: 0}
+  spawnOnDeconstruct: {fileID: 4519819786599941225, guid: 2a170fdb7187e38459de34c4d2b131ad,     type: 3}
   spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 10623b9787a8d384b8d9825b3337ea04, type: 3}


### PR DESCRIPTION
Makes Grills drop 2 rods when cut using wirecutters and 1 rod when destroyed with force
Related to #3317 