### PR TITLE
Small armor fix and readiblity tweaks

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 /// <summary>
 /// Represents armor which provides resistance against various kinds of attacks.
@@ -12,16 +13,16 @@ using System;
 [Serializable]
 public class Armor
 {
-	public float Melee;
-	public float Bullet;
-	public float Laser;
-	public float Energy;
-	public float Bomb;
-	public float Rad;
-	public float Fire;
-	public float Acid;
-	public float Magic;
-	public float Bio;
+	[Range(0,100)] public float Melee;
+	[Range(0,100)] public float Bullet;
+	[Range(0,100)] public float Laser;
+	[Range(0,100)] public float Energy;
+	[Range(0,100)] public float Bomb;
+	[Range(0,100)] public float Rad;
+	[Range(0,100)] public float Fire;
+	[Range(0,100)] public float Acid;
+	[Range(0,100)] public float Magic;
+	[Range(0,100)] public float Bio;
 
 	/// <summary>
 	/// Calculates how much damage would be done based on armor resistance
@@ -31,7 +32,12 @@ public class Armor
 	/// <returns>new damage after applying protection values</returns>
 	public float GetDamage(float damage, AttackType attackType)
 	{
-		return damage * (100 - GetRating(attackType)) * .01f;
+		float rating = GetRating(attackType);
+		if (rating > 100)
+		{
+			rating = 100;
+		}
+		return damage * (1 - rating / 100);
 	}
 
 	/// <summary>
@@ -93,7 +99,7 @@ public class Armor
 	}
 
 	/// <summary>
-	/// Operator override to substract all armor types with ease. Thank you, Redline.
+	/// Operator override to subtract all armor types with ease. Thank you, Redline.
 	/// </summary>
 	public static Armor operator -(Armor a, Armor b)
 	{
@@ -114,8 +120,6 @@ public class Armor
 		return armor;
 	}
 }
-
-
 
 /// <summary>
 /// A type of attack - not quite the same as a type of damage. A type of damage

--- a/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Armor.cs
@@ -13,16 +13,16 @@ using UnityEngine;
 [Serializable]
 public class Armor
 {
-	[Range(0,100)] public float Melee;
-	[Range(0,100)] public float Bullet;
-	[Range(0,100)] public float Laser;
-	[Range(0,100)] public float Energy;
-	[Range(0,100)] public float Bomb;
-	[Range(0,100)] public float Rad;
-	[Range(0,100)] public float Fire;
-	[Range(0,100)] public float Acid;
-	[Range(0,100)] public float Magic;
-	[Range(0,100)] public float Bio;
+	[Range(-100,100)] public float Melee;
+	[Range(-100,100)] public float Bullet;
+	[Range(-100,100)] public float Laser;
+	[Range(-100,100)] public float Energy;
+	[Range(-100,100)] public float Bomb;
+	[Range(-100,100)] public float Rad;
+	[Range(-100,100)] public float Fire;
+	[Range(-100,100)] public float Acid;
+	[Range(-100,100)] public float Magic;
+	[Range(-100,100)] public float Bio;
 
 	/// <summary>
 	/// Calculates how much damage would be done based on armor resistance


### PR DESCRIPTION
### Purpose
This PR makes a small fix to ensure armor to any body part won't be over 100 despite how much the clothing pieces that cover the very same body part add. This is needed because otherwise we will be dealing negative damage.

### Notes:
Also add some tweaks for readibility purpouses: Formula to get reduced damage and the Range attribute to set the armor values in editor.

### Self tests:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.

