### PR TITLE
add Survive Objective for nuke ops

### DIFF
--- a/UnityProject/Assets/Scripts/Antagonists/Antags/NuclearOperative.asset
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/NuclearOperative.asset
@@ -18,5 +18,6 @@ MonoBehaviour:
   needsEscapeObjective: 0
   coreObjectives:
   - {fileID: 11400000, guid: 1a15330eccadc7044b35b5a49a4154b4, type: 2}
+  - {fileID: 11400000, guid: b6107e1c868bada4da25dc2fc840e411, type: 2}
   nuclearOperativeOccupation: {fileID: 11400000, guid: 2b5314e7e17be4700b025e39af217ff2,
     type: 2}

--- a/UnityProject/Assets/Scripts/Antagonists/Antags/NuclearOperative.asset
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/NuclearOperative.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: NuclearOperative
   m_EditorClassIdentifier: 
   antagName: Nuclear Operative
-  NumberOfObjectives: 1
+  NumberOfObjectives: 2
   canUseSharedObjectives: 0
   needsEscapeObjective: 0
   coreObjectives:


### PR DESCRIPTION
### Purpose
The idea is to have an incentive for Nuke Ops to leave the nuke and flee. This is also how it is played in original SS13.

### Notes:
I just added the scriptable object to the Nuke Ops antags.
