### PR TITLE
Fix for Seed Extractor + Rafactor

### DIFF
--- a/UnityProject/Assets/Scripts/Botany/hydroponics tray/SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/Botany/hydroponics tray/SeedExtractor.cs
@@ -13,7 +13,7 @@ public class SeedExtractor : ManagedNetworkBehaviour, IInteractable<HandApply>, 
 
 
 	//Time it takes to process a single piece of produce
-	private float processingTime = 0.2f;
+	private float processingTime = 3f;
 
 	[SerializeField]
 	private RegisterObject registerObject = null;
@@ -64,6 +64,26 @@ public class SeedExtractor : ManagedNetworkBehaviour, IInteractable<HandApply>, 
 		{
 			Chat.AddLocalMsgToChat("The seed extractor finishes processing", (Vector2Int)registerObject.WorldPosition, this.gameObject);
 		}
+	}
+
+	/// <summary>
+	/// Spawns seed packet in world and removes it from internal list
+	/// </summary>
+	/// <param name="seedPacket">Seed packet to spawn</param>
+	public void DispenseSeedPacket(SeedPacket seedPacket)
+	{
+		//Spawn packet
+		Vector3 spawnPos = gameObject.RegisterTile().WorldPositionServer;
+		CustomNetTransform netTransform = seedPacket.GetComponent<CustomNetTransform>();
+		netTransform.AppearAtPosition(spawnPos);
+		netTransform.AppearAtPositionServer(spawnPos);
+		
+		//Notify chat
+		Chat.AddLocalMsgToChat($"{seedPacket.gameObject.ExpensiveName()} was dispensed from the seed extractor", gameObject.RegisterTile().WorldPosition.To2Int(), gameObject);
+
+		//Remove spawned entry from list
+		seedPackets.Remove(seedPacket);
+		updateEvent.Invoke();
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/UI/GUI_SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/UI/GUI_SeedExtractor.cs
@@ -30,14 +30,6 @@ public class GUI_SeedExtractor : NetTab
 	private bool inited = false;
 	private string selectedSeedType;
 
-	private void Start()
-	{
-		if (!CustomNetworkManager.Instance._isServer)
-		{
-			return;
-		}
-	}
-
 	protected override void InitServer()
 	{
 		StartCoroutine(WaitForProvider());
@@ -57,6 +49,9 @@ public class GUI_SeedExtractor : NetTab
 		seedExtractor.UpdateEvent.AddListener(UpdateItems);
 	}
 
+	/// <summary>
+	/// Generates dictionary of seed packets used to populate GUI
+	/// </summary>
 	private void GenerateContentList()
 	{
 		if (!CustomNetworkManager.Instance._isServer)
@@ -93,7 +88,7 @@ public class GUI_SeedExtractor : NetTab
 	/// Updates GUI with changes to SeedExtractor
 	/// Could be optimized to only add/remove rather then rebuild the entire list
 	/// </summary>
-	public void UpdateItems()
+	private void UpdateItems()
 	{
 		GenerateContentList();
 		UpdateList();
@@ -136,6 +131,10 @@ public class GUI_SeedExtractor : NetTab
 		}
 	}
 
+	/// <summary>
+	/// Moves GUI into list of specific seeds
+	/// </summary>
+	/// <param name="seedType">Name of selected seed type</param>
 	public void SelectSeedType(string seedType)
 	{
 		title.SetValue = System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(seedType.ToLower());
@@ -145,6 +144,9 @@ public class GUI_SeedExtractor : NetTab
 		UpdateList();
 	}
 
+	/// <summary>
+	/// Moves GUI back to list of seed types
+	/// </summary>
 	public void Back()
 	{
 		title.SetValue = "Select Seed Packet";
@@ -154,47 +156,23 @@ public class GUI_SeedExtractor : NetTab
 		UpdateList();
 	}
 
-	public void DispenseSeedPacket(SeedPacket item)
+	/// <summary>
+	/// Spawn seed packet in world
+	/// </summary>
+	public void DispenseSeedPacket(SeedPacket seedPacket)
 	{
-		if (item == null || seedExtractor == null) return;
-		SeedPacket itemToSpawn = null;
-		foreach (var vendorItem in seedExtractorContent[item.name])
-		{
-			if (vendorItem == item)
-			{
-				itemToSpawn = item;
-				break;
-			}
-		}
+		if (!CanSell())	return;
+		seedExtractor.DispenseSeedPacket(seedPacket);
 
-		if (!CanSell(itemToSpawn))
-		{
-			return;
-		}
-
-		Vector3 spawnPos = seedExtractor.gameObject.RegisterTile().WorldPositionServer;
-		CustomNetTransform netTransform = itemToSpawn.GetComponent<CustomNetTransform>();
-		netTransform.AppearAtPosition(spawnPos);
-		netTransform.AppearAtPositionServer(spawnPos);
-		//var spawnedItem = Spawn.ServerPrefab(itemToSpawn.gameObject, spawnPos, seedExtractor.transform.parent).GameObject;
-		//something went wrong trying to spawn the item
-		//if (spawnedItem == null) return;
-
-		seedExtractorContent[itemToSpawn.name].Remove(itemToSpawn);
-		if(seedExtractorContent[itemToSpawn.name].Count == 0)
-		{
-			seedExtractorContent.Remove(itemToSpawn.name);
-		}
-
-		SendToChat($"{itemToSpawn.gameObject.ExpensiveName()} was dispensed from the seed extractor");
-
-
-		UpdateList();
 		allowSell = false;
 		StartCoroutine(VendorInputCoolDown());
 	}
 
-	private bool CanSell(SeedPacket itemToSpawn)
+	/// <summary>
+	/// Checks if cooldown has completed, shows message if it hasn't
+	/// </summary>
+	/// <returns>True if cooldown completed</returns>
+	private bool CanSell()
 	{
 		if (allowSell)
 		{
@@ -206,7 +184,7 @@ public class GUI_SeedExtractor : NetTab
 
 	private void SendToChat(string messageToSend)
 	{
-		Chat.AddLocalMsgToChat(messageToSend, seedExtractor.transform.position, seedExtractor?.gameObject);
+		Chat.AddLocalMsgToChat(messageToSend, seedExtractor.gameObject.RegisterTile().WorldPosition.To2Int(), seedExtractor?.gameObject);
 	}
 
 	private IEnumerator VendorInputCoolDown()


### PR DESCRIPTION
# Fix for Seed Extractor + Rafactor

### Purpose
- Fixes seed extractor's list refilling with all old entries every time a new packet is processed.
- Updates seed extractor to run at a more reasonable speed
- Some general refactoring of the code that caused this bug to be more understandable + comments

### This does nothing right?? 
Not sure why it was there when I copied vendors code so I'm removing it
```
private void Start()	
{	
	if (!CustomNetworkManager.Instance._isServer)	
	{	
		return;	
	}	
}
```

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
