### PR TITLE
minor v4039 bugfixes

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Cappuccino.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/drinks/Cappuccino.prefab
@@ -17,10 +17,36 @@ PrefabInstance:
       propertyPath: itemAttributes
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 667038178532149417, guid: 5bffec0720d353440a0d06532a3221f6,
+        type: 3}
+      propertyPath: initialName
+      value: A Cappuccino
+      objectReference: {fileID: 0}
+    - target: {fileID: 667038178532149417, guid: 5bffec0720d353440a0d06532a3221f6,
+        type: 3}
+      propertyPath: initialDescription
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 667038178532149417, guid: 5bffec0720d353440a0d06532a3221f6,
+        type: 3}
+      propertyPath: initialSize
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 963106870793376919, guid: 5bffec0720d353440a0d06532a3221f6,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 5c9f8107433acef4f96b90e0c6628479,
+        type: 3}
+    - target: {fileID: 1024679538077702783, guid: 5bffec0720d353440a0d06532a3221f6,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 1129366686127204299, guid: 5bffec0720d353440a0d06532a3221f6,
         type: 3}
       propertyPath: m_Name
-      value: Cappuccino1
+      value: Cappuccino
       objectReference: {fileID: 0}
     - target: {fileID: 1134857784536455871, guid: 5bffec0720d353440a0d06532a3221f6,
         type: 3}
@@ -77,31 +103,5 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 667038178532149417, guid: 5bffec0720d353440a0d06532a3221f6,
-        type: 3}
-      propertyPath: initialName
-      value: A Cappuccino in an edible mug
-      objectReference: {fileID: 0}
-    - target: {fileID: 667038178532149417, guid: 5bffec0720d353440a0d06532a3221f6,
-        type: 3}
-      propertyPath: initialDescription
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 667038178532149417, guid: 5bffec0720d353440a0d06532a3221f6,
-        type: 3}
-      propertyPath: initialSize
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1024679538077702783, guid: 5bffec0720d353440a0d06532a3221f6,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 963106870793376919, guid: 5bffec0720d353440a0d06532a3221f6,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 5c9f8107433acef4f96b90e0c6628479,
-        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5bffec0720d353440a0d06532a3221f6, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Janitor/SpaceCleaner.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Janitor/SpaceCleaner.prefab
@@ -39,8 +39,8 @@ MonoBehaviour:
   TraitWhitelist: []
   ReagentWhitelist: []
   TransferMode: 0
-  InitialTransferAmount: 20
   PossibleTransferAmounts: []
+  InitialTransferAmount: 20
 --- !u!114 &4872181358128779540
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4901,11 +4901,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: SpaceCleaner
       objectReference: {fileID: 0}
-    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -4949,6 +4944,22 @@ PrefabInstance:
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 5bbb7ae03fb4b214fbabcdff311b3fcb,
+        type: 3}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -5038,12 +5049,12 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.EquippedData
       value: 
       objectReference: {fileID: 4900000, guid: 912883b94b31e1b439d1ac96604e9f2a, type: 3}
-    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: m_Sprite
+      propertyPath: initialTraits.Array.data[0]
       value: 
-      objectReference: {fileID: 21300000, guid: 5bbb7ae03fb4b214fbabcdff311b3fcb,
-        type: 3}
+      objectReference: {fileID: 11400000, guid: f47eb2fc78e3445939292ebdbc0ba2ae,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
 --- !u!1 &2419386692754613975 stripped

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/MimePopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/MimePopulator.asset
@@ -30,6 +30,6 @@ MonoBehaviour:
   - NamedSlot: 6
     Prefab: {fileID: 3011710637427380133, guid: 57b4739d8947544f387d028cd2dd59b9,
       type: 3}
-  - NamedSlot: 1
+  - NamedSlot: 10
     Prefab: {fileID: 4188245363048309518, guid: 55e43c3f69415c540bcd3de664a3a52d,
       type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ResearchDirectoryPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ResearchDirectoryPopulator.asset
@@ -24,6 +24,6 @@ MonoBehaviour:
   - NamedSlot: 6
     Prefab: {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226,
       type: 3}
-  - NamedSlot: 1
+  - NamedSlot: 10
     Prefab: {fileID: 4188245363048309518, guid: 08cfe1b88b57ef54480353de29933380,
       type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/Belts/JanitorBeltCapacity.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/Belts/JanitorBeltCapacity.asset
@@ -22,5 +22,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 5e02bb5046f5e49d99d448363a2cdf86, type: 2}
   - {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
   - {fileID: 11400000, guid: e39c048ec864b47a495a40f9c76af764, type: 2}
+  - {fileID: 11400000, guid: f47eb2fc78e3445939292ebdbc0ba2ae, type: 2}
   Required: []
   Blacklist: []

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/SpaceCleaner.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/SpaceCleaner.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: SpaceCleaner
+  m_EditorClassIdentifier: 
+  traitDescription: Items with this trait can be used to clean stains and blood, usually
+    used by the janitor

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/Grill in doors.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/Grill in doors.asset
@@ -11,8 +11,8 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: Grill in doors
-  m_EditorClassIdentifier: 
-  displayName: 
+  m_EditorClassIdentifier:
+  displayName:
   LayerType: 5
   TileType: 6
   RequiredTiles:
@@ -26,8 +26,8 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   passableException:
-    m_keys: 
-    m_values: 
+    m_keys:
+    m_values:
   maxHealth: 0
   healthStates: []
   resistances:
@@ -51,6 +51,6 @@ MonoBehaviour:
     Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 10228000f4d0b45ccbe54926e21b9cb0, type: 2}
-  spawnOnDeconstruct: {fileID: 0}
+  spawnOnDeconstruct: {fileID: 4519819786599941225, guid: 2a170fdb7187e38459de34c4d2b131ad,     type: 3}
   spawnAmountOnDeconstruct: 2
   sprite: {fileID: 21300000, guid: 10623b9787a8d384b8d9825b3337ea04, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/Grill.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/Grill.asset
@@ -11,8 +11,8 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: Grill
-  m_EditorClassIdentifier: 
-  displayName: 
+  m_EditorClassIdentifier:
+  displayName:
   LayerType: 5
   TileType: 6
   RequiredTiles:
@@ -26,8 +26,8 @@ MonoBehaviour:
   passable: 0
   mineable: 0
   passableException:
-    m_keys: 
-    m_values: 
+    m_keys:
+    m_values:
   maxHealth: 0
   healthStates: []
   resistances:
@@ -51,6 +51,6 @@ MonoBehaviour:
     Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 10228000f4d0b45ccbe54926e21b9cb0, type: 2}
-  spawnOnDeconstruct: {fileID: 0}
+  spawnOnDeconstruct: {fileID: 4519819786599941225, guid: 2a170fdb7187e38459de34c4d2b131ad,     type: 3}
   spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 10623b9787a8d384b8d9825b3337ea04, type: 3}


### PR DESCRIPTION
Fixes 3 of the bugs in 4039 (#3317)
Grills will now drop 2 rods when cut with wirecutters and one rod when destroyed with force
Cappuccino is no longer named 'a cappuccino with an edible cup'
janitor can store spacecleaner in his belt
change mime and r&d populators to spawn in backpacks properly