### PR TITLE
Chair fixes.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/Stool.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/Stool.prefab
@@ -192,6 +192,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+  ignoreExtraRotation: []
 --- !u!114 &114993189208139396
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -220,6 +221,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  soundOnHit: 
   Armor:
     Melee: 0
     Bullet: 0
@@ -271,7 +273,8 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   initialName: stool
-  initialDescription: For sitting or getting strapped onto.
+  initialDescription: A stool for sitting.
+  willHighlight: 1
   exportCost: 0
   exportName: 
   exportMessage: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/comfy_chair.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/comfy_chair.prefab
@@ -20,7 +20,7 @@ GameObject:
   - component: {fileID: 6567235425410853508}
   - component: {fileID: 5579796598989453093}
   - component: {fileID: 7740507522402319616}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: comfy_chair
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -234,6 +234,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &7740507522402319616
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/pewend_left_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/pewend_left_0.prefab
@@ -113,7 +113,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
-  objectType: 0
+  objectType: 1
   AtmosPassable: 1
   Passable: 1
 --- !u!114 &3627631272076510735
@@ -147,6 +147,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &2941685768857086103
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/pewend_left_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/pewend_left_0.prefab
@@ -20,7 +20,7 @@ GameObject:
   - component: {fileID: -4166200168561424486}
   - component: {fileID: 4147946706600726899}
   - component: {fileID: 6550601417579492656}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: pewend_left_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/pewend_right_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/pewend_right_0.prefab
@@ -100,7 +100,7 @@ GameObject:
   - component: {fileID: 4988624756692056802}
   - component: {fileID: -1198996671238818222}
   - component: {fileID: -7867059549849434861}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: pewend_right_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/pewend_right_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/pewend_right_0.prefab
@@ -193,7 +193,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
-  objectType: 0
+  objectType: 1
   AtmosPassable: 1
   Passable: 1
 --- !u!114 &3342342776282640571
@@ -227,6 +227,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &7269255414845508063
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/pewmiddle_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/pewmiddle_0.prefab
@@ -193,7 +193,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
-  objectType: 0
+  objectType: 1
   AtmosPassable: 1
   Passable: 1
 --- !u!114 &-3285347575489872077
@@ -227,6 +227,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &-2452584953163270110
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/pewmiddle_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/pewmiddle_0.prefab
@@ -100,7 +100,7 @@ GameObject:
   - component: {fileID: 7399691763730783495}
   - component: {fileID: -5585593495830839521}
   - component: {fileID: -2193209886874244082}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: pewmiddle_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/shuttle_chair_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/shuttle_chair_0.prefab
@@ -181,7 +181,7 @@ GameObject:
   - component: {fileID: 2101030153401488801}
   - component: {fileID: 6411611869092153326}
   - component: {fileID: -2445378394868782575}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: shuttle_chair_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/shuttle_chair_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/shuttle_chair_0.prefab
@@ -181,7 +181,7 @@ GameObject:
   - component: {fileID: 2101030153401488801}
   - component: {fileID: 6411611869092153326}
   - component: {fileID: -2445378394868782575}
-  m_Layer: 23
+  m_Layer: 11
   m_Name: shuttle_chair_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -274,7 +274,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
-  objectType: 0
+  objectType: 1
   AtmosPassable: 1
   Passable: 1
 --- !u!114 &-7596303361927942555

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofacorner_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofacorner_0.prefab
@@ -113,7 +113,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
-  objectType: 0
+  objectType: 1
   AtmosPassable: 1
   Passable: 1
 --- !u!114 &8039311948146211082
@@ -147,6 +147,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &820665452236891061
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofacorner_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofacorner_0.prefab
@@ -20,7 +20,7 @@ GameObject:
   - component: {fileID: -1210932985207401027}
   - component: {fileID: -241785199089057273}
   - component: {fileID: -862359165737431993}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: sofacorner_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofaend_left_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofaend_left_0.prefab
@@ -180,7 +180,7 @@ GameObject:
   - component: {fileID: 5050898993043993061}
   - component: {fileID: -8446573928811290727}
   - component: {fileID: 5146280897159766934}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: sofaend_left_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofaend_left_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofaend_left_0.prefab
@@ -273,7 +273,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
-  objectType: 0
+  objectType: 1
   AtmosPassable: 1
   Passable: 1
 --- !u!114 &7615799771618278032
@@ -307,6 +307,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &948817315919834099
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofaend_right_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofaend_right_0.prefab
@@ -100,7 +100,7 @@ GameObject:
   - component: {fileID: -7408363982461268671}
   - component: {fileID: 2218311234854299122}
   - component: {fileID: -996643879048408594}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: sofaend_right_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofaend_right_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofaend_right_0.prefab
@@ -193,7 +193,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
-  objectType: 0
+  objectType: 1
   AtmosPassable: 1
   Passable: 1
 --- !u!114 &7862356214891882554
@@ -227,6 +227,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &2213441966020063452
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofamiddle_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofamiddle_0.prefab
@@ -180,7 +180,7 @@ GameObject:
   - component: {fileID: -8282289100227108650}
   - component: {fileID: -9217439162693278525}
   - component: {fileID: -6326857998155813122}
-  m_Layer: 11
+  m_Layer: 23
   m_Name: sofamiddle_0
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofamiddle_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/sofamiddle_0.prefab
@@ -273,7 +273,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   matrixDebugLogging: 0
-  objectType: 0
+  objectType: 1
   AtmosPassable: 1
   Passable: 1
 --- !u!114 &-6056491110923657985
@@ -307,6 +307,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &-3632541438310209097
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/ProjectSettings/Physics2DSettings.asset
+++ b/UnityProject/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: c800805cc800805cc800805cffffffffc800805cc800805cffffffffffffffffc880805ec880805cc800805cc880805cc880805cc800805cc880805cc85b1e3cc800805cc880805cc880805cc880805cc880805cc800805cc800805cff7ffffdc800805cc801005cffffffffffffffffffffffffc880805cff7fffffc800805c
+  m_LayerCollisionMatrix: c800005cc800005cc800005cffffffffc800005cc800005cffffffffffffffffc880005ec880005cc800005cc880005cc880005cc800005cc880005cc85b1e3cc800005cc880005cc880005cc880005cc880005cc800005cc800005cc80080fdc800805cc801005cffffffffffffffffffffffffc880805cff7fffffc800805c


### PR DESCRIPTION
Due to the 'Unshootable Machines' layer causing issue with physics 2D, the shuttle chairs for now have been changed to the 'Machines' layers. Changed the object types for other new seats to better fit what they are.