### PR TITLE
Modify StatueAI to make them act when no one is looking at them

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Statues/NPC_Statue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Statues/NPC_Statue.prefab
@@ -556,10 +556,11 @@ MonoBehaviour:
   followTarget: {fileID: 0}
   spriteHolder: {fileID: 3392343644113499114}
   targetOtherPlayersWhoGetInWay: 1
-  hitDamage: 20
+  onlyHitTarget: 0
+  hitDamage: 70
   attackVerb: slashed
   defaultTarget: 0
-  meleeCoolDown: 0.4
+  meleeCoolDown: 1
 --- !u!114 &5455627643366143253
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/NPC/AI/CatAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/CatAI.cs
@@ -68,6 +68,7 @@ public class CatAI : MobAI
 
 	public override void OnPetted(GameObject performer)
 	{
+		base.OnPetted(performer);
 		int randAction = Random.Range(1,5);
 		switch (randAction)
 		{

--- a/UnityProject/Assets/Scripts/NPC/AI/CorgiAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/CorgiAI.cs
@@ -187,6 +187,8 @@ public class CorgiAI : MobAI
 
 	public override void OnPetted(GameObject performer)
 	{
+		base.OnPetted(performer);
+
 		int randAction = Random.Range(1,6);
 
 		switch (randAction)

--- a/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
@@ -411,8 +411,12 @@ public class MobAI : MonoBehaviour, IServerDespawn
 	/// Triggers on creatures with Pettable component when petted.
 	///</summary>
 	///<param name="performer">The player petting</param>
-	public virtual void OnPetted(GameObject performer){}
-
+	public virtual void OnPetted(GameObject performer)
+	{
+		// face performer
+		var dir = (performer.transform.position - transform.position).normalized;
+		dirSprites.ChangeDirection(dir);
+	}
 	///<summary>
 	/// Triggers when the explorer targets people and found one
 	///</summary>

--- a/UnityProject/Assets/Scripts/NPC/AI/StatueAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/StatueAI.cs
@@ -306,7 +306,7 @@ public class StatueAI : MobAI
 			{
 				FollowTarget(stalked);
 			}
-			yield return WaitFor.Seconds(searchTickRate);
+			yield return WaitFor.Seconds(.2f);
 		}
 
 		Freeze();


### PR DESCRIPTION
# Pull Request Template

### Purpose
This PR will modify StatueAI to take in consideration if people are looking at them before moving.

### Notes:
I also made petted pets to turn and face the person petting them.

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
