### PR TITLE
Fire Resist Action B:20

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/Panel_Hud_Bottom.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/Panel_Hud_Bottom.prefab
@@ -8799,7 +8799,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 8259424027466984da8d84e1310cfce4, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 3983d5c61c36c8e40aac953d97fa3b62, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -232,6 +232,11 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 		SyncFireStacks(fireStacks, 0);
 	}
 
+	public void ChangeFireStacks(float deltaValue)
+	{
+		SyncFireStacks(fireStacks, fireStacks + deltaValue);
+	}
+
 	private void SyncFireStacks(float oldValue, float newValue)
 	{
 		EnsureInit();

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -102,21 +102,14 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 	{
 		if (!Cooldowns.TryStartServer(playerScript, CommonCooldowns.Instance.Interaction)) return;
 
+		// Handle the movement restricted actions first.
 		if (playerScript.playerMove.IsBuckled)
 		{
-			// Are we cuffed AND buckled to a chair? If so we start an overlay timer. Otherwise just unbuckle normally.
-			if (playerScript.playerMove.IsCuffed)
-			{
-
-			}
-			else
+			// Make sure we don't unbuckle if we are currently cuffed.
+			if (!playerScript.playerMove.IsCuffed)
 			{
 				playerScript.playerMove.Unbuckle();
 			}
-		}
-		else if (playerScript.playerMove.IsCuffed) // Check if cuffed.
-		{
-
 		}
 		else if(playerScript.playerHealth.FireStacks > 0) // Check if we are on fire. If we are perform a stop-drop-roll animation and reduce the fire stacks.
 		{
@@ -158,6 +151,18 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 			if (playerScript.playerHealth.FireStacks <= 0)
 			{
 				playerScript.playerHealth.Extinguish();
+			}
+		}
+		else if (playerScript.playerMove.IsCuffed) // Check if cuffed.
+		{
+			if (playerScript.playerSprites != null &&
+				playerScript.playerSprites.clothes.TryGetValue("handcuffs", out var cuffsClothingItem))
+			{
+				if (cuffsClothingItem != null &&
+					cuffsClothingItem.TryGetComponent<RestraintOverlay>(out var restraintOverlay))
+				{
+					restraintOverlay.ServerBeginUnCuffAttempt();
+				}
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
@@ -24,6 +24,13 @@ public class ControlAction : MonoBehaviour
 	/// </summary>
 	public void Resist()
 	{
+		if(PlayerManager.LocalPlayerScript.IsGhost)
+		{
+			return;
+		}
+		
+		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdResist();
+		
 		// TODO implement resist functionality once handcuffs and things are in
 		SoundManager.Play("Click01");
 		Logger.Log("Resist Button", Category.UI);

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/ControlAction.cs
@@ -31,7 +31,6 @@ public class ControlAction : MonoBehaviour
 		
 		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdResist();
 		
-		// TODO implement resist functionality once handcuffs and things are in
 		SoundManager.Play("Click01");
 		Logger.Log("Resist Button", Category.UI);
 	}


### PR DESCRIPTION
This is a PR to introduce resist mechanics into the game. Potentially fulfilling the issue: https://github.com/unitystation/unitystation/issues/2660

- Instead of the "rest" icon there now exists the resist icon as the rest icon was firing off a call to Resist(). As such changes were made to UIManager.prefab.

- Hitting resist whilst buckled but not handcuffed will unbuckle the player.

- Hitting resist whilst on fire and NOT buckled will make the player drop to the ground and roll to remove fire stacks. _This value may need to be tweaked along with the stun time on the ground_ but for now I've just used the values that were present in the byond version.

- Hitting resist whilst not on fire, not buckled, but handcuffed will start the handcuff removal timer.

Any situations missing let me know.

* [x]  Code is sufficiently commented 

* [x]  Code is indented with tabs and not spaces

* [x]  The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**

* [x]  The PR does not bring up any new compile errors

* [x]  The PR has been tested in editor

* [x]  The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)

* [x]  The PR has been tested with round restarts.

* [x]  The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)


![fireroll](https://user-images.githubusercontent.com/3796313/76750007-9a228200-67d1-11ea-9cf0-feba85a94772.gif)
