### PR TITLE
Lamps can now be deconstructed

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/LampBanana.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/LampBanana.prefab
@@ -97,8 +97,9 @@ GameObject:
   - component: {fileID: 114692596090418488}
   - component: {fileID: 114928563535158040}
   - component: {fileID: 7767792003389877533}
+  - component: {fileID: 643836806182836654}
   m_Layer: 11
-  m_Name: PotPlant 6
+  m_Name: LampBanana
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -277,3 +278,20 @@ MonoBehaviour:
   exportCost: 0
   exportName: 
   exportMessage: 
+--- !u!114 &643836806182836654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1562085630854840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 799d5bd9e47a11b4588193b68921813a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  resourcesMadeOf: {fileID: 7785875528613525472, guid: 4569acb573d85cc4d851531fdaedc4d2,
+    type: 3}
+  howMany: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/LampGreen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/LampGreen.prefab
@@ -97,8 +97,9 @@ GameObject:
   - component: {fileID: 114692596090418488}
   - component: {fileID: 114928563535158040}
   - component: {fileID: 7767792003389877533}
+  - component: {fileID: -7394928841894735711}
   m_Layer: 11
-  m_Name: PotPlant 4
+  m_Name: LampGreen
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -277,3 +278,20 @@ MonoBehaviour:
   exportCost: 0
   exportName: 
   exportMessage: 
+--- !u!114 &-7394928841894735711
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1562085630854840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 799d5bd9e47a11b4588193b68921813a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  resourcesMadeOf: {fileID: 4519819786599941225, guid: 2a170fdb7187e38459de34c4d2b131ad,
+    type: 3}
+  howMany: 1

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/LampGrey.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/LampGrey.prefab
@@ -97,8 +97,9 @@ GameObject:
   - component: {fileID: 114692596090418488}
   - component: {fileID: 114928563535158040}
   - component: {fileID: 7767792003389877533}
+  - component: {fileID: -5014777076349897504}
   m_Layer: 11
-  m_Name: PotPlant 5
+  m_Name: LampGrey
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -277,3 +278,20 @@ MonoBehaviour:
   exportCost: 0
   exportName: 
   exportMessage: 
+--- !u!114 &-5014777076349897504
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1562085630854840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 799d5bd9e47a11b4588193b68921813a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  resourcesMadeOf: {fileID: 4519819786599941225, guid: 2a170fdb7187e38459de34c4d2b131ad,
+    type: 3}
+  howMany: 1


### PR DESCRIPTION
The green and grey lamps deconstruct into a singular rod while the banana lamp gives a banana. No current way to construct them sadly.