### PR TITLE
Headless port config option

### DIFF
--- a/UnityProject/Assets/Scripts/Database/ServerData.ServerStatus.cs
+++ b/UnityProject/Assets/Scripts/Database/ServerData.ServerStatus.cs
@@ -130,7 +130,7 @@ namespace DatabaseAPI
 
         private int GetPort()
         {
-	        int port = 7777;
+	        int port = (config.ServerPort != 0) ? config.ServerPort : 7777;
 	        if (telepathyTransport != null)
 	        {
 		        return Convert.ToInt32(telepathyTransport.port);
@@ -184,6 +184,7 @@ namespace DatabaseAPI
     {
         public string RconPass;
         public int RconPort;
+        public int ServerPort;
         //CertKey needed in the future for SSL Rcon
         public string certKey;
         public string HubUser;

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using Mirror;
 using UnityEngine.SceneManagement;
 using UnityEngine.Events;
+using DatabaseAPI;
 
 public class CustomNetworkManager : NetworkManager
 {
@@ -14,6 +15,7 @@ public class CustomNetworkManager : NetworkManager
 	public static CustomNetworkManager Instance;
 
 	[HideInInspector] public bool _isServer;
+	[HideInInspector] private ServerConfig config;
 	public GameObject humanPlayerPrefab;
 	public GameObject ghostPrefab;
 	public GameObject disconnectedViewerPrefab;
@@ -42,6 +44,7 @@ public class CustomNetworkManager : NetworkManager
 	public override void Start()
 	{
 		CheckTransport();
+		ApplyConfig();
 		//Automatically host if starting up game *not* from lobby
 		if (SceneManager.GetActiveScene().name != "Lobby")
 		{
@@ -70,6 +73,28 @@ public class CustomNetworkManager : NetworkManager
 						Logger.Log("No beam data found. Falling back to Telepathy");
 						transport = telepathy;
 					}
+				}
+			}
+		}
+	}
+
+	void ApplyConfig()
+	{
+		config = ServerData.ServerConfig;
+		if (config.ServerPort != 0 && config.ServerPort <= 65535)
+		{
+			Logger.LogFormat("ServerPort defined in config: {0}", Category.Server, config.ServerPort);
+			var booster = GetComponent<BoosterTransport>();
+			if (booster != null)
+			{
+				booster.port = (ushort)config.ServerPort;
+			}
+			else
+			{
+				var telepathy = GetComponent<TelepathyTransport>();
+				if (telepathy != null)
+				{
+					telepathy.port = (ushort)config.ServerPort;
 				}
 			}
 		}


### PR DESCRIPTION
### Purpose
Running multiple servers on the same machine was harder than it should've been because there wasn't any way to specify that the game should host on a different port. 
I've added ServerPort as an option in the config file to remedy that problem. 

### Please make sure you have followed the self checks below before submitting a PR:

- [X] Code is sufficiently commented
- [X] Code is indented with tabs and not spaces
- [X] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [X] The PR does not bring up any new compile errors
- [X] The PR has been tested in editor
- [X] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [X] The PR has been tested with round restarts.
