### PR TITLE
Alter clothing sizes for parents and a few variants.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear.prefab
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a8b83d5d8f2fff468002618ef0d7ff5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  wearType: 3
 --- !u!1001 &3463029306022828862
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -101,6 +102,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 9dd6c830eadb94ceb8578c8ac94dde66,
         type: 2}
+    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: initialSize
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b5f74a79e023479cb5b30a2879621da, type: 3}
 --- !u!1 &1864679013969520924 stripped

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Handwear.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2917128564446547862, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 3021789324208599586, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
       propertyPath: m_Name
@@ -67,11 +72,12 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2917128564446547862, guid: 6b5f74a79e023479cb5b30a2879621da,
+    - target: {fileID: 3107053823204540798, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
-      propertyPath: m_AssetId
+      propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 21300000, guid: 9ee96f0c40b490342aec9b3eb4b93489,
+        type: 3}
     - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
       propertyPath: initialTraits.Array.size
@@ -83,11 +89,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 5e02bb5046f5e49d99d448363a2cdf86,
         type: 2}
-    - target: {fileID: 3107053823204540798, guid: 6b5f74a79e023479cb5b30a2879621da,
+    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 9ee96f0c40b490342aec9b3eb4b93489,
-        type: 3}
+      propertyPath: initialSize
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b5f74a79e023479cb5b30a2879621da, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear.prefab
@@ -103,6 +103,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 8d9bddcf38348465eb528212d15282b5,
         type: 2}
+    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: initialSize
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b5f74a79e023479cb5b30a2879621da, type: 3}
 --- !u!1 &2179959185564930015 stripped

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear.prefab
@@ -118,6 +118,11 @@ PrefabInstance:
       propertyPath: canConnectToTank
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: initialSize
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b5f74a79e023479cb5b30a2879621da, type: 3}
 --- !u!1 &7600017545650087553 stripped

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Neckwear.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Neckwear.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2917128564446547862, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 3021789324208599586, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
       propertyPath: m_Name
@@ -67,11 +72,12 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2917128564446547862, guid: 6b5f74a79e023479cb5b30a2879621da,
+    - target: {fileID: 3107053823204540798, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
-      propertyPath: m_AssetId
+      propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 21300000, guid: e58982c70a93a8b4ebc9357713c9189a,
+        type: 3}
     - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
       propertyPath: initialTraits.Array.size
@@ -83,11 +89,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 03d313a9668074d24b7a143b70a86327,
         type: 2}
-    - target: {fileID: 3107053823204540798, guid: 6b5f74a79e023479cb5b30a2879621da,
+    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: e58982c70a93a8b4ebc9357713c9189a,
-        type: 3}
+      propertyPath: initialSize
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b5f74a79e023479cb5b30a2879621da, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear.prefab
@@ -118,6 +118,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 05e6127af6cf24f08b94fb9922263c26,
         type: 2}
+    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: initialSize
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b5f74a79e023479cb5b30a2879621da, type: 3}
 --- !u!1 &3525490832341156112 stripped

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/BombSuits/BombSuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/BombSuits/BombSuit.prefab
@@ -153,6 +153,11 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A suit designed for safety when handling explosives.
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/BombSuits/SecurityBombSuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/BombSuits/SecurityBombSuit.prefab
@@ -153,6 +153,11 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A suit designed for safety when handling explosives.
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/BombSuits/WhiteBombSuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/BombSuits/WhiteBombSuit.prefab
@@ -153,6 +153,11 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A suit designed for safety when handling explosives.
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/EVASuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/EVASuit.prefab
@@ -129,6 +129,11 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/EmergencyFiresuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/EmergencyFiresuit.prefab
@@ -153,6 +153,11 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A suit that helps protect against fire and heat.
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/AdvancedHardsuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/AdvancedHardsuit.prefab
@@ -192,6 +192,11 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/AtmosphericsHardsuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/AtmosphericsHardsuit.prefab
@@ -192,6 +192,11 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/CaptainsSWATSuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/CaptainsSWATSuit.prefab
@@ -200,6 +200,11 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/EngineeringHardsuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/EngineeringHardsuit.prefab
@@ -192,6 +192,11 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/HeadOfSecuritysHardsuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/HeadOfSecuritysHardsuit.prefab
@@ -192,6 +192,11 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/MedicalHardsuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/MedicalHardsuit.prefab
@@ -192,6 +192,11 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/MiningHardsuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/MiningHardsuit.prefab
@@ -192,6 +192,11 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/PrototypeHardsuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/PrototypeHardsuit.prefab
@@ -198,6 +198,11 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/SecurityHardsuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/SecurityHardsuit.prefab
@@ -192,6 +192,11 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/SyndicateHardsuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/Hardsuits/SyndicateHardsuit.prefab
@@ -201,6 +201,11 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/RadiationSuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/RadiationSuit.prefab
@@ -124,6 +124,11 @@ PrefabInstance:
       value: A suit that protects against radiation. The label reads, 'Made with
         lead. Please do not consume insulation.'
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/SpaceSuit.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Outerwear/SpaceSuit.prefab
@@ -159,6 +159,11 @@ PrefabInstance:
       propertyPath: isEVACapable
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3891274522419703410, guid: a0c29a11d2c864b7982765b5340eed0e,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7534581208369271445, guid: a0c29a11d2c864b7982765b5340eed0e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Uniform.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Uniform.prefab
@@ -103,6 +103,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: df3f1a389c0f2428690a13b95cf1f9f9,
         type: 2}
+    - target: {fileID: 3387296074795883840, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: initialSize
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6b5f74a79e023479cb5b30a2879621da, type: 3}
 --- !u!1 &4658995992363608162 stripped


### PR DESCRIPTION
# Purpose
This PR alters the sizes for the clothing .prefab parents, which means that most clothing will no longer fit inside your pockets anymore.

Also makes hardsuits (except for syndie ones) use the largest size so they can't be stored at all.

### Please make sure you have followed the self checks below before submitting a PR:

- Code is sufficiently commented
- Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [ ] The PR has been tested in editor
- Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- Any new objects / items follow the [Creating Items and Objects Guide](https://github.com/unitystation/unitystation/wiki/Creating-Items-and-Objects%3A-Now-With-Prefab-Variants) (especially concerning the use of prefab variants)
- [ ] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ] The PR has been tested with round restarts.
- The PR has been tested on moving / rotating / rotated-before-joining matrices (if applicable)
