### PR TITLE
make sure client/server can no longer choose booster

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/NetworkManager.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 2924057578287968402}
   - component: {fileID: 2959621213063014110}
   - component: {fileID: 5032898753073590648}
-  - component: {fileID: 1791546816897742244}
   - component: {fileID: 4954124553048819253}
   m_Layer: 0
   m_Name: NetworkManager
@@ -53,7 +52,7 @@ MonoBehaviour:
   showDebugMessages: 0
   offlineScene: Lobby
   onlineScene: OutpostStation
-  transport: {fileID: 1791546816897742244}
+  transport: {fileID: 4954124553048819253}
   networkAddress: localhost
   maxConnections: 100
   authenticator: {fileID: 0}
@@ -1156,45 +1155,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   networkManager: {fileID: 2959621213063014110}
---- !u!114 &1791546816897742244
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2920527550438430692}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 52b2794c3c5fa43638689de2032811b8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  OnClientConnected:
-    m_PersistentCalls:
-      m_Calls: []
-  OnClientDataReceived:
-    m_PersistentCalls:
-      m_Calls: []
-  OnClientError:
-    m_PersistentCalls:
-      m_Calls: []
-  OnClientDisconnected:
-    m_PersistentCalls:
-      m_Calls: []
-  OnServerConnected:
-    m_PersistentCalls:
-      m_Calls: []
-  OnServerDataReceived:
-    m_PersistentCalls:
-      m_Calls: []
-  OnServerError:
-    m_PersistentCalls:
-      m_Calls: []
-  OnServerDisconnected:
-    m_PersistentCalls:
-      m_Calls: []
-  port: 7777
-  boosterPort: 7776
-  beamFile: {fileID: 0}
 --- !u!114 &4954124553048819253
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
For some reason client on staging was initializing booster. So I removed it as an option all together from NetworkManager
