### PR TITLE
add basic random loot system

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/RandomItemSpot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/RandomItemSpot.prefab
@@ -1,0 +1,89 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1158969463323420989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2839352587806555520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17b2fb3ef6787a14ea8ae48d4b78cc60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  poolList: []
+--- !u!1001 &2838674892618678586
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_Name
+      value: RandomItemSpot
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 762be26fb5a93894b9b33ba5a6d6501a,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+--- !u!1 &2839352587806555520 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298,
+    type: 3}
+  m_PrefabInstance: {fileID: 2838674892618678586}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/RandomItemSpot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/RandomItemSpot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: abff3ae0227731244b0814b2055fa6f0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a614f1b859e0fe94f941ae889630c519
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/2%XenoEgg.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/2%XenoEgg.prefab
@@ -15,7 +15,7 @@ PrefabInstance:
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: poolList.Array.data[0].probability
-      value: 2
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/2%XenoEgg.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/2%XenoEgg.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &103916970817573906
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[0].probability
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[0].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: 157fb9a92fe7905449e7f9e32c78e95f,
+        type: 2}
+    - target: {fileID: 2708525666452541148, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 996004e684a76e14898ac82013cebc2a,
+        type: 3}
+    - target: {fileID: 2806690048445349940, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2839352587806555520, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_Name
+      value: 2%XenoEgg
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: abff3ae0227731244b0814b2055fa6f0, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/2%XenoEgg.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/2%XenoEgg.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 21a7be3fbc4ab4d4d904f8bfe6dd2c1a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLoot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLoot.prefab
@@ -1,0 +1,202 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2129169617399254431
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.size
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[0].probability
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[0].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: acbf77ee963f2464bbc6d07ac57f8805,
+        type: 2}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[1].probability
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[1].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: 6f38e1fcd4adc9c4d904d6b2d391afe1,
+        type: 2}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[2].probability
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[2].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: 2c4d1cecba62e4e42a694d900c765fb4,
+        type: 2}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[3].probability
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[3].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: bef2cdf6314a23245a45cf8d7069c7a7,
+        type: 2}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[4].probability
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[4].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: 11e3be478d8ef8a4ba263d9ee8dd08b3,
+        type: 2}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[5].probability
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[5].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: 7722af163801ab84ba6ffd4ed45a5cc3,
+        type: 2}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[6].probability
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[6].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: e04fdca3e848109499e2cd897792deea,
+        type: 2}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[7].probability
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[7].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: 7ec6dedfb200e7e4b9387da053683b1f,
+        type: 2}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[8].probability
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[8].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: 7e88f18ca08669f4986d1b20d06f7991,
+        type: 2}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[9].probability
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[9].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: a023f7a7adb344941b8032b016639640,
+        type: 2}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[10].probability
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[10].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: 1ecac083f128b5348bcdc25a13f4bb4a,
+        type: 2}
+    - target: {fileID: 2806690048445349940, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2839352587806555520, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_Name
+      value: MaintLoot
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: abff3ae0227731244b0814b2055fa6f0, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLoot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLoot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8fb9b82aab871a54fb9bdb7e4a985821
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx2.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx2.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6574224672497382069
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 979859381183702178, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: lootCount
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 979859381183702178, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: fanOut
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4245553451975094303, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_Name
+      value: MaintLootx2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4287156120374906283, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8fb9b82aab871a54fb9bdb7e4a985821, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx2.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx2.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4e067333d18d9724690055be203850b5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx3.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx3.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4036748856119280024
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6243535445382747671, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: lootCount
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6936492600874909470, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7050221238659580586, guid: 4e067333d18d9724690055be203850b5,
+        type: 3}
+      propertyPath: m_Name
+      value: MaintLootx3
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4e067333d18d9724690055be203850b5, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx3.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx3.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fa63846bcecd1d14b8644f96e78f9888
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx4.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx4.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7298620382400829991
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6360831956148715142, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6467592714176708166, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6472239387987690290, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: m_Name
+      value: MaintLootx4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971397566001387407, guid: fa63846bcecd1d14b8644f96e78f9888,
+        type: 3}
+      propertyPath: lootCount
+      value: 4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fa63846bcecd1d14b8644f96e78f9888, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx4.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx4.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 48db417677699164e92ca8f233876e13
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx5.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx5.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &9164355042778325922
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 858497903583317416, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: lootCount
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4361852649415730273, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4361852649415730273, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4361852649415730273, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4361852649415730273, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4361852649415730273, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4361852649415730273, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4361852649415730273, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4361852649415730273, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4361852649415730273, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4361852649415730273, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4361852649415730273, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4367343748361820437, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_Name
+      value: MaintLootx5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4399979898909697185, guid: 48db417677699164e92ca8f233876e13,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 48db417677699164e92ca8f233876e13, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx5.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx5.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1f7a0aab278ff9a4e976011f0abf8c5f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx6.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx6.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7992318731185950481
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4765241873805838083, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4874651286694905795, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4874651286694905795, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4874651286694905795, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4874651286694905795, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4874651286694905795, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4874651286694905795, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4874651286694905795, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4874651286694905795, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4874651286694905795, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4874651286694905795, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4874651286694905795, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4879016485466258103, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: m_Name
+      value: MaintLootx6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8414882515044331018, guid: 1f7a0aab278ff9a4e976011f0abf8c5f,
+        type: 3}
+      propertyPath: lootCount
+      value: 6
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1f7a0aab278ff9a4e976011f0abf8c5f, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx6.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx6.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx7.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx7.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5625759029882236551
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1886375587800867099, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: lootCount
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3227921733449779218, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264078451611781330, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264078451611781330, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264078451611781330, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264078451611781330, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264078451611781330, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264078451611781330, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264078451611781330, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264078451611781330, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264078451611781330, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264078451611781330, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3264078451611781330, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3269565151975028134, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe,
+        type: 3}
+      propertyPath: m_Name
+      value: MaintLootx7
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7e3aa878a9b7aeb4fa1b8485b7dfaffe, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx7.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx7.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c4990df189c8b544980a118094ee5cc9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx8.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx8.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3377986661382648594
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6070701242618040220, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: lootCount
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7122820704006448789, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155483312090520353, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_Name
+      value: MaintLootx8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160406787550635605, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160406787550635605, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160406787550635605, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160406787550635605, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160406787550635605, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160406787550635605, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160406787550635605, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160406787550635605, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160406787550635605, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160406787550635605, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160406787550635605, guid: c4990df189c8b544980a118094ee5cc9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c4990df189c8b544980a118094ee5cc9, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx8.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLootx8.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1e2ab35775ce1ce41afd274356e67d90
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomGloves.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomGloves.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7901846845715637967
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[0].probability
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: poolList.Array.data[0].randomItemPool
+      value: 
+      objectReference: {fileID: 11400000, guid: 7ec6dedfb200e7e4b9387da053683b1f,
+        type: 2}
+    - target: {fileID: 2708525666452541148, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: d478a608994a16e429bd1804f9071b17,
+        type: 3}
+    - target: {fileID: 2806690048445349940, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2839352587806555520, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_Name
+      value: RandomGloves
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: abff3ae0227731244b0814b2055fa6f0, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomGloves.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomGloves.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6381156cbaf58b243a81a5979d2c532b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Others/RandomItemPool.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/RandomItemPool.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Items
+{
+	[CreateAssetMenu(fileName = "RandomItemPool", menuName = "ScriptableObjects/RandomItemPool")]
+	public class RandomItemPool : ScriptableObject
+	{
+		[Tooltip("List of game objects to choose from")][SerializeField]
+		private List<GameObjectPool> pool = null;
+
+		public List<GameObjectPool> Pool => pool;
+	}
+
+	[Serializable]
+	public class GameObjectPool
+	{
+		[Tooltip("Object we will spawn in the world")] [SerializeField]
+		private GameObject prefab = null;
+		[Tooltip("Max amount we can spawn of this object")] [SerializeField]
+		private int maxAmount = 1;
+		[Tooltip("Probability of spawning this item when chosen")] [SerializeField] [Range(0, 100)]
+		private int probability = 100;
+
+		public GameObject Prefab => prefab;
+		public int MaxAmount => maxAmount;
+		public int Probability => probability;
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Others/RandomItemPool.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Others/RandomItemPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ce108c02d022d1940bc023ceca025d81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 762be26fb5a93894b9b33ba5a6d6501a, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+namespace Items
+{
+	public class RandomItemSpot : MonoBehaviour
+	{
+		[Tooltip("Amout of items we could get from this pool")] [SerializeField]
+		private int lootCount = 1;
+		[Tooltip("Should we spread the items in the tile once spawned?")][SerializeField]
+		private bool fanOut = false;
+		[Tooltip("List of possible pools of items to choose from")][SerializeField]
+		private List<PoolData> poolList;
+
+		private void Awake()
+		{
+			EventManager.AddHandler(EVENT.RoundStarted, RollRandomPool);
+		}
+
+		private void RollRandomPool()
+		{
+			foreach (var pool in poolList)
+			{
+				if (pool == null)
+				{
+					continue;
+				}
+
+				if (!DMMath.Prob(pool.Probability))
+				{
+					continue;
+				}
+
+				SpawnItems(pool);
+				break;
+			}
+		}
+
+		private void SpawnItems(PoolData poolData)
+		{
+
+
+			for (int i = 0; i < lootCount; i++)
+			{
+				var item = poolData.RandomItemPool.Pool.PickRandom();
+				var spread = fanOut ? Random.Range(-0.5f,0.5f) : (float?) null;
+
+				if (!DMMath.Prob(item.Probability))
+				{
+					continue;
+				}
+
+				var maxAmt = Random.Range(1, item.MaxAmount+1);
+
+				Spawn.ServerPrefab(
+					item.Prefab,
+					gameObject.RegisterTile().WorldPositionServer,
+					count: maxAmt,
+					scatterRadius: spread);
+			}
+
+			Despawn.ServerSingle(gameObject);
+		}
+	}
+
+	[Serializable]
+	public class PoolData
+	{
+		[Tooltip("Probabilities of spawning from this pool when chosen")] [SerializeField][Range(0,100)]
+		private int probability = 100;
+		[Tooltip("The pool from which we will try to get items")] [SerializeField]
+		private RandomItemPool randomItemPool;
+		public int Probability => probability;
+		public RandomItemPool RandomItemPool => randomItemPool;
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 17b2fb3ef6787a14ea8ae48d4b78cc60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 244b7c20b2d8f1642a4dc2e278fbf20c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/AlienEgg.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/AlienEgg.asset
@@ -12,10 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
   m_Name: AlienEgg
   m_EditorClassIdentifier: 
-  lootCount: 1
-  fanOut: 0
   pool:
   - prefab: {fileID: 8331399007563457964, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
       type: 3}
     maxAmount: 1
-    probability: 100
+    probability: 2

--- a/UnityProject/Assets/Scripts/RandomItemPools/AlienEgg.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/AlienEgg.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: AlienEgg
+  m_EditorClassIdentifier: 
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 8331399007563457964, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
+      type: 3}
+    maxAmount: 1
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/AlienEgg.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/AlienEgg.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 157fb9a92fe7905449e7f9e32c78e95f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonConstructionNCrafting.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonConstructionNCrafting.asset
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: CommonConstructionNCrafting
+  m_EditorClassIdentifier: 
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 5680136605834777345, guid: c3e6805b264a935428b0de415ea57943,
+      type: 3}
+    maxAmount: 5
+    probability: 100
+  - prefab: {fileID: 6254655335276451647, guid: ab486d104d39e584e935c8a5459a967c,
+      type: 3}
+    maxAmount: 20
+    probability: 100
+  - prefab: {fileID: 4519819786599941225, guid: 2a170fdb7187e38459de34c4d2b131ad,
+      type: 3}
+    maxAmount: 25
+    probability: 100
+  - prefab: {fileID: 6254655335276451647, guid: 70a15a1bc92d10944878d2f52dfe2be0,
+      type: 3}
+    maxAmount: 1
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonConstructionNCrafting.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonConstructionNCrafting.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: acbf77ee963f2464bbc6d07ac57f8805
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonEquipment.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonEquipment.asset
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: CommonEquipment
+  m_EditorClassIdentifier: 
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 3573969270142595597, guid: 996d62bfe3bf26c4e95c2a77cadabbd2,
+      type: 3}
+    maxAmount: 0
+    probability: 100
+  - prefab: {fileID: 6200957232458716886, guid: abf4818425fa84c67a62abb4425a4dcb,
+      type: 3}
+    maxAmount: 0
+    probability: 100
+  - prefab: {fileID: 1928361214078489529, guid: 868598a9acc5f40b0811af946a2c4c27,
+      type: 3}
+    maxAmount: 0
+    probability: 100
+  - prefab: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa,
+      type: 3}
+    maxAmount: 0
+    probability: 100
+  - prefab: {fileID: 3921521694364753778, guid: 35cd853acdce0094f9462e049e31ed8e,
+      type: 3}
+    maxAmount: 0
+    probability: 100
+  - prefab: {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226,
+      type: 3}
+    maxAmount: 0
+    probability: 100
+  - prefab: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73,
+      type: 3}
+    maxAmount: 0
+    probability: 100
+  - prefab: {fileID: 2679964424910470999, guid: 7919ffc0a7c666742a83c767f7cb427f,
+      type: 3}
+    maxAmount: 0
+    probability: 100
+  - prefab: {fileID: 5425561884246163851, guid: 16fc8784fe8b167499a09e125d33f7d5,
+      type: 3}
+    maxAmount: 0
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonEquipment.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonEquipment.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6f38e1fcd4adc9c4d904d6b2d391afe1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonFood.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonFood.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: CommonFood
+  m_EditorClassIdentifier: 
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 6602018046170396259, guid: 6744be6888ba21549a52eefcc270e0d5,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6602018046170396259, guid: 629f349d213af5f47b3e32d88c1c65cd,
+      type: 3}
+    maxAmount: 1
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonFood.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonFood.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2c4d1cecba62e4e42a694d900c765fb4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonLightSources.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonLightSources.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: CommonLightSources
+  m_EditorClassIdentifier: 
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb,
+      type: 3}
+    maxAmount: 1
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonLightSources.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonLightSources.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bef2cdf6314a23245a45cf8d7069c7a7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonMedicalNChemical.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonMedicalNChemical.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: CommonMedicalNChemical
+  m_EditorClassIdentifier: 
+  pool:
+  - prefab: {fileID: 7188868217503671157, guid: fc35b50e497fc8d469ec0c0e7abc9cdb,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 2419386692754613975, guid: 72539a60f847bd248bec932a82058e0b,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8582594776399167655, guid: 5eb15adcfc6eff74587417fd1e12310e,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 2303393086579293408, guid: 2aadd00fd99ff354ba118dcaaf5e7cb1,
+      type: 3}
+    maxAmount: 1
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonMedicalNChemical.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonMedicalNChemical.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11e3be478d8ef8a4ba263d9ee8dd08b3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonMisc.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonMisc.asset
@@ -1,0 +1,28 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: CommonMisc
+  m_EditorClassIdentifier: 
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 2819670291326673133, guid: 09868dc1147587f4191af0a4defd8c1d,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 7914790827376970613, guid: 908afbc5b9f871148b5ccd0b81bd147f,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 529109779100470021, guid: d6dc9ea3e3540427bb4c073d115b0137, type: 3}
+    maxAmount: 1
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonMisc.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonMisc.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7722af163801ab84ba6ffd4ed45a5cc3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonTools.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonTools.asset
@@ -1,0 +1,49 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: CommonTools
+  m_EditorClassIdentifier: 
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 8868920090029130384, guid: 366fb594c17e76346bbb29ad4ce021ad,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 1844587092189195201, guid: 3266ceefb65da2f4cb4bbfd297415ad5,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 4930866777566109869, guid: 7976a84ef9209f14697cdd941b913e2a,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6918947953705996213, guid: f709eab732189d6429ae3fa5beaf3fd3,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8238071069653876758, guid: bf74e8243028ec14ebeb6578ebd2fcf4,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 2419386692754613975, guid: e632378292aa9a645bf4a8745061e44d,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 7516689663430431150, guid: 8aa459a6447baed4a95b189f4950f59f,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 2419386692754613975, guid: 72539a60f847bd248bec932a82058e0b,
+      type: 3}
+    maxAmount: 1
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonTools.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonTools.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e04fdca3e848109499e2cd897792deea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/ContrabandGuns.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/ContrabandGuns.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: ContrabandGuns
+  m_EditorClassIdentifier: 
+  probability: 100
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 8582594776399167655, guid: 75bd7f17749d75542afa4d2395205c7b,
+      type: 3}
+    maxAmount: 1
+    probability: 20
+  - prefab: {fileID: 1243752531234666437, guid: 7ed0ebc503149b4c09d3c2d60230b9d1,
+      type: 3}
+    maxAmount: 1
+    probability: 50
+  - prefab: {fileID: 2436724837340589176, guid: b079c584e036a68ea904d4878c6acc6d,
+      type: 3}
+    maxAmount: 1
+    probability: 50
+  - prefab: {fileID: 3576468486086989451, guid: 15c095e2f9c2c9cbcbb3dbb24ca61245,
+      type: 3}
+    maxAmount: 1
+    probability: 50

--- a/UnityProject/Assets/Scripts/RandomItemPools/ContrabandGuns.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/ContrabandGuns.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7da4a2b658ba05b498641fddeb6119d3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/Gloves.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/Gloves.asset
@@ -1,0 +1,49 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: Gloves
+  m_EditorClassIdentifier: 
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6373161644663410599, guid: 676cb7a2be9be4f458d53d0a197a35cd,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6373161644663410599, guid: 143344c7f4c0243688a0bf860fbeed64,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6373161644663410599, guid: 47e758de6e8330e8ba5c0cf96801afa8,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6373161644663410599, guid: 379aa4c441c691bd1810b624a675f481,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6373161644663410599, guid: 2b5931e1b579b4c4087b5dd741deed96,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6373161644663410599, guid: aeaa5bf158ea049459f44fb8a916174c,
+      type: 3}
+    maxAmount: 1
+    probability: 80

--- a/UnityProject/Assets/Scripts/RandomItemPools/Gloves.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/Gloves.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ec6dedfb200e7e4b9387da053683b1f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/TrashOrGrille.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/TrashOrGrille.asset
@@ -1,0 +1,44 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: TrashOrGrille
+  m_EditorClassIdentifier: 
+  probability: 100
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 7376449702682419346, guid: e7a19fe59d5bcfe49a1d885d7fedab6e,
+      type: 3}
+    maxAmount: 1
+    probability: 50
+  - prefab: {fileID: 1562085630854840, guid: 74a4d1096ea27044c9000c8feff1f52d, type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 1722833055556988, guid: 3867b56bd9960f84a8f76cfd857c80b9, type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 7785875528613525472, guid: 3589b6ce8b4d56f44b0d3efb1a5555c8,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 7785875528613525472, guid: 76b2f70b70967b04c9768782b4bec43c,
+      type: 3}
+    maxAmount: 1
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/TrashOrGrille.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/TrashOrGrille.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4f93cf8c461ab57409926fd5a5c257df
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/UncommonConstructionNCrafting.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/UncommonConstructionNCrafting.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: UncommonConstructionNCrafting
+  m_EditorClassIdentifier: 
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 6254655335276451647, guid: 7543d187ee101c148ab143a796d9d175,
+      type: 3}
+    maxAmount: 15
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/UncommonConstructionNCrafting.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/UncommonConstructionNCrafting.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7e88f18ca08669f4986d1b20d06f7991
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/UncommonEquipment.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/UncommonEquipment.asset
@@ -1,0 +1,48 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: UncommonEquipment
+  m_EditorClassIdentifier: 
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 7636118406116123594, guid: df90174791c3adda585b7cb6c9f01473,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 3431291279286482953, guid: 1ae4a2ac3215bf300a744e4ec8d06bce,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 3431291279286482953, guid: ddd85a66da8b22448806f0f8454c01ab,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 20384307089368758, guid: 371b9c216382844659c05791957b28c8, type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6700281191928912403, guid: 0ad6b406825f747548ae2f66be19e5bd,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8654279767492581603, guid: 98de935f80510c4468285ffd5a01d9e0,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 7636118406116123594, guid: 8a90a03870d450740a42e9183126340b,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73,
+      type: 3}
+    maxAmount: 1
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/UncommonEquipment.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/UncommonEquipment.asset
@@ -12,8 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
   m_Name: UncommonEquipment
   m_EditorClassIdentifier: 
-  lootCount: 1
-  fanOut: 0
   pool:
   - prefab: {fileID: 7636118406116123594, guid: df90174791c3adda585b7cb6c9f01473,
       type: 3}

--- a/UnityProject/Assets/Scripts/RandomItemPools/UncommonEquipment.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/UncommonEquipment.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a023f7a7adb344941b8032b016639640
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/RandomItemPools/UncommonTools.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/UncommonTools.asset
@@ -1,0 +1,28 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: UncommonTools
+  m_EditorClassIdentifier: 
+  lootCount: 1
+  fanOut: 0
+  pool:
+  - prefab: {fileID: 6989221924687263735, guid: b735ab74dab174a4f90c79558cd51e43,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 970193913688544828, guid: 32fcd56a575fd884ebae6deb79a43656, type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8127442588295923452, guid: 706cc1f035332384c96f001de4760563,
+      type: 3}
+    maxAmount: 1
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/UncommonTools.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/UncommonTools.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ecac083f128b5348bcdc25a13f4bb4a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Adds the ability for mappers to set random loot spawners. Fixes #2334

### How does it work:
From this:
![image](https://user-images.githubusercontent.com/43683714/80247721-87a33000-863c-11ea-8dd3-8572cf5bc169.png)

To this:
![image](https://user-images.githubusercontent.com/43683714/80248192-70187700-863d-11ea-9083-bdf8d7ce3012.png)


The actual Spawner is a game object that accepts a list of item pools (scriptable objects). At round start it will pick a random pool and roll the pool probability of spawning an item from this pool, when met it will choose a random item from the pool and roll probability for that item, if met it will spawn it. Simple.

![image](https://user-images.githubusercontent.com/43683714/80248313-a9e97d80-863d-11ea-86fe-47feeafc1055.png)

![image](https://user-images.githubusercontent.com/43683714/80248343-b79f0300-863d-11ea-9ca0-bdbd9a0437a5.png)


The system is designed to be flexible and allow devs to combine pools and set their probabilities how ever they want.

I recreated some pools from TG's code, although incomplete because we lack some items.

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
