### PR TITLE
Need to test this, temporary fix for the bans?

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -506,5 +506,5 @@ public class BanEntry
 	public string dateTimeOfBan;
 	public string reason;
 	public string ipAddress;
-	public string clientId;
+	public string clientId = "non-serialised ClientId";
 }


### PR DESCRIPTION
 since client ID was recently been implemented,
the old bands had serialised to empty IDs,
but that means if anything connects with an empty ID it would be counted as banned 