### PR TITLE
Fixes paper closing when hovering over inventory slot

### DIFF
--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemSlot.cs
@@ -295,11 +295,9 @@ public class UI_ItemSlot : TooltipMonoBehaviour
 		{
 			return;
 		}
-
 		sprite = null;
 		image.enabled = false;
 		secondaryImage.enabled = false;
-		ControlTabs.CheckTabClose();
 		image.sprite = null;
 		secondarySprite = null;
 		secondaryImage.sprite = null;
@@ -307,6 +305,7 @@ public class UI_ItemSlot : TooltipMonoBehaviour
 		{
 			amountText.enabled = false;
 		}
+
 
 	}
 


### PR DESCRIPTION
### Purpose
_Stops paper from closing after hovering over an inventory slot_<br>
Fixes #3407
Fixes #3191 


### Notes:
Removes CheckTabClose from Clear(). Originally hesitant about this change but nothing broke so all seems well. Couldn't find anything that depended on it since CheckTabClose is only used in canisters/computers which does not interact with UI_Itemslot and the Null Rod and Paper, which led to the issues.
The Null Rod had this issue as well although it was never reported.

Submitted the PR early because I pressed ctrl+enter woops.
