### PR TITLE
Fix all of the holes in the floor below windows in outpost station

### DIFF
--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced.asset
@@ -15,8 +15,13 @@ MonoBehaviour:
   displayName: 
   LayerType: 1
   TileType: 2
-  RequiredTiles: []
+  RequiredTiles:
+  - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
   WalkingSoundCategory: 0
+  BarefootWalkingSoundCategory: 0
+  ClawFootstepSoundCategory: 0
+  HeavyFootstepSoundCategory: 0
+  ClownFootstepSoundCategory: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Window.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Window.asset
@@ -15,10 +15,16 @@ MonoBehaviour:
   displayName: 
   LayerType: 1
   TileType: 2
-  RequiredTiles: []
+  RequiredTiles:
+  - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
   WalkingSoundCategory: 0
+  BarefootWalkingSoundCategory: 0
+  ClawFootstepSoundCategory: 0
+  HeavyFootstepSoundCategory: 0
+  ClownFootstepSoundCategory: 0
   atmosPassable: 0
   isSealed: 0
+  SpawnWithNoAir: 0
   oreCategory: 0
   MaxHealth: 0
   HealthStates: []


### PR DESCRIPTION
### Purpose
Currently most if not all windows on outpost station have holes that lead out into space below them, this fixes that issue

### Notes:
Ive only fixed the holes on the main station

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
