### PR TITLE
Changes in localization and export price for ores.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Bananium.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Bananium.prefab
@@ -86,7 +86,7 @@ PrefabInstance:
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: initialName
-      value: Bananium
+      value: bananium
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
@@ -96,12 +96,12 @@ PrefabInstance:
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: exportCost
-      value: 0
+      value: 1000
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: exportMessage
-      value: 
+      value: cm3 of bananium
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Gold.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Gold.prefab
@@ -86,7 +86,7 @@ PrefabInstance:
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: initialName
-      value: Gold
+      value: gold
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
@@ -96,12 +96,12 @@ PrefabInstance:
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: exportCost
-      value: 1000
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: exportMessage
-      value: 
+      value: cm3 of gold
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Metal.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Metal.prefab
@@ -86,7 +86,7 @@ PrefabInstance:
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: initialName
-      value: Metal Sheet
+      value: metal sheet
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Plasteel.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Plasteel.prefab
@@ -192,6 +192,11 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.EquippedData
       value: 
       objectReference: {fileID: 4900000, guid: 321325784c5b29c468ba455dbfc144a7, type: 3}
+    - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
+        type: 3}
+      propertyPath: exportMessage
+      value: cm3 of plasteel
+      objectReference: {fileID: 0}
     - target: {fileID: 4589911925418668612, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: stacksWith.Array.size

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/ReinforcedGlassSheet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/ReinforcedGlassSheet.prefab
@@ -129,7 +129,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialName
-      value: Reinforced glass sheet
+      value: reinforced glass sheet
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Silver.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Silver.prefab
@@ -86,7 +86,7 @@ PrefabInstance:
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: initialName
-      value: Silver
+      value: silver
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
@@ -96,12 +96,12 @@ PrefabInstance:
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: exportCost
-      value: 0
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: exportMessage
-      value: 
+      value: cm3 of silver
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/SolidPlasma.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/SolidPlasma.prefab
@@ -100,12 +100,12 @@ PrefabInstance:
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: initialName
-      value: SolidPlasma
+      value: solid plasma
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: initialDescription
-      value: A solid plasma
+      value: Isn't plasma a state of matter? Oh whatever.
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Titanium.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Titanium.prefab
@@ -11,7 +11,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: dedfacba7f4531142897e9fbedba8028,
+      objectReference: {fileID: 21300000, guid: 912539aec9c7cb449af81cd3c8b9c453,
         type: 3}
     - target: {fileID: 189383627748944031, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
@@ -86,7 +86,7 @@ PrefabInstance:
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: initialName
-      value: Titanium
+      value: titanium
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
@@ -96,12 +96,12 @@ PrefabInstance:
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: exportCost
-      value: 0
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: exportMessage
-      value: 
+      value: cm3 of titanium
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Uranium.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Materials/Uranium.prefab
@@ -96,12 +96,12 @@ PrefabInstance:
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: exportCost
-      value: 0
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}
       propertyPath: exportMessage
-      value: 
+      value: cm3 of uranium
       objectReference: {fileID: 0}
     - target: {fileID: 314913272470551177, guid: 208d0d984a62d439babfcfb9d8bfe087,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Bananium Ore.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Bananium Ore.prefab
@@ -91,7 +91,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialName
-      value: Bananium Ore
+      value: bananium ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
@@ -111,7 +111,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: exportMessage
-      value: Ore
+      value: bananium ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/BlueSpace.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/BlueSpace.prefab
@@ -91,17 +91,17 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialName
-      value: BlueSpace
+      value: bluespace crystal
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialDescription
-      value: That stuff you get from the ground
+      value: Crystals with bluespace properties.
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: exportCost
-      value: 400
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
@@ -111,7 +111,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: exportMessage
-      value: Ore
+      value: cm3 of bluespace crystals
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Diamonds.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Diamonds.prefab
@@ -91,7 +91,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialName
-      value: Diamonds
+      value: diamond
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
@@ -101,7 +101,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: exportCost
-      value: 600
+      value: 500
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
@@ -111,7 +111,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: exportMessage
-      value: Ore
+      value: cm3 of diamonds
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Gold Ore.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Gold Ore.prefab
@@ -91,7 +91,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialName
-      value: Gold Ore
+      value: gold ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
@@ -111,7 +111,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: exportMessage
-      value: Ore
+      value: gold ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Iron Ore.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Iron Ore.prefab
@@ -91,12 +91,13 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialName
-      value: Iron Ore
+      value: iron ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialDescription
-      value: That stuff you get from the ground
+      value: Common iron ore often found in sedimentary and igneous layers of the
+        crust.
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
@@ -111,7 +112,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: exportMessage
-      value: Ore
+      value: iron ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Plasma Ore.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Plasma Ore.prefab
@@ -91,7 +91,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialName
-      value: Plasma Ore
+      value: plasma ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
@@ -111,7 +111,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: exportMessage
-      value: Ore
+      value: plasma ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Sand.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Sand.prefab
@@ -91,7 +91,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialName
-      value: Sand
+      value: sand
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
@@ -114,6 +114,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 6097f8423a1b255468e2285de46bc3d3,
         type: 2}
+    - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: exportMessage
+      value: sand
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c3138c3e8a46444199668b85070b1a39, type: 3}
 --- !u!1 &4890765794135269638 stripped

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Silver Ore.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Silver Ore.prefab
@@ -91,7 +91,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialName
-      value: Silver Ore
+      value: silver ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
@@ -111,7 +111,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: exportMessage
-      value: Ore
+      value: silver ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Titanium Ore.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Titanium Ore.prefab
@@ -91,7 +91,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialName
-      value: Titanium Ore
+      value: titanium ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
@@ -111,7 +111,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: exportMessage
-      value: Ore
+      value: titanium ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Uranium Ore.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Ores/Uranium Ore.prefab
@@ -91,7 +91,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: initialName
-      value: Iron Ore
+      value: uranium ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
@@ -111,7 +111,7 @@ PrefabInstance:
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}
       propertyPath: exportMessage
-      value: Ore
+      value: uranium ore
       objectReference: {fileID: 0}
     - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
         type: 3}


### PR DESCRIPTION
### Purpose
This PR changes the localization (names are now not capitalized, export messages added) and export prices for processed ores (and bluespace crystals and diamonds) to be in-line with /tg/ values. The price adjustments are below. Original on the left and adjusted on the right.
- Bananium: 0 > 1000
- Bluespace: 400 > 300
- Diamond:  600 > 500
- Gold: 1000 > 125
- Silver: 0 >  50
- Titanium:  0 > 125
- Uranium: 0 > 100

Other ores or sheets, such as metal and plasma, have not had their prices adjusted.
### Notes:
I also changed the sprite for titanium sheets, since it was using the texture for plastitanium for some reason.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
