### PR TITLE
Get Shuttle Safety System Working

### DIFF
--- a/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/MatrixMove.cs
@@ -289,13 +289,18 @@ public class MatrixMove : ManagedNetworkBehaviour
 	}
 
 	///managed by UpdateManager
-	public override void UpdateMe()
+	public override void FixedUpdateMe()
 	{
 		if (isServer)
 		{
 			CheckMovementServer();
 		}
 
+		
+	}
+
+	public override void UpdateMe()
+	{
 		AnimateMovement();
 	}
 
@@ -375,6 +380,7 @@ public class MatrixMove : ManagedNetworkBehaviour
 		//To stop autopilot
 		DisableAutopilotTarget();
 		TryNotifyPlayers();
+		
 	}
 
 	/// Move for n tiles, regardless of direction, and stop


### PR DESCRIPTION
# Get Shuttle Safety System Working

Code side of #3486 not going to close it in case changes want to be made to the shuttle sensors.

### Purpose
Currently shuttles should be forced to stop when they detect an obstruction. This would fail if the shuttle was moving fast enough, or if the server was overloaded enough.

### Notes:
Code change is tiny, moved the collision detection from UpdateMe() to FixedUpdateMe().
Kept the animation code in UpdateMe()

I didn't see any noticeable performance issues during testing with a server+client locally.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
