### PR TITLE
Make Printer Check If Already Printing Before Printing Again

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/Internal/Printer.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/Internal/Printer.cs
@@ -39,14 +39,15 @@ namespace Assets.Scripts.Items.Bureaucracy.Internal
 			return new Printer(TrayCount + 1, TrayCapacity, TrayOpen);
 		}
 
-		public bool CanPrint(string content) =>
+		public bool CanPrint(string content, bool isAvailableForPrinting) =>
 			content != null
 			&& !TrayOpen
-			&& TrayCount > 0;
+			&& TrayCount > 0
+			&& isAvailableForPrinting;
 
-		public Printer Print(string content, GameObject printerObj)
+		public Printer Print(string content, GameObject printerObj, bool isAvailableForPrinting)
 		{
-			if (!CanPrint(content))
+			if (!CanPrint(content, isAvailableForPrinting))
 				throw new InvalidOperationException("Cannot print");
 
 			var prefab = Spawn.GetPrefabByName("Paper");

--- a/UnityProject/Assets/Scripts/Items/Bureaucracy/Photocopier.cs
+++ b/UnityProject/Assets/Scripts/Items/Bureaucracy/Photocopier.cs
@@ -146,7 +146,7 @@ namespace Assets.Scripts.Items.Bureaucracy
 			OnGuiRenderRequired();
 		}
 
-		public bool CanPrint() => printer.CanPrint(scanner.ScannedText);
+		public bool CanPrint() => printer.CanPrint(scanner.ScannedText, photocopierState == PhotocopierState.Idle);
 
 		[Server]
 		public void Print()
@@ -160,7 +160,7 @@ namespace Assets.Scripts.Items.Bureaucracy
 		{
 			yield return WaitFor.Seconds(4f);
 			SyncPhotocopierState(photocopierState, PhotocopierState.Idle);
-			printer = printer.Print(scanner.ScannedText, gameObject);
+			printer = printer.Print(scanner.ScannedText, gameObject, photocopierState == PhotocopierState.Idle);
 			OnGuiRenderRequired();
 		}
 


### PR DESCRIPTION
### Purpose
This is a fix for Issue #3917 
At the moment the printer object does not check if it is already printing when you press print. You can therefore print many pages in parallel even if there is not enough paper. This then throws exceptions because it is printing with no paper to print to.

### Solution
I made it so the photocopier (currently the only user of the printer object) tells the printer object if it is actually idle and ready to print. The printer now requires to know if the object calling it is idle/available for printing.

### Notes:
The PR does not touch anything to do with networking or matrices. The last three checks in the template are not needed.

### Please make sure you have followed the self-checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [ ] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ] The PR has been tested with round restarts.
- [ ] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)