### PR TITLE
Added integrity to transformer and plasma generator, made transformer more costly to build.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/PowerGeneratorPlasma.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/PowerGeneratorPlasma.prefab
@@ -5164,7 +5164,7 @@ ParticleSystemRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -902452607
-  m_SortingLayer: 15
+  m_SortingLayer: 16
   m_SortingOrder: 34
   m_RenderMode: 0
   m_SortMode: 0
@@ -5208,6 +5208,8 @@ GameObject:
   - component: {fileID: 579887912259031821}
   - component: {fileID: 114102132577365772}
   - component: {fileID: 114904772816368656}
+  - component: {fileID: 2031766418865421906}
+  - component: {fileID: 1348606562097783112}
   m_Layer: 11
   m_Name: PowerGeneratorPlasma
   m_TagString: Untagged
@@ -5463,7 +5465,56 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
-  localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 3703473536
+--- !u!114 &2031766418865421906
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853426429102140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  butcherTime: 2
+  butcherSound: BladeSlice
+--- !u!114 &1348606562097783112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853426429102140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24590037b6b486082fc874d1bfd9d95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  soundOnHit: 
+  Armor:
+    Melee: 0
+    Bullet: 0
+    Laser: 0
+    Energy: 0
+    Bomb: 0
+    Rad: 0
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+  initialIntegrity: 300

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/Transformer.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Electricity/Transformer.prefab
@@ -18,6 +18,8 @@ GameObject:
   - component: {fileID: 3919982737323789382}
   - component: {fileID: 114392163303621646}
   - component: {fileID: 114042349333397026}
+  - component: {fileID: 5103205208060466886}
+  - component: {fileID: -1607867197496824203}
   m_Layer: 11
   m_Name: Transformer
   m_TagString: Untagged
@@ -33,7 +35,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1575520830166772}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2, y: -34, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4920401221825478}
@@ -225,10 +227,59 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneId: 0
   serverOnly: 0
-  localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 162105790
+--- !u!114 &5103205208060466886
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1575520830166772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  butcherTime: 2
+  butcherSound: BladeSlice
+--- !u!114 &-1607867197496824203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1575520830166772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f24590037b6b486082fc874d1bfd9d95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  soundOnHit: 
+  Armor:
+    Melee: 0
+    Bullet: 0
+    Laser: 0
+    Energy: 0
+    Bomb: 0
+    Rad: 0
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 0
+  Resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  HeatResistance: 100
+  initialIntegrity: 100
 --- !u!1 &1744594665423798
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/ScriptableObjects/Construction/BuildList/MetalConstructionList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Construction/BuildList/MetalConstructionList.asset
@@ -117,8 +117,8 @@ MonoBehaviour:
     onePerTile: 1
   - name: High Voltage to Medium Voltage Transformer (left right)
     prefab: {fileID: 1575520830166772, guid: 84482a6a9ce96a746b992465f8766f03, type: 3}
-    cost: 2
-    buildTime: 2
+    cost: 30
+    buildTime: 10
     spawnAmount: 1
     onePerTile: 1
   - name: Department Battery


### PR DESCRIPTION
### Purpose
This PR adds the integrity script to transformers and makes them more costly to build (now takes 30 metal and 10 build time). I did this because people kept building indestructible transformers (only cost 2 metal and 1 build time before) all over the place, which resulted in areas being blocked off.

I also added the integrity script to the plasma generator because someone suggested it on the Discord.

### Please make sure you have followed the self checks below before submitting a PR:

- [ ] Code is sufficiently commented
- [ ] Code is indented with tabs and not spaces
- [ ] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [ ] The PR does not bring up any new compile errors
- [ ] The PR has been tested in editor
- [ ] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [ ] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [ ] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [ ] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ] The PR has been tested with round restarts.
- [ ] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
