### PR TITLE
Some fixes to mobs and xenos.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/CMOBioHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/CMOBioHood.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: bio hood
       objectReference: {fileID: 0}
@@ -17,6 +22,12 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A hood that protects the head and face from biological contaminants.
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/JanitorBioHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/JanitorBioHood.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: bio hood
       objectReference: {fileID: 0}
@@ -17,6 +22,12 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A hood that protects the head and face from biological contaminants.
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/ScientistBioHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/ScientistBioHood.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: bio hood
       objectReference: {fileID: 0}
@@ -17,6 +22,12 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A hood that protects the head and face from biological contaminants.
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/SecurityBioHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/SecurityBioHood.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: bio hood
       objectReference: {fileID: 0}
@@ -17,6 +22,12 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A hood that protects the head and face from biological contaminants.
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/VirologyBioHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/VirologyBioHood.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: bio hood
       objectReference: {fileID: 0}
@@ -17,6 +22,12 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A hood that protects the head and face from biological contaminants.
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/AdvancedHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/AdvancedHardsuitHelmet.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: advanced hardsuit helmet
       objectReference: {fileID: 0}
@@ -23,6 +28,12 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/AtmosphericsHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/AtmosphericsHardsuitHelmet.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: atmospherics hardsuit helmet
       objectReference: {fileID: 0}
@@ -23,6 +28,12 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/EngineeringHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/EngineeringHardsuitHelmet.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: engineering hardsuit helmet
       objectReference: {fileID: 0}
@@ -23,6 +28,12 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/HeadOfSecuritysHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/HeadOfSecuritysHardsuitHelmet.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: head of security's hardsuit helmet
       objectReference: {fileID: 0}
@@ -23,6 +28,12 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/MedicalHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/MedicalHardsuitHelmet.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: medical hardsuit helmet
       objectReference: {fileID: 0}
@@ -24,6 +29,12 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/MiningHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/MiningHardsuitHelmet.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: mining hardsuit helmet
       objectReference: {fileID: 0}
@@ -23,6 +28,12 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/SecurityHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/SecurityHardsuitHelmet.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: security hardsuit helmet
       objectReference: {fileID: 0}
@@ -23,6 +28,12 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/SyndicateHardsuitHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/HardsuitHelmets/SyndicateHardsuitHelmet.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: blood-red hardsuit helmet
       objectReference: {fileID: 0}
@@ -23,6 +28,12 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/RadiationHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/RadiationHood.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: radiation hood
       objectReference: {fileID: 0}
@@ -18,6 +23,12 @@ PrefabInstance:
       value: A hood with radiation protective properties. The label reads, 'Made
         with lead. Please do not consume insulation.'
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 8d9bddcf38348465eb528212d15282b5,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpaceHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpaceHelmet.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
       propertyPath: initialName
       value: space helmet
       objectReference: {fileID: 0}
@@ -23,6 +28,12 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1778182844913246397, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: ba923436cf6803a4f99a5ed73f885d61,
+        type: 2}
     - target: {fileID: 2067487341669760131, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Xenomorph_Queen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Xenomorph_Queen.prefab
@@ -618,5 +618,5 @@ MonoBehaviour:
   huggerCap: 8
   fertility: 50
   eggCooldown: 300
-  alienEgg: {fileID: 8331399007563457964, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
+  alienEgg: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
     type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Xenomorph_Queen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Xenomorph_Queen.prefab
@@ -615,8 +615,8 @@ MonoBehaviour:
   randomSoundProbability: 20
   searchTickRate: 0.5
   currentStatus: 0
-  huggerCap: 4
-  fertility: 30
+  huggerCap: 8
+  fertility: 50
   eggCooldown: 300
   alienEgg: {fileID: 8331399007563457964, guid: 9473c17e4e7f2f24d99f2d788030cd9f,
     type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Alien/Alien Egg.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Alien/Alien Egg.prefab
@@ -1,12 +1,31 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &7489533636973299563
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5322418909914265045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26ab0df8c17d54941b636a01aea0820b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  incubationTime: 80
+  initialState: 0
+  freezeCycle: 0
+  facehugger: {fileID: 4827737755655954553, guid: 89d417cb15d3feb4890b78355113e696,
+    type: 3}
 --- !u!114 &6004374242838787409
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8331399007563460575}
+  m_GameObject: {fileID: 4131865648593569775}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
@@ -52,24 +71,6 @@ MonoBehaviour:
   spriteIndex: 0
   variantIndex: 0
   SetSpriteOnStartUp: 1
---- !u!114 &7489533636973299563
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8331399007563457964}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 26ab0df8c17d54941b636a01aea0820b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  incubationTime: 60
-  initialState: 0
-  facehugger: {fileID: 4827737755655954553, guid: 89d417cb15d3feb4890b78355113e696,
-    type: 3}
 --- !u!1001 &8331399007563543452
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -185,13 +186,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
---- !u!1 &8331399007563457964 stripped
+--- !u!1 &5322418909914265045 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
     type: 3}
   m_PrefabInstance: {fileID: 8331399007563543452}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &8331399007563460575 stripped
+--- !u!1 &4131865648593569775 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5388634654466307187, guid: ebb08cf966efc084aa918bd8d9429604,
     type: 3}

--- a/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
+++ b/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
@@ -44,7 +44,7 @@ namespace Clothing
 			itemAttributesV2.ServerSetArticleDescription("Still pretty scary!");
 		}
 
-		private void KillHugger()
+		public void KillHugger()
 		{
 			isAlive = false;
 			clothingV2.ServerChangeVariant(ClothingV2.ClothingVariantType.Tucked);

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -14,7 +14,7 @@ using UnityEngine.Profiling;
 /// Monitors and calculates health
 /// </summary>
 [RequireComponent(typeof(HealthStateMonitor))]
-public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireExposable, IExaminable
+public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireExposable, IExaminable, IServerSpawn
 {
 	private static readonly float GIB_THRESHOLD = 200f;
 	//damage incurred per tick per fire stack
@@ -816,6 +816,14 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 
 		healthString = pronoun + " is " + healthString + (respiratorySystem.IsSuffocating && !IsDead ? " " + pronoun + " is having trouble breathing!" : "");
 		return healthString;
+	}
+
+	public void OnSpawnServer(SpawnInfo info)
+	{
+		ConsciousState = ConsciousState.CONSCIOUS;
+		OverallHealth = maxHealth;
+		ResetBodyParts();
+		CalculateOverallHealth();
 	}
 }
 

--- a/UnityProject/Assets/Scripts/Health/Living/SimpleAnimal/SimpleAnimal.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/SimpleAnimal/SimpleAnimal.cs
@@ -9,11 +9,17 @@ public class SimpleAnimal : LivingHealthBehaviour
 	public Sprite deadSprite;
 
 	//Syncvar hook so that new players can sync state on start
-	[SyncVar(hook = nameof(SetAliveState))] public bool deadState;
+	[SyncVar(hook = nameof(SyncAliveState))] public bool deadState;
 
 	public SpriteRenderer spriteRend;
 
 	public RegisterObject registerObject;
+
+	[Server]
+	public void SetDeadState(bool isDead)
+	{
+		deadState = isDead;
+	}
 
 	public override void Awake()
 	{
@@ -29,7 +35,7 @@ public class SimpleAnimal : LivingHealthBehaviour
 	private IEnumerator WaitForLoad()
 	{
 		yield return WaitFor.Seconds(2f);
-		SetAliveState(deadState, deadState);
+		SyncAliveState(deadState, deadState);
 	}
 
 	[Server]
@@ -38,10 +44,10 @@ public class SimpleAnimal : LivingHealthBehaviour
 		deadState = true;
 	}
 
-	private void SetAliveState(bool oldState, bool state)
+	private void SyncAliveState(bool oldState, bool state)
 	{
 		deadState = state;
-		
+
 		if (state)
 		{
 			spriteRend.sprite = deadSprite;

--- a/UnityProject/Assets/Scripts/Messages/Server/MobMeleeLerpMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/MobMeleeLerpMessage.cs
@@ -14,12 +14,18 @@ public class MobMeleeLerpMessage : ServerMessage
 
 		var getMob = NetworkIdentity.spawned[mob];
 		var mobMelee = getMob.GetComponent<MobMeleeAttack>();
+		var mobAction = getMob.GetComponent<MobMeleeAction>();
+		if (mobMelee == null & mobAction == null)
+		{
+			return;
+		}
+
 		if (mobMelee == null)
 		{
-			var mobAction = getMob.GetComponent<MobMeleeAction>();
 			mobAction.ClientDoLerpAnimation(dir);
 			return;
 		}
+
 		mobMelee.ClientDoLerpAnimation(dir);
 	}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/GenericFriendlyAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/GenericFriendlyAI.cs
@@ -4,7 +4,7 @@ using WebSocketSharp;
 
 namespace NPC
 {
-	public class GenericFriendlyAI : MobAI
+	public class GenericFriendlyAI : MobAI, IServerSpawn
 	{
 		protected string mobNameCap;
 		protected float timeForNextRandomAction;
@@ -14,10 +14,13 @@ namespace NPC
 		[SerializeField]
 		protected float maxTimeBetweenRandomActions = 30f;
 
+		protected SimpleAnimal simpleAnimal;
+
 		protected override void Awake()
 		{
 			base.Awake();
 			mobNameCap = mobName.IsNullOrEmpty() ? mobName : char.ToUpper(mobName[0]) + mobName.Substring(1);
+			simpleAnimal = GetComponent<SimpleAnimal>();
 			BeginExploring();
 		}
 
@@ -67,6 +70,21 @@ namespace NPC
 
 		protected virtual void DoRandomAction() {}
 
+		public void OnSpawnServer(SpawnInfo info)
+		{
+			OnSpawnMob();
+		}
+
+		protected virtual void OnSpawnMob()
+		{
+			dirSprites.SetToNPCLayer();
+			registerObject.Passable = false;
+			if (simpleAnimal != null)
+			{
+				simpleAnimal.SetDeadState(false);
+			}
+		}
+
 		protected override void OnAttackReceived(GameObject damagedBy = null)
 		{
 			StartFleeing(damagedBy, 5f);
@@ -75,6 +93,5 @@ namespace NPC
 		protected virtual void OnExploringStopped(){}
 		protected virtual void OnFleeingStopped(){}
 		protected virtual void OnFollowStopped(){}
-
 	}
 }

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/GenericFriendlyAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/GenericFriendlyAI.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using UnityEngine;
+using WebSocketSharp;
 
 namespace NPC
 {
@@ -16,7 +17,7 @@ namespace NPC
 		protected override void Awake()
 		{
 			base.Awake();
-			mobNameCap = char.ToUpper(mobName[0]) + mobName.Substring(1);
+			mobNameCap = mobName.IsNullOrEmpty() ? mobName : char.ToUpper(mobName[0]) + mobName.Substring(1);
 			BeginExploring();
 		}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/MouseAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/MouseAI.cs
@@ -51,5 +51,11 @@ namespace NPC
 		{
 			Squeak();
 		}
+
+		protected override void OnSpawnMob()
+		{
+			base.OnSpawnMob();
+			BeginExploring();
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using Clothing;
 using NPC.AI;
 using UnityEngine;
 using Random = UnityEngine.Random;
@@ -394,7 +395,13 @@ namespace NPC
 			var result = Spawn.ServerPrefab(maskObject);
 			var mask = result.GameObject;
 
+			if (IsDead || IsUnconscious)
+			{
+				mask.GetComponent<FacehuggerImpregnation>().KillHugger();
+			}
+
 			Inventory.ServerAdd(mask, handSlot, ReplacementStrategy.DropOther);
+
 			Despawn.ServerSingle(gameObject);
 		}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using Clothing;
 using NPC.AI;
@@ -32,6 +31,13 @@ namespace NPC
 		private int playersLayer;
 		private MobMeleeAction mobMeleeAction;
 		private ConeOfSight coneOfSight;
+		private SimpleAnimal simpleAnimal;
+
+		protected override void Awake()
+		{
+			base.Awake();
+			simpleAnimal = GetComponent<SimpleAnimal>();
+		}
 
 		public override void OnEnable()
 		{
@@ -71,6 +77,7 @@ namespace NPC
 		protected override void ResetBehaviours()
 		{
 			base.ResetBehaviours();
+			mobFollow.followTarget = null;
 			currentStatus = MobStatus.None;
 			searchWaitTime = 0f;
 		}
@@ -217,16 +224,23 @@ namespace NPC
 			if (IsDead || IsUnconscious)
 			{
 				HandleDeathOrUnconscious();
+				return;
 			}
 
-			if (currentStatus == MobStatus.Searching)
+			switch (currentStatus)
 			{
-				HandleSearch();
-			}
-
-			if (currentStatus == MobStatus.Attacking || currentStatus == MobStatus.None)
-			{
-				MonitorIdleness();
+				case MobStatus.Searching:
+					HandleSearch();
+					return;
+				case MobStatus.Attacking:
+					MonitorIdleness();
+					break;
+				case MobStatus.None:
+					MonitorIdleness();
+					break;
+				default:
+					MonitorIdleness();
+					break;
 			}
 		}
 
@@ -235,6 +249,7 @@ namespace NPC
 			if (damagedBy == null)
 			{
 				StartFleeing(damagedBy);
+				return;
 			}
 
 			if (health.OverallHealth < -20f)
@@ -407,7 +422,12 @@ namespace NPC
 
 		public void OnSpawnServer(SpawnInfo info)
 		{
-			XenoQueenAI.CurrentHuggerAmt += 1;
+			XenoQueenAI.CurrentHuggerAmt++;
+			dirSprites.SetToNPCLayer();
+			registerObject.Passable = false;
+			simpleAnimal.SetDeadState(false);
+			ResetBehaviours();
+			BeginSearch();
 		}
 
 		public override void OnDespawnServer(DespawnInfo info)

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
@@ -12,7 +12,7 @@ namespace NPC
 	/// </summary>
 	[RequireComponent(typeof(MobMeleeAttack))]
 	[RequireComponent(typeof(ConeOfSight))]
-	public class GenericHostileAI : MobAI
+	public class GenericHostileAI : MobAI, IServerSpawn
 	{
 		[SerializeField]
 		protected List<string> deathSounds = new List<string>();
@@ -37,6 +37,7 @@ namespace NPC
 		protected int playersLayer;
 		protected MobMeleeAttack mobMeleeAttack;
 		protected ConeOfSight coneOfSight;
+		protected SimpleAnimal simpleAnimal;
 
 		public override void OnEnable()
 		{
@@ -45,6 +46,7 @@ namespace NPC
 			playersLayer = LayerMask.NameToLayer("Players");
 			mobMeleeAttack = GetComponent<MobMeleeAttack>();
 			coneOfSight = GetComponent<ConeOfSight>();
+			simpleAnimal = GetComponent<SimpleAnimal>();
 			PlayRandomSound();
 		}
 
@@ -77,6 +79,7 @@ namespace NPC
 		protected override void ResetBehaviours()
 		{
 			base.ResetBehaviours();
+			mobFollow.followTarget = null;
 			currentStatus = MobStatus.None;
 			searchWaitTime = 0f;
 		}
@@ -294,6 +297,21 @@ namespace NPC
 			if (findTarget != null)
 			{
 				BeginAttack(findTarget);
+			}
+		}
+
+		public void OnSpawnServer(SpawnInfo info)
+		{
+			OnSpawnMob();
+		}
+
+		protected virtual void OnSpawnMob()
+		{
+			dirSprites.SetToNPCLayer();
+			registerObject.Passable = false;
+			if (simpleAnimal != null)
+			{
+				simpleAnimal.SetDeadState(false);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/LarvaeAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/LarvaeAI.cs
@@ -6,7 +6,7 @@ using Random = UnityEngine.Random;
 
 namespace NPC
 {
-	public class LarvaeAI : GenericFriendlyAI, IServerSpawn
+	public class LarvaeAI : GenericFriendlyAI
 	{
 		[Tooltip("Time in seconds this larva will take to become a full grown Xeno")][SerializeField]
 		private float timeToGrow;
@@ -18,6 +18,7 @@ namespace NPC
 		{
 			base.Awake();
 			mobNameCap = mobName.IsNullOrEmpty() ? mobName : char.ToUpper(mobName[0]) + mobName.Substring(1);
+			simpleAnimal = GetComponent<SimpleAnimal>();
 			BeginExploring();
 		}
 
@@ -51,15 +52,17 @@ namespace NPC
 			StartFleeing(damagedBy);
 		}
 
+		protected override void OnSpawnMob()
+		{
+			base.OnSpawnMob();
+			StartFleeing(gameObject, 10f);
+			StartCoroutine(Grow());
+		}
+
 		public override void OnDespawnServer(DespawnInfo info)
 		{
 			base.OnDespawnServer(info);
 			StopAllCoroutines();
-		}
-
-		public void OnSpawnServer(SpawnInfo info)
-		{
-			StartCoroutine(Grow());
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/LarvaeAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/LarvaeAI.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using UnityEngine;
+using WebSocketSharp;
+using Random = UnityEngine.Random;
 
 namespace NPC
 {
@@ -14,7 +17,7 @@ namespace NPC
 		protected override void Awake()
 		{
 			base.Awake();
-			mobNameCap = char.ToUpper(mobName[0]) + mobName.Substring(1);
+			mobNameCap = mobName.IsNullOrEmpty() ? mobName : char.ToUpper(mobName[0]) + mobName.Substring(1);
 			BeginExploring();
 		}
 
@@ -34,6 +37,11 @@ namespace NPC
 		private IEnumerator Grow()
 		{
 			yield return WaitFor.Seconds(timeToGrow);
+			if (IsDead || IsUnconscious)
+			{
+				yield break;
+			}
+
 			Spawn.ServerPrefab(xenomorph, gameObject.transform.position);
 			Despawn.ServerSingle(gameObject);
 		}

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/StatueAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/StatueAI.cs
@@ -149,6 +149,12 @@ namespace NPC
 			}
 		}
 
+		protected override void OnSpawnMob()
+		{
+			base.OnSpawnMob();
+			BeginSearch();
+		}
+
 		private readonly Dictionary<int, Orientation> orientations = new Dictionary<int, Orientation>()
 		{
 			{1, Orientation.Up},

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoQueenAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoQueenAI.cs
@@ -21,12 +21,14 @@ namespace NPC
 		private GameObject alienEgg = null;
 
 		private static int currentHuggerAmt;
+		private static bool resetHandlerAdded = false;
 
 		public static int CurrentHuggerAmt
 		{
 			get => currentHuggerAmt;
 			set => currentHuggerAmt = value;
 		}
+
 
 		private bool CapReached()
 		{
@@ -65,8 +67,26 @@ namespace NPC
 			Spawn.ServerPrefab(alienEgg, gameObject.transform.position);
 		}
 
+		private static void ResetHuggerAmount()
+		{
+			currentHuggerAmt = 0;
+		}
+
+		private static void AddResetHandler()
+		{
+			if (resetHandlerAdded)
+			{
+				return;
+			}
+
+			EventManager.AddHandler(EVENT.RoundStarted, ResetHuggerAmount);
+			resetHandlerAdded = true;
+		}
+
 		public void OnSpawnServer(SpawnInfo info)
 		{
+			AddResetHandler();
+
 			if (fertility != 0)
 			{
 				FertilityLoop();

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoQueenAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoQueenAI.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace NPC
 {
-	public class XenoQueenAI: GenericHostileAI, IServerSpawn
+	public class XenoQueenAI: GenericHostileAI
 	{
 		[Tooltip("Max amount of active facehuggers that can be in the server at once")][SerializeField]
 		private int huggerCap = 0;
@@ -83,14 +83,17 @@ namespace NPC
 			resetHandlerAdded = true;
 		}
 
-		public void OnSpawnServer(SpawnInfo info)
+		protected override void OnSpawnMob()
 		{
+			base.OnSpawnMob();
 			AddResetHandler();
 
 			if (fertility != 0)
 			{
 				FertilityLoop();
 			}
+
+			BeginSearch();
 		}
 	}
 }


### PR DESCRIPTION
### Purpose
Fixes (or attemps to) some issues that were found by players when testing the xenos.
related PR: #3966 

### Notes:
- Prevents players from resuciting a dead xeno by picking it up and dropping again.
- Prevents mobs from spawning dead.
- Resets the cap of facehuggers at round start (it was carried between rounds).
- Adds the antihugger trait to a lot of helmets.
- Some minor tweaks to timing on xeno cycle.

Please note that I wasn't able to prevent mobs from spawning brain dead, so you will ocassionally encounter xenos that won't follow you.