### PR TITLE
Improved preround countdown syncing

### DIFF
--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateCountdownMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateCountdownMessage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using Mirror;
 
 /// <summary>
 ///     Message that tells client the status of the preround countdown
@@ -7,7 +6,7 @@ using System.Collections;
 public class UpdateCountdownMessage : ServerMessage
 {
 	public bool Started;
-	public long EndTime;
+	public double EndTime;
 
 	public override void Process()
 	{
@@ -22,8 +21,8 @@ public class UpdateCountdownMessage : ServerMessage
 	/// <returns></returns>
 	public static UpdateCountdownMessage Send(bool started, float time)
 	{
-		// Calculate when the countdown will end in the unix timestamp
-		long endTime = DateTimeOffset.UtcNow.AddSeconds(time).ToUnixTimeMilliseconds();
+		// Calculate when the countdown will end relative to the current NetworkTime
+		double endTime = NetworkTime.time + time;
 		UpdateCountdownMessage msg = new UpdateCountdownMessage
 		{
 			Started = started,

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -76,9 +76,8 @@ public class JoinedViewer : NetworkBehaviour
 		{
 			if (GameManager.Instance.waitForStart)
 			{
-				// Calculate when the countdown will end in the unix timestamp
-				long endTime = DateTimeOffset.UtcNow.AddSeconds(GameManager.Instance.CountdownTime)
-					.ToUnixTimeMilliseconds();
+				// Calculate when the countdown will end relative to the NetworkTime
+				double endTime = NetworkTime.time + GameManager.Instance.CountdownTime;
 				TargetSyncCountdown(connectionToClient, GameManager.Instance.waitForStart, endTime);
 			}
 			else
@@ -177,7 +176,7 @@ public class JoinedViewer : NetworkBehaviour
 	/// Tells the client to start the countdown if it's already started
 	/// </summary>
 	[TargetRpc]
-	private void TargetSyncCountdown(NetworkConnection target, bool started, long endTime)
+	private void TargetSyncCountdown(NetworkConnection target, bool started, double endTime)
 	{
 		Logger.Log("Syncing countdown!", Category.Round);
 		UIManager.Display.preRoundWindow.GetComponent<GUI_PreRoundWindow>().SyncCountdown(started, endTime);


### PR DESCRIPTION
### Purpose
Switch out the unix timestamp for NetworkTime.time so the countdown doesn't rely on the user having the correct time set anymore.

### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new files are named using PascalCase (to avoid issues on case sensitive file systems)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
