### PR TITLE
ConCommand for Copying UUID to Clipboard

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -38,6 +38,13 @@ namespace IngameDebugConsole
 			Logger.Log($"{ServerData.UserID}");
 		}
 
+		[ConsoleMethod("copyid", "Copies your uuid to your clipboard.")]
+		public static void CopyUserID()
+		{
+			TextUtils.CopyTextToClipboard($"{ServerData.UserID}");
+			Logger.Log($"UUID Copied to clipboard.");
+		}
+
 		[ConsoleMethod("damage-self", "Server only cmd.\nUsage:\ndamage-self <bodyPart> <brute amount> <burn amount>\nExample: damage-self LeftArm 40 20.Insert")]
 		public static void RunDamageSelf(string bodyPartString, int burnDamage, int bruteDamage)
 		{

--- a/UnityProject/Assets/Scripts/Util/TextUtils.cs
+++ b/UnityProject/Assets/Scripts/Util/TextUtils.cs
@@ -69,4 +69,19 @@ public static class TextUtils
 
 		return nearestColor;
 	}
+
+	/// <summary>
+	/// Copies the supplied text to the systems clipboard.
+	/// </summary>
+	/// <param name="text"></param>
+	/// <returns></returns>
+	public static void CopyTextToClipboard(string text)
+	{
+		//Apparently, the TextEditor component has native functionality to copy stuff to clipboard.
+		//This may create garbage, but it shouldn't be called very often so this should be fine.
+		TextEditor temp = new TextEditor();
+		temp.text = text;
+		temp.SelectAll();
+		temp.Copy();
+	}
 }


### PR DESCRIPTION
Added a console command to copy your UUID to clipboard, as well as a util method for copying text to your clipboard in general.

# Easy to way to copy UUID

### Purpose
Previously there was no user friendly way to copy your UUID, and you had to manually type it by looking at it from console. This adds a way to copy it to clipboard using a console command as well as addinga a util function for copying text to your clipboard in general.
Fixes #3932
