### PR TITLE
Fix missing trait for tanks

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/Emergency Oxygen Tank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/Emergency Oxygen Tank.prefab
@@ -140,7 +140,7 @@ PrefabInstance:
         type: 3}
       propertyPath: initialTraits.Array.data[2]
       value: 
-      objectReference: {fileID: 11400000, guid: 985f3296ea5ef9e48998b22a38a14617,
+      objectReference: {fileID: 11400000, guid: a88f1555ca8abf643aea180c637f5329,
         type: 2}
     - target: {fileID: 520041481196620939, guid: cbf90b2e22f389941aaf3912f2b607ee,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/GasContainer.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/GasContainer.prefab
@@ -146,7 +146,8 @@ PrefabInstance:
         type: 3}
       propertyPath: initialTraits.Array.data[2]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 11400000, guid: a88f1555ca8abf643aea180c637f5329,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
 --- !u!1 &133441459033252841 stripped

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tanks/Oxygen Tank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tanks/Oxygen Tank.prefab
@@ -170,6 +170,7 @@ PrefabInstance:
         type: 3}
       propertyPath: initialTraits.Array.data[2]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 11400000, guid: a88f1555ca8abf643aea180c637f5329,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cbf90b2e22f389941aaf3912f2b607ee, type: 3}


### PR DESCRIPTION
The functionality of placing a tank inside a canister to fill it was broken because the tanks were missing traits, this pr readds the trait