### PR TITLE
adds hotkey to toggle between walk and run

### DIFF
--- a/UnityProject/Assets/Scripts/Input System/KeybindManager.cs
+++ b/UnityProject/Assets/Scripts/Input System/KeybindManager.cs
@@ -520,29 +520,29 @@ public class KeybindManager : MonoBehaviour {
 			}
 
 			
-				// Check if new hotkeys has been added to the default dict
-				// Adds them to the user settings in case one is found
-				if (userKeybinds.Count < defaultKeybinds.Count)
+			// Check if new hotkeys has been added to the default dict
+			// Adds them to the user settings in case one is found
+			if (userKeybinds.Count < defaultKeybinds.Count)
+			{
+				foreach (KeyValuePair<KeyAction, DualKeyCombo> entry in defaultKeybinds)
 				{
-					foreach (KeyValuePair<KeyAction, DualKeyCombo> entry in defaultKeybinds)
+					if (!(userKeybinds.ContainsKey(entry.Key)))
 					{
-						if (!(userKeybinds.ContainsKey(entry.Key)))
-						{
-							userKeybinds.Add(entry.Key, entry.Value);
-						}
+						userKeybinds.Add(entry.Key, entry.Value);
 					}
 				}
-				// If we remove a hotkey in the future, we remove it from userKeybinds here
-				else if (userKeybinds.Count > defaultKeybinds.Count)
+			}
+			// If we remove a hotkey in the future, we remove it from userKeybinds here
+			else if (userKeybinds.Count > defaultKeybinds.Count)
+			{
+				foreach (KeyValuePair<KeyAction, DualKeyCombo> entry in userKeybinds)
 				{
-					foreach (KeyValuePair<KeyAction, DualKeyCombo> entry in userKeybinds)
+					if (!(defaultKeybinds.ContainsKey(entry.Key)))
 					{
-						if (!(defaultKeybinds.ContainsKey(entry.Key)))
-						{
-							userKeybinds.Remove(entry.Key);
-						}
+						userKeybinds.Remove(entry.Key);
 					}
 				}
+			}
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/Input System/KeybindManager.cs
+++ b/UnityProject/Assets/Scripts/Input System/KeybindManager.cs
@@ -23,6 +23,7 @@ public enum KeyAction
 	MoveLeft,
 	MoveDown,
 	MoveRight,
+	ToggleWalkun,
 
 	// Actions
 	ActionThrow,
@@ -263,6 +264,7 @@ public class KeybindManager : MonoBehaviour {
 		{ KeyAction.MoveLeft, 	new KeybindMetadata("Move Left", ActionType.Movement)},
 		{ KeyAction.MoveDown, 	new KeybindMetadata("Move Down", ActionType.Movement)},
 		{ KeyAction.MoveRight, 	new KeybindMetadata("Move Right", ActionType.Movement)},
+		{ KeyAction.ToggleWalkun, new KeybindMetadata("Toggle Walk/Run", ActionType.Movement)},
 
 		// Actions
 		{ KeyAction.ActionThrow,	new KeybindMetadata("Throw", ActionType.Action)},
@@ -304,6 +306,7 @@ public class KeybindManager : MonoBehaviour {
 		{ KeyAction.MoveLeft, 		new DualKeyCombo(new KeyCombo(KeyCode.A), new KeyCombo(KeyCode.LeftArrow))},
 		{ KeyAction.MoveDown, 		new DualKeyCombo(new KeyCombo(KeyCode.S), new KeyCombo(KeyCode.DownArrow))},
 		{ KeyAction.MoveRight, 		new DualKeyCombo(new KeyCombo(KeyCode.D), new KeyCombo(KeyCode.RightArrow))},
+		{ KeyAction.ToggleWalkun,   new DualKeyCombo(new KeyCombo(KeyCode.C), null)},
 
 		// Actions
 		{ KeyAction.ActionThrow,	new DualKeyCombo(new KeyCombo(KeyCode.R),	new KeyCombo(KeyCode.End))},

--- a/UnityProject/Assets/Scripts/Input System/KeybindManager.cs
+++ b/UnityProject/Assets/Scripts/Input System/KeybindManager.cs
@@ -23,7 +23,7 @@ public enum KeyAction
 	MoveLeft,
 	MoveDown,
 	MoveRight,
-	ToggleWalkun,
+	ToggleWalkRun,
 
 	// Actions
 	ActionThrow,
@@ -264,7 +264,7 @@ public class KeybindManager : MonoBehaviour {
 		{ KeyAction.MoveLeft, 	new KeybindMetadata("Move Left", ActionType.Movement)},
 		{ KeyAction.MoveDown, 	new KeybindMetadata("Move Down", ActionType.Movement)},
 		{ KeyAction.MoveRight, 	new KeybindMetadata("Move Right", ActionType.Movement)},
-		{ KeyAction.ToggleWalkun, new KeybindMetadata("Toggle Walk/Run", ActionType.Movement)},
+		{ KeyAction.ToggleWalkRun, new KeybindMetadata("Toggle Walk/Run", ActionType.Movement)},
 
 		// Actions
 		{ KeyAction.ActionThrow,	new KeybindMetadata("Throw", ActionType.Action)},
@@ -306,7 +306,7 @@ public class KeybindManager : MonoBehaviour {
 		{ KeyAction.MoveLeft, 		new DualKeyCombo(new KeyCombo(KeyCode.A), new KeyCombo(KeyCode.LeftArrow))},
 		{ KeyAction.MoveDown, 		new DualKeyCombo(new KeyCombo(KeyCode.S), new KeyCombo(KeyCode.DownArrow))},
 		{ KeyAction.MoveRight, 		new DualKeyCombo(new KeyCombo(KeyCode.D), new KeyCombo(KeyCode.RightArrow))},
-		{ KeyAction.ToggleWalkun,   new DualKeyCombo(new KeyCombo(KeyCode.C), null)},
+		{ KeyAction.ToggleWalkRun,   new DualKeyCombo(new KeyCombo(KeyCode.C), null)},
 
 		// Actions
 		{ KeyAction.ActionThrow,	new DualKeyCombo(new KeyCombo(KeyCode.R),	new KeyCombo(KeyCode.End))},

--- a/UnityProject/Assets/Scripts/Input System/KeybindManager.cs
+++ b/UnityProject/Assets/Scripts/Input System/KeybindManager.cs
@@ -518,6 +518,31 @@ public class KeybindManager : MonoBehaviour {
 				ResetKeybinds();
 				ModalPanelManager.Instance.Inform("Unable to read saved keybinds.\nThey were either corrupt or outdated, so they have been reset.");
 			}
+
+			
+				// Check if new hotkeys has been added to the default dict
+				// Adds them to the user settings in case one is found
+				if (userKeybinds.Count < defaultKeybinds.Count)
+				{
+					foreach (KeyValuePair<KeyAction, DualKeyCombo> entry in defaultKeybinds)
+					{
+						if (!(userKeybinds.ContainsKey(entry.Key)))
+						{
+							userKeybinds.Add(entry.Key, entry.Value);
+						}
+					}
+				}
+				// If we remove a hotkey in the future, we remove it from userKeybinds here
+				else if (userKeybinds.Count > defaultKeybinds.Count)
+				{
+					foreach (KeyValuePair<KeyAction, DualKeyCombo> entry in userKeybinds)
+					{
+						if (!(defaultKeybinds.ContainsKey(entry.Key)))
+						{
+							userKeybinds.Remove(entry.Key);
+						}
+					}
+				}
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/Input System/KeybindManager.cs
+++ b/UnityProject/Assets/Scripts/Input System/KeybindManager.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Newtonsoft.Json;
+using System.Linq;
 
 /// <summary>
 /// Describes all possible actions which can be mapped to a key
@@ -519,30 +520,12 @@ public class KeybindManager : MonoBehaviour {
 				ModalPanelManager.Instance.Inform("Unable to read saved keybinds.\nThey were either corrupt or outdated, so they have been reset.");
 			}
 
-			
-			// Check if new hotkeys has been added to the default dict
-			// Adds them to the user settings in case one is found
-			if (userKeybinds.Count < defaultKeybinds.Count)
-			{
-				foreach (KeyValuePair<KeyAction, DualKeyCombo> entry in defaultKeybinds)
-				{
-					if (!(userKeybinds.ContainsKey(entry.Key)))
-					{
-						userKeybinds.Add(entry.Key, entry.Value);
-					}
-				}
-			}
-			// If we remove a hotkey in the future, we remove it from userKeybinds here
-			else if (userKeybinds.Count > defaultKeybinds.Count)
-			{
-				foreach (KeyValuePair<KeyAction, DualKeyCombo> entry in userKeybinds)
-				{
-					if (!(defaultKeybinds.ContainsKey(entry.Key)))
-					{
-						userKeybinds.Remove(entry.Key);
-					}
-				}
-			}
+			// Properly updating user keybinds when we add or remove one
+			var newHotkeys        = defaultKeybinds.Keys.Except(userKeybinds.Keys);
+			var deprecatedHotKeys = userKeybinds.Keys.Except(defaultKeybinds.Keys);
+
+			foreach (KeyAction entry in newHotkeys) userKeybinds.Add(entry, defaultKeybinds[entry]);
+			foreach (KeyAction entry in deprecatedHotKeys) userKeybinds.Remove(entry);
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/Input System/KeyboardInputManager.cs
+++ b/UnityProject/Assets/Scripts/Input System/KeyboardInputManager.cs
@@ -159,6 +159,7 @@ public class KeyboardInputManager : MonoBehaviour
 		{ KeyAction.ActionDrop,		() => {	UIManager.Action.Drop(); }},
 		{ KeyAction.ActionResist,	() => { UIManager.Action.Resist(); }},
 		{ KeyAction.ActionStopPull, () => { UIManager.Action.StopPulling(); }},
+		{ KeyAction.ToggleWalkun,   () => { UIManager.WalkRun.RunWalk(); }},
 
 		{  KeyAction.HandSwap, 		() => { UIManager.Hands.Swap(); }},
 		{  KeyAction.HandActivate,	() => { UIManager.Hands.Activate(); }},

--- a/UnityProject/Assets/Scripts/Input System/KeyboardInputManager.cs
+++ b/UnityProject/Assets/Scripts/Input System/KeyboardInputManager.cs
@@ -159,7 +159,7 @@ public class KeyboardInputManager : MonoBehaviour
 		{ KeyAction.ActionDrop,		() => {	UIManager.Action.Drop(); }},
 		{ KeyAction.ActionResist,	() => { UIManager.Action.Resist(); }},
 		{ KeyAction.ActionStopPull, () => { UIManager.Action.StopPulling(); }},
-		{ KeyAction.ToggleWalkun,   () => { UIManager.WalkRun.RunWalk(); }},
+		{ KeyAction.ToggleWalkRun,   () => { UIManager.WalkRun.RunWalk(); }},
 
 		{  KeyAction.HandSwap, 		() => { UIManager.Hands.Swap(); }},
 		{  KeyAction.HandActivate,	() => { UIManager.Hands.Activate(); }},


### PR DESCRIPTION
# Pull Request Template

### Purpose
fix #2963
Adds a new bindable hotkey to toggle walk and run. Default key is C.
### Notes:
Players might need to reset their key settings in order to register the new hotkey in their systems.  At least I had to.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
