### PR TITLE
Make staging server Portainer-public.

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -9,5 +9,7 @@ services:
       HUB_USERNAME: $HUB_USERNAME
       HUB_PASSWORD: $HUB_PASSWORD
       SERVER_NAME: Unitystation - EU02 Staging
+    labels:
+      - io.portainer.accesscontrol.public
     volumes:
       - /etc/UnityStation/admin:/Unitystation_Data/StreamingAssets/admin


### PR DESCRIPTION
### Make the staging public in Portainer

#### Notes
This should make staging server public on Portainer so it is always available even to non-admins.