### PR TITLE
randomizes rebel (Cargonia) department

### DIFF
--- a/UnityProject/Assets/Scripts/Antagonists/Antags/Cargonian.asset
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/Cargonian.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a07440fe04c5e242a672af539eb7bc3, type: 3}
   m_Name: Cargonian
   m_EditorClassIdentifier: 
-  antagName: Cargonian
+  antagName: Rebel
   NumberOfObjectives: 2
   canUseSharedObjectives: 0
   needsEscapeObjective: 0

--- a/UnityProject/Assets/Scripts/Antagonists/Antags/Cargonian.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/Cargonian.cs
@@ -10,7 +10,7 @@ namespace Antagonists
 		{
 			var newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest);
 			UpdateChatMessage.Send(newPlayer, ChatChannel.System, ChatModifier.None,
-				"<color=red>As a member of the Cargonian Members Federation you have been ordered to help in the efforts to secede from the rest of the station.</color>");
+				"<color=red>Something has awaked in you. You feel the urgent need to rebel with your brothers against this station.</color>");
 			// spawn them normally, with their preferred occupation
 			return newPlayer;
 		}

--- a/UnityProject/Assets/Scripts/Antagonists/Antags/Cargonian.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/Cargonian.cs
@@ -10,7 +10,7 @@ namespace Antagonists
 		{
 			var newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest);
 			UpdateChatMessage.Send(newPlayer, ChatChannel.System, ChatModifier.None,
-				"<color=red>Something has awaked in you. You feel the urgent need to rebel with your brothers against this station.</color>");
+				"<color=red>Something has awoken in you. You feel the urgent need to rebel with your brothers against this station.</color>");
 			// spawn them normally, with their preferred occupation
 			return newPlayer;
 		}

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/Cargo Eliminate Security.asset
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/Cargo Eliminate Security.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   objectiveName: Cargo Eliminate Security
   IsUnique: 1
-  description: Eliminate all security forces on board the station and announce Cargonia's
-    rule over the remaining crew
+  description: Eliminate all security forces on board the station and announce your
+    Department's rule over the remaining crew

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/Cargo Men Survival.asset
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/Cargo Men Survival.asset
@@ -12,6 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 69b083ebb7990d54f8e5f9a1c38ca9dc, type: 3}
   m_Name: Cargo Men Survival
   m_EditorClassIdentifier: 
-  objectiveName: Cargomen survival
+  objectiveName: Rebels Survival
   IsUnique: 1
-  description: Make sure that at least 50% of all cargonians are alive by round end
+  description: Make sure that at least 50% of all rebels are alive by round end

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/CargoMenSurvival.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/CargoMenSurvival.cs
@@ -20,27 +20,27 @@ namespace Antagonists
 		/// </summary>
 		protected override bool CheckCompletion()
 		{
-			int allCargomen = 0;
-			int allAliveCargomen = 0;
+			int allRebels = 0;
+			int allAliveRebels = 0;
 			foreach (var p in PlayerList.Instance.AllPlayers)
 			{
 				if (p.Script == null) continue;
-				if (p.Job == JobType.CARGOTECH || p.Job == JobType.QUARTERMASTER
-				                               || p.Job == JobType.MINER)
+				
+				foreach (JobType rebeljob in GameManager.Instance.Rebels)
 				{
-					allCargomen++;
+					if (p.Job == rebeljob) allRebels++;
 				}
 
 				if (p.Script.playerHealth != null)
 				{
 					if (!p.Script.playerHealth.IsDead)
 					{
-						allAliveCargomen++;
+						allAliveRebels++;
 					}
 				}
 			}
 
-			if (allAliveCargomen >= (double)allCargomen / 2)
+			if (allAliveRebels >= (double)allRebels / 2)
 			{
 				return true;
 			}

--- a/UnityProject/Assets/Scripts/GameModes/Cargonia.cs
+++ b/UnityProject/Assets/Scripts/GameModes/Cargonia.cs
@@ -1,5 +1,8 @@
 using UnityEngine;
 using Antagonists;
+using System.Collections;
+using System.Collections.Generic;
+using System;
 
 [CreateAssetMenu(menuName="ScriptableObjects/GameModes/Cargonia")]
 public class Cargonia : GameMode
@@ -7,9 +10,16 @@ public class Cargonia : GameMode
 	/// <summary>
 	/// Set up the station for the game mode
 	/// </summary>
+	private List<JobType> RebelJob;
+
 	public override void SetupRound()
 	{
 		Logger.Log("Setting up traitor round!", Category.GameMode);
+		//Select a random department
+		var rnd = new System.Random();
+		var RebelDep = (Departments) rnd.Next(Enum.GetNames(typeof(Departments)).Length);
+		RebelJob = RebelJobs[RebelDep];
+		GameManager.Instance.Rebels = RebelJob;
 	}
 	/// <summary>
 	/// Begin the round
@@ -34,16 +44,30 @@ public class Cargonia : GameMode
 	// {
 
 	// }
+	private  enum Departments 
+	{
+		Engineering,
+		Science,
+		Medical,
+		Service,
+		Supply
+	}
+
+	private readonly Dictionary<Departments, List<JobType>> RebelJobs = new Dictionary<Departments, List<JobType>>() {
+		{Departments.Engineering,
+		new List<JobType>{JobType.CHIEF_ENGINEER, JobType.ENGINEER, JobType.ATMOSTECH}},
+		{Departments.Science,
+		new List<JobType>{JobType.RD, JobType.GENETICIST, JobType.SCIENTIST, JobType.ROBOTICIST}},
+		{Departments.Medical,
+		new List<JobType>{JobType.CMO, JobType.DOCTOR, JobType.CHEMIST, JobType.VIROLOGIST}},
+		{Departments.Service,
+		new List<JobType>{JobType.CLOWN, JobType.JANITOR, JobType.BARTENDER, JobType.COOK, JobType.BOTANIST, JobType.MIME, JobType.CHAPLAIN, JobType.CURATOR}},
+		{Departments.Supply,
+		new List<JobType>{JobType.QUARTERMASTER, JobType.CARGOTECH, JobType.MINER}}
+	};
 
 	protected override bool ShouldSpawnAntag(PlayerSpawnRequest spawnRequest)
 	{
-		if (spawnRequest.RequestedOccupation.JobType == JobType.CARGOTECH
-		    || spawnRequest.RequestedOccupation.JobType == JobType.QUARTERMASTER
-		    || spawnRequest.RequestedOccupation.JobType == JobType.MINER)
-		{
-			return true;
-		}
-
-		return false;
+		return RebelJob.Contains(spawnRequest.RequestedOccupation.JobType);
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
@@ -33,6 +33,11 @@ public partial class GameManager
 	public bool SecretGameMode = true;
 
 	/// <summary>
+	/// Array of jobs from a randomized department. Used for Rebels gamemode (ex Cargonia)
+	/// </summary>
+	public List<JobType> Rebels;
+
+	/// <summary>
 	/// The state of the current round
 	/// </summary>
 	public RoundState CurrentRoundState


### PR DESCRIPTION
# Pull Request Template

### Purpose
This PR will randomize the rebel department at roundstart from this list of Departments:
- Engineering
- Science
- Medical
- Service
- Supply

### Notes:
This PR won't solve these problems:
- I'm not taking in account if the rebel department has players  (It was like this before the PR)
- Players have talked about how the second objective, killing all security, could be changed for something that diversifies the gameplay. I'm not changing it yet.

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
