### PR TITLE
WindowObject proper Despawn

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Construction/WindowObject.cs
+++ b/UnityProject/Assets/Scripts/Objects/Construction/WindowObject.cs
@@ -8,7 +8,6 @@ using Random = UnityEngine.Random;
 /// </summary>
 public class WindowObject : NetworkBehaviour, ICheckedInteractable<HandApply>
 {
-	private TileChangeManager tileChangeManager;
 
 	private RegisterObject registerObject;
 	private ObjectBehaviour objectBehaviour;
@@ -18,7 +17,6 @@ public class WindowObject : NetworkBehaviour, ICheckedInteractable<HandApply>
 
 	private void Start()
 	{
-		tileChangeManager = GetComponentInParent<TileChangeManager>();
 		registerObject = GetComponent<RegisterObject>();
 		GetComponent<Integrity>().OnWillDestroyServer.AddListener(OnWillDestroyServer);
 		objectBehaviour = GetComponent<ObjectBehaviour>();
@@ -71,6 +69,7 @@ public class WindowObject : NetworkBehaviour, ICheckedInteractable<HandApply>
 						"You secure the window.",
 						$"{interaction.Performer.ExpensiveName()} secures the window.",
 						() => ScrewToFloor(interaction));
+					return;
 				}
 			}
 			else
@@ -96,6 +95,7 @@ public class WindowObject : NetworkBehaviour, ICheckedInteractable<HandApply>
 					"You disassemble the window.",
 					$"{interaction.Performer.ExpensiveName()} disassembles the window.",
 					() => Disassemble(interaction));
+				return;
 			}
 			else
 			{
@@ -112,13 +112,13 @@ public class WindowObject : NetworkBehaviour, ICheckedInteractable<HandApply>
 		Vector3Int cellPos = interactableTiles.WorldToCell(interaction.TargetObject.TileWorldPosition());
 		interactableTiles.TileChangeManager.UpdateTile(cellPos, layerTile);
 		interactableTiles.TileChangeManager.SubsystemManager.UpdateAt(cellPos);
-		GetComponent<CustomNetTransform>().DisappearFromWorldServer();
+		Despawn.ServerSingle(gameObject);
 	}
 	[Server]
 	private void Disassemble(HandApply interaction)
 	{
 		Spawn.ServerPrefab(CommonPrefabs.Instance.GlassSheet, registerObject.WorldPositionServer, count: 4);
-		GetComponent<CustomNetTransform>().DisappearFromWorldServer();
+		Despawn.ServerSingle(gameObject);
 	}
 
 }


### PR DESCRIPTION
Proper Despawn for the WindowObject.


### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
