### PR TITLE
Tweak for random loot spawner

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
@@ -24,53 +24,55 @@ namespace Items
 
 		private void RollRandomPool()
 		{
-			PoolData pool = null;
-			while (pool == null)
+			for (int i = 0; i <= lootCount; i++)
 			{
+				PoolData pool = null;
+				// Roll attempt is a safe check in the case the mapper did tables with low % and we can't find
+				// anything to spawn in 5 attempts
 				int rollAttempt = 0;
 
-				var tryPool = poolList.PickRandom();
-				if (DMMath.Prob(tryPool.Probability))
+				while (pool == null)
 				{
-					pool = tryPool;
-				}
-				else
-				{
-					rollAttempt ++;
+
+					if (rollAttempt >= MaxAmountRolls)
+					{
+						continue;
+					}
+
+					var tryPool = poolList.PickRandom();
+					if (DMMath.Prob(tryPool.Probability))
+					{
+						pool = tryPool;
+					}
+					else
+					{
+						rollAttempt ++;
+					}
 				}
 
-				if (rollAttempt >= MaxAmountRolls)
-				{
-					Destroy(gameObject);
-					break;
-				}
+				SpawnItems(pool);
 			}
 
-			SpawnItems(pool);
+			Destroy(gameObject);
 		}
 
 		private void SpawnItems(PoolData poolData)
 		{
-			for (int i = 0; i < lootCount; i++)
+			var item = poolData.RandomItemPool.Pool.PickRandom();
+			var spread = fanOut ? Random.Range(-0.5f,0.5f) : (float?) null;
+
+			if (!DMMath.Prob(item.Probability))
 			{
-				var item = poolData.RandomItemPool.Pool.PickRandom();
-				var spread = fanOut ? Random.Range(-0.5f,0.5f) : (float?) null;
-
-				if (!DMMath.Prob(item.Probability))
-				{
-					continue;
-				}
-
-				var maxAmt = Random.Range(1, item.MaxAmount+1);
-
-				Spawn.ServerPrefab(
-					item.Prefab,
-					gameObject.RegisterTile().WorldPositionServer,
-					count: maxAmt,
-					scatterRadius: spread);
+				return;
 			}
 
-			Destroy(gameObject);
+			var maxAmt = Random.Range(1, item.MaxAmount+1);
+
+			Spawn.ServerPrefab(
+				item.Prefab,
+				gameObject.RegisterTile().WorldPositionServer,
+				count: maxAmt,
+				scatterRadius: spread);
 		}
 	}
 


### PR DESCRIPTION
### Purpose
This little tweak should diversify the type of items spawned by rerolling the loot table instead of the item from the chosen loot table when we have a lootcount > 1.

### How it worked previously:
1- Pick a random loot table
2- Roll loot table probability  (if roll failed, pick a random table again)
3- Pick a random item and roll probability until loot count was met.

Problem with this approach is if the Random Gloves table was chosen, you will end up with 8 gloves in the same spot.

### How it works now:
1- Pick a random loot table
2- Roll loot table probability (if roll failed, pick a random table again)
3- Pick a random item and roll item probability (only spawns something if the roll was a sucess)
4- jump to 1 until the loot count is met.


### Please make sure you have followed the self checks below before submitting a PR:

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [x] Any new / changed components follow the [Component Development Checklist](https://github.com/unitystation/unitystation/wiki/Component-Development-Checklist)
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [x] The PR has been tested with round restarts.
