### PR TITLE
Arrivals spawn fix

### DIFF
--- a/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
@@ -102,7 +102,7 @@ public static class PlayerSpawn
 			JobType.SYNDICATE
 		});
 	//Time to start spawning players at arrivals
-	private static readonly System.DateTime ARRIVALS_SPAWN_TIME = System.DateTime.Today.AddHours(12).AddMinutes(2);
+	private static readonly System.DateTime ARRIVALS_SPAWN_TIME = new System.DateTime().AddHours(12).AddMinutes(2);
 
 	/// <summary>
 	/// Spawns a new player character and transfers the connection's control into the new body.

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -213,7 +213,7 @@ public partial class GameManager : MonoBehaviour
 
 	public void ResetRoundTime()
 	{
-		stationTime = DateTime.Today.AddHours(12);
+		stationTime = new DateTime().AddHours(12);
 		counting = true;
 		StartCoroutine(NotifyClientsRoundTime());
 	}
@@ -317,7 +317,7 @@ public partial class GameManager : MonoBehaviour
 			// TODO make job selection stuff
 
 			// Standard round start setup
-			stationTime = DateTime.Today.AddHours(12);
+			stationTime = new DateTime().AddHours(12);
 			counting = true;
 			RespawnCurrentlyAllowed = GameMode.CanRespawn;
 			StartCoroutine(WaitToInitEscape());


### PR DESCRIPTION
# Fix permanent arrivals spawn once server date changes

### Purpose
Changed GameManager's stationTime and new ARRIVALS_SPAWN_TIME to use new DateTime() instead of DateTime.Today so it's the same value every round. 

Realized ARRIVALS_SPAWN_TIME would be stuck with the date of whenever the server started. Arrivals spawn logic would break after the server goes past midnight.
