### PR TITLE
More stringent checks on account handling

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -164,20 +164,20 @@ public partial class PlayerList
 		return adminUsers.Contains(userID);
 	}
 
-	public async Task<bool> ValidatePlayer(string clientID, string username,
-		string userid, int clientVersion, ConnectedPlayer playerConn,
-		string token)
+	public async Task<bool> ValidatePlayer(string unverifiedClientId, string unverifiedUsername,
+		string unverifiedUserid, int unverifiedClientVersion, ConnectedPlayer unverifiedConnPlayer,
+		string unverifiedToken)
 	{
-		var validAccount = await CheckUserState(userid, token, playerConn, clientID);
+		var validAccount = await CheckUserState(unverifiedUserid, unverifiedToken, unverifiedConnPlayer, unverifiedClientId);
 
 		if (!validAccount)
 		{
 			return false;
 		}
 
-		if (clientVersion != GameData.BuildNumber)
+		if (unverifiedClientVersion != GameData.BuildNumber)
 		{
-			StartCoroutine(KickPlayer(playerConn, $"Invalid Client Version! You need version {GameData.BuildNumber}." +
+			StartCoroutine(KickPlayer(unverifiedConnPlayer, $"Invalid Client Version! You need version {GameData.BuildNumber}." +
 			                                      " This can be acquired through the station hub."));
 			return false;
 		}
@@ -186,21 +186,25 @@ public partial class PlayerList
 	}
 
 	//Check if tokens match and if the player is an admin or is banned
-	private async Task<bool> CheckUserState(string userid, string token, ConnectedPlayer playerConn, string clientID)
+	private async Task<bool> CheckUserState(
+		string unverifiedUserid,
+		string unverifiedToken,
+		ConnectedPlayer unverifiedConnPlayer,
+		string unverifiedClientId)
 	{
 		if (GameData.Instance.OfflineMode)
 		{
-			Logger.Log($"{playerConn.Username} logged in successfully in offline mode. " +
-			           $"userid: {userid}", Category.Admin);
+			Logger.Log($"{unverifiedConnPlayer.Username} logged in successfully in offline mode. " +
+			           $"userid: {unverifiedUserid}", Category.Admin);
 			return true;
 		}
 
 		//allow empty token for local offline testing
-		if (string.IsNullOrEmpty(token) || string.IsNullOrEmpty(userid))
+		if (string.IsNullOrEmpty(unverifiedToken) || string.IsNullOrEmpty(unverifiedUserid))
 		{
-			StartCoroutine(KickPlayer(playerConn, $"Server Error: Account has invalid cookie."));
+			StartCoroutine(KickPlayer(unverifiedConnPlayer, $"Server Error: Account has invalid cookie."));
 			Logger.Log($"A user tried to connect with null userid or token value" +
-			           $"Details: Username: {playerConn.Username}, ClientID: {clientID}, IP: {playerConn.Connection.address}",
+			           $"Details: Username: {unverifiedConnPlayer.Username}, ClientID: {unverifiedClientId}, IP: {unverifiedConnPlayer.Connection.address}",
 				Category.Admin);
 			return false;
 		}
@@ -208,67 +212,84 @@ public partial class PlayerList
 		//check if they are already logged in, skip this check if offline mode is enable or if not a release build.
 		if (BuildPreferences.isForRelease)
 		{
-			var otherUser = GetByUserID(userid);
+			var otherUser = GetByUserID(unverifiedUserid);
 			if (otherUser != null)
 			{
 				if (otherUser.Connection != null && otherUser.GameObject != null)
 				{
-					if (playerConn.UserId == userid
-					    && playerConn.Connection != otherUser.Connection)
+					if (unverifiedConnPlayer.UserId == unverifiedUserid
+					    && unverifiedConnPlayer.Connection != otherUser.Connection)
 					{
 						StartCoroutine(
-							KickPlayer(playerConn, $"Server Error: You are already logged into this server!"));
+							KickPlayer(unverifiedConnPlayer, $"Server Error: You are already logged into this server!"));
 						Logger.Log($"A user tried to connect with another client while already logged in \r\n" +
-						           $"Details: Username: {playerConn.Username}, ClientID: {clientID}, IP: {playerConn.Connection.address}",
+						           $"Details: Username: {unverifiedConnPlayer.Username}, ClientID: {unverifiedClientId}, IP: {unverifiedConnPlayer.Connection.address}",
 							Category.Admin);
 						return false;
 					}
 				}
 			}
+
+			otherUser = GetByConnection(unverifiedConnPlayer.Connection);
+			if (otherUser != null)
+			{
+				StartCoroutine(
+					KickPlayer(unverifiedConnPlayer, $"Server Error: You already have an existing connection with the server!"));
+				Logger.LogWarning($"Warning 2 simultaneous connections from same IP detected\r\n" +
+				           $"Details: Unverified Username: {unverifiedConnPlayer.Username}, Unverified ClientID: {unverifiedClientId}, IP: {unverifiedConnPlayer.Connection.address}",
+					Category.Admin);
+			}
 		}
-
-		var refresh = new RefreshToken {userID = userid, refreshToken = token};
+		var refresh = new RefreshToken {userID = unverifiedUserid, refreshToken = unverifiedToken};//Assuming this validates it for now
 		var response = await ServerData.ValidateToken(refresh, true);
-
 		//fail, unless doing local offline testing
-		if (response == null)
+		if (!GameData.Instance.OfflineMode)
 		{
-			return false;
+			if (response == null)
+			{
+				StartCoroutine(KickPlayer(unverifiedConnPlayer, $"Server Error: Server request error"));
+				Logger.Log($"Server request error for " +
+				           $"Details: Username: {unverifiedConnPlayer.Username}, ClientID: {unverifiedClientId}, IP: {unverifiedConnPlayer.Connection.address}",
+					Category.Admin);
+				return false;
+			}
+		}
+		else
+		{
+			if (response == null) return false;
 		}
 
 		//allow error response for local offline testing
 		if (response.errorCode == 1)
 		{
-			StartCoroutine(KickPlayer(playerConn, $"Server Error: Account has invalid cookie."));
+			StartCoroutine(KickPlayer(unverifiedConnPlayer, $"Server Error: Account has invalid cookie."));
 			Logger.Log($"A spoof attempt was recorded. " +
-			           $"Details: Username: {playerConn.Username}, ClientID: {clientID}, IP: {playerConn.Connection.address}",
+			           $"Details: Username: {unverifiedConnPlayer.Username}, ClientID: {unverifiedClientId}, IP: {unverifiedConnPlayer.Connection.address}",
 				Category.Admin);
 			return false;
 		}
-
+		var Userid = unverifiedUserid;
+		var Token = unverifiedToken;
 		//whitelist checking:
-
-
 		var lines = File.ReadAllLines(whiteListPath);
 
 		//Adds server to admin list if not already in it.
-
-		if (userid == ServerData.UserID && !adminUsers.Contains(userid))
+		if (Userid == ServerData.UserID && !adminUsers.Contains(Userid))
 		{
 			File.AppendAllLines(adminsPath, new string[]
 			{
-			"\r\n" + userid
+			"\r\n" + Userid
 			});
 
-			adminUsers.Add(userid);
-			var user = GetByUserID(userid);
+			adminUsers.Add(Userid);
+			var user = GetByUserID(Userid);
 
 			if (user == null) return false;
 
 			var newToken = System.Guid.NewGuid().ToString();
-			if (!loggedInAdmins.ContainsKey(userid))
+			if (!loggedInAdmins.ContainsKey(Userid))
 			{
-				loggedInAdmins.Add(userid, newToken);
+				loggedInAdmins.Add(Userid, newToken);
 				AdminEnableMessage.Send(user.Connection, newToken);
 			}
 		}
@@ -276,18 +297,18 @@ public partial class PlayerList
 		//Checks whether the userid is in either the Admins or whitelist AND that the whitelist file has something in it.
 		//Whitelist only activates if whitelist is populated.
 
-		if (lines.Length > 0 && !adminUsers.Contains(userid) && !whiteListUsers.Contains(userid) )
+		if (lines.Length > 0 && !adminUsers.Contains(Userid) && !whiteListUsers.Contains(Userid) )
 		{
-			StartCoroutine(KickPlayer(playerConn, $"Server Error: This account is not whitelisted."));
+			StartCoroutine(KickPlayer(unverifiedConnPlayer, $"Server Error: This account is not whitelisted."));
 
-			Logger.Log($"{playerConn.Username} tried to log in but the account is not whitelisted. " +
-						   $"IP: {playerConn.Connection.address}", Category.Admin);
+			Logger.Log($"{unverifiedConnPlayer.Username} tried to log in but the account is not whitelisted. " +
+						   $"IP: {unverifiedConnPlayer.Connection.address}", Category.Admin);
 			return false;
 		}
 
 
 		//banlist checking:
-		var banEntry = banList?.CheckForEntry(userid, playerConn.Connection.address);
+		var banEntry = banList?.CheckForEntry(Userid, unverifiedConnPlayer.Connection.address);
 		if (banEntry != null)
 		{
 			var entryTime = DateTime.ParseExact(banEntry.dateTimeOfBan,"O",CultureInfo.InvariantCulture);
@@ -297,21 +318,21 @@ public partial class PlayerList
 				//Old ban, remove it
 				banList.banEntries.Remove(banEntry);
 				SaveBanList();
-				Logger.Log($"{playerConn.Username} ban has expired and the user has logged back in.", Category.Admin);
+				Logger.Log($"{unverifiedConnPlayer.Username} ban has expired and the user has logged back in.", Category.Admin);
 			}
 			else
 			{
 				//User is still banned:
-				StartCoroutine(KickPlayer(playerConn, $"Server Error: This account is banned. " +
+				StartCoroutine(KickPlayer(unverifiedConnPlayer, $"Server Error: This account is banned. " +
 				                                      $"Check your initial ban message for expiry time"));
-				Logger.Log($"{playerConn.Username} tried to log back in but the account is banned. " +
-				           $"IP: {playerConn.Connection.address}", Category.Admin);
+				Logger.Log($"{unverifiedConnPlayer.Username} tried to log back in but the account is banned. " +
+				           $"IP: {unverifiedConnPlayer.Connection.address}", Category.Admin);
 				return false;
 			}
 		}
 
-		Logger.Log($"{playerConn.Username} logged in successfully. " +
-		           $"userid: {userid}", Category.Admin);
+		Logger.Log($"{unverifiedConnPlayer.Username} logged in successfully. " +
+		           $"userid: {Userid}", Category.Admin);
 
 		return true;
 	}

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -282,6 +282,13 @@ public partial class PlayerList : NetworkBehaviour
 		return getInternal(player => player.UserId == byUserID);
 	}
 
+
+	[Server]
+	public ConnectedPlayer GetByConnection(NetworkConnection connection)
+	{
+		return getInternal(player => player.Connection == connection);
+	}
+
 	[Server]
 	public List<ConnectedPlayer> GetAllByUserID(string byUserID)
 	{
@@ -394,13 +401,13 @@ public partial class PlayerList : NetworkBehaviour
 	}
 
 	[Server]
-	public GameObject TakeLoggedOffPlayer(string clientId)
+	public GameObject TakeLoggedOffPlayer(string userId)
 	{
-		Logger.LogTraceFormat("Searching for logged off players with id {0}", Category.Connections, clientId);
+		Logger.LogTraceFormat("Searching for logged off players with userId {0}", Category.Connections, userId);
 		foreach (var player in loggedOff)
 		{
-			Logger.LogTraceFormat("Found logged off player with id {0}", Category.Connections, player.ClientId);
-			if (player.ClientId == clientId)
+			Logger.LogTraceFormat("Found logged off player with userId {0}", Category.Connections, player.UserId);
+			if (player.UserId == userId)
 			{
 				loggedOff.Remove(player);
 				return player.GameObject;

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -401,7 +401,7 @@ public partial class PlayerList : NetworkBehaviour
 	}
 
 	[Server]
-	public GameObject TakeLoggedOffPlayer(string userId)
+	public GameObject TakeLoggedOffPlayerbyUserId(string userId)
 	{
 		Logger.LogTraceFormat("Searching for logged off players with userId {0}", Category.Connections, userId);
 		foreach (var player in loggedOff)
@@ -409,6 +409,23 @@ public partial class PlayerList : NetworkBehaviour
 			Logger.LogTraceFormat("Found logged off player with userId {0}", Category.Connections, player.UserId);
 			if (player.UserId == userId)
 			{
+				loggedOff.Remove(player);
+				return player.GameObject;
+			}
+		}
+
+		return null;
+	}
+
+	[Server]
+	public GameObject TakeLoggedOffPlayerbyClientId(string ClientId)
+	{
+		Logger.LogTraceFormat("Searching for logged off players with userId {0}", Category.Connections, ClientId);
+		foreach (var player in loggedOff)
+		{
+			if (player.ClientId == ClientId)
+			{
+				Logger.LogTraceFormat("Found logged off player with userId {0}", Category.Connections, player.ClientId);
 				loggedOff.Remove(player);
 				return player.GameObject;
 			}

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -67,7 +67,15 @@ public class JoinedViewer : NetworkBehaviour
 		if (!isValidPlayer) return; //this validates Userid and Token
 		var Userid = unverifiedUserid;
 		// Check if they have a player to rejoin. If not, assign them a new client ID
-		var loggedOffPlayer = PlayerList.Instance.TakeLoggedOffPlayer(Userid);
+		GameObject loggedOffPlayer = null;
+		if (BuildPreferences.isForRelease)
+		{
+			loggedOffPlayer = PlayerList.Instance.TakeLoggedOffPlayerbyUserId(Userid);
+		}
+		else
+		{
+			loggedOffPlayer = PlayerList.Instance.TakeLoggedOffPlayerbyClientId(unverifiedClientId);
+		}
 
 		if (loggedOffPlayer != null)
 		{

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -33,37 +33,41 @@ public class JoinedViewer : NetworkBehaviour
 	}
 
 	[Command]
-	private void CmdServerSetupPlayer(string clientID, string username,
-		string userid, int clientVersion, string token)
+	private void CmdServerSetupPlayer(string unverifiedClientId, string unverifiedUsername,
+		string unverifiedUserid, int unverifiedClientVersion, string unverifiedToken)
 	{
-		ServerSetUpPlayer(clientID, username, userid, clientVersion, token);
+		ServerSetUpPlayer(unverifiedClientId, unverifiedUsername, unverifiedUserid, unverifiedClientVersion, unverifiedToken);
 	}
 
 	[Server]
-	private async void ServerSetUpPlayer(string clientID, string username, string userid, int clientVersion,
-		string token)
+	private async void ServerSetUpPlayer(
+		string unverifiedClientId,
+		string unverifiedUsername,
+		string unverifiedUserid,
+		int unverifiedClientVersion,
+		string unverifiedToken)
 	{
-		Logger.LogFormat("A joinedviewer called CmdServerSetupPlayer on this server, clientID: {0} username: {1}",
+		Logger.LogFormat("A joinedviewer called CmdServerSetupPlayer on this server, Unverified ClientId: {0} Unverified Username: {1}",
 			Category.Connections,
-			clientID, username);
+			unverifiedClientId, unverifiedUsername);
 
 		//Register player to player list (logging code exists in PlayerList so no need for extra logging here)
-		var connPlayer = PlayerList.Instance.AddOrUpdate(new ConnectedPlayer
+		var unverifiedConnPlayer = PlayerList.Instance.AddOrUpdate(new ConnectedPlayer
 		{
 			Connection = connectionToClient,
 			GameObject = gameObject,
-			Username = username,
+			Username = unverifiedUsername,
 			Job = JobType.NULL,
-			ClientId = clientID,
-			UserId = userid
+			ClientId = unverifiedClientId,
+			UserId = unverifiedUserid
 		});
 
-		var isValidPlayer = await PlayerList.Instance.ValidatePlayer(clientID, username,
-			userid, clientVersion, connPlayer, token);
-		if (!isValidPlayer) return;
-
+		var isValidPlayer = await PlayerList.Instance.ValidatePlayer(unverifiedClientId, unverifiedUsername,
+			unverifiedUserid, unverifiedClientVersion, unverifiedConnPlayer, unverifiedToken);
+		if (!isValidPlayer) return; //this validates Userid and Token
+		var Userid = unverifiedUserid;
 		// Check if they have a player to rejoin. If not, assign them a new client ID
-		var loggedOffPlayer = PlayerList.Instance.TakeLoggedOffPlayer(clientID);
+		var loggedOffPlayer = PlayerList.Instance.TakeLoggedOffPlayer(Userid);
 
 		if (loggedOffPlayer != null)
 		{
@@ -78,11 +82,11 @@ public class JoinedViewer : NetworkBehaviour
 		if (loggedOffPlayer == null)
 		{
 			//This is the players first time connecting to this round, assign them a Client ID;
-			var oldID = clientID;
-			clientID = Guid.NewGuid().ToString();
-			connPlayer.ClientId = clientID;
+			var oldID = unverifiedClientId;
+			unverifiedClientId = Guid.NewGuid().ToString();
+			unverifiedConnPlayer.ClientId = unverifiedClientId;
 			Logger.LogFormat("This server did not find a logged off player with clientID {0}, assigning" +
-			                 " joined viewer a new ID {1}", Category.Connections, oldID, clientID);
+			                 " joined viewer a new ID {1}", Category.Connections, oldID, unverifiedClientId);
 		}
 
 		// Sync all player data and the connected player count
@@ -112,11 +116,11 @@ public class JoinedViewer : NetworkBehaviour
 		}
 		else
 		{
-			TargetLocalPlayerSetupNewPlayer(connectionToClient, connPlayer.ClientId,
+			TargetLocalPlayerSetupNewPlayer(connectionToClient, unverifiedConnPlayer.ClientId,
 				GameManager.Instance.CurrentRoundState);
 		}
 
-		PlayerList.Instance.CheckAdminState(connPlayer, userid);
+		PlayerList.Instance.CheckAdminState(unverifiedConnPlayer, Userid);
 	}
 
 	/// <summary>


### PR DESCRIPTION
So  I am unable to investigate the token Authentication stuff 
so idk if it actually has anything wrong with it, Since I can't view the code for it,
I cleaned the other bits up and added naming to Highlight what Variables are Unchecked soShouldn't be trusted from client

Using Userid more dependable than client ID,
for logout bodies, hoping that that HTTP request authenticates the
Userid and token properly,
added more stringent checks on null return on the HTTP request 

### automatic kick for multiple accounts on one IP

A brief check in editor,
Not tested relogging