### PR TITLE
Fix NRE caused by null objects attacking NPC's

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Friendly/NPC_Runtime.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Friendly/NPC_Runtime.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 114582363912736342}
   - component: {fileID: 114774533267492450}
   - component: {fileID: 114791056930384320}
+  - component: {fileID: 2396704058319493381}
   - component: {fileID: 144592572944150269}
   - component: {fileID: 5061804172772503656}
   - component: {fileID: -6765002746793913123}
@@ -194,6 +195,20 @@ MonoBehaviour:
   sceneId: 0
   serverOnly: 0
   m_AssetId: 
+--- !u!114 &2396704058319493381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1722833055556988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  butcherTime: 2
+  butcherSound: BladeSlice
 --- !u!114 &144592572944150269
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/NPC/AI/CatAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/CatAI.cs
@@ -82,7 +82,7 @@ public class CatAI : MobAI
 				StartCoroutine(ChaseTail(Random.Range(1,5)));
 				break;
 			case 4:
-				StartFleeing(performer.transform, 5f);
+				StartFleeing(performer, 5f);
 				break;
 			// case 5:
 			// 	StartCoroutine(LayDown(Random.Range(10,15)));//TODO
@@ -93,7 +93,7 @@ public class CatAI : MobAI
 	protected override void OnAttackReceived(GameObject damagedBy)
 	{
 		Hiss(damagedBy);
-		FleeFromAttacker(damagedBy, 10F);
+		StartFleeing(damagedBy, 10F);
 	}
 
 	void OnFollowingStopped()
@@ -216,7 +216,7 @@ public class CatAI : MobAI
 	public void RunFromDog(Transform dog)
 	{
 		Hiss(dog.gameObject);
-		StartFleeing(dog, 10f);
+		StartFleeing(dog.gameObject, 10f);
 	}
 
 	IEnumerator LayDown(int cycles)

--- a/UnityProject/Assets/Scripts/NPC/AI/ClownAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/ClownAI.cs
@@ -117,7 +117,7 @@ public class ClownAI : MobAI
 			//30% chance the Clown decides to flee:
 			if (Random.value < 0.3f)
 			{
-				StartFleeing(damagedBy.transform, 5f);
+				StartFleeing(damagedBy, 5f);
 				return;
 			}
 		}

--- a/UnityProject/Assets/Scripts/NPC/AI/CorgiAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/CorgiAI.cs
@@ -101,7 +101,7 @@ public class CorgiAI : MobAI
 		//We want these ones to happen right away:
 		if (msg.Contains($"{dogName} run") || msg.Contains($"{dogName} get out of here"))
 		{
-			StartFleeing(speaker.GameObject.transform, 10f);
+			StartFleeing(speaker.GameObject, 10f);
 			yield break;
 		}
 
@@ -220,7 +220,7 @@ public class CorgiAI : MobAI
 	protected override void OnAttackReceived(GameObject damagedBy)
 	{
 		SingleBark();
-		StartFleeing(damagedBy.transform);
+		StartFleeing(damagedBy);
 	}
 
 	//Updates only on the server

--- a/UnityProject/Assets/Scripts/NPC/AI/GenericAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/GenericAI.cs
@@ -117,7 +117,7 @@ public class GenericAI : MobAI
 			//30% chance the mob decides to flee:
 			if (Random.value < 0.3f)
 			{
-				StartFleeing(damagedBy.transform, 5f);
+				StartFleeing(damagedBy, 5f);
 				return;
 			}
 		}

--- a/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobAI.cs
@@ -244,10 +244,16 @@ public class MobAI : MonoBehaviour, IServerDespawn
 	/// <summary>
 	/// Start fleeing from the target
 	/// </summary>
-	protected void StartFleeing(Transform fleeTarget, float fleeDuration = -1f)
+	protected void StartFleeing(GameObject fleeTarget, float fleeDuration = -1f)
 	{
 		ResetBehaviours();
-		mobFlee.FleeFromTarget(fleeTarget);
+
+		if (fleeTarget == null) //run from itself?
+		{
+			fleeTarget = gameObject;
+		}
+
+		mobFlee.FleeFromTarget(fleeTarget.transform);
 		fleeTimeMax = fleeDuration;
 		fleeingTime = 0f;
 	}
@@ -340,23 +346,6 @@ public class MobAI : MonoBehaviour, IServerDespawn
 	}
 
 	/// <summary>
-	/// Common behavior for npc's to run from their attackers.
-	/// Call this within OnAttackReceive method
-	/// </summary>
-	/// <param name="attackedBy">GameObject from the attacker. This can be null on fire!</param>
-	/// <param name="fleeDuration">Time in seconds the flee behavior will last. Defaults to forever</param>
-	protected void FleeFromAttacker(GameObject attackedBy = null, float fleeDuration = -1f)
-	{
-		if (attackedBy == null) //run from itself?
-		{
-			StartFleeing(gameObject.transform, fleeDuration);
-			return;
-		}
-
-		StartFleeing(attackedBy.transform, fleeDuration);
-	}
-
-	/// <summary>
 	/// Common behavior to flee from attacker if health is less than X
 	/// Call this within OnAttackedReceive method
 	/// </summary>
@@ -372,7 +361,7 @@ public class MobAI : MonoBehaviour, IServerDespawn
 
 		if (health.OverallHealth < healthThreshold)
 		{
-			StartFleeing(attackedBy.transform, fleeDuration);
+			StartFleeing(attackedBy, fleeDuration);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/MouseAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MouseAI.cs
@@ -52,13 +52,13 @@ public class MouseAI : MobAI
 	public override void OnPetted(GameObject performer)
 	{
 		Squeak();
-		StartFleeing(performer.transform, 3f);
+		StartFleeing(performer, 3f);
 	}
 
 	protected override void OnAttackReceived(GameObject damagedBy)
 	{
 		Squeak();
-		FleeFromAttacker(damagedBy, 5f);
+		StartFleeing(damagedBy, 5f);
 	}
 
 	void OnExploringStooped()

--- a/UnityProject/Assets/Scripts/NPC/AI/ParrotAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/ParrotAI.cs
@@ -65,7 +65,7 @@ public class ParrotAI : MobAI
 
 	protected override void OnAttackReceived(GameObject damagedBy)
 	{
-		StartFleeing(damagedBy.transform, 5f);
+		StartFleeing(damagedBy, 5f);
 	}
 
 	// Steals shit from your active hand
@@ -85,10 +85,10 @@ public class ParrotAI : MobAI
 
 	IEnumerator FleeAndDrop(GameObject dude, GameObject stolenThing)
 	{
-		StartFleeing(dude.transform, 3f);
+		StartFleeing(dude, 3f);
 		yield return WaitFor.Seconds(3f);
 		Spawn.ServerPrefab(stolenThing, gameObject.WorldPosServer());
-		StartFleeing(dude.transform, 5f);
+		StartFleeing(dude, 5f);
 		yield break;
 	}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/StatueAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/StatueAI.cs
@@ -237,7 +237,7 @@ public class StatueAI : MobAI
 			//10% chance the statue decides to flee:
 			if (Random.value < 0.1f)
 			{
-				StartFleeing(damagedBy.transform, 5f);
+				StartFleeing(damagedBy, 5f);
 				return;
 			}
 		}

--- a/UnityProject/Assets/Scripts/NPC/AI/XenoAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/XenoAI.cs
@@ -117,7 +117,7 @@ public class XenoAI : MobAI
 			//30% chance the xeno decides to flee:
 			if (Random.value < 0.3f)
 			{
-				StartFleeing(damagedBy.transform, 5f);
+				StartFleeing(damagedBy, 5f);
 				return;
 			}
 		}


### PR DESCRIPTION
# Pull Request Template

### Purpose
Refactored StartFleeing method from MobAI to use GameObject instead of transform and added a null check. All NPC's who referenced this method are updated.

### Notes:
Deleted unused method, FleeFromAttacker

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
