### PR TITLE
Quick fix for asteroid plants being removed + refactor

### DIFF
--- a/UnityProject/Assets/Scripts/Botany/GrownFood.cs
+++ b/UnityProject/Assets/Scripts/Botany/GrownFood.cs
@@ -55,7 +55,7 @@ public class GrownFood : NetworkBehaviour, IInteractable<HandActivate>
 	/// </summary>
 	public void SetUpFood(PlantData newPlantData)
 	{
-		plantData.SetValues(newPlantData);
+		plantData = PlantData.CreateNewPlant(newPlantData);
 		SyncSize(SizeScale, 0.5f + (newPlantData.Potency / 200f));
 		SetupChemicalContents();
 		SetupEdible();
@@ -96,8 +96,7 @@ public class GrownFood : NetworkBehaviour, IInteractable<HandActivate>
 		{
 			var seedObject = Spawn.ServerPrefab(SeedPacket, interaction.Performer.RegisterTile().WorldPositionServer, parent: interaction.Performer.transform.parent).GameObject;
 			var seedPacket = seedObject.GetComponent<SeedPacket>();
-			seedPacket.plantData = new PlantData();
-			seedPacket.plantData.SetValues(plantData);
+			seedPacket.plantData = PlantData.CreateNewPlant(plantData);
 
 			seedPacket.SyncPlant(null, plantData.Name);
 

--- a/UnityProject/Assets/Scripts/Botany/PlantData.cs
+++ b/UnityProject/Assets/Scripts/Botany/PlantData.cs
@@ -27,6 +27,41 @@ public class PlantData
 	public List<Reagent> ReagentProduction = new List<Reagent>();
 	public List<DefaultPlantData> MutatesInTo = new List<DefaultPlantData>();
 
+	public int Age { get; set; }
+	public int NextGrowthStageProgress { get; set; }
+	public float Health { get; set; }
+
+	//Use static methods to create new instances of PlantData
+	private PlantData() { }
+
+	/// <summary>
+	/// Gets a new instance of PlantData based on param
+	/// </summary>
+	/// <param name="defaultPlantData">DefaultPlantData to copy</param>
+	/// <returns></returns>
+	public static PlantData CreateNewPlant(DefaultPlantData defaultPlantData)
+	{
+		PlantData newPlant = new PlantData();
+		newPlant.SetValues(defaultPlantData);
+		newPlant.Health = 100;
+		newPlant.Age = 0;
+		return newPlant;
+	}
+
+	/// <summary>
+	/// Gets a new instance of PlantData based on param
+	/// </summary>
+	/// <param name="plantData">PlantData to copy</param>
+	/// <returns></returns>
+	public static PlantData CreateNewPlant(PlantData plantData)
+	{
+		PlantData newPlant = new PlantData();
+		newPlant.SetValues(plantData);
+		newPlant.Health = 100;
+		newPlant.Age = 0;
+		return newPlant;
+	}
+
 	/// <summary>
 	/// Mutates the plant instance this is run against
 	/// </summary>
@@ -63,7 +98,7 @@ public class PlantData
 	/// Initializes plant with data another plant object
 	/// </summary>
 	/// <param name="_PlantData">data to copy</param>
-	public void SetValues(PlantData _PlantData)
+	private void SetValues(PlantData _PlantData)
 	{
 		Plantname = _PlantData.Plantname;
 		Description = _PlantData.Description;
@@ -90,7 +125,7 @@ public class PlantData
 	/// Initializes plant with data from default plant
 	/// </summary>
 	/// <param name="DefaultPlantData">DefaultPlantData.plantdata's values are copied</param>
-	public void SetValues(DefaultPlantData DefaultPlantData)
+	private void SetValues(DefaultPlantData DefaultPlantData)
 	{
 		var _PlantData = DefaultPlantData.plantData;
 		Name = _PlantData.Name;
@@ -141,7 +176,7 @@ public class PlantData
 	/// Combine plants reagents removing any duplicates, Keeps highest yield
 	/// </summary>
 	/// <param name="Reagents">New reagents to combine</param>
-	public void CombineReagentProduction(List<Reagent> Reagents)
+	private void CombineReagentProduction(List<Reagent> Reagents)
 	{
 		var ToRemove = new List<Reagent>();
 		Reagents.AddRange(ReagentProduction);

--- a/UnityProject/Assets/Scripts/Botany/seed packet/SeedPacket.cs
+++ b/UnityProject/Assets/Scripts/Botany/seed packet/SeedPacket.cs
@@ -37,8 +37,7 @@ public class SeedPacket : NetworkBehaviour
 	{
 		if (defaultPlantData != null)
 		{
-			plantData = new PlantData();
-			plantData.SetValues(defaultPlantData);
+			plantData = PlantData.CreateNewPlant(defaultPlantData);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Editor/GeneratePlantSOs.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Editor/GeneratePlantSOs.cs
@@ -39,11 +39,10 @@ public class GeneratePlantSOs : EditorWindow
 			//\\	Logger.Log(Datapiece.Key);
 			//\\}
 
-			var plantdata = new PlantData
-			{
-				ProduceObject = food,
-				Name = plat["name"] as string
-			};
+			var plantdata = PlantData.CreateNewPlant((PlantData)null);
+			plantdata.ProduceObject = food;
+			plantdata.Name = plat["name"] as string;
+
 			if (plat.ContainsKey("plantname"))
 			{
 				plantdata.Plantname = plat["plantname"] as string;


### PR DESCRIPTION
# Oops I broke asteroid plants

### Purpose
- Soil trays were initialized and then instantly emptied, fixed that :)
- Moved some data that made sense into the PlantData class and and did some refactor to ensure plant health and age were being reset properly

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [x] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
- [x] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
