### PR TITLE
Hydrogen Tubes Name Fix

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/ShuttleHeater.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/ShuttleHeater.prefab
@@ -250,7 +250,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  initialName: Hydrogen Tubes
+  initialName: hydrogen tubes
   initialDescription: These tubes are under pressure, you rater not mess with them...
   willHighlight: 1
   exportCost: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/ShuttleHeater.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/ShuttleHeater.prefab
@@ -19,6 +19,7 @@ GameObject:
   - component: {fileID: 3905972319176629353}
   - component: {fileID: 114635844588374680}
   - component: {fileID: 4065898036911112169}
+  - component: {fileID: 7308677628257758891}
   m_Layer: 11
   m_Name: ShuttleHeater
   m_TagString: Untagged
@@ -118,7 +119,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  butcherKnifeTrait: {fileID: 0}
   butcherTime: 2
   butcherSound: BladeSlice
 --- !u!114 &114850447683734040
@@ -168,6 +168,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  soundOnHit: 
   Armor:
     Melee: 0
     Bullet: 0
@@ -205,6 +206,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &114635844588374680
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -217,10 +219,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDirty: 0
+  sceneId: 0
   serverOnly: 0
-  localPlayerAuthority: 0
   m_AssetId: 
-  m_SceneId: 1820402633
 --- !u!114 &4065898036911112169
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -234,6 +236,26 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   prefabSpriteOrientation: 3
+--- !u!114 &7308677628257758891
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1547459616489196}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: baefcc8407233924095693a84ff89db1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  initialName: Hydrogen Tubes
+  initialDescription: These tubes are under pressure, you rater not mess with them...
+  willHighlight: 1
+  exportCost: 0
+  exportName: 
+  exportMessage: 
 --- !u!1 &1663957144760596
 GameObject:
   m_ObjectHideFlags: 0
@@ -279,6 +301,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_E.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_E.prefab
@@ -267,7 +267,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  initialName: Shuttle Engine
+  initialName: shuttle engine
   initialDescription: 
   willHighlight: 1
   exportCost: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_E.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_E.prefab
@@ -20,6 +20,7 @@ GameObject:
   - component: {fileID: 114432764300660568}
   - component: {fileID: 2122850763136765348}
   - component: {fileID: 9126864633854263488}
+  - component: {fileID: -1416166912547758311}
   m_Layer: 11
   m_Name: Shuttle_engine_E
   m_TagString: Untagged
@@ -107,7 +108,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  butcherKnifeTrait: {fileID: 0}
   butcherTime: 2
   butcherSound: BladeSlice
 --- !u!114 &114527569982132238
@@ -185,6 +185,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  soundOnHit: 
   Armor:
     Melee: 0
     Bullet: 0
@@ -218,6 +219,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDirty: 0
   sceneId: 0
   serverOnly: 0
   m_AssetId: 
@@ -237,6 +239,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &9126864633854263488
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,6 +253,26 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   prefabChildrenOrientation: 3
+--- !u!114 &-1416166912547758311
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1227037416355100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: baefcc8407233924095693a84ff89db1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  initialName: Shuttle Engine
+  initialDescription: 
+  willHighlight: 1
+  exportCost: 0
+  exportName: 
+  exportMessage: 
 --- !u!1 &1304629330313378
 GameObject:
   m_ObjectHideFlags: 0
@@ -4968,6 +4991,7 @@ ParticleSystemRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -4991,7 +5015,7 @@ ParticleSystemRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -902452607
-  m_SortingLayer: 15
+  m_SortingLayer: 16
   m_SortingOrder: 35
   m_RenderMode: 1
   m_SortMode: 0
@@ -5061,6 +5085,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -5161,6 +5186,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_W.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_W.prefab
@@ -348,7 +348,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  initialName: Shuttle Engine
+  initialName: shuttle engine
   initialDescription: 
   willHighlight: 1
   exportCost: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_W.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_W.prefab
@@ -45,6 +45,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -100,6 +101,7 @@ GameObject:
   - component: {fileID: 114493828767894876}
   - component: {fileID: 2380196287676553691}
   - component: {fileID: 3463832648861927421}
+  - component: {fileID: -1737255753765160339}
   m_Layer: 11
   m_Name: Shuttle_engine_W
   m_TagString: Untagged
@@ -187,7 +189,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  butcherKnifeTrait: {fileID: 0}
   butcherTime: 2
   butcherSound: BladeSlice
 --- !u!114 &114660013788037466
@@ -265,6 +266,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  soundOnHit: 
   Armor:
     Melee: 0
     Bullet: 0
@@ -298,6 +300,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDirty: 0
   sceneId: 0
   serverOnly: 0
   m_AssetId: 
@@ -317,6 +320,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &3463832648861927421
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -330,6 +334,26 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   prefabChildrenOrientation: 3
+--- !u!114 &-1737255753765160339
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1846819303320804}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: baefcc8407233924095693a84ff89db1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  initialName: Shuttle Engine
+  initialDescription: 
+  willHighlight: 1
+  exportCost: 0
+  exportName: 
+  exportMessage: 
 --- !u!1 &1875447609467830
 GameObject:
   m_ObjectHideFlags: 0
@@ -5048,6 +5072,7 @@ ParticleSystemRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -5071,7 +5096,7 @@ ParticleSystemRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -902452607
-  m_SortingLayer: 15
+  m_SortingLayer: 16
   m_SortingOrder: 35
   m_RenderMode: 1
   m_SortMode: 0
@@ -5193,6 +5218,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_center.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_center.prefab
@@ -267,7 +267,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  initialName: Shuttle Engine
+  initialName: shuttle engine
   initialDescription: 
   willHighlight: 1
   exportCost: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_center.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Shuttle/Shuttle_engine_center.prefab
@@ -20,6 +20,7 @@ GameObject:
   - component: {fileID: 114460770380257942}
   - component: {fileID: 4273586469488225513}
   - component: {fileID: 7270181232405884206}
+  - component: {fileID: 8058492716842047817}
   m_Layer: 11
   m_Name: Shuttle_engine_center
   m_TagString: Untagged
@@ -107,7 +108,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  butcherKnifeTrait: {fileID: 0}
   butcherTime: 2
   butcherSound: BladeSlice
 --- !u!114 &114006670304239386
@@ -185,6 +185,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  soundOnHit: 
   Armor:
     Melee: 0
     Bullet: 0
@@ -218,6 +219,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDirty: 0
   sceneId: 0
   serverOnly: 0
   m_AssetId: 
@@ -237,6 +239,7 @@ MonoBehaviour:
   syncInterval: 0.1
   InitialDirection: 3
   ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
 --- !u!114 &7270181232405884206
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -250,6 +253,26 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   prefabChildrenOrientation: 3
+--- !u!114 &8058492716842047817
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1418031129727510}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: baefcc8407233924095693a84ff89db1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  initialName: Shuttle Engine
+  initialDescription: 
+  willHighlight: 1
+  exportCost: 0
+  exportName: 
+  exportMessage: 
 --- !u!1 &1649971036973084
 GameObject:
   m_ObjectHideFlags: 0
@@ -4968,6 +4991,7 @@ ParticleSystemRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -4991,7 +5015,7 @@ ParticleSystemRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -902452607
-  m_SortingLayer: 15
+  m_SortingLayer: 16
   m_SortingOrder: 35
   m_RenderMode: 1
   m_SortMode: 0
@@ -5061,6 +5085,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -5161,6 +5186,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:


### PR DESCRIPTION
# Hydrogen Tubes and Shuttle Engines

### Purpose
Fixes #3944
Adds Object Attributes to the three shuttle engine prefabs and to the ShuttleHeater (this is the Hydrogen Tubes prefab)

### Notes:
Adds in names for the two above objects

### Self Checks

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [x] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
- [x] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
