### PR TITLE
Set dirty sceneid changes

### DIFF
--- a/UnityProject/Assets/Scripts/Editor/Tools/Tools.cs
+++ b/UnityProject/Assets/Scripts/Editor/Tools/Tools.cs
@@ -22,6 +22,7 @@ public class Tools : Editor
 		foreach (var i in identities)
 		{
 			i.AssignSceneID();
+			EditorUtility.SetDirty(i);
 		}
 		Logger.Log($"{identities.Length} network identities were reassigned scene ids");
 	}


### PR DESCRIPTION
Sets the NetworkIdentities to dirty when the sceneids are updated. Resaved pog after running the tool
