### PR TITLE
Prevents TypingIcon from rendering while unconscious

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/Server/ServerTypingMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/ServerTypingMessage.cs
@@ -30,7 +30,14 @@ public class ServerTypingMessage : ServerMessage
 			yield break;
 
 		var showTyping = state == TypingState.TYPING;
-		icon.ToggleTypingIcon(showTyping);
+
+		// check if player is conscious before generating typing icon
+		bool isPlayerConscious = (player.playerHealth.ConsciousState == ConsciousState.CONSCIOUS ||
+								  player.playerHealth.ConsciousState == ConsciousState.BARELY_CONSCIOUS);
+		if (isPlayerConscious)
+		{
+			icon.ToggleTypingIcon(showTyping);
+		}
 	}
 
 	public static ServerTypingMessage Send(PlayerScript player, TypingState state)


### PR DESCRIPTION
### Purpose
Fixes #3578 Added a check to ServerTypingMessage Process() method which ensures the player is conscious before rendering the TypingIcon.

### Notes:
I know this was Low Priority but I figured it might be an easier fix. I have professional experience with C# but am new to Unity and its unique composition, so I thought it might be a good issue to tackle. Let me know if this could potentially be done in a manner that makes more sense and I'll gladly look into it.

### Please make sure you have followed the self checks below before submitting a PR:

- [ x ] Code is sufficiently commented
- [ x ] Code is indented with tabs and not spaces
- [ x ] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [ x ] The PR does not bring up any new compile errors
- [ x ] The PR has been tested in editor
- [ N/A ] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [ N/A ] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [ N/A ] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [ x ] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ x ] The PR has been tested with round restarts.
- [ x ] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
