### PR TITLE
Update EmptyItemList to only rescan once per list update

### DIFF
--- a/UnityProject/Assets/Scripts/UI/EmptyItemList.cs
+++ b/UnityProject/Assets/Scripts/UI/EmptyItemList.cs
@@ -13,11 +13,27 @@ public class EmptyItemList : NetUIDynamicList
 	{
 		for (int i = 0; i < count; i++)
 		{
-			AddItem();
+			AttemptAdd();
 		}
+		NetworkTabManager.Instance.Rescan(MasterTab.NetTabDescriptor);
+		UpdatePeepers();
 	}
 
 	public bool AddItem()
+	{
+		if(!AttemptAdd())
+		{
+			return false;
+		}
+
+		//rescan elements  and notify
+		NetworkTabManager.Instance.Rescan(MasterTab.NetTabDescriptor);
+		UpdatePeepers();
+
+		return true;
+	}
+
+	private bool AttemptAdd()
 	{
 		//add new entry
 		var newEntry = Add();
@@ -27,11 +43,7 @@ public class EmptyItemList : NetUIDynamicList
 			return false;
 		}
 		Logger.Log($"ItemList: Item add success! newEntry={newEntry}", Category.ItemSpawn);
-
-		//rescan elements  and notify
-		NetworkTabManager.Instance.Rescan(MasterTab.NetTabDescriptor);
-		UpdatePeepers();
-
 		return true;
+
 	}
 }


### PR DESCRIPTION

### Purpose
Quick fix so this isn't called once for every item on the list every time it's updated
```
NetworkTabManager.Instance.Rescan(MasterTab.NetTabDescriptor);
UpdatePeepers();
```
Makes EmptyItemList less glitchy with large lists
### Notes:
Partial fix of #3002, I think the list is still completely regenerated every time one is added but this should improve things
### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
