### PR TITLE
Cultivator and trowel actually do damage.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Botany/Trowel.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Botany/Trowel.prefab
@@ -60,6 +60,12 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 0f4ba0f47ed46439a9e8ff8285153727,
+        type: 3}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialTraits.Array.size
@@ -71,11 +77,26 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 6f1dc4e7ed40b8841958f8a373261742,
         type: 2}
-    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 0f4ba0f47ed46439a9e8ff8285153727,
+      propertyPath: initialName
+      value: trowel
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: initialDescription
+      value: A small handheld shovel used for digging up plants and occasionally stabbing
+        people.
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: throwDamage
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: hitDamage
+      value: 5
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Botany/cultivator.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Botany/cultivator.prefab
@@ -24,11 +24,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: cultivator
       objectReference: {fileID: 0}
-    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: m_AssetId
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -73,6 +68,17 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 519a321c89ed1f3468452cd73b3492d5,
+        type: 3}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialTraits.Array.size
@@ -87,7 +93,7 @@ PrefabInstance:
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialName
-      value: Cultivator
+      value: cultivator
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -162,12 +168,16 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.EquippedData
       value: 
       objectReference: {fileID: 4900000, guid: 4e0b7c2b4cae8cc41a48b774ba884175, type: 3}
-    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 519a321c89ed1f3468452cd73b3492d5,
+      propertyPath: hitDamage
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: throwDamage
+      value: 7
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
 --- !u!1 &705731933776011035 stripped


### PR DESCRIPTION
### Purpose
This PR just makes the cultivator and trowel do five melee damage and seven thrown damage (in brute).

Also changes the localization for both.

### Please make sure you have followed the self checks below before submitting a PR:

- [ ] Code is sufficiently commented
- [ ] Code is indented with tabs and not spaces
- [ ] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [ ] The PR does not bring up any new compile errors
- [ ] The PR has been tested in editor
- [ ] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [ ] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [ ] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [ ] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ] The PR has been tested with round restarts.
- [ ] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
