### PR TITLE
Fixes issue with click-moving shotgun shells into hand

### DIFF
--- a/UnityProject/Assets/Scripts/Weapons/MagazineBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Weapons/MagazineBehaviour.cs
@@ -166,6 +166,10 @@ public class MagazineBehaviour : NetworkBehaviour, IServerSpawn, IExaminable, IC
 		return ("Loaded " + toTransfer + (toTransfer == 1 ? " piece" : " pieces") + " of ammunition.");
 	}
 
+	/// <summary>
+	/// Returns true if it is possible to fill this magazine with the interaction target object,
+	/// which occurs when the interaction target is a clip of the same ammo type.
+	/// </summary>
 	public bool WillInteract(InventoryApply interaction, NetworkSide side)
 	{
 		if (!DefaultWillInteract.Default(interaction, side)) return false;
@@ -173,7 +177,7 @@ public class MagazineBehaviour : NetworkBehaviour, IServerSpawn, IExaminable, IC
 		MagazineBehaviour mag = interaction.TargetObject.GetComponent<MagazineBehaviour>();
 
 		if (mag == null) return false;
-
+		if (mag == this) return false;
 		if (mag.ammoType != ammoType || !isClip) return false;
 
 		return true;


### PR DESCRIPTION
### Purpose
Fixes #3711 

### Notes
Fixes a bug that arose as an unintended side effect of allowing magazines (especially the internal magazines of shotguns) to be filled with clips of the same ammo type. 

Because of the way clicking a clip from an empty hand slot works, the interaction target and the clip doing the "filling" were the same, leading the game to think a magazine refill was possible (it's not), and preventing players from click-moving shotgun shells into their hand.

### Self checks:
- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [x] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [ ] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
- [ ] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
