### PR TITLE
Modification to rebel survival objective (by corp-0/Gilles) and start text tweak.

### DIFF
--- a/UnityProject/Assets/Scripts/Antagonists/Antags/Cargonian.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/Cargonian.cs
@@ -10,7 +10,7 @@ namespace Antagonists
 		{
 			var newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest);
 			UpdateChatMessage.Send(newPlayer, ChatChannel.System, ChatModifier.None,
-				"<color=red>Something has awoken in you. You feel the urgent need to rebel with your brothers against this station.</color>");
+				"<color=red>Something has awoken in you. You feel the urgent need to rebel alongside all your brothers in your deparment against this station.</color>");
 			// spawn them normally, with their preferred occupation
 			return newPlayer;
 		}

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/CargoMenSurvival.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/CargoMenSurvival.cs
@@ -33,7 +33,7 @@ namespace Antagonists
 
 				if (p.Script.playerHealth != null)
 				{
-					if (!p.Script.playerHealth.IsDead)
+					if (!p.Script.playerHealth.IsDead & GameManager.Instance.Rebels.Contains(p.Job))
 					{
 						allAliveRebels++;
 					}


### PR DESCRIPTION
### Purpose
This PR changes a line in CargoMenSurvival.cs (code supplied by corp-0/Gilles) so that rebels properly get redtext if half of their department dies instead of half the station. 
This PR also changes the initial chat message seen when spawning as a rebel to hopefully clarify that other people in your department are your allies.

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [ ] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [ ] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ] The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
