### PR TITLE
Give windows and grilles armor values.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/DirectionalWindow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/DirectionalWindow.prefab
@@ -45,6 +45,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -230,8 +231,8 @@ MonoBehaviour:
     Energy: 0
     Bomb: 0
     Rad: 0
-    Fire: 0
-    Acid: 0
+    Fire: 80
+    Acid: 100
     Magic: 0
     Bio: 0
   Resistances:
@@ -239,10 +240,10 @@ MonoBehaviour:
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
-  HeatResistance: 100
+  HeatResistance: 800
   initialIntegrity: 200
 --- !u!114 &114876689548865824
 MonoBehaviour:
@@ -256,6 +257,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDirty: 0
   sceneId: 0
   serverOnly: 0
   m_AssetId: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/GrilleObject.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/GrilleObject.prefab
@@ -45,6 +45,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -206,6 +207,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+  ignoreExtraRotation: []
 --- !u!114 &114590610092742494
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -222,16 +224,16 @@ MonoBehaviour:
   syncInterval: 0.1
   soundOnHit: GrillHit
   Armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
+    Melee: 50
+    Bullet: 70
+    Laser: 70
+    Energy: 100
+    Bomb: 10
+    Rad: 100
     Fire: 0
     Acid: 0
     Magic: 0
-    Bio: 0
+    Bio: 100
   Resistances:
     LavaProof: 0
     FireProof: 0
@@ -254,6 +256,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDirty: 0
   sceneId: 0
   serverOnly: 0
   m_AssetId: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/RDirectionalWindow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/RDirectionalWindow.prefab
@@ -45,6 +45,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -224,25 +225,25 @@ MonoBehaviour:
   syncInterval: 0.1
   soundOnHit: GlassHit
   Armor:
-    Melee: 0
+    Melee: 80
     Bullet: 0
     Laser: 0
     Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
+    Bomb: 25
+    Rad: 100
+    Fire: 80
+    Acid: 100
     Magic: 0
-    Bio: 0
+    Bio: 100
   Resistances:
     LavaProof: 0
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
-  HeatResistance: 100
+  HeatResistance: 1600
   initialIntegrity: 200
 --- !u!114 &114876689548865824
 MonoBehaviour:
@@ -256,6 +257,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDirty: 0
   sceneId: 0
   serverOnly: 0
   m_AssetId: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/ReinforcedWindow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/ReinforcedWindow.prefab
@@ -45,6 +45,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -206,6 +207,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+  ignoreExtraRotation: []
 --- !u!114 &114590610092742494
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -222,25 +224,25 @@ MonoBehaviour:
   syncInterval: 0.1
   soundOnHit: GlassHit
   Armor:
-    Melee: 0
+    Melee: 80
     Bullet: 0
     Laser: 0
     Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
+    Bomb: 25
+    Rad: 100
+    Fire: 80
+    Acid: 100
     Magic: 0
-    Bio: 0
+    Bio: 100
   Resistances:
     LavaProof: 0
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
-  HeatResistance: 100
+  HeatResistance: 1600
   initialIntegrity: 200
 --- !u!114 &114876689548865824
 MonoBehaviour:
@@ -254,6 +256,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDirty: 0
   sceneId: 0
   serverOnly: 0
   m_AssetId: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/TDirectionalWindow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/TDirectionalWindow.prefab
@@ -45,6 +45,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -224,25 +225,25 @@ MonoBehaviour:
   syncInterval: 0.1
   soundOnHit: GlassHit
   Armor:
-    Melee: 0
+    Melee: 80
     Bullet: 0
     Laser: 0
     Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
+    Bomb: 25
+    Rad: 100
+    Fire: 80
+    Acid: 100
     Magic: 0
-    Bio: 0
+    Bio: 100
   Resistances:
     LavaProof: 0
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
-  HeatResistance: 100
+  HeatResistance: 1600
   initialIntegrity: 200
 --- !u!114 &114876689548865824
 MonoBehaviour:
@@ -256,6 +257,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDirty: 0
   sceneId: 0
   serverOnly: 0
   m_AssetId: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Window.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Window.prefab
@@ -45,6 +45,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -206,6 +207,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteMatrixRotationBehavior: 1
+  ignoreExtraRotation: []
 --- !u!114 &114590610092742494
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -228,8 +230,8 @@ MonoBehaviour:
     Energy: 0
     Bomb: 0
     Rad: 0
-    Fire: 0
-    Acid: 0
+    Fire: 80
+    Acid: 100
     Magic: 0
     Bio: 0
   Resistances:
@@ -237,10 +239,10 @@ MonoBehaviour:
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
-  HeatResistance: 100
+  HeatResistance: 800
   initialIntegrity: 200
 --- !u!114 &114876689548865824
 MonoBehaviour:
@@ -254,6 +256,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDirty: 0
   sceneId: 0
   serverOnly: 0
   m_AssetId: 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/Grill.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/Grill.asset
@@ -12,14 +12,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: Grill
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: grille
   LayerType: 5
   TileType: 6
   RequiredTiles:
   - {fileID: 11400000, guid: e8a2685c8a14b7043bf58bde4374c6b1, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 0
+  SpawnWithNoAir: 0
   oreCategory: 0
   MaxHealth: 0
   HealthStates: []
@@ -39,16 +40,16 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
+    Melee: 50
+    Bullet: 70
+    Laser: 70
+    Energy: 100
+    Bomb: 10
+    Rad: 100
     Fire: 0
     Acid: 0
     Magic: 0
-    Bio: 0
+    Bio: 100
   tileInteractions:
   - {fileID: 11400000, guid: 8e5b0c6f1995489408133f815f767c27, type: 2}
   - {fileID: 11400000, guid: 107560a7c6045ac478f5555e9487ba89, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/GrillDestroyed.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/GrillDestroyed.asset
@@ -12,14 +12,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: GrillDestroyed
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: grille
   LayerType: 5
   TileType: 6
   RequiredTiles:
   - {fileID: 11400000, guid: e8a2685c8a14b7043bf58bde4374c6b1, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 0
+  SpawnWithNoAir: 0
   oreCategory: 0
   MaxHealth: 0
   HealthStates: []
@@ -39,16 +40,16 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
+    Melee: 50
+    Bullet: 70
+    Laser: 70
+    Energy: 100
+    Bomb: 10
+    Rad: 100
     Fire: 0
     Acid: 0
     Magic: 0
-    Bio: 0
+    Bio: 100
   tileInteractions:
   - {fileID: 11400000, guid: 10228000f4d0b45ccbe54926e21b9cb0, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced.asset
@@ -12,16 +12,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: WindowReinforced
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: reinforced window
   LayerType: 1
   TileType: 2
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
@@ -40,20 +36,20 @@ MonoBehaviour:
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
   armor:
-    Melee: 0
+    Melee: 80
     Bullet: 0
     Laser: 0
     Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
+    Bomb: 25
+    Rad: 100
+    Fire: 80
+    Acid: 100
     Magic: 0
-    Bio: 0
+    Bio: 100
   tileInteractions:
   - {fileID: 11400000, guid: d5be8b3cdb39edf449d5d7770fcaf55a, type: 2}
   - {fileID: 11400000, guid: 4635ca63f127a4b1cb58c7ff9de5695a, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced_Unsecuring_Step_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced_Unsecuring_Step_1.asset
@@ -12,11 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: WindowReinforced_Unsecuring_Step_1
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: reinforced window
   LayerType: 1
   TileType: 2
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
@@ -35,20 +35,20 @@ MonoBehaviour:
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
   armor:
-    Melee: 0
+    Melee: 80
     Bullet: 0
     Laser: 0
     Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
+    Bomb: 25
+    Rad: 100
+    Fire: 80
+    Acid: 100
     Magic: 0
-    Bio: 0
+    Bio: 100
   tileInteractions:
   - {fileID: 11400000, guid: 50443094b78a109479ae69d71ba210a6, type: 2}
   - {fileID: 11400000, guid: 56202775cd46ef44593ac9f8dc26c961, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced_Unsecuring_Step_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced_Unsecuring_Step_2.asset
@@ -12,11 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: WindowReinforced_Unsecuring_Step_2
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: reinforced window
   LayerType: 1
   TileType: 2
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
@@ -35,20 +35,20 @@ MonoBehaviour:
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
   armor:
-    Melee: 0
+    Melee: 80
     Bullet: 0
     Laser: 0
     Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
+    Bomb: 25
+    Rad: 100
+    Fire: 80
+    Acid: 100
     Magic: 0
-    Bio: 0
+    Bio: 100
   tileInteractions:
   - {fileID: 11400000, guid: 63475e1665725c54c99244d0499e9ea8, type: 2}
   - {fileID: 11400000, guid: a25ba21001ad22247994b5f3e90c5f52, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/ShuttleWindow.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/ShuttleWindow.asset
@@ -16,9 +16,10 @@ MonoBehaviour:
   LayerType: 1
   TileType: 2
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
+  SpawnWithNoAir: 0
   oreCategory: 0
   MaxHealth: 0
   HealthStates: []
@@ -34,7 +35,7 @@ MonoBehaviour:
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
   armor:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Window.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Window.asset
@@ -12,16 +12,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: Window
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: window
   LayerType: 1
   TileType: 2
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
@@ -40,7 +36,7 @@ MonoBehaviour:
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
   armor:
@@ -50,8 +46,8 @@ MonoBehaviour:
     Energy: 0
     Bomb: 0
     Rad: 0
-    Fire: 0
-    Acid: 0
+    Fire: 80
+    Acid: 100
     Magic: 0
     Bio: 0
   tileInteractions:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowPod.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowPod.asset
@@ -12,13 +12,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: WindowPod
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: pod window
   LayerType: 1
   TileType: 2
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
+  SpawnWithNoAir: 0
   oreCategory: 0
   MaxHealth: 0
   HealthStates: []
@@ -34,20 +35,20 @@ MonoBehaviour:
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
   armor:
-    Melee: 0
+    Melee: 90
     Bullet: 0
     Laser: 0
     Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
+    Bomb: 50
+    Rad: 100
+    Fire: 80
+    Acid: 100
     Magic: 0
-    Bio: 0
+    Bio: 100
   tileInteractions:
   - {fileID: 11400000, guid: 4635ca63f127a4b1cb58c7ff9de5695a, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowShuttle.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowShuttle.asset
@@ -12,13 +12,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: WindowShuttle
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: shuttle window
   LayerType: 1
   TileType: 2
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
+  SpawnWithNoAir: 0
   oreCategory: 0
   MaxHealth: 0
   HealthStates: []
@@ -34,18 +35,18 @@ MonoBehaviour:
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
   armor:
-    Melee: 0
+    Melee: 90
     Bullet: 0
     Laser: 0
     Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
+    Bomb: 50
+    Rad: 100
+    Fire: 80
+    Acid: 100
     Magic: 0
     Bio: 0
   tileInteractions:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowTinted.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowTinted.asset
@@ -12,13 +12,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: WindowTinted
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: tinted window
   LayerType: 1
   TileType: 2
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
+  SpawnWithNoAir: 0
   oreCategory: 0
   MaxHealth: 0
   HealthStates: []
@@ -34,20 +35,20 @@ MonoBehaviour:
     FireProof: 0
     Flammable: 0
     UnAcidable: 0
-    AcidProof: 0
+    AcidProof: 1
     Indestructable: 0
     FreezeProof: 0
   armor:
-    Melee: 0
+    Melee: 80
     Bullet: 0
     Laser: 0
     Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
+    Bomb: 25
+    Rad: 100
+    Fire: 80
+    Acid: 100
     Magic: 0
-    Bio: 0
+    Bio: 100
   tileInteractions:
   - {fileID: 11400000, guid: 4635ca63f127a4b1cb58c7ff9de5695a, type: 2}
   spawnOnDeconstruct: {fileID: 0}


### PR DESCRIPTION
### Purpose
This PR gives windows and grilles (both tile .assets and .prefabs) armor values ported over from /tg/. Where it would have taken around 20 baton strikes to break a reinforced window, it now takes around 100 baton strikes. 

Windows of all kinds are still quite vulnerable to bullets or laser however, and fire still tears thru them quick despite them having 80 resistance against fire.

### Please make sure you have followed the self checks below before submitting a PR:
- Code is sufficiently commented
- Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [ ] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ] The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
