### PR TITLE
Fixed moving and performing other actions while typing.

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -711,7 +711,7 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 		{
 			bool beingDraggedWithCuffs = playerMove.IsCuffed && playerScript.pushPull.IsBeingPulledClient;
 
-			if (playerMove.allowInput && !playerMove.IsBuckled && !beingDraggedWithCuffs)
+			if (playerMove.allowInput && !playerMove.IsBuckled && !beingDraggedWithCuffs && !UIManager.IsInputFocus)
 			{
 				StartCoroutine(DoProcess(moveActions));
 			}


### PR DESCRIPTION
Fixes #4038  issue. Now players won't move or perform other unwanted actions while typing in the chat window.