### PR TITLE
3029 chat cut in half

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Chat/ChatSystem.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Chat/ChatSystem.prefab
@@ -623,7 +623,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &224044340976132104
 RectTransform:
   m_ObjectHideFlags: 0
@@ -985,7 +985,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: -216.73, y: -1165.2075}
+  m_AnchoredPosition: {x: -216.73, y: -0.00012207031}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
 --- !u!222 &222333231492848688
@@ -2000,8 +2000,8 @@ MonoBehaviour:
   activeRadioChannelPanel: {fileID: 1549249320892692889}
   activeChannelTemplate: {fileID: 8380570029279695647}
   InputFieldChat: {fileID: 6487468842456376085}
-  thresholdMarkerBottom: {fileID: 0}
-  thresholdMarkerTop: {fileID: 0}
+  thresholdMarkerBottom: {fileID: 9002736259520338227}
+  thresholdMarkerTop: {fileID: 2121891336962855131}
   adminHelpChat: {fileID: 7497176922575414754}
   entryPool: {fileID: 4984957583611271286}
 --- !u!114 &4984957583611271286
@@ -2144,7 +2144,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: 0.000030517578, y: -4.794983}
-  m_SizeDelta: {x: 0, y: 19}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: -0.01}
 --- !u!114 &4562691947668370983
 MonoBehaviour:
@@ -3070,7 +3070,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &9207531746528235545
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3169,7 +3169,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2807939661053576224}
   m_HandleRect: {fileID: 5333097039435445460}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -3536,7 +3536,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -4259,7 +4259,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.8}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -4320,7 +4320,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &665822459925676373
 RectTransform:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Chat/ChatSystem.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Chat/ChatSystem.prefab
@@ -446,6 +446,7 @@ RectTransform:
   m_Children:
   - {fileID: 9002736259520338227}
   - {fileID: 224576715969102918}
+  - {fileID: 2121891336962855131}
   m_Father: {fileID: 8533227384194854147}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -984,7 +985,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: -216.73, y: 0}
+  m_AnchoredPosition: {x: -216.73, y: -1165.2075}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
 --- !u!222 &222333231492848688
@@ -1999,9 +2000,8 @@ MonoBehaviour:
   activeRadioChannelPanel: {fileID: 1549249320892692889}
   activeChannelTemplate: {fileID: 8380570029279695647}
   InputFieldChat: {fileID: 6487468842456376085}
-  scrollHandle: {fileID: 2807939661053576224}
-  scrollBackground: {fileID: 50052018069764188}
-  thresholdMarker: {fileID: 9002736259520338227}
+  thresholdMarkerBottom: {fileID: 0}
+  thresholdMarkerTop: {fileID: 0}
   adminHelpChat: {fileID: 7497176922575414754}
   entryPool: {fileID: 4984957583611271286}
 --- !u!114 &4984957583611271286
@@ -2555,6 +2555,41 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2123243453920981833
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2121891336962855131}
+  m_Layer: 5
+  m_Name: thresholdMarkerTop
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2121891336962855131
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123243453920981833}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224798581258123564}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.000061035156}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2235971909617706385
 GameObject:
   m_ObjectHideFlags: 0
@@ -3134,7 +3169,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2807939661053576224}
   m_HandleRect: {fileID: 5333097039435445460}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -4684,7 +4719,7 @@ GameObject:
   m_Component:
   - component: {fileID: 9002736259520338227}
   m_Layer: 5
-  m_Name: thresholdMarker
+  m_Name: thresholdMarkerBottom
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4967,15 +5002,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 115e79e65ed316546aea2bf6ffdcc366, type: 3}
---- !u!1 &9091622191222137699 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1618776996635460, guid: 115e79e65ed316546aea2bf6ffdcc366,
-    type: 3}
-  m_PrefabInstance: {fileID: 9092255765942517799}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &9021516341056411997 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 224321409555159418, guid: 115e79e65ed316546aea2bf6ffdcc366,
+    type: 3}
+  m_PrefabInstance: {fileID: 9092255765942517799}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &9091622191222137699 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1618776996635460, guid: 115e79e65ed316546aea2bf6ffdcc366,
     type: 3}
   m_PrefabInstance: {fileID: 9092255765942517799}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatEntry.cs
@@ -15,7 +15,8 @@ public class ChatEntry : MonoBehaviour
 	[SerializeField] private List<Text> allText = new List<Text>();
 	[SerializeField] private List<Image> allImages = new List<Image>();
 	[SerializeField] private List<Button> allButtons = new List<Button>();
-	public Transform thresholdMarker;
+	public Transform thresholdMarkerBottom;
+	public Transform thresholdMarkerTop;
 	private Coroutine waitToCheck;
 
 
@@ -142,8 +143,12 @@ public class ChatEntry : MonoBehaviour
 	IEnumerator WaitToCheckPos()
 	{
 		yield return WaitFor.EndOfFrame;
-		var offset = thresholdMarker.position - transform.position;
-		if (offset.y > -427f && offset.y < -0f)
+
+		// Get the chat entry's position outside of it's child position under ChatFeed.
+		float entryYPositionOutsideChatFeedParent = transform.localPosition.y + transform.parent.localPosition.y;
+
+		// Check to see if the chat entry is inside the VIEWPORT thresholds, and if so we will enable viewing it.
+		if (entryYPositionOutsideChatFeedParent > thresholdMarkerBottom.localPosition.y && entryYPositionOutsideChatFeedParent < thresholdMarkerTop.localPosition.y) 
 		{
 			ToggleUIElements(true);
 		}

--- a/UnityProject/Assets/Scripts/Chat/ChatUI.cs
+++ b/UnityProject/Assets/Scripts/Chat/ChatUI.cs
@@ -22,7 +22,8 @@ public class ChatUI : MonoBehaviour
 	[SerializeField] private GameObject activeRadioChannelPanel = null;
 	[SerializeField] private GameObject activeChannelTemplate = null;
 	[SerializeField] private InputField InputFieldChat = null;
-	[SerializeField] private Transform thresholdMarker = null;
+	[SerializeField] private Transform thresholdMarkerBottom = null;
+	[SerializeField] private Transform thresholdMarkerTop = null;
 	[SerializeField] private AdminHelpChat adminHelpChat = null;
 	private bool windowCoolDown = false;
 
@@ -206,7 +207,8 @@ public class ChatUI : MonoBehaviour
 
 		GameObject entry = entryPool.GetChatEntry();
 		var chatEntry = entry.GetComponent<ChatEntry>();
-		chatEntry.thresholdMarker = thresholdMarker;
+		chatEntry.thresholdMarkerBottom = thresholdMarkerBottom;
+		chatEntry.thresholdMarkerTop = thresholdMarkerTop;
 		chatEntry.SetText(message);
 		allEntries.Add(chatEntry);
 		SetEntryTransform(entry);


### PR DESCRIPTION
Fixes #3029 issue. It used to cut off and not display chat entries on the top portion of the chat box on higher resolution windows. Now it will correctly display the messages no matter the size or scaling of the game window.

Decided to use threshold objects to pin the viewable range because 1) it was already sort of set up to do that and 2) It's easier than re-writing how the chat works. It also means you have the option to dynamically change the viewable messages in-game by adjusting the RectTransform of the threshold objects.