### PR TITLE
Makes the bar-stool and shuttle-seat unshootable.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/chairs_bar.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/chairs_bar.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1463353046376569348}
   - component: {fileID: 5550071810911483408}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: Front
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -90,7 +90,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3367356935213924318}
   - component: {fileID: 1764975225713064315}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: Sprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -180,7 +180,7 @@ GameObject:
   - component: {fileID: 3385541160428677379}
   - component: {fileID: 4792015667158574305}
   - component: {fileID: -1016215171651041673}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: chairs_bar
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -307,6 +307,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &-2499762898432582042
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/shuttle_chair_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/shuttle_chair_0.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3202164745322436533}
   - component: {fileID: 5588146378019075436}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: Sprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -90,7 +90,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8674889304118096553}
   - component: {fileID: 6332421542784671258}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: Front
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -181,7 +181,7 @@ GameObject:
   - component: {fileID: 2101030153401488801}
   - component: {fileID: 6411611869092153326}
   - component: {fileID: -2445378394868782575}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: shuttle_chair_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -308,6 +308,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &-5948057208104375277
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
As the title states, both seats can now be shot over. Was annoying especially in shuttles where someone could simply hide behind the seats.