### PR TITLE
Fixes: Dead players are unpushable with magboots on

### DIFF
--- a/UnityProject/Assets/ItemMagBoots.cs
+++ b/UnityProject/Assets/ItemMagBoots.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Atmospherics;
@@ -84,6 +84,29 @@ public class ItemMagBoots : NetworkBehaviour,
 	{
 		this.player = newPlayer;
 		isOn = !isOn;
+	}
+
+	private void OnPlayerDeath()
+	{
+		if (isServer)
+		{
+			if (isOn)
+			{
+				ServerChangeState(this.player);
+			}
+			UIActionManager.Toggle(this, false);
+			player.Script.playerHealth.OnDeathNotifyEvent -= OnPlayerDeath;
+			player = null;
+		}
+		else
+		{
+			if (isOn)
+			{
+				ClientChangeSpeed(initialSpeed);
+			}
+			UIActionManager.Toggle(this, false);
+		}
+
 	}
 
 	#region UI related

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -75,6 +75,8 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 
 	public event Action<GameObject> applyDamageEvent;
 
+	public event Action OnDeathNotifyEvent;
+
 	public ConsciousState ConsciousState
 	{
 		get => consciousState;
@@ -551,6 +553,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 		{
 			return;
 		}
+		OnDeathNotifyEvent?.Invoke();
 		afterDeathDamage = 0;
 		ConsciousState = ConsciousState.DEAD;
 		OnDeathActions();
@@ -767,20 +770,20 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	/// figure out what to pass to the client, based on many parameters such as
 	/// role, medical skill (if they get implemented), equipped medical scanners,
 	/// etc. In principle takes care of building the string from start to finish,
-	/// so logic generating examine text can be completely separate from examine 
+	/// so logic generating examine text can be completely separate from examine
 	/// request or netmessage processing.
 	/// </summary>
 	public string Examine(Vector3 worldPos)
 	{
 		var healthFraction = OverallHealth/maxHealth;
 		var healthString  = "";
-		
+
 		if (!IsDead)
 		{
 			if (healthFraction < 0.2f)
 			{
 				healthString = "heavily wounded.";
-			}			
+			}
 			else if (healthFraction < 0.6f)
 			{
 				healthString = "wounded.";


### PR DESCRIPTION
### Bug Fix
Bug: If you die while wearing magboots which are turned on, your dead body will stay unpushable. Also ghosts/dead players can't toggle boots now.