### PR TITLE
Find janitor's missing belt and ID

### DIFF
--- a/UnityProject/Assets/Scripts/Inventory/Structure/DefinedSlotCapacity.cs
+++ b/UnityProject/Assets/Scripts/Inventory/Structure/DefinedSlotCapacity.cs
@@ -113,7 +113,7 @@ public class DefinedSlotCapacity : SlotCapacity
 		else
 		{
 			Logger.LogTraceFormat("Whitelist is {0}", Category.Inventory,
-				String.Join(", ", Whitelist.Select(it => it.name)));
+				String.Join(", ", Whitelist.Select(it => it == null ? "null" : it.name)));
 			if (itemAttrs == null)
 			{
 				Logger.LogTrace("Item has no ItemAttributes, thus has no whitelisted traits", Category.Inventory);


### PR DESCRIPTION
### Purpose
Fixes #3354 

### Notes
Avoids NRE that caused inventory to not load in some cases such as janitor's id and belt