### PR TITLE
Fix substring for emote commands

### DIFF
--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -87,21 +87,21 @@ public partial class Chat
 		// Emote
 		if (message.StartsWith("*") || message.StartsWith("/me ",true,CultureInfo.CurrentCulture))
 		{
-			message = message.Replace("/me","") // note that there is no space here as compared to the above if
-			message = message.Substring(1);     // so that this substring can properly cut off both * and the space
+			message = message.Replace("/me",""); // note that there is no space here as compared to the above if
+			message = message.Substring(1);      // so that this substring can properly cut off both * and the space
 			chatModifiers |= ChatModifier.Emote;
 		}
 		// Whisper
 		else if (message.StartsWith("#") || message.StartsWith("/w ",true,CultureInfo.CurrentCulture))
 		{
-			message = message.Replace("/w","")
+			message = message.Replace("/w","");
 			message = message.Substring(1); 
 			chatModifiers |= ChatModifier.Whisper;
 		}
 		// Sing
 		else if (message.StartsWith("%") || message.StartsWith("/s ",true,CultureInfo.CurrentCulture))
 		{
-			message = message.Replace("/s","")
+			message = message.Replace("/s","");
 			message = message.Substring(1); 
 			message = Sing(message);
 			chatModifiers |= ChatModifier.Sing;

--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -87,19 +87,19 @@ public partial class Chat
 		// Emote
 		if (message.StartsWith("*") || message.StartsWith("/me ",true,CultureInfo.CurrentCulture))
 		{
-			message = message.Substring(1);
+			message = message.Substring(message.StartsWith("/me ") ? 4 : 1);
 			chatModifiers |= ChatModifier.Emote;
 		}
 		// Whisper
 		else if (message.StartsWith("#") || message.StartsWith("/w ",true,CultureInfo.CurrentCulture))
 		{
-			message = message.Substring(1);
+			message = message.Substring(message.StartsWith("/w ") ? 3 : 1);
 			chatModifiers |= ChatModifier.Whisper;
 		}
 		// Sing
 		else if (message.StartsWith("%") || message.StartsWith("/s ",true,CultureInfo.CurrentCulture))
 		{
-			message = message.Substring(1);
+			message = message.Substring(message.StartsWith("/s ") ? 3 : 1);
 			message = Sing(message);
 			chatModifiers |= ChatModifier.Sing;
 		}

--- a/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.Process.cs
@@ -87,19 +87,22 @@ public partial class Chat
 		// Emote
 		if (message.StartsWith("*") || message.StartsWith("/me ",true,CultureInfo.CurrentCulture))
 		{
-			message = message.Substring(message.StartsWith("/me ") ? 4 : 1);
+			message = message.Replace("/me","") // note that there is no space here as compared to the above if
+			message = message.Substring(1);     // so that this substring can properly cut off both * and the space
 			chatModifiers |= ChatModifier.Emote;
 		}
 		// Whisper
 		else if (message.StartsWith("#") || message.StartsWith("/w ",true,CultureInfo.CurrentCulture))
 		{
-			message = message.Substring(message.StartsWith("/w ") ? 3 : 1);
+			message = message.Replace("/w","")
+			message = message.Substring(1); 
 			chatModifiers |= ChatModifier.Whisper;
 		}
 		// Sing
 		else if (message.StartsWith("%") || message.StartsWith("/s ",true,CultureInfo.CurrentCulture))
 		{
-			message = message.Substring(message.StartsWith("/s ") ? 3 : 1);
+			message = message.Replace("/s","")
+			message = message.Substring(1); 
 			message = Sing(message);
 			chatModifiers |= ChatModifier.Sing;
 		}


### PR DESCRIPTION
adds a check to set the start length of the substring if its using a /command, because /command is longer than the single character way