### PR TITLE
prohibits sec and cmd jobs to spawn as traitors

### DIFF
--- a/UnityProject/Assets/Scripts/GameModes/Traitor.cs
+++ b/UnityProject/Assets/Scripts/GameModes/Traitor.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using Antagonists;
+using System.Collections.Generic;
 
 [CreateAssetMenu(menuName="ScriptableObjects/GameModes/Traitor")]
 public class Traitor : GameMode
@@ -35,8 +36,21 @@ public class Traitor : GameMode
 
 	// }
 
+	private List<JobType> LoyalImplanted = new List<JobType> 
+	{
+		JobType.CAPTAIN,
+		JobType.HOP,
+		JobType.HOS,
+		JobType.WARDEN,
+		JobType.SECURITY_OFFICER,
+		JobType.DETECTIVE,
+	};
+
 	protected override bool ShouldSpawnAntag(PlayerSpawnRequest spawnRequest)
 	{
-		return AntagManager.Instance.AntagCount == 0 && PlayerList.Instance.InGamePlayers.Count > 0;
+		
+		return !LoyalImplanted.Contains(spawnRequest.RequestedOccupation.JobType)
+				&& AntagManager.Instance.AntagCount == 0 
+				&& PlayerList.Instance.InGamePlayers.Count > 0;
 	}
 }

--- a/UnityProject/Assets/Scripts/GameModes/Traitor.cs
+++ b/UnityProject/Assets/Scripts/GameModes/Traitor.cs
@@ -48,7 +48,6 @@ public class Traitor : GameMode
 
 	protected override bool ShouldSpawnAntag(PlayerSpawnRequest spawnRequest)
 	{
-		
 		return !LoyalImplanted.Contains(spawnRequest.RequestedOccupation.JobType)
 				&& AntagManager.Instance.AntagCount == 0 
 				&& PlayerList.Instance.InGamePlayers.Count > 0;


### PR DESCRIPTION
# Pull Request Template

### Purpose
Adds a check to make it impossible to spawn as traitor with a security or command job.

### Notes:
closes #3607

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
