### PR TITLE
Improved statue AI

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Statues/NPC_Statue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Statues/NPC_Statue.prefab
@@ -483,7 +483,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e1d7861cc0289714b8989f7181986a18, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  fieldOfView: 180
+  fieldOfView: 360
 --- !u!114 &3493423571535560689
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/NPC/AI/MobExplore.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobExplore.cs
@@ -104,7 +104,7 @@ protected Vector3Int actionPosition;
 				return (registerObj.Matrix.Get<FloorDecal>(checkPos, true).Any(p => p.Cleanable));
 			case Target.missingFloor:
 				// Checks the topmost tile if its the base layer (below the floor)
-				return interactableTiles.MetaTileMap.GetTile(checkPos).LayerType == LayerType.Base;
+				return interactableTiles.MetaTileMap.GetTile(checkPos)?.LayerType == LayerType.Base;
 			case Target.injuredPeople:
 				return false;
 			// this includes ghosts!

--- a/UnityProject/Assets/Scripts/NPC/AI/StatueAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/StatueAI.cs
@@ -257,38 +257,6 @@ public class StatueAI : MobAI
 		}
 	}
 
-	private void DoRandomMove()
-	{
-		var nudgeDir = GetNudgeDirFromInt(Random.Range(0, 8));
-		if (registerObject.Matrix.IsSpaceAt(registerObject.LocalPosition + nudgeDir.To3Int(), true))
-		{
-			for (int i = 0; i < 8; i++)
-			{
-				var testDir = GetNudgeDirFromInt(i);
-				var checkTile = registerObject.LocalPosition + testDir.To3Int();
-				if (!registerObject.Matrix.IsSpaceAt(checkTile, true))
-				{
-					if (registerObject.Matrix.IsPassableAt(checkTile, true))
-					{
-						nudgeDir = testDir;
-						break;
-					}
-					else
-					{
-						if (registerObject.Matrix.GetFirst<DoorController>(checkTile, true))
-						{
-							nudgeDir = testDir;
-							break;
-						}
-					}
-				}
-			}
-		}
-
-		NudgeInDirection(nudgeDir);
-		movementTickRate = Random.Range(1f, 3f);
-	}
-
 	void PlaySound()
 	{
 		if (!IsDead && !IsUnconscious && GenericSounds.Count > 0)


### PR DESCRIPTION
# Pull Request Template

### Purpose
This PR will improve the Statue behavior making it only responds when no one is seeing it. 

Before it was checking if people inside its cone had an opposite face direction (very lazy solution). Now it will actually check if someone is looking at it, although since the game has only 4 directions, it can fail when you're very close to the thing. Don't be very close to the thing.

### Notes:
I also added a Null check so hopefully server stop spamming the NRE Doobly has been crying about.

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
