### PR TITLE
Maintenance loot and xenomorph egg spawners in Outpost and tweaks to loot tables.

### DIFF
--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonEquipment.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonEquipment.asset
@@ -12,42 +12,68 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
   m_Name: CommonEquipment
   m_EditorClassIdentifier: 
-  lootCount: 1
-  fanOut: 0
   pool:
-  - prefab: {fileID: 3573969270142595597, guid: 996d62bfe3bf26c4e95c2a77cadabbd2,
+  - prefab: {fileID: 6404652678407139925, guid: 996d62bfe3bf26c4e95c2a77cadabbd2,
       type: 3}
-    maxAmount: 0
+    maxAmount: 1
     probability: 100
   - prefab: {fileID: 6200957232458716886, guid: abf4818425fa84c67a62abb4425a4dcb,
       type: 3}
-    maxAmount: 0
+    maxAmount: 1
     probability: 100
   - prefab: {fileID: 1928361214078489529, guid: 868598a9acc5f40b0811af946a2c4c27,
       type: 3}
-    maxAmount: 0
+    maxAmount: 1
     probability: 100
   - prefab: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa,
       type: 3}
-    maxAmount: 0
-    probability: 100
+    maxAmount: 1
+    probability: 25
+  - prefab: {fileID: 7106618204054676533, guid: 7ca9937224493ae47be250db23caef24,
+      type: 3}
+    maxAmount: 1
+    probability: 25
+  - prefab: {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb,
+      type: 3}
+    maxAmount: 1
+    probability: 25
+  - prefab: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4,
+      type: 3}
+    maxAmount: 1
+    probability: 25
   - prefab: {fileID: 3921521694364753778, guid: 35cd853acdce0094f9462e049e31ed8e,
       type: 3}
-    maxAmount: 0
+    maxAmount: 1
     probability: 100
   - prefab: {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226,
       type: 3}
-    maxAmount: 0
+    maxAmount: 1
     probability: 100
   - prefab: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73,
       type: 3}
-    maxAmount: 0
+    maxAmount: 1
     probability: 100
   - prefab: {fileID: 2679964424910470999, guid: 7919ffc0a7c666742a83c767f7cb427f,
       type: 3}
-    maxAmount: 0
+    maxAmount: 1
     probability: 100
   - prefab: {fileID: 5425561884246163851, guid: 16fc8784fe8b167499a09e125d33f7d5,
       type: 3}
-    maxAmount: 0
+    maxAmount: 1
     probability: 100
+  - prefab: {fileID: 3431291279286482953, guid: e6f80a7fd02e2c14ea72a1410452b690,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6700281191928912403, guid: 1334bf0b7e3617941944a3b9c8c504c5,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523,
+      type: 3}
+    maxAmount: 1
+    probability: 50
+  - prefab: {fileID: 6313332283237824220, guid: 4c734bb9f1d853f40bb830ca96ef0260,
+      type: 3}
+    maxAmount: 1
+    probability: 50

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonFood.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonFood.asset
@@ -12,14 +12,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
   m_Name: CommonFood
   m_EditorClassIdentifier: 
-  lootCount: 1
-  fanOut: 0
   pool:
   - prefab: {fileID: 6602018046170396259, guid: 6744be6888ba21549a52eefcc270e0d5,
       type: 3}
     maxAmount: 1
     probability: 100
   - prefab: {fileID: 6602018046170396259, guid: 629f349d213af5f47b3e32d88c1c65cd,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37,
       type: 3}
     maxAmount: 1
     probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonLightSources.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonLightSources.asset
@@ -12,10 +12,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
   m_Name: CommonLightSources
   m_EditorClassIdentifier: 
-  lootCount: 1
-  fanOut: 0
   pool:
   - prefab: {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 2654578771155045139, guid: 5a7fa3c926dc42141889e9b72c5d314d,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 1052293997073687485, guid: dd6e2e9864d545b4a8a1447881f61d7c,
       type: 3}
     maxAmount: 1
     probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonMisc.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonMisc.asset
@@ -12,17 +12,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
   m_Name: CommonMisc
   m_EditorClassIdentifier: 
-  lootCount: 1
-  fanOut: 0
   pool:
   - prefab: {fileID: 2819670291326673133, guid: 09868dc1147587f4191af0a4defd8c1d,
       type: 3}
     maxAmount: 1
     probability: 100
-  - prefab: {fileID: 7914790827376970613, guid: 908afbc5b9f871148b5ccd0b81bd147f,
+  - prefab: {fileID: 3775655333583056072, guid: 47e554b7c6d142949a9ecca95c2cd526,
+      type: 3}
+    maxAmount: 1
+    probability: 25
+  - prefab: {fileID: 7914350351518715449, guid: 908afbc5b9f871148b5ccd0b81bd147f,
       type: 3}
     maxAmount: 1
     probability: 100
   - prefab: {fileID: 529109779100470021, guid: d6dc9ea3e3540427bb4c073d115b0137, type: 3}
     maxAmount: 1
     probability: 100
+  - prefab: {fileID: 2905805395148660121, guid: 1d2a97390d806414381b5edafdddb3c3,
+      type: 3}
+    maxAmount: 1
+    probability: 50

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonTools.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonTools.asset
@@ -12,8 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
   m_Name: CommonTools
   m_EditorClassIdentifier: 
-  lootCount: 1
-  fanOut: 0
   pool:
   - prefab: {fileID: 8868920090029130384, guid: 366fb594c17e76346bbb29ad4ce021ad,
       type: 3}
@@ -26,11 +24,18 @@ MonoBehaviour:
   - prefab: {fileID: 4930866777566109869, guid: 7976a84ef9209f14697cdd941b913e2a,
       type: 3}
     maxAmount: 1
-    probability: 100
+    probability: 33
   - prefab: {fileID: 6918947953705996213, guid: f709eab732189d6429ae3fa5beaf3fd3,
       type: 3}
     maxAmount: 1
-    probability: 100
+    probability: 33
+  - prefab: {fileID: 663820125157934168, guid: 8c2f7b54bdcb16f4b9c23ef38c73ab28, type: 3}
+    maxAmount: 1
+    probability: 33
+  - prefab: {fileID: 8096842924384943973, guid: 1bd4d6ea60dfdc1498ee8f06b7289fb4,
+      type: 3}
+    maxAmount: 1
+    probability: 33
   - prefab: {fileID: 8238071069653876758, guid: bf74e8243028ec14ebeb6578ebd2fcf4,
       type: 3}
     maxAmount: 1

--- a/UnityProject/Assets/Scripts/RandomItemPools/UncommonTools.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/UncommonTools.asset
@@ -12,8 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
   m_Name: UncommonTools
   m_EditorClassIdentifier: 
-  lootCount: 1
-  fanOut: 0
   pool:
   - prefab: {fileID: 6989221924687263735, guid: b735ab74dab174a4f90c79558cd51e43,
       type: 3}
@@ -23,6 +21,10 @@ MonoBehaviour:
     maxAmount: 1
     probability: 100
   - prefab: {fileID: 8127442588295923452, guid: 706cc1f035332384c96f001de4760563,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8568672687853555390, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
       type: 3}
     maxAmount: 1
     probability: 100


### PR DESCRIPTION
### Purpose
This PR adds maint loot spawners and xeno egg spawners added by #4026 to Outpost. I was pretty arbitrary while placing them down so they could use adjustments from people who actually know what they are doing.

I also tweaked the loot tables that the maint loot spawners use a bit.

### Please make sure you have followed the self checks below before submitting a PR:
- Code is sufficiently commented
- Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [ ] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ] The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
