### PR TITLE
Fix Missing Produce Sprites

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjects/Plant default/banana_bluespace.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Plant default/banana_bluespace.asset
@@ -25,8 +25,9 @@ MonoBehaviour:
       - {fileID: 21300000, guid: 1029559942504d04e991feae6b0d4bea, type: 3}
       EquippedData: {fileID: 0}
     ProduceSprite:
-      Texture: {fileID: 0}
-      Sprites: []
+      Texture: {fileID: 2800000, guid: 0cba270313518844cb8ac7d47ccdf84b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 0cba270313518844cb8ac7d47ccdf84b, type: 3}
       EquippedData: {fileID: 0}
     GrowthSprites:
     - Texture: {fileID: 2800000, guid: b97704a4e09faa645bb3da61882cb7db, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Plant default/chili.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Plant default/chili.asset
@@ -58,9 +58,9 @@ MonoBehaviour:
       - {fileID: 21300000, guid: 56e4fa612184ba6449fb4456bd226462, type: 3}
       EquippedData: {fileID: 0}
     DeadSprite:
-      Texture: {fileID: 2800000, guid: 825562d7a39dede4c8d0540bf4627e49, type: 3}
+      Texture: {fileID: 2800000, guid: 524f6f5c850ccd5478dbf92dff2ee2ef, type: 3}
       Sprites:
-      - {fileID: 21300000, guid: 825562d7a39dede4c8d0540bf4627e49, type: 3}
+      - {fileID: 21300000, guid: 524f6f5c850ccd5478dbf92dff2ee2ef, type: 3}
       EquippedData: {fileID: 0}
     WeedResistance: 50
     WeedGrowthRate: 10

--- a/UnityProject/Assets/Resources/ScriptableObjects/Plant default/chili_ghost.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Plant default/chili_ghost.asset
@@ -24,8 +24,9 @@ MonoBehaviour:
       - {fileID: 21300000, guid: 7b5d2716158748941a0ef88a8fdb14c7, type: 3}
       EquippedData: {fileID: 0}
     ProduceSprite:
-      Texture: {fileID: 0}
-      Sprites: []
+      Texture: {fileID: 2800000, guid: 5d2619d359f632f43982b1d38be459fe, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 5d2619d359f632f43982b1d38be459fe, type: 3}
       EquippedData: {fileID: 0}
     GrowthSprites:
     - Texture: {fileID: 2800000, guid: 371304afa19b3294c8e9c4b5422a72ed, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Plant default/coffee.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Plant default/coffee.asset
@@ -24,8 +24,9 @@ MonoBehaviour:
       - {fileID: 21300000, guid: 4819193b63071fc4f9576c8209d608b4, type: 3}
       EquippedData: {fileID: 0}
     ProduceSprite:
-      Texture: {fileID: 0}
-      Sprites: []
+      Texture: {fileID: 2800000, guid: ef4ce4dcb258bd847acb788b83cf5cd0, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: ef4ce4dcb258bd847acb788b83cf5cd0, type: 3}
       EquippedData: {fileID: 0}
     GrowthSprites:
     - Texture: {fileID: 2800000, guid: 5f9db44445378fe47899bfcda6b80fd5, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Plant default/coffee_robusta.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Plant default/coffee_robusta.asset
@@ -24,8 +24,9 @@ MonoBehaviour:
       - {fileID: 21300000, guid: 1ab48a7ac39a6b14ba4d97edf67d5dee, type: 3}
       EquippedData: {fileID: 0}
     ProduceSprite:
-      Texture: {fileID: 0}
-      Sprites: []
+      Texture: {fileID: 2800000, guid: 45125428c14586f42812f59630338bbd, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 45125428c14586f42812f59630338bbd, type: 3}
       EquippedData: {fileID: 0}
     GrowthSprites:
     - Texture: {fileID: 2800000, guid: eb212eaade522994b8fcd3fc0b190173, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Plant default/eggplant_eggy.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Plant default/eggplant_eggy.asset
@@ -24,8 +24,9 @@ MonoBehaviour:
       - {fileID: 21300000, guid: b4fb4c1782212ba4a86669c58aad5010, type: 3}
       EquippedData: {fileID: 0}
     ProduceSprite:
-      Texture: {fileID: 0}
-      Sprites: []
+      Texture: {fileID: 2800000, guid: 8505bc48dd893b243b405cd893553199, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 8505bc48dd893b243b405cd893553199, type: 3}
       EquippedData: {fileID: 0}
     GrowthSprites:
     - Texture: {fileID: 2800000, guid: 112627c9c092faf4c8cfeb07e1539437, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Plant default/kudzu.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Plant default/kudzu.asset
@@ -24,8 +24,9 @@ MonoBehaviour:
       - {fileID: 21300000, guid: bf04229f2071a194f8b50006c31341b6, type: 3}
       EquippedData: {fileID: 0}
     ProduceSprite:
-      Texture: {fileID: 0}
-      Sprites: []
+      Texture: {fileID: 2800000, guid: 452ec1814b4b1bb47973bdf7a71dd63b, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 452ec1814b4b1bb47973bdf7a71dd63b, type: 3}
       EquippedData: {fileID: 0}
     GrowthSprites:
     - Texture: {fileID: 2800000, guid: aa606050fcca0f449bc6f3f3fc552d36, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Plant default/tea.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Plant default/tea.asset
@@ -24,8 +24,9 @@ MonoBehaviour:
       - {fileID: 21300000, guid: 31b0340cb7067b741a15710de8f1f8d2, type: 3}
       EquippedData: {fileID: 0}
     ProduceSprite:
-      Texture: {fileID: 0}
-      Sprites: []
+      Texture: {fileID: 2800000, guid: 7895de15cc5b12842acedf4a6aca3006, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 7895de15cc5b12842acedf4a6aca3006, type: 3}
       EquippedData: {fileID: 0}
     GrowthSprites:
     - Texture: {fileID: 2800000, guid: cbd950ac6c26cdc45a077aa5965a86c8, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Plant default/tea_astra.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Plant default/tea_astra.asset
@@ -24,8 +24,9 @@ MonoBehaviour:
       - {fileID: 21300000, guid: 948154af71032ed4e8104d96636c9d9c, type: 3}
       EquippedData: {fileID: 0}
     ProduceSprite:
-      Texture: {fileID: 0}
-      Sprites: []
+      Texture: {fileID: 2800000, guid: 82d60ab1ec36f6d47b607f1568fe2585, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: 82d60ab1ec36f6d47b607f1568fe2585, type: 3}
       EquippedData: {fileID: 0}
     GrowthSprites:
     - Texture: {fileID: 2800000, guid: df7ac5843134ed7409259252dfff60e6, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Plant default/tobacco.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Plant default/tobacco.asset
@@ -24,8 +24,9 @@ MonoBehaviour:
       - {fileID: 21300000, guid: 1d09d1da57fe6014380251fd9a96a044, type: 3}
       EquippedData: {fileID: 0}
     ProduceSprite:
-      Texture: {fileID: 0}
-      Sprites: []
+      Texture: {fileID: 2800000, guid: a594d6527cae4cb4d909a5fd82f4f7eb, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: a594d6527cae4cb4d909a5fd82f4f7eb, type: 3}
       EquippedData: {fileID: 0}
     GrowthSprites:
     - Texture: {fileID: 2800000, guid: 04b827b902c7e054daeb790afa827dfb, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Plant default/tobacco_space.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Plant default/tobacco_space.asset
@@ -24,8 +24,9 @@ MonoBehaviour:
       - {fileID: 21300000, guid: ae4b0a14f36f76246a917ca2480b9b1d, type: 3}
       EquippedData: {fileID: 0}
     ProduceSprite:
-      Texture: {fileID: 0}
-      Sprites: []
+      Texture: {fileID: 2800000, guid: c2d5b98a9a2ec734ab028057f0fa0414, type: 3}
+      Sprites:
+      - {fileID: 21300000, guid: c2d5b98a9a2ec734ab028057f0fa0414, type: 3}
       EquippedData: {fileID: 0}
     GrowthSprites:
     - Texture: {fileID: 2800000, guid: 87d69e13ca23b544da1ce7bb93e1af88, type: 3}


### PR DESCRIPTION
# Fix Missing Produce Sprites
### Purpose
links to some of the produce sprites broke with #3527 

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- The PR does not include any unnecessary .meta, .prefab or <b>.unity (scene) changes</b>
- The PR does not bring up any new compile errors
- The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
