### PR TITLE
Fixes mining rock/ore tiles creating space wind out of nowhere

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
@@ -10,9 +10,15 @@ public class AtmosSystem : SubsystemBehaviour
 
 		foreach (Vector3Int position in bounds.allPositionsWithin)
 		{
+			//get toptile at pos to check if it should spawn with no air
+			bool spawnWithNoAir = false;
+			var topTile = metaTileMap.GetTile(position,true);
+			if (topTile is BasicTile)
+			{
+				spawnWithNoAir = (topTile as BasicTile).SpawnWithNoAir;
+			}
 			MetaDataNode node = metaDataLayer.Get(position, false);
-
-			node.GasMix = new GasMix( (node.IsRoom||node.IsOccupied) ? GasMixes.Air : GasMixes.Space );
+			node.GasMix = new GasMix( (node.IsRoom||node.IsOccupied) && !spawnWithNoAir ? GasMixes.Air : GasMixes.Space );
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
@@ -27,6 +27,9 @@ public abstract class BasicTile : LayerTile
 	[SerializeField]
 	private bool isSealed;
 
+	[Tooltip("Should this tile get initialized with Space gasmix at round start (e.g. asteroids)?")]
+	public bool SpawnWithNoAir;
+
 	[FormerlySerializedAs("OreCategorie")]
 	[SerializeField]
 	private OreCategory oreCategory;

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Bananium Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Bananium Ore.asset
@@ -16,9 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
+  WalkingSoundCategory: 0
   atmosPassable: 0
   isSealed: 0
-  OreCategorie: 9
+  SpawnWithNoAir: 1
+  oreCategory: 9
   MaxHealth: 0
   HealthStates: []
   passable: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/BlueSpace Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/BlueSpace Ore.asset
@@ -16,9 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
+  WalkingSoundCategory: 0
   atmosPassable: 0
   isSealed: 0
-  OreCategorie: 6
+  SpawnWithNoAir: 1
+  oreCategory: 6
   MaxHealth: 0
   HealthStates: []
   passable: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Diamond ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Diamond ore.asset
@@ -16,9 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
+  WalkingSoundCategory: 0
   atmosPassable: 0
   isSealed: 0
-  OreCategorie: 8
+  SpawnWithNoAir: 1
+  oreCategory: 8
   MaxHealth: 0
   HealthStates: []
   passable: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Gold Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Gold Ore.asset
@@ -16,9 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
+  WalkingSoundCategory: 0
   atmosPassable: 0
   isSealed: 0
-  OreCategorie: 4
+  SpawnWithNoAir: 1
+  oreCategory: 4
   MaxHealth: 0
   HealthStates: []
   passable: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Iron Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Iron Ore.asset
@@ -16,9 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
+  WalkingSoundCategory: 0
   atmosPassable: 0
   isSealed: 0
-  OreCategorie: 1
+  SpawnWithNoAir: 1
+  oreCategory: 1
   MaxHealth: 0
   HealthStates: []
   passable: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Plasma Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Plasma Ore.asset
@@ -16,9 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
+  WalkingSoundCategory: 0
   atmosPassable: 0
   isSealed: 0
-  OreCategorie: 2
+  SpawnWithNoAir: 1
+  oreCategory: 2
   MaxHealth: 0
   HealthStates: []
   passable: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Silver Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Silver Ore.asset
@@ -16,9 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
+  WalkingSoundCategory: 0
   atmosPassable: 0
   isSealed: 0
-  OreCategorie: 3
+  SpawnWithNoAir: 1
+  oreCategory: 3
   MaxHealth: 0
   HealthStates: []
   passable: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Titanium Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Titanium Ore.asset
@@ -16,9 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
+  WalkingSoundCategory: 0
   atmosPassable: 0
   isSealed: 0
-  OreCategorie: 7
+  SpawnWithNoAir: 1
+  oreCategory: 7
   MaxHealth: 0
   HealthStates: []
   passable: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Uranium Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Uranium Ore.asset
@@ -16,9 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
+  WalkingSoundCategory: 0
   atmosPassable: 0
   isSealed: 0
-  OreCategorie: 5
+  SpawnWithNoAir: 1
+  oreCategory: 5
   MaxHealth: 0
   HealthStates: []
   passable: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rock_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rock_wall.asset
@@ -17,17 +17,21 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  Mineable: 1
-  PassableException:
-    m_keys: 
-    m_values: 
-  OreCategorie: 2
+  WalkingSoundCategory: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 1
+  oreCategory: 2
   MaxHealth: 0
   HealthStates: []
-  Resistances:
+  passable: 0
+  mineable: 1
+  passableException:
+    m_keys: 
+    m_values: 
+  maxHealth: 0
+  healthStates: []
+  resistances:
     LavaProof: 0
     FireProof: 0
     Flammable: 0
@@ -35,7 +39,7 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  Armor:
+  armor:
     Melee: 0
     Bullet: 0
     Laser: 0
@@ -46,10 +50,9 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+  tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0
-  deconstructionType: 0
-  DestroyedTile: {fileID: 0}
   connectCategory: 0
   connectType: 1
   spriteSheet:


### PR DESCRIPTION
# Pull Request Template

### Purpose
fixes #2890 

### Notes:
See changes for details, but mostly adds a flag to LayerTile to override atmosmanager initialization of gasmixes on grids thus avoiding storing a cube of air in every rock and ore tile of asteroids. I considered simply checking  if it was being  ran on a gameobject with asteroid component, but after chatting with foma we agreed it would smell a bit, so went for this instead.

RFC before merge if deemed appropriate, it's small changes and i needed an excuse to learn basic atmos anyway so no harm done if we want to go another way.

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
- [x] The PR has been tested on moving / rotating / rotated-before-joining matrices (afaik asteroids are rotated at init so yes)
