### PR TITLE
Lighttube and pick up stuff

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear/BlackGloves.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear/BlackGloves.prefab
@@ -7,17 +7,17 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 5947731994596095198, guid: f819cf8b4a0534ec59570563e52c8508,
-        type: 3}
-      propertyPath: m_Name
-      value: BlackGloves
-      objectReference: {fileID: 0}
     - target: {fileID: 790289613151823707, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
       propertyPath: clothData
       value: 
       objectReference: {fileID: 11400000, guid: 90875af41838ba343a8bde75046a1b5e,
         type: 2}
+    - target: {fileID: 5947731994596095198, guid: f819cf8b4a0534ec59570563e52c8508,
+        type: 3}
+      propertyPath: m_Name
+      value: BlackGloves
+      objectReference: {fileID: 0}
     - target: {fileID: 5951811045126588842, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -80,6 +80,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
+        type: 3}
       propertyPath: initialName
       value: black gloves
       objectReference: {fileID: 0}
@@ -88,5 +93,11 @@ PrefabInstance:
       propertyPath: initialDescription
       value: These gloves are fire-resistant.
       objectReference: {fileID: 0}
+    - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 10a21ec3d5e7d1d489334ee8c7382ba7,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f819cf8b4a0534ec59570563e52c8508, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear/BlackGloves.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear/BlackGloves.prefab
@@ -81,7 +81,7 @@ PrefabInstance:
     - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
@@ -98,6 +98,12 @@ PrefabInstance:
       propertyPath: initialTraits.Array.data[1]
       value: 
       objectReference: {fileID: 11400000, guid: 10a21ec3d5e7d1d489334ee8c7382ba7,
+        type: 2}
+    - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
+        type: 3}
+      propertyPath: initialTraits.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 30a421d219292474595f4c1e34917e51,
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f819cf8b4a0534ec59570563e52c8508, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear/BotanistsLeatherGloves.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear/BotanistsLeatherGloves.prefab
@@ -96,6 +96,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
+        type: 3}
       propertyPath: initialName
       value: botanist's leather gloves
       objectReference: {fileID: 0}
@@ -105,5 +110,11 @@ PrefabInstance:
       value: These leather gloves protect against thorns, barbs, prickles, spikes
         and other harmful objects of floral origin.  They're also quite warm.
       objectReference: {fileID: 0}
+    - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 30a421d219292474595f4c1e34917e51,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f819cf8b4a0534ec59570563e52c8508, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear/CaptainGloves.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear/CaptainGloves.prefab
@@ -7,17 +7,23 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 5947731994596095198, guid: f819cf8b4a0534ec59570563e52c8508,
-        type: 3}
-      propertyPath: m_Name
-      value: CaptainGloves
-      objectReference: {fileID: 0}
     - target: {fileID: 790289613151823707, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
       propertyPath: clothData
       value: 
       objectReference: {fileID: 11400000, guid: 42daddf00dcd73945bfce9864c942900,
         type: 2}
+    - target: {fileID: 5799337935409317762, guid: f819cf8b4a0534ec59570563e52c8508,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: c4d5798b5f7636b41b286a08c368cf68,
+        type: 3}
+    - target: {fileID: 5947731994596095198, guid: f819cf8b4a0534ec59570563e52c8508,
+        type: 3}
+      propertyPath: m_Name
+      value: CaptainGloves
+      objectReference: {fileID: 0}
     - target: {fileID: 5951811045126588842, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -80,6 +86,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
+        type: 3}
       propertyPath: initialName
       value: captain's gloves
       objectReference: {fileID: 0}
@@ -89,11 +100,11 @@ PrefabInstance:
       value: Regal blue gloves, with a nice gold trim, a diamond anti-shock coating,
         and an integrated thermal barrier. Swanky.
       objectReference: {fileID: 0}
-    - target: {fileID: 5799337935409317762, guid: f819cf8b4a0534ec59570563e52c8508,
+    - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
-      propertyPath: m_Sprite
+      propertyPath: initialTraits.Array.data[1]
       value: 
-      objectReference: {fileID: 21300000, guid: c4d5798b5f7636b41b286a08c368cf68,
-        type: 3}
+      objectReference: {fileID: 11400000, guid: 10a21ec3d5e7d1d489334ee8c7382ba7,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f819cf8b4a0534ec59570563e52c8508, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear/CaptainGloves.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear/CaptainGloves.prefab
@@ -87,7 +87,7 @@ PrefabInstance:
     - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
@@ -105,6 +105,12 @@ PrefabInstance:
       propertyPath: initialTraits.Array.data[1]
       value: 
       objectReference: {fileID: 11400000, guid: 10a21ec3d5e7d1d489334ee8c7382ba7,
+        type: 2}
+    - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
+        type: 3}
+      propertyPath: initialTraits.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 30a421d219292474595f4c1e34917e51,
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f819cf8b4a0534ec59570563e52c8508, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear/InsulatedGloves.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear/InsulatedGloves.prefab
@@ -97,7 +97,7 @@ PrefabInstance:
     - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
         type: 3}
@@ -114,6 +114,12 @@ PrefabInstance:
       propertyPath: initialTraits.Array.data[1]
       value: 
       objectReference: {fileID: 11400000, guid: 1213038ef37bbdf498fd3434a3459ce0,
+        type: 2}
+    - target: {fileID: 6081843052801809340, guid: f819cf8b4a0534ec59570563e52c8508,
+        type: 3}
+      propertyPath: initialTraits.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 30a421d219292474595f4c1e34917e51,
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f819cf8b4a0534ec59570563e52c8508, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/Materials/Resources/GlassShard.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/Materials/Resources/GlassShard.prefab
@@ -46,6 +46,25 @@ MonoBehaviour:
   TraitRequired: {fileID: 11400000, guid: aaed69546e98a47d8b488a046d00ebe7, type: 2}
   TransformTo: {fileID: 5680136605834777345, guid: ea07289ba72453444a4ff1202b47a57d,
     type: 3}
+--- !u!114 &8670566117553005211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2265521501557685915}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 669232669da8f03448704f901bcfc787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  doesDamage: 1
+  doesDamageChance: 0.5
+  amountOfDamage: 10
+  attackType: 0
+  damageType: 0
+  protectionItemTraits:
+  - {fileID: 11400000, guid: 30a421d219292474595f4c1e34917e51, type: 2}
 --- !u!1001 &2266199196745466401
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/Materials/Resources/GlassShard.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/Materials/Resources/GlassShard.prefab
@@ -101,11 +101,22 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 114734890905785284, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: doesDamage
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 40b0aa452345ccc4c9ecae14031d3063,
+        type: 3}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialTraits.Array.size
@@ -211,12 +222,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: eca72cf10c773424ab1605cf913b19a1,
         type: 2}
-    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 40b0aa452345ccc4c9ecae14031d3063,
-        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
 --- !u!1 &2265521501557685915 stripped

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/LightReplacer.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/LightReplacer.prefab
@@ -1,0 +1,119 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7407580487173923613
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: itemSprites.InventoryIcon.Sprites.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: itemSprites.InventoryIcon.Texture
+      value: 
+      objectReference: {fileID: 2800000, guid: 8fed609f94e7fba48927e483401b78cb, type: 3}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: itemSprites.InventoryIcon.Sprites.Array.data[0]
+      value: 
+      objectReference: {fileID: 21300000, guid: 8fed609f94e7fba48927e483401b78cb,
+        type: 3}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: initialName
+      value: Light Replacer
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: initialDescription
+      value: Allows turned on lights to be replaced.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: initialTraits.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 61d5dc37185ebac4ab0e92eb5ba2594f,
+        type: 2}
+    - target: {fileID: 8470250495983453963, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 8fed609f94e7fba48927e483401b78cb,
+        type: 3}
+    - target: {fileID: 8568555645537651171, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8605860254165158179, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8605860254165158179, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8605860254165158179, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8605860254165158179, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8605860254165158179, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8605860254165158179, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8605860254165158179, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8605860254165158179, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8605860254165158179, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8605860254165158179, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8605860254165158179, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8610225452865205335, guid: c9c58a9243d494537abcb4ee470efab0,
+        type: 3}
+      propertyPath: m_Name
+      value: LightReplacer
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c9c58a9243d494537abcb4ee470efab0, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/LightReplacer.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/LightReplacer.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 81e4f93f9ae0fc64aad2053ade3ae29e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/JanitorPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/JanitorPopulator.asset
@@ -24,6 +24,9 @@ MonoBehaviour:
   - NamedSlot: 1
     Prefab: {fileID: 1069655924402247308, guid: 43a2f25b1176348c68d5d896d48d2fc6,
       type: 3}
+  - NamedSlot: 11
+    Prefab: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73,
+      type: 3}
   skirtVariant: {fileID: 4011149429169960813, guid: cad85b5dad5b95d468fc34d2c6a01947,
     type: 3}
   duffelVariant: {fileID: 0}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/CommonTraitsSingleton.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/CommonTraitsSingleton.asset
@@ -54,3 +54,4 @@ MonoBehaviour:
   Insulated: {fileID: 11400000, guid: 1213038ef37bbdf498fd3434a3459ce0, type: 2}
   InternalBattery: {fileID: 11400000, guid: 7a8a160ea6ef075498f62f1898e1964d, type: 2}
   AntiFacehugger: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61, type: 2}
+  PickUpProtection: {fileID: 11400000, guid: 30a421d219292474595f4c1e34917e51, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/CommonTraitsSingleton.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/CommonTraitsSingleton.asset
@@ -44,6 +44,8 @@ MonoBehaviour:
   Squeaky: {fileID: 11400000, guid: 66ec94743369ae744a8b1595701b0520, type: 2}
   LightTube: {fileID: 11400000, guid: 82327368297d15b41971f9a171ce14cf, type: 2}
   LightBulb: {fileID: 11400000, guid: e3c06d233d4623549bc9ec895f304ff5, type: 2}
+  LightReplacer: {fileID: 11400000, guid: 61d5dc37185ebac4ab0e92eb5ba2594f, type: 2}
+  BlackGloves: {fileID: 11400000, guid: 10a21ec3d5e7d1d489334ee8c7382ba7, type: 2}
   Broken: {fileID: 11400000, guid: 11ce8d65a70014d4997c0bf4f1045b67, type: 2}
   Breakable: {fileID: 11400000, guid: 86782de91b339c1438d9f4e310d321f4, type: 2}
   Rods: {fileID: 11400000, guid: d823ef2f0f86bd240b865220bbd5c6a3, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Effect/PickUpProtection.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Effect/PickUpProtection.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: PickUpProtection
+  m_EditorClassIdentifier: 
+  traitDescription: FOR GLOVES, prevent damage when picking items up.

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Effect/PickUpProtection.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Effect/PickUpProtection.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 30a421d219292474595f4c1e34917e51
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/BlackGloves.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/BlackGloves.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: BlackGloves
+  m_EditorClassIdentifier: 
+  traitDescription: 'For fire resist on black gloves, stop damage removing lights
+
+'

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/BlackGloves.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/BlackGloves.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10a21ec3d5e7d1d489334ee8c7382ba7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/LightReplacer.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/LightReplacer.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: LightReplacer
+  m_EditorClassIdentifier: 
+  traitDescription: Replacer lights without damaging user

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/LightReplacer.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/LightReplacer.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 61d5dc37185ebac4ab0e92eb5ba2594f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Inventory/DamageOnPickUp.cs
+++ b/UnityProject/Assets/Scripts/Inventory/DamageOnPickUp.cs
@@ -45,7 +45,7 @@ public class DamageOnPickUp : MonoBehaviour, IServerInventoryMove
 		{
 			foreach (var trait in protectionItemTraits)
 			{
-				if (trait == null || Validations.HasItemTrait(info.MovedObject.gameObject, trait)) return;
+				if (trait == null || Validations.HasItemTrait(player.Equipment.GetClothingItem(NamedSlot.hands).GameObjectReference, trait)) return;
 			}
 
 			if (info.ToSlot.NamedSlot == NamedSlot.leftHand)

--- a/UnityProject/Assets/Scripts/Inventory/DamageOnPickUp.cs
+++ b/UnityProject/Assets/Scripts/Inventory/DamageOnPickUp.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DamageOnPickUp : MonoBehaviour, IServerInventoryMove
+{
+	/// <summary>
+	/// Does damage to active left or right arm.
+	/// </summary>
+	public bool doesDamage;
+
+	/// <summary>
+	/// 1 = 100%
+	/// </summary>
+	public float doesDamageChance = 1f;
+
+	public float amountOfDamage = 10f;
+
+	public AttackType attackType;
+
+	public DamageType damageType;
+
+	public ItemTrait[] protectionItemTraits;
+
+	private PlayerScript player;
+
+	public void OnInventoryMoveServer(InventoryMove info)
+	{
+		if (info.InventoryMoveType != InventoryMoveType.Add) return;
+
+		if (info.ToSlot != null && info.ToSlot?.NamedSlot != null)
+		{
+			player = info.ToRootPlayer?.PlayerScript;
+
+			if (player != null)
+			{
+				DoDamage(info);
+			}
+		}
+	}
+
+	private void DoDamage(InventoryMove info)
+	{
+		if (doesDamage && Random.value < doesDamageChance)
+		{
+			foreach (var trait in protectionItemTraits)
+			{
+				if (trait == null || Validations.HasItemTrait(info.MovedObject.gameObject, trait)) return;
+			}
+
+			if (info.ToSlot.NamedSlot == NamedSlot.leftHand)
+			{
+				player.playerHealth.ApplyDamageToBodypart(gameObject, amountOfDamage, attackType, damageType, BodyPartType.LeftArm);
+			}
+			else
+			{
+				player.playerHealth.ApplyDamageToBodypart(gameObject, amountOfDamage, attackType, damageType, BodyPartType.RightArm);
+			}
+
+			Chat.AddExamineMsgFromServer(player.gameObject, "<color=red>You injure yourself picking up the " + GetComponent<ItemAttributesV2>().ArticleName + "</color>");
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Inventory/DamageOnPickUp.cs.meta
+++ b/UnityProject/Assets/Scripts/Inventory/DamageOnPickUp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 669232669da8f03448704f901bcfc787
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Inventory/Pickupable.cs
@@ -28,6 +28,24 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 	public bool CanPickup => canPickup;
 
 	/// <summary>
+	/// Does damage to active left or right arm.
+	/// </summary>
+	public bool doesDamage;
+
+	/// <summary>
+	/// 1 = 100%
+	/// </summary>
+	public float doesDamageChance = 1f;
+
+	public float amountOfDamage = 10f;
+
+	public AttackType attackType;
+
+	public DamageType damageType;
+
+	public bool protectionByGloveItemTrait;
+
+	/// <summary>
 	/// Which inventory slot this is currently in, null if not in inventory
 	/// </summary>
 	public ItemSlot ItemSlot => itemSlot;
@@ -180,6 +198,20 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 			{
 				Logger.LogTraceFormat("Pickup success! server pos:{0} player pos:{1} (floating={2})", Category.Security,
 					cnt.ServerState.WorldPosition, interaction.Performer.transform.position, cnt.IsFloatingServer);
+
+				if (doesDamage && Random.value < doesDamageChance && protectionByGloveItemTrait ? !Validations.HasItemTrait(interaction.PerformerPlayerScript.Equipment.GetClothingItem(NamedSlot.hands).GameObjectReference, CommonTraits.Instance.PickUpProtection): true)
+				{
+					if (interaction.HandSlot.NamedSlot == NamedSlot.leftHand)
+					{
+						interaction.PerformerPlayerScript.playerHealth.ApplyDamageToBodypart(gameObject, amountOfDamage, attackType, damageType, BodyPartType.LeftArm);
+					}
+					else
+					{
+						interaction.PerformerPlayerScript.playerHealth.ApplyDamageToBodypart(gameObject, amountOfDamage, attackType, damageType, BodyPartType.RightArm);
+					}
+
+					Chat.AddExamineMsgFromServer(interaction.Performer, "<color=red>You injure yourself picking up the " + this.name + "</color>");
+				}
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Inventory/Pickupable.cs
@@ -28,24 +28,6 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 	public bool CanPickup => canPickup;
 
 	/// <summary>
-	/// Does damage to active left or right arm.
-	/// </summary>
-	public bool doesDamage;
-
-	/// <summary>
-	/// 1 = 100%
-	/// </summary>
-	public float doesDamageChance = 1f;
-
-	public float amountOfDamage = 10f;
-
-	public AttackType attackType;
-
-	public DamageType damageType;
-
-	public bool protectionByGloveItemTrait;
-
-	/// <summary>
 	/// Which inventory slot this is currently in, null if not in inventory
 	/// </summary>
 	public ItemSlot ItemSlot => itemSlot;
@@ -198,20 +180,6 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 			{
 				Logger.LogTraceFormat("Pickup success! server pos:{0} player pos:{1} (floating={2})", Category.Security,
 					cnt.ServerState.WorldPosition, interaction.Performer.transform.position, cnt.IsFloatingServer);
-
-				if (doesDamage && Random.value < doesDamageChance && protectionByGloveItemTrait ? !Validations.HasItemTrait(interaction.PerformerPlayerScript.Equipment.GetClothingItem(NamedSlot.hands).GameObjectReference, CommonTraits.Instance.PickUpProtection): true)
-				{
-					if (interaction.HandSlot.NamedSlot == NamedSlot.leftHand)
-					{
-						interaction.PerformerPlayerScript.playerHealth.ApplyDamageToBodypart(gameObject, amountOfDamage, attackType, damageType, BodyPartType.LeftArm);
-					}
-					else
-					{
-						interaction.PerformerPlayerScript.playerHealth.ApplyDamageToBodypart(gameObject, amountOfDamage, attackType, damageType, BodyPartType.RightArm);
-					}
-
-					Chat.AddExamineMsgFromServer(interaction.Performer, "<color=red>You injure yourself picking up the " + GetComponent<ItemAttributesV2>().ArticleName + "</color>");
-				}
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/Inventory/Pickupable.cs
+++ b/UnityProject/Assets/Scripts/Inventory/Pickupable.cs
@@ -210,7 +210,7 @@ public class Pickupable : NetworkBehaviour, IPredictedCheckedInteractable<HandAp
 						interaction.PerformerPlayerScript.playerHealth.ApplyDamageToBodypart(gameObject, amountOfDamage, attackType, damageType, BodyPartType.RightArm);
 					}
 
-					Chat.AddExamineMsgFromServer(interaction.Performer, "<color=red>You injure yourself picking up the " + this.name + "</color>");
+					Chat.AddExamineMsgFromServer(interaction.Performer, "<color=red>You injure yourself picking up the " + GetComponent<ItemAttributesV2>().ArticleName + "</color>");
 				}
 			}
 			else

--- a/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
+++ b/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
@@ -39,6 +39,8 @@ public class CommonTraits : SingletonScriptableObject<CommonTraits>
 	public ItemTrait Squeaky;
 	public ItemTrait LightTube;
 	public ItemTrait LightBulb;
+	public ItemTrait LightReplacer;
+	public ItemTrait BlackGloves;
 	public ItemTrait Broken;
 	public ItemTrait Breakable;
 	public ItemTrait Rods;

--- a/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
+++ b/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
@@ -49,4 +49,5 @@ public class CommonTraits : SingletonScriptableObject<CommonTraits>
 	public ItemTrait Insulated;
 	public ItemTrait InternalBattery;
 	public ItemTrait AntiFacehugger;
+	public ItemTrait PickUpProtection;
 }

--- a/UnityProject/Assets/Scripts/Lighting/LightMountStates.cs
+++ b/UnityProject/Assets/Scripts/Lighting/LightMountStates.cs
@@ -89,12 +89,12 @@ public class LightMountStates : NetworkBehaviour, ICheckedInteractable<HandApply
 				if (interaction.HandSlot.NamedSlot == NamedSlot.leftHand)
 				{
 					interaction.PerformerPlayerScript.playerHealth.ApplyDamageToBodypart(gameObject, 10f, AttackType.Energy, DamageType.Burn, BodyPartType.LeftArm);
-					Chat.AddExamineMsgFromServer(interaction.Performer, "You burn your left hand while attempting to remove the light");
+					Chat.AddExamineMsgFromServer(interaction.Performer, "<color=red>You burn your left hand while attempting to remove the light</color>");
 				}
 				else
 				{
 					interaction.PerformerPlayerScript.playerHealth.ApplyDamageToBodypart(gameObject, 10f, AttackType.Energy, DamageType.Burn, BodyPartType.RightArm);
-					Chat.AddExamineMsgFromServer(interaction.Performer, "You burn your right hand while attempting to remove the light");
+					Chat.AddExamineMsgFromServer(interaction.Performer, "<color=red>You burn your right hand while attempting to remove the light</color>");
 				}
 				return;
 			}

--- a/UnityProject/Assets/Scripts/Lighting/LightMountStates.cs
+++ b/UnityProject/Assets/Scripts/Lighting/LightMountStates.cs
@@ -84,6 +84,27 @@ public class LightMountStates : NetworkBehaviour, ICheckedInteractable<HandApply
 	{
 		if (interaction.HandObject == null)
 		{
+			if (state == LightMountState.On && state != LightMountState.MissingBulb && state != LightMountState.Broken && !Validations.HasItemTrait(interaction.PerformerPlayerScript.Equipment.GetClothingItem(NamedSlot.hands).GameObjectReference, CommonTraits.Instance.BlackGloves))
+			{
+				if (interaction.HandSlot.NamedSlot == NamedSlot.leftHand)
+				{
+					interaction.PerformerPlayerScript.playerHealth.ApplyDamageToBodypart(gameObject, 10f, AttackType.Energy, DamageType.Burn, BodyPartType.LeftArm);
+					Chat.AddExamineMsgFromServer(interaction.Performer, "You burn your left hand while attempting to remove the light");
+				}
+				else
+				{
+					interaction.PerformerPlayerScript.playerHealth.ApplyDamageToBodypart(gameObject, 10f, AttackType.Energy, DamageType.Burn, BodyPartType.RightArm);
+					Chat.AddExamineMsgFromServer(interaction.Performer, "You burn your right hand while attempting to remove the light");
+				}
+				return;
+			}
+
+			Spawn.ServerPrefab(state == LightMountState.Broken ? appliableBrokenItem : appliableItem,
+				interaction.Performer.WorldPosServer());
+			ServerChangeLightState(LightMountState.MissingBulb);
+		}
+		else if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.LightReplacer) && state != LightMountState.MissingBulb)
+		{
 			Spawn.ServerPrefab(state == LightMountState.Broken ? appliableBrokenItem : appliableItem,
 				interaction.Performer.WorldPosServer());
 			ServerChangeLightState(LightMountState.MissingBulb);


### PR DESCRIPTION
Makes on lights do damage when trying to remove.

Remove on lights safely by using black gloves or light replacer.

Added logic for damage when picking up items, some gloves protect.

Picking up glass shards deals a 50% chance for 10 damage.

Janitor Starts with black gloves.

#4025 Has been merged into this

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [x] Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
