### PR TITLE
Adds an empty station scene

### DIFF
--- a/UnityProject/Assets/Scenes/NewStation.unity.meta
+++ b/UnityProject/Assets/Scenes/NewStation.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 409368b0d2d28b6429be8ed9eafcf681
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add per title, this PR adds an empty station scene for new and old mappers alike to duplicate so they no longer have to spend 10 minutes deleting thing from a tile palette.

Asteroids and shuttles have been left in the scene.