### PR TITLE
Fixes for bio hoods and virology biosuit, again.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/CMOBioHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/CMOBioHood.prefab
@@ -147,7 +147,7 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 726b69b3fc50b384694213d0cd6a95f1,
+      objectReference: {fileID: 11400000, guid: 817b86ab583f3f24ea315d34e225f11a,
         type: 2}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/JanitorBioHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/JanitorBioHood.prefab
@@ -147,7 +147,7 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: aab53e8cb27815b4095110083bf99427,
+      objectReference: {fileID: 11400000, guid: 9907bf0d2c43f3c41bed482f509e9b48,
         type: 2}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/ScientistBioHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/ScientistBioHood.prefab
@@ -147,7 +147,7 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: e4eea7d0b9b6c0e4dbd875caeded94ab,
+      objectReference: {fileID: 11400000, guid: 20571bf138745304b9fadc3acffcb036,
         type: 2}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/VirologyBioHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/VirologyBioHood.prefab
@@ -147,7 +147,7 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: 8842e00fcbee9bc4faf7cda270635d54,
+      objectReference: {fileID: 11400000, guid: 43b0090cf30ba4b4886ffded1ecb4363,
         type: 2}
     - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/BioSuits/VirologyBioSuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/BioSuits/VirologyBioSuit.prefab
@@ -147,7 +147,7 @@ PrefabInstance:
         type: 3}
       propertyPath: clothData
       value: 
-      objectReference: {fileID: 11400000, guid: f071df8138dba2940be4e75f75ea4997,
+      objectReference: {fileID: 11400000, guid: a340923a4816ca041be745bb7477a45b,
         type: 2}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}

--- a/UnityProject/Assets/Textures/clothing/head/bio hood/CMO bio hood.asset
+++ b/UnityProject/Assets/Textures/clothing/head/bio hood/CMO bio hood.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
       - {fileID: 21300002, guid: 5ce528cb97aa6584d8880ae9efa7c92c, type: 3}
       - {fileID: 21300004, guid: 5ce528cb97aa6584d8880ae9efa7c92c, type: 3}
       - {fileID: 21300006, guid: 5ce528cb97aa6584d8880ae9efa7c92c, type: 3}
-      EquippedData: {fileID: 4900000, guid: f43479e1e963e884ab4bcb5f756ab793, type: 3}
+      EquippedData: {fileID: 4900000, guid: 9a8acf47c355b8648ae4bdf30d1a79b7, type: 3}
     InHandsLeft:
       Texture: {fileID: 2800000, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
       Sprites:
@@ -28,7 +28,7 @@ MonoBehaviour:
       - {fileID: 21300002, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
       - {fileID: 21300004, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
       - {fileID: 21300006, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
-      EquippedData: {fileID: 4900000, guid: 05e0ae330c799a0488d36758366a37ac, type: 3}
+      EquippedData: {fileID: 4900000, guid: 495afdef95e734b48a38f972a2a12f4a, type: 3}
     InHandsRight:
       Texture: {fileID: 2800000, guid: a2403da3ba73a0748972f5c32e2036e6, type: 3}
       Sprites:

--- a/UnityProject/Assets/Textures/clothing/head/bio hood/CMO bio hood.asset.meta
+++ b/UnityProject/Assets/Textures/clothing/head/bio hood/CMO bio hood.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 42f08948db5fe504d891911fd59839cb
+guid: 817b86ab583f3f24ea315d34e225f11a
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/UnityProject/Assets/Textures/clothing/head/bio hood/janitor bio hood.asset
+++ b/UnityProject/Assets/Textures/clothing/head/bio hood/janitor bio hood.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
       - {fileID: 21300002, guid: 137f6a2bdcbd5f24b86b392088392bf4, type: 3}
       - {fileID: 21300004, guid: 137f6a2bdcbd5f24b86b392088392bf4, type: 3}
       - {fileID: 21300006, guid: 137f6a2bdcbd5f24b86b392088392bf4, type: 3}
-      EquippedData: {fileID: 4900000, guid: c36e26f122a61e84180751d47a09523c, type: 3}
+      EquippedData: {fileID: 4900000, guid: 9a022f2363c976546b43221e858aa4dd, type: 3}
     InHandsLeft:
       Texture: {fileID: 2800000, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
       Sprites:
@@ -28,7 +28,7 @@ MonoBehaviour:
       - {fileID: 21300002, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
       - {fileID: 21300004, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
       - {fileID: 21300006, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
-      EquippedData: {fileID: 4900000, guid: 05e0ae330c799a0488d36758366a37ac, type: 3}
+      EquippedData: {fileID: 4900000, guid: 495afdef95e734b48a38f972a2a12f4a, type: 3}
     InHandsRight:
       Texture: {fileID: 2800000, guid: a2403da3ba73a0748972f5c32e2036e6, type: 3}
       Sprites:

--- a/UnityProject/Assets/Textures/clothing/head/bio hood/janitor bio hood.asset.meta
+++ b/UnityProject/Assets/Textures/clothing/head/bio hood/janitor bio hood.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5c0a1e7b509c74b4d9203eeb1c24e921
+guid: 9907bf0d2c43f3c41bed482f509e9b48
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/UnityProject/Assets/Textures/clothing/head/bio hood/science bio hood.asset
+++ b/UnityProject/Assets/Textures/clothing/head/bio hood/science bio hood.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dba9e42ad4040154b8541513b096645f, type: 3}
-  m_Name: scientist bio hood
+  m_Name: science bio hood
   m_EditorClassIdentifier: 
   Base:
     Equipped:
@@ -28,7 +28,7 @@ MonoBehaviour:
       - {fileID: 21300002, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
       - {fileID: 21300004, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
       - {fileID: 21300006, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
-      EquippedData: {fileID: 4900000, guid: 05e0ae330c799a0488d36758366a37ac, type: 3}
+      EquippedData: {fileID: 4900000, guid: 495afdef95e734b48a38f972a2a12f4a, type: 3}
     InHandsRight:
       Texture: {fileID: 2800000, guid: a2403da3ba73a0748972f5c32e2036e6, type: 3}
       Sprites:

--- a/UnityProject/Assets/Textures/clothing/head/bio hood/science bio hood.asset.meta
+++ b/UnityProject/Assets/Textures/clothing/head/bio hood/science bio hood.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4eb751df0efe4014f924a889446eb625
+guid: 20571bf138745304b9fadc3acffcb036
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/UnityProject/Assets/Textures/clothing/head/bio hood/virology bio hood.asset
+++ b/UnityProject/Assets/Textures/clothing/head/bio hood/virology bio hood.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
       - {fileID: 21300002, guid: 4bef902bba0865743a98cde594db70a1, type: 3}
       - {fileID: 21300004, guid: 4bef902bba0865743a98cde594db70a1, type: 3}
       - {fileID: 21300006, guid: 4bef902bba0865743a98cde594db70a1, type: 3}
-      EquippedData: {fileID: 4900000, guid: 30f3c31f3b4bfa3458f7a0e3f9390d87, type: 3}
+      EquippedData: {fileID: 4900000, guid: 6f97b313b62ac72468e2d3bfccb6de49, type: 3}
     InHandsLeft:
       Texture: {fileID: 2800000, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
       Sprites:
@@ -28,7 +28,7 @@ MonoBehaviour:
       - {fileID: 21300002, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
       - {fileID: 21300004, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
       - {fileID: 21300006, guid: 6224674a93440394cb54282c85b75f2f, type: 3}
-      EquippedData: {fileID: 4900000, guid: 05e0ae330c799a0488d36758366a37ac, type: 3}
+      EquippedData: {fileID: 4900000, guid: 495afdef95e734b48a38f972a2a12f4a, type: 3}
     InHandsRight:
       Texture: {fileID: 2800000, guid: a2403da3ba73a0748972f5c32e2036e6, type: 3}
       Sprites:

--- a/UnityProject/Assets/Textures/clothing/head/bio hood/virology bio hood.asset.meta
+++ b/UnityProject/Assets/Textures/clothing/head/bio hood/virology bio hood.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 293a8f7c7fbdf7a4ab72f541a5b8180e
+guid: 43b0090cf30ba4b4886ffded1ecb4363
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/UnityProject/Assets/Textures/clothing/suits/bio suit/virology bio suit.asset
+++ b/UnityProject/Assets/Textures/clothing/suits/bio suit/virology bio suit.asset
@@ -16,10 +16,10 @@ MonoBehaviour:
     Equipped:
       Texture: {fileID: 2800000, guid: 0510a8d69d8205b4699d76f66cbd16dd, type: 3}
       Sprites:
-      - {fileID: 6921171874582534189, guid: 0510a8d69d8205b4699d76f66cbd16dd, type: 3}
-      - {fileID: 2492282557572942008, guid: 0510a8d69d8205b4699d76f66cbd16dd, type: 3}
-      - {fileID: -5052046381032950190, guid: 0510a8d69d8205b4699d76f66cbd16dd, type: 3}
-      - {fileID: -5121597200721271180, guid: 0510a8d69d8205b4699d76f66cbd16dd, type: 3}
+      - {fileID: 21300000, guid: 0510a8d69d8205b4699d76f66cbd16dd, type: 3}
+      - {fileID: 21300002, guid: 0510a8d69d8205b4699d76f66cbd16dd, type: 3}
+      - {fileID: 21300004, guid: 0510a8d69d8205b4699d76f66cbd16dd, type: 3}
+      - {fileID: 21300006, guid: 0510a8d69d8205b4699d76f66cbd16dd, type: 3}
       EquippedData: {fileID: 4900000, guid: cd5ba54dcccd3fa428811f1aaaac5189, type: 3}
     InHandsLeft:
       Texture: {fileID: 2800000, guid: 6a8c52312efb4684aadd1722271a6912, type: 3}

--- a/UnityProject/Assets/Textures/clothing/suits/bio suit/virology bio suit.asset.meta
+++ b/UnityProject/Assets/Textures/clothing/suits/bio suit/virology bio suit.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f071df8138dba2940be4e75f75ea4997
+guid: a340923a4816ca041be745bb7477a45b
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0


### PR DESCRIPTION
### Purpose
This PR redoes the .assets for some of the bio hoods and the virology bio suit as in my last PR. I did it again because in my previous PR I neglected to commit and push the .asset files for said hoods. Oops.
Also the virology bio suit was still not appearing even with the new .prefab and .asset.

### Notes
Changes the .prefab files like the previous PR, so that they point to the correct .asset files.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
