### PR TITLE
Replaces Cargonian Escape objective with a coup objective

### DIFF
--- a/UnityProject/Assets/Scripts/Antagonists/Antags/Cargonian.asset
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/Cargonian.asset
@@ -18,4 +18,4 @@ MonoBehaviour:
   needsEscapeObjective: 0
   coreObjectives:
   - {fileID: 11400000, guid: b9c3d945f4d15ac439a8b8bfa9b90cd7, type: 2}
-  - {fileID: 11400000, guid: 48dc38d1e30b99d4eab91a6febb8cc3c, type: 2}
+  - {fileID: 11400000, guid: 5da49e1e84982bd4f952e3c6cb6c8a68, type: 2}

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/Cargo Eliminate Security.asset
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/Cargo Eliminate Security.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0847e7a58124fb64db06bace9e36cb75, type: 3}
+  m_Name: Cargo Eliminate Security
+  m_EditorClassIdentifier: 
+  objectiveName: Cargo Eliminate Security
+  IsUnique: 1
+  description: Eliminate all security forces on board the station and publicly announce
+    Cargonia's new rule over the remaining crew.

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/Cargo Eliminate Security.asset
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/Cargo Eliminate Security.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   objectiveName: Cargo Eliminate Security
   IsUnique: 1
-  description: Eliminate all security forces on board the station and publicly announce
-    Cargonia's new rule over the remaining crew.
+  description: Eliminate all security forces on board the station and announce Cargonia's
+    rule over the remaining crew

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/Cargo Eliminate Security.asset.meta
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/Cargo Eliminate Security.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5da49e1e84982bd4f952e3c6cb6c8a68
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/CargoEliminateSecurity.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/CargoEliminateSecurity.cs
@@ -5,11 +5,8 @@ using System.Linq;
 
 namespace Antagonists
 {
-	/// <summary>
-	/// An objective to set off the nuke on the station
-	/// </summary>
-	[CreateAssetMenu(menuName="ScriptableObjects/Objectives/OnlyCargoMenEscape")]
-	public class OnlyCargoMenEscape : Objective
+	[CreateAssetMenu(menuName="ScriptableObjects/Objectives/CargoEliminateSecurity")]
+	public class CargoEliminateSecurity : Objective
 	{
 		protected override void Setup()
 		{
@@ -17,16 +14,15 @@ namespace Antagonists
 
 		protected override bool CheckCompletion()
 		{
-			int playersFound = 0;
 			foreach (Transform t in GameManager.Instance.PrimaryEscapeShuttle.MatrixInfo.Objects.transform)
 			{
 				var player = t.GetComponent<PlayerScript>();
 				if (player != null)
 				{
-					playersFound++;
 					var playerDetails = PlayerList.Instance.Get(player.gameObject);
-					if (playerDetails.Job != JobType.CARGOTECH && playerDetails.Job != JobType.MINER
-					                                           && playerDetails.Job != JobType.QUARTERMASTER)
+					if (playerDetails.Job == JobType.SECURITY_OFFICER || playerDetails.Job == JobType.HOS
+					                                           || playerDetails.Job != JobType.DETECTIVE
+					                                           || playerDetails.Job != JobType.WARDEN)
 					{
 						if(playerDetails.Script == null || playerDetails.Script.playerHealth == null) continue;
 						if (!playerDetails.Script.playerHealth.IsDead)
@@ -37,12 +33,7 @@ namespace Antagonists
 				}
 			}
 
-			if (playersFound != 0)
-			{
-				return true;
-			}
-
-			return false;
+			return true;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/CargoEliminateSecurity.cs.meta
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/CargoEliminateSecurity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0847e7a58124fb64db06bace9e36cb75
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Managers/CentComm.cs
+++ b/UnityProject/Assets/Scripts/Managers/CentComm.cs
@@ -103,13 +103,15 @@ public class CentComm : MonoBehaviour
 		//Determine Plasma order:
 		PlasmaOrderRequestAmt = Random.Range(5, 50);
 		SendReportToStation();
+
+		//Check for coup game modes:
 		if (GameManager.Instance.GetGameModeName(true) == "Cargonia")
 		{
-			StartCoroutine(WaitToNotifySecOfCargonia());
+			StartCoroutine(WaitToNotifySecOfCoup());
 		}
 	}
 
-	IEnumerator WaitToNotifySecOfCargonia()
+	IEnumerator WaitToNotifySecOfCoup()
 	{
 		yield return WaitFor.Seconds(600f);
 
@@ -122,7 +124,7 @@ public class CentComm : MonoBehaviour
 			                                      || p.Job != JobType.WARDEN)
 			{
 				UpdateChatMessage.Send(p.GameObject, ChatChannel.System, ChatModifier.None,
-					"<color=red>Direct Centcomm Intelligence Report: It appears that cargo technicians may be planning to stage a coup on board this station.</color>");
+					"<color=red><size=50><b>Attention! It is believed that some of the crew on-station may be planning to stage a coup!</b></size></color>");
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Managers/CentComm.cs
+++ b/UnityProject/Assets/Scripts/Managers/CentComm.cs
@@ -103,6 +103,28 @@ public class CentComm : MonoBehaviour
 		//Determine Plasma order:
 		PlasmaOrderRequestAmt = Random.Range(5, 50);
 		SendReportToStation();
+		if (GameManager.Instance.GetGameModeName(true) == "Cargonia")
+		{
+			StartCoroutine(WaitToNotifySecOfCargonia());
+		}
+	}
+
+	IEnumerator WaitToNotifySecOfCargonia()
+	{
+		yield return WaitFor.Seconds(600f);
+
+		foreach (var p in PlayerList.Instance.AllPlayers)
+		{
+			if (p.Script == null || p.Script.playerHealth == null || p.Script.playerHealth.IsDead) continue;
+
+			if (p.Job == JobType.SECURITY_OFFICER || p.Job == JobType.HOS
+			                                      || p.Job != JobType.DETECTIVE
+			                                      || p.Job != JobType.WARDEN)
+			{
+				UpdateChatMessage.Send(p.GameObject, ChatChannel.System, ChatModifier.None,
+					"<color=red>Direct Centcomm Intelligence Report: It appears that cargo technicians may be planning to stage a coup on board this station.</color>");
+			}
+		}
 	}
 
 	private void SendReportToStation()

--- a/UnityProject/Assets/Scripts/Weapons/MagazineBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/MagazineBehaviour.cs
@@ -157,6 +157,7 @@ public class MagazineBehaviour : NetworkBehaviour, IServerSpawn, IExaminable, IC
 	/// </summary>
 	public String LoadFromClip( MagazineBehaviour clip)
 	{
+		if (clip == null) return "";
 		int toTransfer = Math.Min(magazineSize - serverAmmoRemains, clip.serverAmmoRemains);
 
 		clip.ExpendAmmo(toTransfer);


### PR DESCRIPTION
Players complained of cargo being too murderboney with the escape objective. So I replaced it with a coup objective and also notify security after 10minutes that a coup may be being planned by people on board the station.
