### PR TITLE
Make Tazer use tazer sound.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Energy/Resources/Tazer.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Energy/Resources/Tazer.prefab
@@ -407,11 +407,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 7680527389759007793, guid: c456c86d5736aee499478a158376781e,
-        type: 3}
-      propertyPath: m_Name
-      value: Tazer
-      objectReference: {fileID: 0}
     - target: {fileID: -851605047464713454, guid: c456c86d5736aee499478a158376781e,
         type: 3}
       propertyPath: ProjectileVelocity
@@ -427,6 +422,17 @@ PrefabInstance:
       propertyPath: SpawnsCaseing
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: -851605047464713454, guid: c456c86d5736aee499478a158376781e,
+        type: 3}
+      propertyPath: FiringSound
+      value: ShootTazer
+      objectReference: {fileID: 0}
+    - target: {fileID: 7523055829715214189, guid: c456c86d5736aee499478a158376781e,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: f264a8df03da4284f9e6b61552375398,
+        type: 3}
     - target: {fileID: 7675599241638187333, guid: c456c86d5736aee499478a158376781e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -481,6 +487,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7680527389759007793, guid: c456c86d5736aee499478a158376781e,
+        type: 3}
+      propertyPath: m_Name
+      value: Tazer
       objectReference: {fileID: 0}
     - target: {fileID: 7710870028303749509, guid: c456c86d5736aee499478a158376781e,
         type: 3}
@@ -566,12 +577,6 @@ PrefabInstance:
       value: A low-capacity, energy-based stun gun used by security teams to subdue
         targets at range.
       objectReference: {fileID: 0}
-    - target: {fileID: 7523055829715214189, guid: c456c86d5736aee499478a158376781e,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: f264a8df03da4284f9e6b61552375398,
-        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c456c86d5736aee499478a158376781e, type: 3}
 --- !u!4 &6511642736210826542 stripped

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/SoundManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/SoundManager.prefab
@@ -14038,7 +14038,7 @@ AudioSource:
     type: 2}
   m_audioClip: {fileID: 8300000, guid: 8e463cd3151312149a6cef903b798ccb, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 0.2
+  m_Volume: 0.6
   m_Pitch: 1.1
   Loop: 0
   Mute: 0


### PR DESCRIPTION
### Purpose
This PR just makes the Tazer point to ShootTazer in its Firing Sound variable, which causes Gunshot_tazer.ogg to play when you fire the Tazer. 

I also adjusted the volume of ShootTazer to be in line with the other gunshot stuff (for example, ShootLaser and ShootLMG).

Other weapons have not been altered, so the other energy guns will still use ShootLaser and play Gunshot_laser.ogg.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
