### PR TITLE
Add a Way to Add Nutriment and Other Botany Updates

### DIFF
--- a/UnityProject/Assets/Scripts/Botany/hydroponics tray/HydroponicsTray.cs
+++ b/UnityProject/Assets/Scripts/Botany/hydroponics tray/HydroponicsTray.cs
@@ -9,55 +9,66 @@ using Mirror;
 public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>, IServerSpawn
 {
 	[SyncVar(hook = nameof(UpdateHarvestFlag))]
-	public bool showHarvestFlag;
+	private bool showHarvestFlag;
 	[SyncVar(hook = nameof(UpdateWeedsFlag))]
-	public bool showWeedsFlag;
+	private bool showWeedsFlag;
 	[SyncVar(hook = nameof(UpdateWaterFlag))]
-	public bool showWaterFlag;
+	private bool showWaterFlag;
 	[SyncVar(hook = nameof(UpdateNutrimentFlag))]
-	public bool showNutrimenetFlag;
+	private bool showNutrimenetFlag;
 	[SyncVar(hook = nameof(UpdatePlantStage))]
-	public PlantSpriteStage plantCurrentStage;
+	private PlantSpriteStage plantCurrentStage;
 	[SyncVar(hook = nameof(UpdatePlantGrowthStage))]
-	public int growingPlantStage;
+	private int growingPlantStage;
 	[SyncVar(hook = nameof(UpdatePlant))]
-	public string plantSyncString;
+	private string plantSyncString;
 
+	[SerializeField]
 	private RegisterTile registerTile;
+	[SerializeField]
+	private bool isSoilPile;
+	[SerializeField]
+	private List<DefaultPlantData> potentialWeeds = new List<DefaultPlantData>();
+	[SerializeField]
+	private PlantTrayModification modification;
+	[SerializeField]
+	private ReagentContainer reagentContainer;
+	[SerializeField]
+	private SpriteHandler plantSprite;
+	[SerializeField]
+	private SpriteHandler harvestNotifier;
+	[SerializeField]
+	private SpriteHandler weedNotifier;
+	[SerializeField]
+	private SpriteHandler waterNotifier;
+	[SerializeField]
+	private SpriteHandler nutrimentNotifier;
+	[SerializeField]
+	private PlantData plantData;
+	[SerializeField]
+	private float tickRate;
 
-	
-	
-	public bool isSoilPile;
-	public List<DefaultPlantData> potentialWeeds = new List<DefaultPlantData>();
-	public List<GameObject> readyProduce = new List<GameObject>();
-	public PlantTrayModification modification;
-	public ReagentContainer reagentContainer;
-	public SpriteHandler plantSprite;
-
-	public SpriteHandler harvestNotifier;
-	public SpriteHandler weedNotifier;
-	public SpriteHandler waterNotifier;
-	public SpriteHandler nutrimentNotifier;
-	public PlantData plantData;
-	public bool hasPlant;
 
 	private static readonly System.Random random = new System.Random();
-
-	public float tickRate = 0.1f;
-	public float tickCount;
-	public float weedLevel; //10
-	public float nutritionLevel = 100;
-
-	public int numberOfUpdatesAlive;
 	
-	public int plantSubStage;
-	public float plantHealth = 100;
-	public bool readyToHarvest;
+
+	private readonly List<GameObject> readyProduce = new List<GameObject>();
+	private float tickCount;
+	private float weedLevel; //10
+	private float nutritionLevel;
+	private bool hasPlant;
+	private int numberOfUpdatesAlive;
+	private int plantNextGrowthStageProgress;
+	private float plantHealth;
+	private bool readyToHarvest;
 	//private bool IsServer; //separate flag as NetworkBehaviour isServer is not accurate when destroying an object
 
 	public void OnSpawnServer(SpawnInfo info)
 	{
 		EnsureInit();
+		nutritionLevel = 100;
+		plantHealth = 100;
+		numberOfUpdatesAlive = 0;
 		if (isSoilPile)
 		{
 			hasPlant = false;
@@ -69,6 +80,19 @@ public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>
 			readyToHarvest = true;
 			ProduceCrop();
 		}
+		else
+		{
+			plantData = null;
+			hasPlant = false;
+		}
+		UpdateHarvestFlag(showHarvestFlag, false);
+		UpdateWeedsFlag(showWeedsFlag, false);
+		UpdateWaterFlag(showWaterFlag, false);
+		UpdateNutrimentFlag(showNutrimenetFlag, false);
+		UpdatePlant(plantSyncString, null);
+		UpdatePlantStage(plantCurrentStage, PlantSpriteStage.None);
+		UpdatePlantGrowthStage(growingPlantStage, 0);
+
 	}
 
 	/// <summary>
@@ -148,12 +172,12 @@ public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>
 			//Logger.Log(plantData.NumberOfUpdatesAlive.ToString());
 			if (!readyToHarvest)
 			{
-				plantSubStage = plantSubStage + (int)Math.Round(plantData.GrowthSpeed / 10f);
+				plantNextGrowthStageProgress = plantNextGrowthStageProgress + (int)Math.Round(plantData.GrowthSpeed / 10f);
 
-				if (plantSubStage > 100)
+				if (plantNextGrowthStageProgress > 100)
 				{
 					//Logger.Log("NutritionLevel" + NutritionLevel);
-					plantSubStage = 0;
+					plantNextGrowthStageProgress = 0;
 					if (nutritionLevel > 0 || plantData.PlantTrays.Contains(PlantTrays.Weed_Adaptation))
 					{
 						if (!plantData.PlantTrays.Contains(PlantTrays.Weed_Adaptation))
@@ -519,7 +543,7 @@ public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>
 		}
 
 		UpdatePlantGrowthStage(growingPlantStage, 0);
-		plantSubStage = 0;
+		plantNextGrowthStageProgress = 0;
 		plantHealth = 100;
 		readyToHarvest = false;
 		numberOfUpdatesAlive = 0;
@@ -700,7 +724,7 @@ public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>
 			{
 				hasPlant = true;
 				readyToHarvest = false;
-				plantSubStage = 0;
+				plantNextGrowthStageProgress = 0;
 				UpdatePlantGrowthStage(growingPlantStage,0);
 				UpdatePlantStage(plantCurrentStage, PlantSpriteStage.Growing);
 				UpdateHarvestFlag(harvestNotifier, false);

--- a/UnityProject/Assets/Scripts/Botany/hydroponics tray/HydroponicsTray.cs
+++ b/UnityProject/Assets/Scripts/Botany/hydroponics tray/HydroponicsTray.cs
@@ -622,6 +622,8 @@ public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>
 					if (!objectContainer.InSolidForm)
 					{
 						objectContainer.MoveReagentsTo(5, reagentContainer);
+						Chat.AddActionMsgToChat(interaction.Performer, $"You add reagents to the {gameObject.ExpensiveName()}.",
+							$"{interaction.Performer.name} adds reagents to the {gameObject.ExpensiveName()}.");
 						if (reagentContainer.Contains("mutagen", 5))
 						{
 							reagentContainer.Contents["mutagen"] = reagentContainer.Contents["mutagen"] - 5;
@@ -655,7 +657,7 @@ public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>
 			if (objectItemAttributes.HasTrait(CommonTraits.Instance.Bucket))
 			{
 				Chat.AddActionMsgToChat(interaction.Performer, $"You water the {gameObject.ExpensiveName()}.",
-					$"{interaction.Performer.name} waters the tray.");
+					$"{interaction.Performer.name} waters the {gameObject.ExpensiveName()}.");
 				reagentContainer.Contents["water"] = 100f;
 				return;
 			}
@@ -684,8 +686,8 @@ public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>
 			if (hasPlant)
 			{
 				Chat.AddActionMsgToChat(interaction.Performer,
-						$"You compost the {foodObject.name} in the {gameObject.ExpensiveName()}",
-						$"{interaction.Performer.name} composts {foodObject.name} in the {gameObject.ExpensiveName()}");
+						$"You compost the {foodObject.name} in the {gameObject.ExpensiveName()}.",
+						$"{interaction.Performer.name} composts {foodObject.name} in the {gameObject.ExpensiveName()}.");
 				nutritionLevel = nutritionLevel + foodObject.plantData.Potency;
 				Despawn.ServerSingle(interaction.HandObject);
 				return;
@@ -700,8 +702,8 @@ public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>
 				UpdatePlantStage(PlantSpriteStage.None, PlantSpriteStage.Growing);
 				Inventory.ServerVanish(slot);
 				Chat.AddActionMsgToChat(interaction.Performer,
-						$"You plant the {foodObject.name} in the {gameObject.ExpensiveName()}",
-						$"{interaction.Performer.name} plants the {foodObject.name} in the {gameObject.ExpensiveName()}");
+						$"You plant the {foodObject.name} in the {gameObject.ExpensiveName()}.",
+						$"{interaction.Performer.name} plants the {foodObject.name} in the {gameObject.ExpensiveName()}.");
 			}
 			
 		}
@@ -718,8 +720,8 @@ public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>
 			UpdatePlantStage(PlantSpriteStage.None, PlantSpriteStage.Growing);
 			Inventory.ServerVanish(slot);
 			Chat.AddActionMsgToChat(interaction.Performer,
-						$"You plant the {Object.name} in the {gameObject.ExpensiveName()}",
-						$"{interaction.Performer.name} plants the {Object.name} in the {gameObject.ExpensiveName()}");
+						$"You plant the {Object.name} in the {gameObject.ExpensiveName()}.",
+						$"{interaction.Performer.name} plants the {Object.name} in the {gameObject.ExpensiveName()}.");
 			return;
 		}
 

--- a/UnityProject/Assets/Scripts/Botany/hydroponics tray/HydroponicsTray.cs
+++ b/UnityProject/Assets/Scripts/Botany/hydroponics tray/HydroponicsTray.cs
@@ -681,16 +681,29 @@ public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>
 		var foodObject = slot?.Item?.GetComponent<GrownFood>();
 		if (foodObject != null)
 		{
-			hasPlant = true;
-			plantData = new PlantData();
-			plantData.SetValues(foodObject.plantData);
-			UpdatePlant(null, plantData.Name);
-			UpdatePlantGrowthStage(0, 0);
-			UpdatePlantStage(PlantSpriteStage.None, PlantSpriteStage.Growing);
-			Inventory.ServerVanish(slot);
-			/*nutritionLevel = nutritionLevel + foodObject.plantData.Potency;
-			Despawn.ServerSingle(interaction.HandObject);
-			return;*/
+			if (hasPlant)
+			{
+				Chat.AddActionMsgToChat(interaction.Performer,
+						$"You compost the {foodObject.name} in the {gameObject.ExpensiveName()}",
+						$"{interaction.Performer.name} composts {foodObject.name} in the {gameObject.ExpensiveName()}");
+				nutritionLevel = nutritionLevel + foodObject.plantData.Potency;
+				Despawn.ServerSingle(interaction.HandObject);
+				return;
+			}
+			else
+			{
+				hasPlant = true;
+				plantData = new PlantData();
+				plantData.SetValues(foodObject.plantData);
+				UpdatePlant(null, plantData.Name);
+				UpdatePlantGrowthStage(0, 0);
+				UpdatePlantStage(PlantSpriteStage.None, PlantSpriteStage.Growing);
+				Inventory.ServerVanish(slot);
+				Chat.AddActionMsgToChat(interaction.Performer,
+						$"You plant the {foodObject.name} in the {gameObject.ExpensiveName()}",
+						$"{interaction.Performer.name} plants the {foodObject.name} in the {gameObject.ExpensiveName()}");
+			}
+			
 		}
 
 		//If hand slot contains seeds, plant the seeds
@@ -704,7 +717,9 @@ public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>
 			UpdatePlantGrowthStage(0, 0);
 			UpdatePlantStage(PlantSpriteStage.None, PlantSpriteStage.Growing);
 			Inventory.ServerVanish(slot);
-
+			Chat.AddActionMsgToChat(interaction.Performer,
+						$"You plant the {Object.name} in the {gameObject.ExpensiveName()}",
+						$"{interaction.Performer.name} plants the {Object.name} in the {gameObject.ExpensiveName()}");
 			return;
 		}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Editor/GeneratePlantSOs.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Editor/GeneratePlantSOs.cs
@@ -16,6 +16,7 @@ public class GeneratePlantSOs : EditorWindow
 		DirectoryInfo d = new DirectoryInfo(Application.dataPath + @"\Textures\objects\hydroponics\growing");
 		FileInfo[] Files = d.GetFiles("*.png");// \\Getting Text files
 		var ListFiles = new List<string>();
+		dictonaryErrors = new Dictionary<string, string>();
 		var PlantDictionary = new Dictionary<string, DefaultPlantData>();
 		var PlantDictionaryObject = new Dictionary<string, System.Object>();
 		
@@ -447,7 +448,7 @@ public class GeneratePlantSOs : EditorWindow
 	{
 		if (dictonaryErrors.ContainsKey(key))
 		{
-			dictonaryErrors.Add(key, $"dictonaryErrors[key]\n{error}");
+			dictonaryErrors[key] = $"{dictonaryErrors[key]}\n{error}";
 		}
 		else
 			dictonaryErrors.Add(key, error);

--- a/UnityProject/Assets/Scripts/Tilemaps/Editor/GeneratePlantSOs.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Editor/GeneratePlantSOs.cs
@@ -9,8 +9,8 @@ public class GeneratePlantSOs : EditorWindow
 	[MenuItem("Tools/GeneratePlantSOs")]
 	public static void Generate()
 	{
-		float progressbarStep = 0;
-		float progressbarState = 0;
+		float progressbarStep;
+		float progressbarState;
 		DirectoryInfo d = new DirectoryInfo(Application.dataPath + @"\Textures\objects\hydroponics\growing");
 		FileInfo[] Files = d.GetFiles("*.png");// \\Getting Text files
 		var ListFiles = new List<string>();
@@ -25,10 +25,11 @@ public class GeneratePlantSOs : EditorWindow
 		var json = (Resources.Load(@"Metadata\plants") as TextAsset).ToString();
 		var plats = JsonConvert.DeserializeObject<List<Dictionary<string, object>>>(json);
 
-		progressbarStep = 1f / plats.Count;
+		progressbarStep = 1f / plats.Count * ListFiles.Count;
 		progressbarState = 0;
 		foreach (var plat in plats)
 		{
+			EditorUtility.DisplayProgressBar("Progress", "Loading plant: " + plat["name"], progressbarState);
 			//\\foreach (var Datapiece in plat)
 			//\\{
 			//\\	Logger.Log(Datapiece.Key);
@@ -106,7 +107,7 @@ public class GeneratePlantSOs : EditorWindow
 			//var Growingsprites = new List<string>();
 			foreach (var ListFile in ListFiles)
 			{
-				EditorUtility.DisplayProgressBar("Progress", "Loading plant: " + ListFile, progressbarState += progressbarStep);
+				EditorUtility.DisplayProgressBar("Progress", $"Loading sprite '{ListFile}' for plant {plantdata.Name}", progressbarState);
 				if (ListFile.Contains(seed_packet))
 				{
 					var Namecheck = ListFile;
@@ -165,6 +166,7 @@ public class GeneratePlantSOs : EditorWindow
 						plantdata.FullyGrownSprite = plantdata.GrowthSprites[plantdata.GrowthSprites.Count - 1];
 					}
 				}
+				progressbarState += progressbarStep;
 			}
 			plantdata.WeedResistance = int.Parse(plat["weed_resistance"].ToString());
 			plantdata.WeedGrowthRate = int.Parse(plat["weed_growth_rate"].ToString());

--- a/UnityProject/Assets/Scripts/Tilemaps/Editor/GeneratePlantSOs.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Editor/GeneratePlantSOs.cs
@@ -25,11 +25,11 @@ public class GeneratePlantSOs : EditorWindow
 		var json = (Resources.Load(@"Metadata\plants") as TextAsset).ToString();
 		var plats = JsonConvert.DeserializeObject<List<Dictionary<string, object>>>(json);
 
-		progressbarStep = 1f / plats.Count * ListFiles.Count;
+		progressbarStep = 1f / (plats.Count * ListFiles.Count);
 		progressbarState = 0;
 		foreach (var plat in plats)
 		{
-			EditorUtility.DisplayProgressBar("Progress", "Loading plant: " + plat["name"], progressbarState);
+			EditorUtility.DisplayProgressBar("Step 1/3 Setting Sprites", "Loading plant: " + plat["name"], progressbarState);
 			//\\foreach (var Datapiece in plat)
 			//\\{
 			//\\	Logger.Log(Datapiece.Key);
@@ -107,7 +107,7 @@ public class GeneratePlantSOs : EditorWindow
 			//var Growingsprites = new List<string>();
 			foreach (var ListFile in ListFiles)
 			{
-				EditorUtility.DisplayProgressBar("Progress", $"Loading sprite '{ListFile}' for plant {plantdata.Name}", progressbarState);
+				
 				if (ListFile.Contains(seed_packet))
 				{
 					var Namecheck = ListFile;
@@ -120,6 +120,7 @@ public class GeneratePlantSOs : EditorWindow
 
 					if (Namecheck == seed_packet)
 					{
+						EditorUtility.DisplayProgressBar("Step 1/3 Setting Sprites", $"Loading sprite '{ListFile}' for plant {plantdata.Name}", progressbarState);
 						if (!ListFile.Contains("-dead"))
 						{
 							if (!ListFile.Contains("-harvest"))
@@ -281,7 +282,7 @@ public class GeneratePlantSOs : EditorWindow
 		progressbarState = 0;
 		foreach (var pant in PlantDictionary)
 		{
-			EditorUtility.DisplayProgressBar("Progress", "Loading mutations for: " + pant.Value.plantData.Name, progressbarState += progressbarStep);
+			EditorUtility.DisplayProgressBar("Step 2/3 Setting Mutations", "Loading mutations for: " + pant.Value.plantData.Name, progressbarState += progressbarStep);
 			if (PlantDictionaryObject.ContainsKey(pant.Value.plantData.Name))
 			{
 				var Mutations = JsonConvert.DeserializeObject<List<string>>(PlantDictionaryObject[pant.Value.plantData.Name].ToString());
@@ -328,13 +329,13 @@ public class GeneratePlantSOs : EditorWindow
 			DefaultPlantData defaultPlant = AssetDatabase.LoadMainAssetAtPath(@"Assets\Resources\ScriptableObjects\Plant default\" + pant.Value.plantData.Name + ".asset") as DefaultPlantData;
 			if (defaultPlant != null)
 			{
-				EditorUtility.DisplayProgressBar("Progress", "Updating asset: " + pant.Value.plantData.Name, progressbarState += progressbarStep);
+				EditorUtility.DisplayProgressBar("Step 3/3 Saving ScriptObjects", "Updating asset: " + pant.Value.plantData.Name, progressbarState += progressbarStep);
 				EditorUtility.CopySerialized(pant.Value, defaultPlant);
 				AssetDatabase.SaveAssets();
 			}
 			else
 			{
-				EditorUtility.DisplayProgressBar("Progress", "Creating asset: " + pant.Value.plantData.Name, progressbarState += progressbarStep);
+				EditorUtility.DisplayProgressBar("Step 3/3 Saving ScriptObjects", "Creating asset: " + pant.Value.plantData.Name, progressbarState += progressbarStep);
 				defaultPlant = new DefaultPlantData();
 				EditorUtility.CopySerialized(pant.Value, defaultPlant);
 				AssetDatabase.CreateAsset(pant.Value, @"Assets\Resources\ScriptableObjects\Plant default\" + pant.Value.plantData.Name + ".asset");


### PR DESCRIPTION
# Botany Updates

### Botany
- Re-adds the ability to 'compost' produce to add nutriment to trays, can still plant in empty trays.
    - Nutriment does nothing ATM but this lets you clear the flag and anyone who doesn't read this won't know it's pointless 🙂 
- Adds chat messages to more botany interactions so it's more clear what is happening.
- Refactored HydropnoicTray.cs's fields, most are now private.
- Updated init logic to better reset state between rounds
### GeneratePlantSOs tool
- Updates to GeneratePlantSOs
- Now shows errors for missing sprites (shows as warning if it's a mutation plant as they can use their parents plant sprites)
- Progress bars make me happy

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [x] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
- [x] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
