### PR TITLE
null check to stop trays NRE spam in server

### DIFF
--- a/UnityProject/Assets/Scripts/Botany/hydroponics tray/HydroponicsTray.cs
+++ b/UnityProject/Assets/Scripts/Botany/hydroponics tray/HydroponicsTray.cs
@@ -446,7 +446,7 @@ public class HydroponicsTray : ManagedNetworkBehaviour, IInteractable<HandApply>
 		{
 			var produceObject = Spawn
 				.ServerPrefab(plantData.ProduceObject, registerTile.WorldPositionServer, transform.parent)
-				.GameObject;
+				?.GameObject;
 
 			if (produceObject == null)
 			{


### PR DESCRIPTION
For some reason Spawn results in HydroponicsTrays.cs line 447 is returning null. 
I just added a `?` to stop the NRE spam, but someone better versed in Hydroponic system should check what's going on.
