### PR TITLE
Delay to join after round starts.

### DIFF
--- a/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
+++ b/UnityProject/Assets/Scripts/UI/ControlDisplays.cs
@@ -223,7 +223,7 @@ public class ControlDisplays : MonoBehaviour
 		jobSelectWindow.SetActive(false);
 		teamSelectionWindow.SetActive(false);
 		preRoundWindow.SetActive(true);
-		preRoundWindow.GetComponent<GUI_PreRoundWindow>().SetUIForJoining();
+		StartCoroutine(preRoundWindow.GetComponent<GUI_PreRoundWindow>().SetUIForJoining());
 	}
 
 	public void SetScreenForTeamSelect()

--- a/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
+++ b/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using Mirror;
 using TMPro;
 using UnityEngine;
@@ -70,7 +71,7 @@ public class GUI_PreRoundWindow : MonoBehaviour
 		}
 		else
 		{
-			SetUIForJoining();
+			StartCoroutine(SetUIForJoining());
 		}
 	}
 
@@ -186,11 +187,12 @@ public class GUI_PreRoundWindow : MonoBehaviour
 	/// <summary>
 	/// Show round started and join button
 	/// </summary>
-	public void SetUIForJoining()
+	public IEnumerator SetUIForJoining()
 	{
-		joinPanel.SetActive(true);
 		timerPanel.SetActive(false);
 		playerWaitPanel.SetActive(false);
+		yield return WaitFor.Seconds(2f);
+		joinPanel.SetActive(true);
 		mainPanel.SetActive(true);
 	}
 }


### PR DESCRIPTION
Adds 2 second delay for when allowing to join after round starts.

- [x] Code is sufficiently commented
- [x] Code is indented with tabs and not spaces
- [x] The PR does not include any unnecessary .meta, .prefab or **.unity (scene) changes**
- [x] The PR does not bring up any new compile errors
- [x] The PR has been tested in editor
- [ ] The PR has been tested in multiplayer (with 2 clients and late joiners, if applicable)
- [ ] The PR has been tested with round restarts.
