### PR TITLE
Toolbox held sprite quickfix

### DIFF
--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/toolbox_lefthand/toolbox_lefthand_toolbox_white.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/toolbox_lefthand/toolbox_lefthand_toolbox_white.png.meta
@@ -4,16 +4,16 @@ TextureImporter:
   internalIDToNameTable:
   - first:
       213: 21300000
-    second: toolbox_red_0
+    second: toolbox_white_0
   - first:
       213: 21300002
-    second: toolbox_red_1
+    second: toolbox_white_1
   - first:
       213: 21300004
-    second: toolbox_red_2
+    second: toolbox_white_2
   - first:
       213: 21300006
-    second: toolbox_red_3
+    second: toolbox_white_3
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
@@ -98,7 +98,7 @@ TextureImporter:
     serializedVersion: 2
     sprites:
     - serializedVersion: 2
-      name: toolbox_red_0
+      name: toolbox_white_0
       rect:
         serializedVersion: 2
         x: 0
@@ -119,7 +119,7 @@ TextureImporter:
       edges: []
       weights: []
     - serializedVersion: 2
-      name: toolbox_red_1
+      name: toolbox_white_1
       rect:
         serializedVersion: 2
         x: 32
@@ -140,7 +140,7 @@ TextureImporter:
       edges: []
       weights: []
     - serializedVersion: 2
-      name: toolbox_red_2
+      name: toolbox_white_2
       rect:
         serializedVersion: 2
         x: 64
@@ -161,7 +161,7 @@ TextureImporter:
       edges: []
       weights: []
     - serializedVersion: 2
-      name: toolbox_red_3
+      name: toolbox_white_3
       rect:
         serializedVersion: 2
         x: 96

--- a/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/toolbox_righthand/toolbox_righthand_toolbox_white.png.meta
+++ b/UnityProject/Assets/Textures/mobs/races/_shared textures/in hands/equipment/toolbox_righthand/toolbox_righthand_toolbox_white.png.meta
@@ -4,16 +4,16 @@ TextureImporter:
   internalIDToNameTable:
   - first:
       213: 21300000
-    second: toolbox_red_0
+    second: toolbox_white_0
   - first:
       213: 21300002
-    second: toolbox_red_1
+    second: toolbox_white_1
   - first:
       213: 21300004
-    second: toolbox_red_2
+    second: toolbox_white_2
   - first:
       213: 21300006
-    second: toolbox_red_3
+    second: toolbox_white_3
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
@@ -98,7 +98,7 @@ TextureImporter:
     serializedVersion: 2
     sprites:
     - serializedVersion: 2
-      name: toolbox_red_0
+      name: toolbox_white_0
       rect:
         serializedVersion: 2
         x: 0
@@ -119,7 +119,7 @@ TextureImporter:
       edges: []
       weights: []
     - serializedVersion: 2
-      name: toolbox_red_1
+      name: toolbox_white_1
       rect:
         serializedVersion: 2
         x: 32
@@ -140,7 +140,7 @@ TextureImporter:
       edges: []
       weights: []
     - serializedVersion: 2
-      name: toolbox_red_2
+      name: toolbox_white_2
       rect:
         serializedVersion: 2
         x: 64
@@ -161,7 +161,7 @@ TextureImporter:
       edges: []
       weights: []
     - serializedVersion: 2
-      name: toolbox_red_3
+      name: toolbox_white_3
       rect:
         serializedVersion: 2
         x: 96


### PR DESCRIPTION
Small patch to fix the held sprite for the ce's toolbox