### PR TITLE
Bar stool and shuttle seat fixes

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/chairs_bar.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/chairs_bar.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1463353046376569348}
   - component: {fileID: 5550071810911483408}
-  m_Layer: 23
+  m_Layer: 0
   m_Name: Front
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -90,7 +90,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3367356935213924318}
   - component: {fileID: 1764975225713064315}
-  m_Layer: 23
+  m_Layer: 0
   m_Name: Sprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/shuttle_chair_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/shuttle_chair_0.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3202164745322436533}
   - component: {fileID: 5588146378019075436}
-  m_Layer: 23
+  m_Layer: 0
   m_Name: Sprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -90,7 +90,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8674889304118096553}
   - component: {fileID: 6332421542784671258}
-  m_Layer: 23
+  m_Layer: 0
   m_Name: Front
   m_TagString: Untagged
   m_Icon: {fileID: 0}


### PR DESCRIPTION
Sprite were invisible due to being on the wrong layers, now fixed.