### PR TITLE
Internal magazines and clips(partial fix of #3312)

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Generic Internal Magazine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Generic Internal Magazine.prefab
@@ -1,0 +1,92 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &820886777150758510
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3097138933977987719, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_Name
+      value: Generic Internal Magazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 3129732272286336819, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3169463835222568116, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: isClip
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3176908863337649637, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3176908863337649637, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: initialTraits.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 1ada82b29ea18174d8b349f1563393b0,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2c406df2572ceba47af8a9de4f9a50ba, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Generic Internal Magazine.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Generic Internal Magazine.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d819938d5d7681c4ba69845f60102a8c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Ammo_Boxes/Magazine_9mmbox.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Ammo_Boxes/Magazine_9mmbox.prefab
@@ -7,11 +7,22 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 3097138933977987719, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+    - target: {fileID: 2885341641989622235, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
-      propertyPath: m_Name
-      value: Magazine_9mmbox1
+      propertyPath: m_LightProbeUsage
+      value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2885341641989622235, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_ReflectionProbeUsage
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2885341641989622235, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 26bcf747fd5de07479bc2af66c281f40,
+        type: 3}
     - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -67,6 +78,31 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3097138933977987719, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_Name
+      value: Magazine_9mmbox
+      objectReference: {fileID: 0}
+    - target: {fileID: 3129732272286336819, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3169463835222568116, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: magazineSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 3169463835222568116, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: ammoType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3169463835222568116, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: isClip
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3176908863337649637, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
       propertyPath: initialName
@@ -81,37 +117,6 @@ PrefabInstance:
         type: 3}
       propertyPath: initialSize
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3129732272286336819, guid: 2c406df2572ceba47af8a9de4f9a50ba,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885341641989622235, guid: 2c406df2572ceba47af8a9de4f9a50ba,
-        type: 3}
-      propertyPath: m_LightProbeUsage
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885341641989622235, guid: 2c406df2572ceba47af8a9de4f9a50ba,
-        type: 3}
-      propertyPath: m_ReflectionProbeUsage
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885341641989622235, guid: 2c406df2572ceba47af8a9de4f9a50ba,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 26bcf747fd5de07479bc2af66c281f40,
-        type: 3}
-    - target: {fileID: 3169463835222568116, guid: 2c406df2572ceba47af8a9de4f9a50ba,
-        type: 3}
-      propertyPath: magazineSize
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 3169463835222568116, guid: 2c406df2572ceba47af8a9de4f9a50ba,
-        type: 3}
-      propertyPath: ammoType
-      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2c406df2572ceba47af8a9de4f9a50ba, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_Slug.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Resources/Rifles/Magazine_Slug.prefab
@@ -7,11 +7,22 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 3097138933977987719, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+    - target: {fileID: 2885341641989622235, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
-      propertyPath: m_Name
-      value: Magazine_Slug
+      propertyPath: m_LightProbeUsage
+      value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2885341641989622235, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_ReflectionProbeUsage
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2885341641989622235, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: fbf0091e6ffa65a4e826e55f089f97ab,
+        type: 3}
     - target: {fileID: 3091929310079895539, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -67,20 +78,30 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3097138933977987719, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_Name
+      value: Magazine_Slug
+      objectReference: {fileID: 0}
+    - target: {fileID: 3129732272286336819, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 3169463835222568116, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
       propertyPath: magazineSize
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3169463835222568116, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
       propertyPath: ammoType
       value: 9
       objectReference: {fileID: 0}
-    - target: {fileID: 3129732272286336819, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+    - target: {fileID: 3169463835222568116, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
-      propertyPath: m_AssetId
-      value: 
+      propertyPath: isClip
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3176908863337649637, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
@@ -90,7 +111,7 @@ PrefabInstance:
     - target: {fileID: 3176908863337649637, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
       propertyPath: initialName
-      value: Shutgun Slug
+      value: Shotgun Slug
       objectReference: {fileID: 0}
     - target: {fileID: 3176908863337649637, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
@@ -108,21 +129,5 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: c5ea118354e234f9fa2e1e18ce0adff8,
         type: 2}
-    - target: {fileID: 2885341641989622235, guid: 2c406df2572ceba47af8a9de4f9a50ba,
-        type: 3}
-      propertyPath: m_LightProbeUsage
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885341641989622235, guid: 2c406df2572ceba47af8a9de4f9a50ba,
-        type: 3}
-      propertyPath: m_ReflectionProbeUsage
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885341641989622235, guid: 2c406df2572ceba47af8a9de4f9a50ba,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: fbf0091e6ffa65a4e826e55f089f97ab,
-        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2c406df2572ceba47af8a9de4f9a50ba, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Cshotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Cshotgun_Ballistic.prefab
@@ -7,11 +7,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 7425590482768185424, guid: f46dc50d35397f04f8f6be3fb49668ca,
-        type: 3}
-      propertyPath: m_Name
-      value: Cshotgun_Ballistic
-      objectReference: {fileID: 0}
     - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
       propertyPath: AmmoType
@@ -38,12 +33,21 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1932369758612010, guid: 1508ddac0ee0e46d5b6ec0f94ffb4179,
         type: 3}
-    - target: {fileID: 9027814007798219086, guid: f46dc50d35397f04f8f6be3fb49668ca,
+    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
-      propertyPath: itemStorageCapacity
-      value: 
-      objectReference: {fileID: 11400000, guid: 3aaa2fa3215284e608242ef34b8c7aa4,
-        type: 2}
+      propertyPath: ammoType
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: MagInternal
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: MagSize
+      value: 7
+      objectReference: {fileID: 0}
     - target: {fileID: 7053030124553676594, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
       propertyPath: itemSprites.LeftHand.Texture
@@ -147,10 +151,21 @@ PrefabInstance:
       propertyPath: throwDamage
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 7349041914971061004, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 2e6f5f7cdeffe584f94fe5f84bce1345,
+        type: 3}
     - target: {fileID: 7392881626475492836, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425590482768185424, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: m_Name
+      value: Cshotgun_Ballistic
       objectReference: {fileID: 0}
     - target: {fileID: 7430795432937076004, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
@@ -207,11 +222,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7349041914971061004, guid: f46dc50d35397f04f8f6be3fb49668ca,
+    - target: {fileID: 9027814007798219086, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
-      propertyPath: m_Sprite
+      propertyPath: itemStorageCapacity
       value: 
-      objectReference: {fileID: 21300000, guid: 2e6f5f7cdeffe584f94fe5f84bce1345,
-        type: 3}
+      objectReference: {fileID: 11400000, guid: 89c4ca9ba5f44ce4f897a1684803eb2c,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f46dc50d35397f04f8f6be3fb49668ca, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Sawn_Shotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Sawn_Shotgun_Ballistic.prefab
@@ -7,11 +7,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 7425590482768185424, guid: f46dc50d35397f04f8f6be3fb49668ca,
-        type: 3}
-      propertyPath: m_Name
-      value: Sawn_Shotgun_Ballistic
-      objectReference: {fileID: 0}
     - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
       propertyPath: SmartGun
@@ -37,12 +32,21 @@ PrefabInstance:
       propertyPath: ProjectileVelocity
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 9027814007798219086, guid: f46dc50d35397f04f8f6be3fb49668ca,
+    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
-      propertyPath: itemStorageCapacity
-      value: 
-      objectReference: {fileID: 11400000, guid: 3aaa2fa3215284e608242ef34b8c7aa4,
-        type: 2}
+      propertyPath: ammoType
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: MagInternal
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: MagSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7053030124553676594, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
       propertyPath: initialName
@@ -121,10 +125,21 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.EquippedData
       value: 
       objectReference: {fileID: 4900000, guid: 530173ab2806149429b276e6407a1775, type: 3}
+    - target: {fileID: 7349041914971061004, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 30a286f24e88f3f4b9829b5d0f2df7df,
+        type: 3}
     - target: {fileID: 7392881626475492836, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425590482768185424, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: m_Name
+      value: Sawn_Shotgun_Ballistic
       objectReference: {fileID: 0}
     - target: {fileID: 7430795432937076004, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
@@ -181,11 +196,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7349041914971061004, guid: f46dc50d35397f04f8f6be3fb49668ca,
+    - target: {fileID: 9027814007798219086, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
-      propertyPath: m_Sprite
+      propertyPath: itemStorageCapacity
       value: 
-      objectReference: {fileID: 21300000, guid: 30a286f24e88f3f4b9829b5d0f2df7df,
-        type: 3}
+      objectReference: {fileID: 11400000, guid: 89c4ca9ba5f44ce4f897a1684803eb2c,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f46dc50d35397f04f8f6be3fb49668ca, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Shotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Ballistics/Resources/Shotgun_Ballistic.prefab
@@ -7,11 +7,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 7425590482768185424, guid: f46dc50d35397f04f8f6be3fb49668ca,
-        type: 3}
-      propertyPath: m_Name
-      value: Shotgun_Ballistic
-      objectReference: {fileID: 0}
     - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
       propertyPath: AmmoType
@@ -43,12 +38,21 @@ PrefabInstance:
       propertyPath: SpawnsCaseing
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9027814007798219086, guid: f46dc50d35397f04f8f6be3fb49668ca,
+    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
-      propertyPath: itemStorageCapacity
-      value: 
-      objectReference: {fileID: 11400000, guid: 3aaa2fa3215284e608242ef34b8c7aa4,
-        type: 2}
+      propertyPath: ammoType
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: MagInternal
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: MagSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7053030124553676594, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
       propertyPath: initialName
@@ -127,10 +131,21 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.EquippedData
       value: 
       objectReference: {fileID: 4900000, guid: 530173ab2806149429b276e6407a1775, type: 3}
+    - target: {fileID: 7349041914971061004, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 28868ddac4e1b8c4a8ec58f10e87dcb0,
+        type: 3}
     - target: {fileID: 7392881626475492836, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425590482768185424, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: m_Name
+      value: Shotgun_Ballistic
       objectReference: {fileID: 0}
     - target: {fileID: 7430795432937076004, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
@@ -187,11 +202,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7349041914971061004, guid: f46dc50d35397f04f8f6be3fb49668ca,
+    - target: {fileID: 9027814007798219086, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
-      propertyPath: m_Sprite
+      propertyPath: itemStorageCapacity
       value: 
-      objectReference: {fileID: 21300000, guid: 28868ddac4e1b8c4a8ec58f10e87dcb0,
-        type: 3}
+      objectReference: {fileID: 11400000, guid: 89c4ca9ba5f44ce4f897a1684803eb2c,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f46dc50d35397f04f8f6be3fb49668ca, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/Magazines/InternalMagazine.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/Magazines/InternalMagazine.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c909446621c41cd975e26eab73860a6, type: 3}
+  m_Name: InternalMagazine
+  m_EditorClassIdentifier: 
+  MaxItemSize: 5
+  Whitelist:
+  - {fileID: 11400000, guid: 1ada82b29ea18174d8b349f1563393b0, type: 2}
+  Required: []
+  Blacklist: []

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/Magazines/InternalMagazine.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/Magazines/InternalMagazine.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 89c4ca9ba5f44ce4f897a1684803eb2c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/SOs singletons/AmmoPrefabs.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/SOs singletons/AmmoPrefabs.asset
@@ -28,3 +28,5 @@ MonoBehaviour:
   smg9mm: {fileID: 742292832060491855, guid: 87a4c03d0874aca4e8fc5376739bdf44, type: 3}
   Syringe: {fileID: 742292832060491855, guid: 1a1736d27813d474cb212e74038e7c9d, type: 3}
   uzi9mm: {fileID: 742292832060491855, guid: ed7e0ecac17e8ab45ae891ef388f3d8f, type: 3}
+  Internal: {fileID: 2422759989583602921, guid: d819938d5d7681c4ba69845f60102a8c,
+    type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Magazine/InternalMagazine.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Magazine/InternalMagazine.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: InternalMagazine
+  m_EditorClassIdentifier: 
+  traitDescription: An object with this trait can hold an internal magazine.

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Magazine/InternalMagazine.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Magazine/InternalMagazine.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ada82b29ea18174d8b349f1563393b0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Weapons/AmmoPrefabs.cs
+++ b/UnityProject/Assets/Scripts/Weapons/AmmoPrefabs.cs
@@ -33,6 +33,8 @@ public class AmmoPrefabs : SingletonScriptableObject<AmmoPrefabs>
 	private GameObject Syringe;
 	[SerializeField]
 	private GameObject uzi9mm;
+	[SerializeField]
+	private GameObject Internal;
 
 	/// <summary>
 	/// Get the prefab of the ammo type so you can
@@ -68,6 +70,8 @@ public class AmmoPrefabs : SingletonScriptableObject<AmmoPrefabs>
 				return Instance._5Point56mm;
 			case AmmoType._9mm:
 				return Instance._9mm;
+			case AmmoType.Internal:
+				return Instance.Internal;
 		}
 		return null;
 	}

--- a/UnityProject/Assets/Scripts/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Gun.cs
@@ -4,6 +4,11 @@ using System.Linq;
 using UnityEngine;
 using Mirror;
 using UnityEngine.Serialization;
+
+#if UNITY_EDITOR
+ using UnityEditor;
+#endif
+
 /// <summary>
 ///  Allows an object to behave like a gun and fire shots. Server authoritative with client prediction.
 /// </summary>
@@ -22,8 +27,9 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 	/// </summary>
 	[FormerlySerializedAs("AmmoType")] public AmmoType ammoType;
 
-	//server-side flag indicating if the gun is currently held by a player
-	private bool serverIsHeld;
+	//server-side object indicating the player holding the weapon (null if none)
+	private GameObject serverHolder;
+
 
 	/// <summary>
 	///     The current magazine for this weapon, null means empty
@@ -37,9 +43,22 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 	public bool SpawnsCaseing = true;
 
 	/// <summary>
-	///     If the gun should eject it's magazine automatically
+	///     Whether the gun uses an internal magazine.
 	/// </summary>
+	[HideInInspector]
+	public bool MagInternal = false;
+
+	/// <summary>
+	///     If the gun should eject it's magazine automatically (external-magazine-specific)
+	/// </summary>
+	[HideInInspector] // will be shown by the code at the very end, if appropriate
 	public bool SmartGun = false;
+
+	/// <summary>
+	///     Size of the internal magazine (internal-magazine-specific)
+	/// </summary>
+	[HideInInspector] // will be shown by the code at the very end, if appropriate
+	public int MagSize = 10;
 
 	/// <summary>
 	///     The the current recoil variance this weapon has reached
@@ -144,18 +163,49 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 
 	private void Init()
 	{
-		//populate with a full mag on spawn
-		Logger.LogTraceFormat("Auto-populate magazine for {0}", Category.Inventory, name);
+		if (MagInternal)
+		{
+			//automatic ejection always disabled
+			SmartGun = false;
 
-		//AmmoPrefabs
-		GameObject ammoPrefab = AmmoPrefabs.GetAmmoPrefab(ammoType);
+			//populate with a full internal mag on spawn
+			Logger.LogTraceFormat("Auto-populate internal magazine for {0}", Category.Inventory, name);
 
-		Inventory.ServerAdd(Spawn.ServerPrefab(ammoPrefab).GameObject, magSlot);
+			//Make generic magazine and modify it to fit weapon
+			GameObject ammoPrefab = AmmoPrefabs.GetAmmoPrefab(AmmoType.Internal);
+
+			Inventory.ServerAdd(Spawn.ServerPrefab(ammoPrefab).GameObject, magSlot);
+
+			CurrentMagazine.ChangeSize(MagSize);
+			CurrentMagazine.ammoType = ammoType;
+
+			if (isServer)
+			{
+				CurrentMagazine.ServerSetAmmoRemains(MagSize);
+			}
+		}
+		else
+		{
+			//populate with a full external mag on spawn
+			Logger.LogTraceFormat("Auto-populate external magazine for {0}", Category.Inventory, name);
+
+			//AmmoPrefabs
+			GameObject ammoPrefab = AmmoPrefabs.GetAmmoPrefab(ammoType);
+
+			Inventory.ServerAdd(Spawn.ServerPrefab(ammoPrefab).GameObject, magSlot);
+		}
 	}
 
 	public void OnInventoryMoveServer(InventoryMove info)
 	{
-		serverIsHeld = info.ToPlayer != null;
+		if (info.ToPlayer != null)
+		{
+			serverHolder = info.ToPlayer.gameObject;
+		}
+		else
+		{
+			serverHolder = null;
+		}
 	}
 
 	#endregion
@@ -172,7 +222,6 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 			{
 				Logger.LogTrace("Server rejected shot - No magazine being loaded", Category.Firearms);
 			}
-
 			return false;
 		}
 
@@ -182,7 +231,7 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 		//firing countdown
 		if (Projectile != null && CurrentMagazine.ClientAmmoRemains <= 0 && (interaction.Performer != PlayerManager.LocalPlayer || FireCountDown <= 0))
 		{
-			if (SmartGun)
+			if (SmartGun) // should be forced off when using an internal magazine
 			{
 				RequestUnload(CurrentMagazine);
 				OutOfAmmoSFX();
@@ -195,7 +244,6 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 			{
 				Logger.LogTrace("Server rejected shot - out of ammo", Category.Firearms);
 			}
-
 			return false;
 		}
 
@@ -263,8 +311,8 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 
 	public bool Interact(HandActivate interaction)
 	{
-		//try ejecting the mag
-		if (CurrentMagazine != null)
+		//try ejecting the mag if external
+		if (CurrentMagazine != null && !MagInternal)
 		{
 			RequestUnload(CurrentMagazine);
 			return true;
@@ -275,15 +323,15 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 
 	public bool Interact(InventoryApply interaction)
 	{
-		//only reload if the gun is the target and mag is in hand slot
+		//only reload if the gun is the target and mag/clip is in hand slot
 		if (interaction.TargetObject == gameObject && interaction.IsFromHandSlot)
 		{
 			if (interaction.UsedObject != null)
 			{
-				MagazineBehaviour magazine = interaction.UsedObject.GetComponent<MagazineBehaviour>();
-				if (magazine)
+				MagazineBehaviour mag = interaction.UsedObject.GetComponent<MagazineBehaviour>();
+				if (mag)
 				{
-					TryReload(magazine);
+					TryReload(mag.gameObject);
 					return true;
 				}
 			}
@@ -292,9 +340,9 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 		return false;
 	}
 
-	public string  Examine(Vector3 pos)
+	public string Examine(Vector3 pos)
 	{
-		return WeaponType + " - Fires " + ammoType + " ammunition (" + (CurrentMagazine != null?(CurrentMagazine.ServerAmmoRemains.ToString() + " rounds loaded in magazine"):"It's empty!") + ")";
+		return WeaponType + " - Fires " + ammoType + " ammunition (" + (CurrentMagazine != null ? (CurrentMagazine.ServerAmmoRemains.ToString() + " rounds loaded in magazine") : "It's empty!") + ")";
 	}
 
 	#endregion
@@ -305,7 +353,7 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 	private void Update()
 	{
 		//don't process if we are server and the gun is not held by anyone
-		if (isServer && !serverIsHeld) return;
+		if (isServer && serverHolder == null) return;
 
 		//if we are client, make sure we've initialized
 		if (!isServer && !PlayerManager.LocalPlayer) return;
@@ -343,7 +391,8 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 		{
 			// done processing shot queue,
 			// perform the queued unload action, causing all clients and server to update their version of this Weapon
-			//due to the syncvar hook
+			// due to the syncvar hook
+			// there should not be an unload action for internal magazines
 			Inventory.ServerDrop(magSlot);
 			queuedUnload = false;
 
@@ -352,19 +401,31 @@ public class Gun : NetworkBehaviour, IPredictedCheckedInteractable<AimApply>, IC
 		{
 			//done processing shot queue, perform the reload, causing all clients and server to update their version of this Weapon
 			//due to the syncvar hook
-			var magazine = NetworkIdentity.spawned[queuedLoadMagNetID];
-			var fromSlot = magazine.GetComponent<Pickupable>().ItemSlot;
-			Inventory.ServerTransfer(fromSlot, magSlot);
-			queuedLoadMagNetID = NetId.Invalid;
+			if (MagInternal)
+			{
+				var clip = NetworkIdentity.spawned[queuedLoadMagNetID];
+				MagazineBehaviour clipComp = clip.GetComponent<MagazineBehaviour>();
+				string message = CurrentMagazine.LoadFromClip(clipComp);
+				Chat.AddExamineMsg(serverHolder, message);
+				queuedLoadMagNetID = NetId.Invalid;
+			}
+			else
+			{
+				var magazine = NetworkIdentity.spawned[queuedLoadMagNetID];
+				var fromSlot = magazine.GetComponent<Pickupable>().ItemSlot;
+				Inventory.ServerTransfer(fromSlot, magSlot);
+				queuedLoadMagNetID = NetId.Invalid;
+			}
 		}
 	}
 
 	/// <summary>
 	/// attempt to reload the weapon with the item given
 	/// </summary>
-	private void TryReload(MagazineBehaviour magazine)
+	private void TryReload(GameObject ammo)
 	{
-		if (CurrentMagazine == null)
+		MagazineBehaviour magazine = ammo.GetComponent<MagazineBehaviour>();
+		if (CurrentMagazine == null || (MagInternal && magazine.isClip))
 		{
 			//RELOAD
 			// If the item used on the gun is a magazine, check type and reload
@@ -711,3 +772,26 @@ public enum WeaponType
 	FullyAutomatic = 1,
 	Burst = 2
 }
+
+#if UNITY_EDITOR
+	[CustomEditor(typeof(Gun), true)]
+	public class GunEditor : Editor
+	{
+		public override void OnInspectorGUI()
+		{
+			DrawDefaultInspector(); // for other non-HideInInspector fields
+
+			Gun script = (Gun)target;
+		
+			script.MagInternal = EditorGUILayout.Toggle("Magazine Internal", script.MagInternal);
+		
+			if (script.MagInternal) // show exclusive fields depending on whether magazine is internal
+			{
+				script.MagSize = EditorGUILayout.IntField("Internal Magazine Size", script.MagSize);
+			}
+			else{
+				script.SmartGun = EditorGUILayout.Toggle("Smart Gun", script.SmartGun);
+			}
+		}
+	}
+#endif


### PR DESCRIPTION
### Content
- Magazines now may be classified as "clips" by setting a toggle in the editor. Clips can be used to reload other magazines. The name is modeled after things like stripper clips, but also includes singular bullets and ammo boxes.
- Guns may now have internal magazines by setting a toggle in the editor. These can not be ejected and only be reloaded with clips applied to the gun.
- All shotguns are set to use internal magazines. The combat shotgun holds 7 shells, the others hold 5. (see #3312)
- Shotgun slugs and the 9mm ammo box have been made clips.

### Notes:
- MagazineBehaviour was rewritten in large parts, as the syncing previously only served to decrease client-side ammo if it was too high, so increases in content would not be properly synced. (On a sidenote, the RNG was moved into a table instead of starting it again and advancing to the wanted position.)
- Clips are currently just deleted when emptied. While this makes sense for shotgun slugs (if the gun casings are replaced at least) for stripper clips we might want some garbage and we might just want to use regular magazines for reloading other magazines.
- Weapons with internal magazines spawn their own magazine on initialization and adjust the size and content. The spawned magazine is a new prefab which is a variant of the generic magazine.
- There is no pump action in this. Shotguns are still semi-automatic.

### Self-Checks:

* [x] Code is sufficiently commented
* [x] Code is indented with tabs and not spaces
* [ ] The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b> [I think using a new internal magazine instead of a generic one and making internal magazines a new type of ammunition for mag slot purposes is reasonable]
* [x] The PR does not bring up any new compile errors
* [x] The PR has been tested in editor
* [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
* [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
* [ ] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants) [The generic internal magazine is placed right next to the generic magazine instead of in some folder like all other variants, though I think this is reasonable]
* [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable) [local]
* [x] The PR has been tested with round restarts.
* [x] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
