### PR TITLE
Show the reason why a person cannot be cloned

### DIFF
--- a/UnityProject/Assets/Scripts/Medical/ClonableStatus.cs
+++ b/UnityProject/Assets/Scripts/Medical/ClonableStatus.cs
@@ -1,0 +1,13 @@
+/// <summary>
+/// This is used to represent the status of a player's Mind object when it comes to
+/// cloning. The only item here that allows for cloning is Cloneable, the others are
+/// just there to inform why the player can't be cloned.
+/// </summary>
+public enum CloneableStatus
+{
+	Cloneable,
+	OldRecord,
+	DenyingCloning,
+	StillAlive,
+	Offline
+}

--- a/UnityProject/Assets/Scripts/Medical/ClonableStatus.cs.meta
+++ b/UnityProject/Assets/Scripts/Medical/ClonableStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 787d92db779f7445988533f6344d5dcf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
+++ b/UnityProject/Assets/Scripts/Medical/CloningConsole.cs
@@ -98,14 +98,16 @@ public class CloningConsole : MonoBehaviour, IServerSpawn
 	{
 		if (cloningPod && cloningPod.CanClone())
 		{
-			if(record.mind.ConfirmClone(record.mobID))
+			var status = record.mind.GetCloneableStatus(record.mobID);
+
+			if(status == CloneableStatus.Cloneable)
 			{
 				cloningPod.ServerStartCloning(record);
 				cloningRecords.Remove(record);
 			}
 			else
 			{
-				cloningPod.statusString = "Initialisation failure.";
+				cloningPod.UpdateStatusString(status);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Medical/CloningPod.cs
+++ b/UnityProject/Assets/Scripts/Medical/CloningPod.cs
@@ -44,7 +44,7 @@ public class CloningPod : NetworkBehaviour
 		{
 			console.UpdateDisplay();
 		}
-		if(record.mind.IsOnline(record.mind.GetCurrentMob()))
+		if (record.mind.IsOnline(record.mind.GetCurrentMob()))
 		{
 			PlayerSpawn.ServerClonePlayer(record.mind, transform.position.CutToInt());
 		}
@@ -53,15 +53,7 @@ public class CloningPod : NetworkBehaviour
 
 	public bool CanClone()
 	{
-		if(statusSync == CloningPodStatus.Cloning)
-		{
-			return false;
-		}
-		else
-		{
-			return true;
-		}
-
+		return statusSync == CloningPodStatus.Empty;
 	}
 
 	public void SyncSprite(CloningPodStatus oldValue, CloningPodStatus value)

--- a/UnityProject/Assets/Scripts/Medical/CloningPod.cs
+++ b/UnityProject/Assets/Scripts/Medical/CloningPod.cs
@@ -56,6 +56,24 @@ public class CloningPod : NetworkBehaviour
 		return statusSync == CloningPodStatus.Empty;
 	}
 
+	/// <summary>
+	/// Updates the cloning pod's status string according to a mind's state
+	/// </summary>
+	public void UpdateStatusString(CloneableStatus status)
+	{
+		statusString = statusStrings[status];
+	}
+
+	private static Dictionary<CloneableStatus, string> statusStrings =
+		new Dictionary<CloneableStatus, string>
+		{
+			{ CloneableStatus.Cloneable, "Cloning will commence shortly." },
+			{ CloneableStatus.OldRecord, "Outdated record." },
+			{ CloneableStatus.DenyingCloning, "Spirit is denying cloning." },
+			{ CloneableStatus.StillAlive, "Person is still alive." },
+			{ CloneableStatus.Offline, "Spirit cannot be found." }
+		};
+
 	public void SyncSprite(CloningPodStatus oldValue, CloningPodStatus value)
 	{
 		statusSync = value;

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -100,15 +100,18 @@ public class Mind
 		IsGhosting = false;
 	}
 
-	public bool ConfirmClone(int recordMobID)
+	/// <summary>
+	/// Get the cloneable status of the player's mind, relative to the passed mob ID.
+	/// </summary>
+	public CloneableStatus GetCloneableStatus(int recordMobID)
 	{
 		if (bodyMobID != recordMobID)
 		{  //an old record might still exist even after several body swaps
-			return false;
+			return CloneableStatus.OldRecord;
 		}
 		if (DenyCloning)
 		{
-			return false;
+			return CloneableStatus.DenyingCloning;
 		}
 		var currentMob = GetCurrentMob();
 		if (!IsGhosting)
@@ -116,15 +119,15 @@ public class Mind
 			var livingHealthBehaviour = currentMob.GetComponent<LivingHealthBehaviour>();
 			if (!livingHealthBehaviour.IsDead)
 			{
-				return false;
+				return CloneableStatus.StillAlive;
 			}
 		}
 		if (!IsOnline(currentMob))
 		{
-			return false;
+			return CloneableStatus.Offline;
 		}
 
-		return true;
+		return CloneableStatus.Cloneable;
 	}
 
 	public bool IsOnline(GameObject currentMob)

--- a/UnityProject/Assets/Scripts/Player/Mind.cs
+++ b/UnityProject/Assets/Scripts/Player/Mind.cs
@@ -130,11 +130,7 @@ public class Mind
 	public bool IsOnline(GameObject currentMob)
 	{
 		NetworkConnection connection = currentMob.GetComponent<NetworkIdentity>().connectionToClient;
-		if (PlayerList.Instance.ContainsConnection(connection) == false)
-		{
-			return false;
-		}
-		return true;
+		return PlayerList.Instance.ContainsConnection(connection);
 	}
 
 	/// <summary>


### PR DESCRIPTION
# Show the reason why a person cannot be cloned

### Purpose
At the time, when you try to clone someone and it fails, there's no way to see why it failed. The cloning console simply displays the message `Initialisation failure.` This can lead to some confusion, since it is not obvious what initialisation failure means.

This PR sets the status display to something readable when cloning fails, such as `Spirit cannot be found` for when the player has disconnected, or `Person is still alive` when, you guessed it, the person is still alive.

### Notes:
For cloning to work as it does today, you kind of have to admit the existence of spirits, or something similar, in character. There might be some other more appropriate name, like Mind, as the class is named, or soul, or whatever. It's arbitrary really. But you can't avoid the fact that sometimes, the cloning machine mysteriously fails to work. If you were to build a cloner today that could perfectly recreate a scanned dead body and make it alive again, then it would have to be possible to create many copies of a single person. Since UnityStation will only allow one alive clone per physical player, you have to come up with something that can adequately explain why you can't clone the clown 50 times. Spirits fill that purpose at least somewhat.

I also simplified some logic in the code I touched. I couldn't help it!

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [x] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)

  *No new items or objects!*

- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

  *Tested with host-client and client*

- [ ] The PR has been tested with round restarts.
- [ ] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
