### PR TITLE
Make different welding tank .prefabs similar, directional sprites for booze and soda dispensers.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Bar/BoozeDispenser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Bar/BoozeDispenser.prefab
@@ -6,7 +6,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5972872610322627283}
+  m_GameObject: {fileID: 6406346259585755381}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
@@ -23,7 +23,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5972872610322627283}
+  m_GameObject: {fileID: 6406346259585755381}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5657f3ab371d77f449cbbb38e86b7d4c, type: 3}
@@ -35,14 +35,14 @@ MonoBehaviour:
   Down: {fileID: 21300000, guid: 69f1f20089fb9ae499bc9aca582de209, type: 3}
   Left: {fileID: 21300006, guid: 69f1f20089fb9ae499bc9aca582de209, type: 3}
   Up: {fileID: 21300002, guid: 69f1f20089fb9ae499bc9aca582de209, type: 3}
-  spriteRenderer: {fileID: 5972872610322607608}
+  spriteRenderer: {fileID: 6595474460572830946}
 --- !u!114 &6957727407797718013
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5972872610322627283}
+  m_GameObject: {fileID: 6406346259585755381}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
@@ -57,6 +57,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -7628244273918246941, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: isInitiallyNotPushable
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
       propertyPath: m_Size.x
@@ -138,6 +143,16 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7971921043980192432, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: initialDescription
+      value: Contains a large reservoir of the good stuff.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971921043980192432, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: initialName
+      value: booze dispenser
+      objectReference: {fileID: 0}
     - target: {fileID: 9212640593017544930, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
       propertyPath: m_AssetId
@@ -145,13 +160,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b06b702714bab49b9ad949eab1ca4534, type: 3}
---- !u!1 &5972872610322627283 stripped
+--- !u!1 &6406346259585755381 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
     type: 3}
   m_PrefabInstance: {fileID: 5972872610322709877}
   m_PrefabAsset: {fileID: 0}
---- !u!212 &5972872610322607608 stripped
+--- !u!212 &6595474460572830946 stripped
 SpriteRenderer:
   m_CorrespondingSourceObject: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
     type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Bar/BoozeDispenser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Bar/BoozeDispenser.prefab
@@ -1,5 +1,55 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-8814891180236395169
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5972872610322627283}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  InitialDirection: 3
+  ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
+--- !u!114 &553736562539033351
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5972872610322627283}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5657f3ab371d77f449cbbb38e86b7d4c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  Right: {fileID: 21300004, guid: 69f1f20089fb9ae499bc9aca582de209, type: 3}
+  Down: {fileID: 21300000, guid: 69f1f20089fb9ae499bc9aca582de209, type: 3}
+  Left: {fileID: 21300006, guid: 69f1f20089fb9ae499bc9aca582de209, type: 3}
+  Up: {fileID: 21300002, guid: 69f1f20089fb9ae499bc9aca582de209, type: 3}
+  spriteRenderer: {fileID: 5972872610322607608}
+--- !u!114 &6957727407797718013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5972872610322627283}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteMatrixRotationBehavior: 1
+  ignoreExtraRotation: []
 --- !u!1001 &5972872610322709877
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7,6 +57,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
       propertyPath: m_Sprite
@@ -80,3 +145,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b06b702714bab49b9ad949eab1ca4534, type: 3}
+--- !u!1 &5972872610322627283 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
+    type: 3}
+  m_PrefabInstance: {fileID: 5972872610322709877}
+  m_PrefabAsset: {fileID: 0}
+--- !u!212 &5972872610322607608 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+    type: 3}
+  m_PrefabInstance: {fileID: 5972872610322709877}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Bar/SodaDispenser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Bar/SodaDispenser.prefab
@@ -6,7 +6,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7526306905240286939}
+  m_GameObject: {fileID: 7095102647972717821}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
@@ -23,7 +23,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7526306905240286939}
+  m_GameObject: {fileID: 7095102647972717821}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5657f3ab371d77f449cbbb38e86b7d4c, type: 3}
@@ -35,14 +35,14 @@ MonoBehaviour:
   Down: {fileID: 21300000, guid: 5d5bf60ac6590ae4aa31bd08c2e7e652, type: 3}
   Left: {fileID: 21300006, guid: 5d5bf60ac6590ae4aa31bd08c2e7e652, type: 3}
   Up: {fileID: 21300002, guid: 5d5bf60ac6590ae4aa31bd08c2e7e652, type: 3}
-  spriteRenderer: {fileID: 7526306905240265200}
+  spriteRenderer: {fileID: 6996028302146191594}
 --- !u!114 &9131542180434988290
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7526306905240286939}
+  m_GameObject: {fileID: 7095102647972717821}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
@@ -57,6 +57,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -7628244273918246941, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: isInitiallyNotPushable
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
       propertyPath: m_Sprite
@@ -123,6 +128,16 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7971921043980192432, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: initialName
+      value: soda dispenser
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971921043980192432, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: initialDescription
+      value: Contains a large reservoir of soft drinks.
+      objectReference: {fileID: 0}
     - target: {fileID: 9212640593017544930, guid: b06b702714bab49b9ad949eab1ca4534,
         type: 3}
       propertyPath: m_AssetId
@@ -130,13 +145,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b06b702714bab49b9ad949eab1ca4534, type: 3}
---- !u!1 &7526306905240286939 stripped
+--- !u!1 &7095102647972717821 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
     type: 3}
   m_PrefabInstance: {fileID: 7526306905240367485}
   m_PrefabAsset: {fileID: 0}
---- !u!212 &7526306905240265200 stripped
+--- !u!212 &6996028302146191594 stripped
 SpriteRenderer:
   m_CorrespondingSourceObject: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
     type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Bar/SodaDispenser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Bar/SodaDispenser.prefab
@@ -1,19 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-5558735821845627893
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7526306905240286939}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  spriteMatrixRotationBehavior: 1
-  ignoreExtraRotation: []
 --- !u!114 &4765779200241239965
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -50,7 +36,7 @@ MonoBehaviour:
   Left: {fileID: 21300006, guid: 5d5bf60ac6590ae4aa31bd08c2e7e652, type: 3}
   Up: {fileID: 21300002, guid: 5d5bf60ac6590ae4aa31bd08c2e7e652, type: 3}
   spriteRenderer: {fileID: 7526306905240265200}
---- !u!114 &3439824830871043203
+--- !u!114 &9131542180434988290
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Bar/SodaDispenser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Bar/SodaDispenser.prefab
@@ -1,5 +1,69 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-5558735821845627893
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7526306905240286939}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteMatrixRotationBehavior: 1
+  ignoreExtraRotation: []
+--- !u!114 &4765779200241239965
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7526306905240286939}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  InitialDirection: 3
+  ChangeDirectionWithMatrix: 1
+  DisableSyncing: 0
+--- !u!114 &7418045713740773264
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7526306905240286939}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5657f3ab371d77f449cbbb38e86b7d4c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  Right: {fileID: 21300004, guid: 5d5bf60ac6590ae4aa31bd08c2e7e652, type: 3}
+  Down: {fileID: 21300000, guid: 5d5bf60ac6590ae4aa31bd08c2e7e652, type: 3}
+  Left: {fileID: 21300006, guid: 5d5bf60ac6590ae4aa31bd08c2e7e652, type: 3}
+  Up: {fileID: 21300002, guid: 5d5bf60ac6590ae4aa31bd08c2e7e652, type: 3}
+  spriteRenderer: {fileID: 7526306905240265200}
+--- !u!114 &3439824830871043203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7526306905240286939}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06639902572409c80160fe696467bed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteMatrixRotationBehavior: 1
+  ignoreExtraRotation: []
 --- !u!1001 &7526306905240367485
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -80,3 +144,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b06b702714bab49b9ad949eab1ca4534, type: 3}
+--- !u!1 &7526306905240286939 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
+    type: 3}
+  m_PrefabInstance: {fileID: 7526306905240367485}
+  m_PrefabAsset: {fileID: 0}
+--- !u!212 &7526306905240265200 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+    type: 3}
+  m_PrefabInstance: {fileID: 7526306905240367485}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Tanks/FuelTank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Tanks/FuelTank.prefab
@@ -20,6 +20,7 @@ GameObject:
   - component: {fileID: 114536480436588622}
   - component: {fileID: 6622438585055889099}
   - component: {fileID: 6583254002094982938}
+  - component: {fileID: 9019940786057255883}
   m_Layer: 11
   m_Name: FuelTank
   m_TagString: Untagged
@@ -214,7 +215,7 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
-  initialIntegrity: 100
+  initialIntegrity: 300
 --- !u!114 &114536480436588622
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -227,6 +228,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDirty: 0
   sceneId: 0
   serverOnly: 0
   m_AssetId: 
@@ -258,15 +260,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxCapacity: 100
+  UseStandardExamine: 1
+  ExamineAmount: 0
+  ExamineContent: 0
+  maxCapacity: 1000
   reactionSet: {fileID: 11400000, guid: 2d5f766d9268838aa8d819bee2a442a7, type: 2}
-  reagentMix:
-    temperature: 0
+  initialReagentMix:
+    temperature: 273.15
     reagents:
       m_keys:
       - {fileID: 11400000, guid: f4f9cca4ec6d74752a99cdbf95072489, type: 2}
       m_values:
-      - 100
+      - 1000
   itemAttributes: {fileID: 0}
   traitWhitelist: []
   reagentWhitelist:
@@ -274,6 +279,26 @@ MonoBehaviour:
   transferMode: 2
   possibleTransferAmounts: []
   transferAmount: 20
+--- !u!114 &9019940786057255883
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677789019931390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d25f701f64474544993c1372b83c1b0d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  initialName: fuel tank
+  initialDescription: A tank full of industrial welding fuel. Do not consume.
+  willHighlight: 1
+  exportCost: 0
+  exportName: 
+  exportMessage: 
 --- !u!1 &1754091207019976
 GameObject:
   m_ObjectHideFlags: 0
@@ -319,6 +344,7 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:

--- a/UnityProject/Assets/Resources/textures/Objects.spriteatlas
+++ b/UnityProject/Assets/Resources/textures/Objects.spriteatlas
@@ -43,7 +43,7 @@ SpriteAtlas:
     variantMultiplier: 1
     packables:
     - {fileID: 102900000, guid: 30a7a1119ea109a4ea0d228bbb9f5297, type: 3}
-    totalSpriteSurfaceArea: 21359920
+    totalSpriteSurfaceArea: 21428528
     bindAsDefault: 1
   m_MasterAtlas: {fileID: 0}
   m_PackedSprites:
@@ -5731,6 +5731,24 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 86517aa4d9ca47b4c8e77d3fe6bc00d7, type: 3}
   - {fileID: 21300006, guid: 86517aa4d9ca47b4c8e77d3fe6bc00d7, type: 3}
   - {fileID: 21300004, guid: 86517aa4d9ca47b4c8e77d3fe6bc00d7, type: 3}
+  - {fileID: -4351150644770572491, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: 1251820693659632575, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: 6961802538447911207, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: 4106881395898673252, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: 5399270680963873595, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: -1061856799901130237, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: 1210377355069897012, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: 5979386791730379284, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: 8703128856924854413, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: 965337075340090404, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: 8647828239065918026, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: -2048358173489525685, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: 2313480792443481819, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: -4921068442906992512, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: -8982908389419522036, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: 4077288278973081940, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: -5489772963193932273, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
+  - {fileID: -8788106736673486409, guid: dea63ba4c6c073e46a68c9c7ed6dd61d, type: 3}
   - {fileID: 21300000, guid: b9dcdba494aeafe4fa4eba68f6fd1382, type: 3}
   - {fileID: 21300000, guid: 165b3ca4aa0b70848be8732268b674a2, type: 3}
   - {fileID: 21300000, guid: 4bfb3ca4fa875bf4fa6482013b9fbdbb, type: 3}
@@ -10294,6 +10312,54 @@ SpriteAtlas:
   - {fileID: 21300000, guid: 923dda988337d4e49bc30016a97685cf, type: 3}
   - {fileID: 21300000, guid: 323f6b98803f30c44a8cddb260a862a8, type: 3}
   - {fileID: 21300000, guid: b82d9b98a0e104c4aa234e4c5270f4fd, type: 3}
+  - {fileID: 4167756058514293442, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 8258934151242425456, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -5528687766843547563, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 1397283247289568373, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -6146069264073678850, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -3393479497183616016, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -5778034745173872678, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 7531882304442279066, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 7607999488932893697, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 4985288024565579289, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 3084385247106617380, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -8108525515600822214, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -1528118665403014503, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -3392457668526736566, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -7912559750963844340, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -278314666232131318, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -1072390242456395133, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 3196294792163662400, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -8867055189563445288, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 5046508452451233759, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -8819863698858986736, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -505419035486264478, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 2905136463560408135, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 7301928554511008425, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 4791061416493681910, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -8684799511376457343, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 5854429756378874921, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 5896458685502104779, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -9007487333453502542, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 2328158423756394351, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -9187466927837081844, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 8870078760620263316, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 5331697898862603025, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -3698170512361751116, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -3053687810481415209, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 7704670883223005128, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -4955913371497951891, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 6370680953384207630, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 1584867591930356886, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 4737036582645304758, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -4154021966097630109, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 9218175563245646996, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 3223241621178492856, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -2136102715921212678, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: -2906105453355631731, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 2261833811114741147, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 4301293152268136496, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
+  - {fileID: 3116951913514835499, guid: 8a68cd9823bcbbc4ea58db062339a340, type: 3}
   - {fileID: 21300000, guid: 33b79f988c8714c4cae101a2e540ab32, type: 3}
   - {fileID: 21300000, guid: 639820a8628540c478d0ea4a47b69f82, type: 3}
   - {fileID: 21300004, guid: ac41f1a8969523b4c81f254832269d24, type: 3}
@@ -13381,6 +13447,7 @@ SpriteAtlas:
   - {fileID: 21300004, guid: 43f0262ba46934c449aee90b6c75c462, type: 3}
   - {fileID: 21300002, guid: 43f0262ba46934c449aee90b6c75c462, type: 3}
   - {fileID: 21300000, guid: 43f0262ba46934c449aee90b6c75c462, type: 3}
+  - {fileID: 21300000, guid: 3ec4f62b4f8583f45bfc674b596a587e, type: 3}
   - {fileID: 21300000, guid: 33a9f62b6bdd1e046aaaf3a28f9d5a5d, type: 3}
   - {fileID: 21300000, guid: e267c82b885113e48a35fa20d2c64856, type: 3}
   - {fileID: 21300006, guid: f8d63a2b55dadeb40a48a2109d1de0c0, type: 3}
@@ -24659,6 +24726,24 @@ SpriteAtlas:
   - crema1_0
   - crema1_3
   - crema1_2
+  - stationobjs_autolathe_nfull_8
+  - stationobjs_autolathe_nfull_9
+  - stationobjs_autolathe_nfull_6
+  - stationobjs_autolathe_nfull_7
+  - stationobjs_autolathe_nfull_4
+  - stationobjs_autolathe_nfull_5
+  - stationobjs_autolathe_nfull_2
+  - stationobjs_autolathe_nfull_3
+  - stationobjs_autolathe_nfull_0
+  - stationobjs_autolathe_nfull_1
+  - stationobjs_autolathe_nfull_15
+  - stationobjs_autolathe_nfull_14
+  - stationobjs_autolathe_nfull_17
+  - stationobjs_autolathe_nfull_16
+  - stationobjs_autolathe_nfull_11
+  - stationobjs_autolathe_nfull_10
+  - stationobjs_autolathe_nfull_13
+  - stationobjs_autolathe_nfull_12
   - lighting_markerbronze
   - moonflower-harvest
   - medical_fill_construction
@@ -29222,6 +29307,54 @@ SpriteAtlas:
   - mycelium-angel
   - closet_alien
   - structures_woodenbarricade-snow-old
+  - window_plastitanium_39
+  - window_plastitanium_15
+  - window_plastitanium_38
+  - window_plastitanium_14
+  - window_plastitanium_17
+  - window_plastitanium_16
+  - window_plastitanium_11
+  - window_plastitanium_10
+  - window_plastitanium_13
+  - window_plastitanium_12
+  - window_plastitanium_8
+  - window_plastitanium_9
+  - window_plastitanium_6
+  - window_plastitanium_7
+  - window_plastitanium_4
+  - window_plastitanium_5
+  - window_plastitanium_2
+  - window_plastitanium_3
+  - window_plastitanium_0
+  - window_plastitanium_1
+  - window_plastitanium_46
+  - window_plastitanium_47
+  - window_plastitanium_44
+  - window_plastitanium_45
+  - window_plastitanium_42
+  - window_plastitanium_43
+  - window_plastitanium_40
+  - window_plastitanium_41
+  - window_plastitanium_24
+  - window_plastitanium_25
+  - window_plastitanium_26
+  - window_plastitanium_27
+  - window_plastitanium_37
+  - window_plastitanium_20
+  - window_plastitanium_36
+  - window_plastitanium_21
+  - window_plastitanium_35
+  - window_plastitanium_22
+  - window_plastitanium_34
+  - window_plastitanium_23
+  - window_plastitanium_33
+  - window_plastitanium_32
+  - window_plastitanium_31
+  - window_plastitanium_30
+  - window_plastitanium_28
+  - window_plastitanium_29
+  - window_plastitanium_19
+  - window_plastitanium_18
   - pipe_cleaner_1562403272.7885144
   - closet_eng_weld_door
   - grinder-o1_2
@@ -32309,6 +32442,7 @@ SpriteAtlas:
   - dpvent_map_on-2_2
   - dpvent_map_on-2_1
   - dpvent_map_on-2_0
+  - foreign Aileen_egg_squished
   - maintenance_closed
   - overlays_panel_closed
   - fwall_opening_3

--- a/UnityProject/Assets/Scripts/Furniture/DirectionalSprite.cs
+++ b/UnityProject/Assets/Scripts/Furniture/DirectionalSprite.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Linq;
+using UnityEngine;
+using Mirror;
+using UnityEngine.Serialization;
+
+/// <summary>
+/// Behavior for an object which has a different sprite for each direction it is facing and changes
+/// facing when Directional tells it to. 
+/// Copied from OccupiableDirectionalSprite.cs. Comments from that preserved.
+///
+/// Initial orientation should be set in Directional.
+/// </summary>
+[ExecuteInEditMode]
+[RequireComponent(typeof(Directional))]
+public class DirectionalSprite : NetworkBehaviour
+{
+	[Header("Base Sprites")]
+	[Tooltip("Base sprite when facing right")]
+	[FormerlySerializedAs("s_right")]
+	public Sprite Right;
+	[Tooltip("Base sprite when facing down")]
+	[FormerlySerializedAs("s_down")]
+	public Sprite Down;
+	[Tooltip("Base sprite when facing left")]
+	[FormerlySerializedAs("s_left")]
+	public Sprite Left;
+	[Tooltip("Base sprite when facing up")]
+	[FormerlySerializedAs("s_up")]
+	public Sprite Up;
+
+	[Tooltip("sprite renderer on which to render the base sprite")]
+	public SpriteRenderer spriteRenderer;
+
+	private const string BASE_SPRITE_LAYER_NAME = "Machines";
+
+	private Directional directional;
+
+	public void Awake()
+	{
+		EnsureInit();
+	}
+
+	private void EnsureInit()
+	{
+		if (directional != null || gameObject == null) return;
+		directional = GetComponent<Directional>();
+		directional.OnDirectionChange.AddListener(OnDirectionChanged);
+		OnDirectionChanged(directional.CurrentDirection);
+	}
+
+	public override void OnStartClient()
+	{
+		EnsureInit();
+		//must invoke this because SyncVar hooks are not called on client init
+		OnDirectionChanged(directional.CurrentDirection);
+	}
+
+	private void OnDirectionChanged(Orientation newDir)
+	{
+		if (newDir == Orientation.Up)
+		{
+			spriteRenderer.sprite = Up;
+		}
+		else if (newDir == Orientation.Down)
+		{
+			spriteRenderer.sprite = Down;
+		}
+		else if (newDir == Orientation.Left)
+		{
+			spriteRenderer.sprite = Left;
+		}
+		else
+		{
+			spriteRenderer.sprite = Right;
+		}
+	}
+
+//changes the rendered sprite in editor based on the value set in Directional
+#if UNITY_EDITOR
+	private void Update()
+	{
+		if (Application.isEditor && !Application.isPlaying)
+		{
+			var dir = GetComponent<Directional>().InitialOrientation;
+			if (dir == Orientation.Up)
+			{
+				spriteRenderer.sprite = Up;
+			}
+			else if (dir == Orientation.Down)
+			{
+				spriteRenderer.sprite = Down;
+			}
+			else if (dir == Orientation.Left)
+			{
+				spriteRenderer.sprite = Left;
+			}
+			else
+			{
+				spriteRenderer.sprite = Right;
+			}
+		}
+	}
+#endif
+}

--- a/UnityProject/Assets/Scripts/Furniture/DirectionalSprite.cs.meta
+++ b/UnityProject/Assets/Scripts/Furniture/DirectionalSprite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5657f3ab371d77f449cbbb38e86b7d4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
This PR modifies FuelTank.prefab to have similar stats to WeldingFuel.prefab and also gives it localization.

This PR also adds DirectionalSprite.cs, which is based on OccupiableDirectionalSprite.cs but with all the code about seating sprites and layers removed. DirectionalSprite.cs is meant for objects with multiple facing directions that aren't meant to be sat in. **To be completely clear, I have no proficiency in coding and just stripped out what didn't seem necessary after testing.** 

I made the booze and soda dispensers use the new Directional Sprite component, so they can now face different directions. They also have the Upright Sprites component now so they change directions properly on rotating shuttles.

### Notes
Again, I don't really know what I'm doing in regards to code but the new script seems to work fine from what I've tested. I've preserved all the comments relating to code that I didn't remove. Either way, I would appreciate it if the new script I monkeyed together is reviewed.

### Please make sure you have followed the self checks below before submitting a PR:
- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ] The PR has been tested with round restarts.
- [x] The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
