### PR TITLE
Prevent error when handcuffing dead players

### DIFF
--- a/UnityProject/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -297,7 +297,7 @@ namespace Mirror
                 payload = writer.ToArraySegment()
             };
 
-            conn.Send(message, channelId);
+            if(conn != null) conn.Send(message, channelId);
         }
 
         /// <summary>

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -505,7 +505,7 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 		Inventory.ServerDrop(targetStorage.GetNamedItemSlot(NamedSlot.leftHand));
 		Inventory.ServerDrop(targetStorage.GetNamedItemSlot(NamedSlot.rightHand));
 
-		TargetPlayerUIHandCuffToggle(connectionToClient, true);
+		if(connectionToClient != null) TargetPlayerUIHandCuffToggle(connectionToClient, true);
 	}
 
 	[TargetRpc]


### PR DESCRIPTION
It was trying to send a TargetRPC using a null connection
