### PR TITLE
Ban time and Null checks

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -323,7 +323,7 @@ public partial class PlayerList
 			{
 				//User is still banned:
 				StartCoroutine(KickPlayer(unverifiedConnPlayer, $"Server Error: This account is banned. " +
-				                                      $"You were banned for {banEntry.reason}. This ban has {banEntry.minutes} minutes remaining."));
+				                                      $"You were banned for {banEntry.reason}. This ban has {banEntry.minutes - totalMins} minutes remaining."));
 				Logger.Log($"{unverifiedConnPlayer.Username} tried to log back in but the account is banned. " +
 				           $"IP: {unverifiedConnPlayer.Connection.address}", Category.Admin);
 				return false;

--- a/UnityProject/Assets/Scripts/UI/AdminTools/AdminGlobalSound.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/AdminGlobalSound.cs
@@ -50,7 +50,11 @@ namespace AdminTools
 			var adminId = DatabaseAPI.ServerData.UserID;
 			var adminToken = PlayerList.Instance.AdminToken;
 
-			PlayerManager.LocalPlayerScript.playerNetworkActions.CmdPlaySound(index, adminId, adminToken);
+			var action = PlayerManager.LocalPlayerScript.playerNetworkActions;
+
+			if (action == null) return;
+
+			action.CmdPlaySound(index, adminId, adminToken);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/AdminTools/AdminGlobalSound.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/AdminGlobalSound.cs
@@ -50,11 +50,11 @@ namespace AdminTools
 			var adminId = DatabaseAPI.ServerData.UserID;
 			var adminToken = PlayerList.Instance.AdminToken;
 
-			var action = PlayerManager.LocalPlayerScript.playerNetworkActions;
+			var action = PlayerManager.LocalPlayerScript;
 
 			if (action == null) return;
 
-			action.CmdPlaySound(index, adminId, adminToken);
+			action.playerNetworkActions.CmdPlaySound(index, adminId, adminToken);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/AdminTools/AdminPlayersScrollView.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/AdminPlayersScrollView.cs
@@ -92,6 +92,8 @@ namespace AdminTools
 
 			if (SelectedPlayer == null)
 			{
+				if (playerEntries.Count == 0) return;
+
 				SelectPlayerInList(playerEntries[0]);
 			}
 			else

--- a/UnityProject/Assets/Scripts/UI/AdminTools/CentCommPage.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/CentCommPage.cs
@@ -13,11 +13,11 @@ namespace AdminTools
         {
 
             string text = CentCommInputBox.text;
-			var action = PlayerManager.LocalPlayerScript.playerNetworkActions;
+			var action = PlayerManager.LocalPlayerScript;
 
 			if (action == null) return;
 
-			action.CmdSendCentCommAnnouncement(DatabaseAPI.ServerData.UserID, PlayerList.Instance.AdminToken, text);
+			action.playerNetworkActions.CmdSendCentCommAnnouncement(DatabaseAPI.ServerData.UserID, PlayerList.Instance.AdminToken, text);
 
             adminTools.ShowMainPage();
         }
@@ -25,11 +25,11 @@ namespace AdminTools
         public void SendCentCommReport()
         {
             string text = CentCommInputBox.text;
-			var action = PlayerManager.LocalPlayerScript.playerNetworkActions;
+			var action = PlayerManager.LocalPlayerScript;
 
 			if (action == null) return;
 
-			action.CmdSendCentCommReport(DatabaseAPI.ServerData.UserID, PlayerList.Instance.AdminToken, text);
+			action.playerNetworkActions.CmdSendCentCommReport(DatabaseAPI.ServerData.UserID, PlayerList.Instance.AdminToken, text);
 
             adminTools.ShowMainPage();
         }

--- a/UnityProject/Assets/Scripts/UI/AdminTools/CentCommPage.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/CentCommPage.cs
@@ -13,9 +13,11 @@ namespace AdminTools
         {
 
             string text = CentCommInputBox.text;
-            PlayerManager.LocalPlayerScript.playerNetworkActions.CmdSendCentCommAnnouncement(DatabaseAPI.ServerData.UserID,
-                                                                                            PlayerList.Instance.AdminToken,
-                                                                                            text);
+			var action = PlayerManager.LocalPlayerScript.playerNetworkActions;
+
+			if (action == null) return;
+
+			action.CmdSendCentCommAnnouncement(DatabaseAPI.ServerData.UserID, PlayerList.Instance.AdminToken, text);
 
             adminTools.ShowMainPage();
         }
@@ -23,9 +25,11 @@ namespace AdminTools
         public void SendCentCommReport()
         {
             string text = CentCommInputBox.text;
-            PlayerManager.LocalPlayerScript.playerNetworkActions.CmdSendCentCommReport(DatabaseAPI.ServerData.UserID,
-                                                                                        PlayerList.Instance.AdminToken,
-                                                                                        text);
+			var action = PlayerManager.LocalPlayerScript.playerNetworkActions;
+
+			if (action == null) return;
+
+			action.CmdSendCentCommReport(DatabaseAPI.ServerData.UserID, PlayerList.Instance.AdminToken, text);
 
             adminTools.ShowMainPage();
         }


### PR DESCRIPTION
Makes it so ban time is shown as time left

Added null checks to global sounds and centcomm messages so the dont create NRE in lobby when used.

Fixes out of range exception for admin player chat.

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
