### PR TITLE
Window disassembly fix

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -162,7 +162,7 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 		//translate to the tile interaction system
 
 		//pass the interaction down to the basic tile
-		LayerTile tile = LayerTileAt(interaction.WorldPositionTarget);
+		LayerTile tile = LayerTileAt(interaction.WorldPositionTarget, true);
 		if (tile is BasicTile basicTile)
 		{
 			var tileApply = new TileApply(interaction.Performer, interaction.UsedObject, interaction.Intent,
@@ -194,7 +194,7 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 		//find the indicated tile interaction
 		var worldPosTarget = (Vector2)performer.transform.position + targetVector;
 		//pass the interaction down to the basic tile
-		LayerTile tile = LayerTileAt(worldPosTarget);
+		LayerTile tile = LayerTileAt(worldPosTarget, true);
 		if (tile is BasicTile basicTile)
 		{
 			if (tileInteractionIndex >= basicTile.TileInteractions.Count)
@@ -227,7 +227,7 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 	{
 		Logger.Log("Interaction detected on InteractableTiles.");
 
-		LayerTile tile = LayerTileAt(interaction.ShadowWorldLocation);
+		LayerTile tile = LayerTileAt(interaction.ShadowWorldLocation, true);
 
 		if(tile is BasicTile basicTile)
 		{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/TileChangeManager.cs
@@ -163,6 +163,11 @@ public class TileChangeManager : NetworkBehaviour
 			{
 				OnFloorOrPlatingRemoved.Invoke( cellPosition );
 			}
+			else if (layerType == LayerType.Windows)
+			{
+				RemoveTile(cellPosition, LayerType.Effects);
+			}
+
 			return layerTile;
 		}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -527,7 +527,6 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 
 		if (data.Damage >= MAX_WINDOW_DAMAGE)
 		{
-			tileChangeManager.RemoveTile(cellPos, LayerType.Effects);
 			tileChangeManager.RemoveTile(cellPos, LayerType.Windows);
 			data.WindowDamage = WindowDamageLevel.Broken;
 

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/WindowDamage/crack01.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/WindowDamage/crack01.asset
@@ -17,11 +17,7 @@ MonoBehaviour:
   TileType: 8
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
@@ -54,8 +50,7 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
-  tileInteractions:
-  - {fileID: 11400000, guid: 4635ca63f127a4b1cb58c7ff9de5695a, type: 2}
+  tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 550675a608327a743bc8f4c257d83c2b, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/WindowDamage/crack02.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/WindowDamage/crack02.asset
@@ -17,11 +17,7 @@ MonoBehaviour:
   TileType: 8
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
@@ -54,8 +50,7 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
-  tileInteractions:
-  - {fileID: 11400000, guid: 4635ca63f127a4b1cb58c7ff9de5695a, type: 2}
+  tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 7e573ede0b9ab1741b1c95d8d408e5db, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/WindowDamage/crack03.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/WindowDamage/crack03.asset
@@ -17,11 +17,7 @@ MonoBehaviour:
   TileType: 8
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
@@ -54,8 +50,7 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
-  tileInteractions:
-  - {fileID: 11400000, guid: 4635ca63f127a4b1cb58c7ff9de5695a, type: 2}
+  tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 4ca7c22b64ebc8245a9f828eae0badf6, type: 3}


### PR DESCRIPTION
### Purpose
Fixes windows being unable to be disassembled if they had a damage overlay on top.

### Please make sure you have followed the self checks below before submitting a PR:

- [X] Code is sufficiently commented
- [X] Code is indented with tabs and not spaces
- [X] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [X] The PR does not bring up any new compile errors
- [X] The PR has been tested in editor
- [X] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [X] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [X] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [X] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ] The PR has been tested with round restarts.
- [ ] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
