### PR TITLE
Refactor DoorController to Remove Duplicate IsOpen/IsClosed

### DIFF
--- a/UnityProject/Assets/Scripts/Doors/DoorController.cs
+++ b/UnityProject/Assets/Scripts/Doors/DoorController.cs
@@ -43,7 +43,10 @@ public class DoorController : NetworkBehaviour
 		[Tooltip("Does this door open automatically when you walk into it?")]
 		public bool IsAutomatic = true;
 
-		public bool IsOpened;
+		/// <summary>
+		/// Makes registerTile door closed state accessible
+		/// </summary>
+		public bool IsClosed { get { return registerTile.IsClosed; } set { registerTile.IsClosed = value; } }
 		[SyncVar(hook = nameof(SyncIsWelded))]
 		[HideInInspector]private bool isWelded = false;
 		/// <summary>
@@ -128,7 +131,7 @@ public class DoorController : NetworkBehaviour
 			// the below logic and reopen the door if the client got stuck in the door in the .15 s gap.
 
 			//only do this check when door is closing, and only for doors that block all directions (like airlocks)
-			if (CustomNetworkManager.IsServer && !IsOpened && !registerTile.OneDirectionRestricted && !ignorePassableChecks)
+			if (CustomNetworkManager.IsServer && IsClosed && !registerTile.OneDirectionRestricted && !ignorePassableChecks)
 			{
 				if (!MatrixManager.IsPassableAt(registerTile.WorldPositionServer, registerTile.WorldPositionServer,
 					isServer: true, includingPlayers: true, context: this.gameObject))
@@ -144,7 +147,7 @@ public class DoorController : NetworkBehaviour
 
 		public void BoxCollToggleOn()
 		{
-			registerTile.IsClosed = true;
+			IsClosed = true;
 
 			SetLayer(closedLayer);
 
@@ -153,7 +156,7 @@ public class DoorController : NetworkBehaviour
 
 		public void BoxCollToggleOff()
 		{
-			registerTile.IsClosed = false;
+			IsClosed = false;
 
 			SetLayer(openLayer);
 
@@ -208,7 +211,7 @@ public class DoorController : NetworkBehaviour
 		public void ServerTryClose()
 		{
 			// Sliding door is not passable according to matrix
-            if( IsOpened && !isPerformingAction && ( matrix.CanCloseDoorAt( registerTile.LocalPositionServer, true ) || doorType == DoorType.sliding ) ) {
+            if( !IsClosed && !isPerformingAction && ( matrix.CanCloseDoorAt( registerTile.LocalPositionServer, true ) || doorType == DoorType.sliding ) ) {
 	            ServerClose();
             }
 			else
@@ -219,7 +222,7 @@ public class DoorController : NetworkBehaviour
 
 		public void ServerClose() {
 			if (gameObject == null) return; // probably destroyed by a shuttle crash
-			IsOpened = false;
+			IsClosed = true;
 			if ( !isPerformingAction ) {
 				DoorUpdateMessage.SendToAll( gameObject, DoorUpdateType.Close );
 				if (damageOnClose)
@@ -239,12 +242,12 @@ public class DoorController : NetworkBehaviour
 			if (AccessRestrictions != null)
 			{
 				if (AccessRestrictions.CheckAccess(Originator)) {
-					if (!IsOpened && !isPerformingAction) {
+					if (IsClosed && !isPerformingAction) {
 						ServerOpen();
 					}
 				}
 				else {
-					if (!IsOpened && !isPerformingAction) {
+					if (IsClosed && !isPerformingAction) {
 						ServerAccessDenied();
 					}
 				}
@@ -267,7 +270,7 @@ public class DoorController : NetworkBehaviour
 		{
 			if (this == null || gameObject == null) return; // probably destroyed by a shuttle crash
 			ResetWaiting();
-			IsOpened = true;
+			IsClosed = false;
 
 			if (!isPerformingAction)
 			{
@@ -349,7 +352,7 @@ public class DoorController : NetworkBehaviour
 		/// <param name="playerGameObject">game object of the player to inform</param>
 		public void NotifyPlayer(GameObject playerGameObject)
 		{
-			if (IsOpened)
+			if (!IsClosed)
 			{
 				DoorUpdateMessage.Send(playerGameObject, gameObject, DoorUpdateType.Open, true);
 			}

--- a/UnityProject/Assets/Scripts/Doors/GeneralDoorAnimator.cs
+++ b/UnityProject/Assets/Scripts/Doors/GeneralDoorAnimator.cs
@@ -47,7 +47,13 @@ public class GeneralDoorAnimator : DoorAnimator
 			var cn = child.name.ToUpper();
 			if(cn.Contains("DOORBASE")) doorbase = child.gameObject.GetComponent<SpriteRenderer>();
 		}
-		if (!doorController.IsOpened)
+		tileChangeManager = GetComponentInParent<TileChangeManager>();
+	}
+
+	public void Start()
+	{
+		//Call doorController after awake so it has a chance to init
+		if (doorController.IsClosed)
 		{
 			doorbase.sprite = sprites[closeFrame + (int)direction];
 		}
@@ -55,7 +61,6 @@ public class GeneralDoorAnimator : DoorAnimator
 		{
 			doorbase.sprite = sprites[openFrame + (int)direction];
 		}
-		tileChangeManager = GetComponentInParent<TileChangeManager>();
 	}
 
 	public override void OpenDoor(bool skipAnimation)

--- a/UnityProject/Assets/Scripts/Doors/InteractableDoor.cs
+++ b/UnityProject/Assets/Scripts/Doors/InteractableDoor.cs
@@ -52,7 +52,7 @@ public class InteractableDoor : NetworkBehaviour, IPredictedCheckedInteractable<
 	/// </summary>
 	public void Bump(GameObject byPlayer)
 	{
-		if (!Controller.IsOpened && Controller.IsAutomatic)
+		if (Controller.IsClosed && Controller.IsAutomatic)
 		{
 			Controller.ServerTryOpen(byPlayer);
 		}
@@ -62,7 +62,7 @@ public class InteractableDoor : NetworkBehaviour, IPredictedCheckedInteractable<
 	{
 		//Server actions
 		// Close the door if it's open
-		if (Controller.IsOpened)
+		if (!Controller.IsClosed)
 		{
 			Controller.ServerTryClose();
 		}

--- a/UnityProject/Assets/Scripts/Switches/DoorSwitch.cs
+++ b/UnityProject/Assets/Scripts/Switches/DoorSwitch.cs
@@ -74,7 +74,7 @@ public class DoorSwitch : NetworkBehaviour, ICheckedInteractable<HandApply>
 	{
 		for (int i = 0; i < doorControllers.Length; i++)
 		{
-			if (!doorControllers[i].IsOpened)
+			if (doorControllers[i].IsClosed)
 			{
 				doorControllers[i].ServerOpen();
 			}


### PR DESCRIPTION
# Refactor DoorController

### Purpose
Fixes #3432 
Removes IsOpen from DoorController and replaces it with property .IsClosed that uses the registerTile.IsClosed field

### Notes:
Exisiting elements on maps may see some issues where if both IsOpen and IsClosed were checked they will now load closed rather than open.
![image](https://user-images.githubusercontent.com/17316823/75636654-ed53dc80-5bf6-11ea-9baa-1bcb55d661bd.png)
Example at SEC desk on OutpostStation

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
