### PR TITLE
Bartender spawns with (Slim) Armor Vest and Laceup Shoes.

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/BartenderPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/BartenderPopulator.asset
@@ -22,7 +22,7 @@ MonoBehaviour:
     Prefab: {fileID: 3431291279286482953, guid: 0c3e7a0b25eff4d33a4f511cfc36b5d9,
       type: 3}
   - NamedSlot: 3
-    Prefab: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa,
+    Prefab: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2,
       type: 3}
   - NamedSlot: 0
     Prefab: {fileID: 3921521694364753778, guid: 98de935f80510c4468285ffd5a01d9e0,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/BartenderPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/BartenderPopulator.asset
@@ -24,3 +24,6 @@ MonoBehaviour:
   - NamedSlot: 3
     Prefab: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa,
       type: 3}
+  - NamedSlot: 0
+    Prefab: {fileID: 3921521694364753778, guid: 98de935f80510c4468285ffd5a01d9e0,
+      type: 3}


### PR DESCRIPTION
### Purpose
Updated the Bartender populator so that Bartenders spawn with the slim variation of the Armor Vest (added in [my previous PR](https://github.com/unitystation/unitystation/pull/3358)) and Laceup Shoes, as in /tg/station. That's it.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
