### PR TITLE
Table climb fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/TileInteraction/TableInteractionClimb.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/TileInteraction/TableInteractionClimb.cs
@@ -14,7 +14,7 @@ public class TableInteractionClimb : TileInteraction
 
 		PlayerSync playerSync;
 		CustomNetTransform netTransform;
-		if(interaction.UsedObject.TryGetComponent<PlayerSync>(out playerSync))
+		if(interaction.UsedObject.TryGetComponent(out playerSync))
 		{
 			if (playerSync.IsMoving)
 			{
@@ -23,20 +23,21 @@ public class TableInteractionClimb : TileInteraction
 
 			// Do a sanity check to make sure someone isn't dropping the shadow from like 9000 tiles away.
 			var mag = (playerSync.ServerPosition - interaction.PerformerPlayerScript.PlayerSync.ServerPosition).magnitude;
-			if (mag >= 2.0f)
+			if (mag > PlayerScript.interactionDistance)
 			{
+				//interaction.PerformerPlayerScript
 				return false;
 			}	
 		}
-		else if(interaction.UsedObject.TryGetComponent<CustomNetTransform>(out netTransform))
+		else if(interaction.UsedObject.TryGetComponent(out netTransform)) // Do the same check but for mouse draggable objects this time.
 		{
 			var mag = (netTransform.ServerPosition - interaction.PerformerPlayerScript.PlayerSync.ServerPosition).magnitude;
-			if (mag >= 2.0f)
+			if (mag > PlayerScript.interactionDistance)
 			{
 				return false;
 			}
 		}
-		else
+		else // Not sure what this object is so assume that we can't interact with it at all.
 		{
 			return false;
 		}

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/TileInteraction/TableInteractionClimb.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/TileInteraction/TableInteractionClimb.cs
@@ -5,22 +5,64 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "TableInteractionClimb", menuName = "Interaction/TileInteraction/TableInteractionClimb")]
 public class TableInteractionClimb : TileInteraction
 {
+	static private List<TileType> excludeTiles = new List<TileType>() { TileType.Table };
+
 	public override bool WillInteract(TileApply interaction, NetworkSide side)
 	{
 		if (!DefaultWillInteract.Default(interaction, side)) return false;
 		if (interaction.TileApplyType != TileApply.ApplyType.MouseDrop) return false;
+
+		PlayerSync playerSync;
+		CustomNetTransform netTransform;
+		if(interaction.UsedObject.TryGetComponent<PlayerSync>(out playerSync))
+		{
+			if (playerSync.IsMoving)
+			{
+				return false;
+			}
+
+			// Do a sanity check to make sure someone isn't dropping the shadow from like 9000 tiles away.
+			var mag = (playerSync.ServerPosition - interaction.PerformerPlayerScript.PlayerSync.ServerPosition).magnitude;
+			if (mag >= 2.0f)
+			{
+				return false;
+			}	
+		}
+		else if(interaction.UsedObject.TryGetComponent<CustomNetTransform>(out netTransform))
+		{
+			var mag = (netTransform.ServerPosition - interaction.PerformerPlayerScript.PlayerSync.ServerPosition).magnitude;
+			if (mag >= 2.0f)
+			{
+				return false;
+			}
+		}
+		else
+		{
+			return false;
+		}
+
 		return true;
 	}
 
 	public override void ServerPerformInteraction(TileApply interaction)
 	{
+		if (!interaction.UsedObject.RegisterTile().Matrix.IsPassableAt(interaction.TargetCellPos, true, true, null, excludeTiles))
+		{
+			return;
+		}
+
 		StandardProgressActionConfig cfg = new StandardProgressActionConfig(StandardProgressActionType.Construction, false, false, false);
-		StandardProgressAction.Create(cfg, () =>
+		var x = StandardProgressAction.Create(cfg, () =>
 		{
 			PlayerScript playerScript;
 			if (interaction.UsedObject.TryGetComponent(out playerScript))
 			{
-				playerScript.PlayerSync.SetPosition(interaction.WorldPositionTarget);
+				List<TileType> excludeTiles = new List<TileType>() { TileType.Table };
+
+				if (playerScript.registerTile.Matrix.IsPassableAt(interaction.TargetCellPos, true, true, null, excludeTiles))
+				{
+					playerScript.PlayerSync.SetPosition(interaction.WorldPositionTarget);
+				}
 			}
 			else
 			{
@@ -30,6 +72,6 @@ public class TableInteractionClimb : TileInteraction
 					transformComp.AppearAtPositionServer(interaction.WorldPositionTarget);
 				}
 			}
-		}).ServerStartProgress(interaction.WorldPositionTarget, 3.0f, interaction.Performer);
+		}).ServerStartProgress(interaction.UsedObject.RegisterTile(), 3.0f, interaction.Performer);
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Layer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Tilemaps;
 
@@ -125,13 +126,24 @@ using UnityEngine.Tilemaps;
 			}
 		}
 
-		public virtual bool IsPassableAt( Vector3Int from, Vector3Int to, bool isServer,
-			CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null )
-		{
-			return !tilemap.HasTile(to) || tilemap.GetTile<BasicTile>(to).IsPassable(collisionType);
-		}
+	public virtual bool IsPassableAt(Vector3Int from, Vector3Int to, bool isServer,
+		CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null, List<TileType> excludeTiles = null)
+	{
+		// There's not tile here so its passable.
+		if (!tilemap.HasTile(to))
+			return true;
 
-		public virtual bool IsAtmosPassableAt(Vector3Int from, Vector3Int to, bool isServer)
+		var tile = tilemap.GetTile<BasicTile>(to);
+
+		// Return passable if the tile type is being excluded from checks.
+		if (excludeTiles != null && excludeTiles.Contains(tile.TileType))
+			return true;
+
+		return tile.IsPassable(collisionType);
+		//return !tilemap.HasTile(to) || tilemap.GetTile<BasicTile>(to).IsPassable(collisionType);
+	}
+
+	public virtual bool IsAtmosPassableAt(Vector3Int from, Vector3Int to, bool isServer)
 		{
 			return !tilemap.HasTile(to) || tilemap.GetTile<BasicTile>(to).IsAtmosPassable();
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -89,9 +89,9 @@ public class Matrix : MonoBehaviour
 		}
 	}
 
-	public bool IsPassableAt(Vector3Int position, bool isServer, bool includingPlayers = true)
+	public bool IsPassableAt(Vector3Int position, bool isServer, bool includingPlayers = true, List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null)
 	{
-		return IsPassableAt(position, position, isServer, includingPlayers: includingPlayers);
+		return IsPassableAt(position, position, isServer, includingPlayers: includingPlayers, excludeLayers: excludeLayers, excludeTiles: excludeTiles);
 	}
 
 	/// <summary>
@@ -109,9 +109,9 @@ public class Matrix : MonoBehaviour
 	/// <param name="includingPlayers">Set this to false to ignore players from check</param>
 	/// <param name="context">Is excluded from passable check</param>
 	/// <returns></returns>
-	public bool IsPassableAt(Vector3Int origin, Vector3Int position, bool isServer, CollisionType collisionType = CollisionType.Player, bool includingPlayers = true, GameObject context = null)
+	public bool IsPassableAt(Vector3Int origin, Vector3Int position, bool isServer, CollisionType collisionType = CollisionType.Player, bool includingPlayers = true, GameObject context = null, List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null)
 	{
-		return MetaTileMap.IsPassableAt(origin, position, isServer, collisionType: collisionType, inclPlayers: includingPlayers, context: context);
+		return MetaTileMap.IsPassableAt(origin, position, isServer, collisionType: collisionType, inclPlayers: includingPlayers, context: context, excludeLayers: excludeLayers, excludeTiles: excludeTiles);
 	}
 
 	public bool IsAtmosPassableAt(Vector3Int position, bool isServer)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -101,32 +101,39 @@ public class MetaTileMap : MonoBehaviour
 	}
 
 	public bool IsPassableAt(Vector3Int origin, Vector3Int to, bool isServer,
-		CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null)
+		CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null, List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null)
 	{
 		Vector3Int toX = new Vector3Int(to.x, origin.y, origin.z);
 		Vector3Int toY = new Vector3Int(origin.x, to.y, origin.z);
 
-		return _IsPassableAt(origin, toX, isServer, collisionType, inclPlayers, context) &&
-		       _IsPassableAt(toX, to, isServer, collisionType, inclPlayers, context) ||
-		       _IsPassableAt(origin, toY, isServer, collisionType, inclPlayers, context) &&
-		       _IsPassableAt(toY, to, isServer, collisionType, inclPlayers, context);
+		return _IsPassableAt(origin, toX, isServer, collisionType, inclPlayers, context, excludeLayers, excludeTiles) &&
+			   _IsPassableAt(toX, to, isServer, collisionType, inclPlayers, context, excludeLayers, excludeTiles) ||
+			   _IsPassableAt(origin, toY, isServer, collisionType, inclPlayers, context, excludeLayers, excludeTiles) &&
+			   _IsPassableAt(toY, to, isServer, collisionType, inclPlayers, context, excludeLayers, excludeTiles);
 	}
 
+
 	private bool _IsPassableAt(Vector3Int origin, Vector3Int to, bool isServer,
-		CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null)
+		CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null, List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null)
 	{
 		for (var i = 0; i < SolidLayersValues.Length; i++)
 		{
 			// Skip floor & base collisions if this is not a shuttle
 			if (collisionType != CollisionType.Shuttle &&
-			    (SolidLayersValues[i].LayerType == LayerType.Floors ||
-			     SolidLayersValues[i].LayerType == LayerType.Base))
+				(SolidLayersValues[i].LayerType == LayerType.Floors ||
+				 SolidLayersValues[i].LayerType == LayerType.Base))
+			{
+				continue;
+			}
+
+			// Skip if the current tested layer is being excluded.
+			if (excludeLayers != null && excludeLayers.Contains(SolidLayersValues[i].LayerType))
 			{
 				continue;
 			}
 
 			if (!SolidLayersValues[i].IsPassableAt(origin, to, isServer, collisionType: collisionType,
-				inclPlayers: inclPlayers, context: context))
+				inclPlayers: inclPlayers, context: context, excludeTiles))
 			{
 				return false;
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
@@ -81,7 +81,7 @@ public class ObjectLayer : Layer
 	}
 
 	public override bool IsPassableAt(Vector3Int origin, Vector3Int to, bool isServer,
-									  CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null)
+									  CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null, List<TileType> excludeTiles = null)
 	{
 		//Targeting windoors here
 		foreach ( RegisterTile t in isServer ? ServerObjects.Get(origin) : ClientObjects.Get(origin) )
@@ -101,7 +101,7 @@ public class ObjectLayer : Layer
 			}
 		}
 
-		return base.IsPassableAt(origin, to, isServer, collisionType: collisionType, inclPlayers: inclPlayers, context: context);
+		return base.IsPassableAt(origin, to, isServer, collisionType: collisionType, inclPlayers: inclPlayers, context: context, excludeTiles: excludeTiles);
 	}
 
 	public override bool IsAtmosPassableAt(Vector3Int origin, Vector3Int to, bool isServer)


### PR DESCRIPTION
Adds essential checks to table climbing:

- Checks the distance between the interacting player and the target. This is so you can't run 9000 tiles away and slingshot someone onto a table.

- Performs a collision check to make sure that the tile you're climbing onto is actually passable. Necessary so that you can't climb onto a table that has been blocked by shutters.

IsPassableAt was modified to take optional parameters for exclusion of specific layers and/or tile types from the collision checks. In most cases these two parameters are going to be null and thus skipped over. 

Assuming the C# runtime adequately flags the branches as likely false there shouldn't be any visible change in the performance of these functions.

**Notes:** 
Will still need some extensive tests done. There's only so many cases that can be tested locally.
Notably need to figure out if there are any cases where the distance between source and target are not enough to prevent magically teleporting people.