### PR TITLE
Fixes a bunch of server killing bugs

### DIFF
--- a/UnityProject/Assets/Animations/UI/LoadingScreen.meta
+++ b/UnityProject/Assets/Animations/UI/LoadingScreen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 93b470276aefe3d4fa3e0b8309e801e0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Plugins/Editor.meta
+++ b/UnityProject/Assets/Plugins/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bdf10081dbc4e0d4293747290943e7f2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Ammo_Boxes.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Ammo_Boxes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ddc5b74773d2a584b9ad3544149e3ed4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Rifles.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Magazines/Rifles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2a4c623a0abc7eb409d7792ffbd377bf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Alien/AlienEggCycle.cs
+++ b/UnityProject/Assets/Scripts/Alien/AlienEggCycle.cs
@@ -2,10 +2,11 @@
 using System.Collections;
 using Mirror;
 using UnityEngine;
+using Random = System.Random;
 
 namespace Alien
 {
-	public class AlienEggCycle : NetworkBehaviour, IInteractable<HandApply>, IServerSpawn
+	public class AlienEggCycle : NetworkBehaviour, IInteractable<HandApply>
 	{
 		private const float OPENING_ANIM_TIME = 1.6f;
 		private const int SMALL_SPRITE = 0;
@@ -14,8 +15,6 @@ namespace Alien
 		private const int HATCHED_SPRITE = 3;
 		private const int SQUISHED_SPRITE = 4;
 
-		[Tooltip("How much  time should the egg take incubating the facehugger. This includes from the growing phase until the actual spawn")]
-		[SerializeField]
 		private float incubationTime = 300;
 		[Tooltip("In what state will this egg spawn in the world.")]
 		[SerializeField]
@@ -34,53 +33,102 @@ namespace Alien
 		private ObjectAttributes objectAttributes;
 		public EggState State => currentState;
 
+		private float serverTimer = 0f;
+		private bool noLongerAlive = false;
+		private bool initialized = false;
+
 		private void Awake()
 		{
+			Init();
+		}
+
+		void Init()
+		{
+			if (initialized) return;
 			spriteHandler = GetComponentInChildren<SpriteHandler>();
 			registerObject = GetComponent<RegisterObject>();
 			objectAttributes = GetComponent<ObjectAttributes>();
-
-			EnsureInit();
+			initialized = true;
 		}
 
-		public void OnSpawnServer(SpawnInfo info)
-		{
-			//FIXME This shouldn't be called by client yet it seems it is
-			if (!isServer)
-			{
-				return;
-			}
-
-			EnsureInit();
-		}
-
-		private void EnsureInit()
+		private void OnDisable()
 		{
 			if (isServer)
 			{
-				UpdateState(initialState);
+				UpdateManager.Remove(CallbackType.UPDATE, UpdateMe);
+			}
+		}
+
+		public override void OnStartClient()
+		{
+			base.OnStartClient();
+			SyncState(currentState, currentState);
+		}
+
+		public override void OnStartServer()
+		{
+			base.OnStartServer();
+			UpdateState(initialState);
+			noLongerAlive = false;
+			incubationTime = UnityEngine.Random.Range(60f, 400f);
+			serverTimer = 0f;
+			UpdateManager.Add(CallbackType.UPDATE, UpdateMe);
+		}
+
+		void UpdateMe()
+		{
+			if (freezeCycle || noLongerAlive) return;
+			ServerMonitorEggState();
+		}
+
+		void ServerMonitorEggState()
+		{
+			serverTimer += Time.deltaTime;
+			if (currentState == EggState.Growing)
+			{
+				if (serverTimer > incubationTime)
+				{
+					incubationTime = UnityEngine.Random.Range(60f, 400f);
+					UpdateState(EggState.Grown);
+					serverTimer = 0f;
+				}
 			}
 
-			SyncState(currentState, currentState);
+			if (currentState == EggState.Grown)
+			{
+				if (serverTimer > incubationTime)
+				{
+					UpdateState(EggState.Burst);
+					serverTimer = 0f;
+				}
+			}
+
+			if (currentState == EggState.Burst)
+			{
+				if (serverTimer > OPENING_ANIM_TIME)
+				{
+					Spawn.ServerPrefab(facehugger, gameObject.RegisterTile().WorldPositionServer);
+					noLongerAlive = true;
+				}
+			}
 		}
 
 		private void SyncState(EggState oldState, EggState newState)
 		{
 			currentState = newState;
+			if(!initialized) Init();
 
 			switch (currentState)
 			{
 				case EggState.Growing:
-					StopAllCoroutines();
-					StartCoroutine(nameof(StartIncubation));
+					spriteHandler.SetSprite(spriteHandler.Sprites[SMALL_SPRITE]);
 					break;
 				case EggState.Grown:
-					StopAllCoroutines();
-					StartCoroutine(nameof(FinishIncubation));
+					spriteHandler.SetSprite(spriteHandler.Sprites[BIG_SPRITE]);
 					break;
 				case EggState.Burst:
 					StopAllCoroutines();
-					StartCoroutine(nameof(OpenEgg));
+					StartCoroutine(OpenEgg());
 					break;
 				case EggState.Squished:
 					spriteHandler.SetSprite(spriteHandler.Sprites[SQUISHED_SPRITE]);
@@ -88,43 +136,15 @@ namespace Alien
 			}
 		}
 
-		private IEnumerator StartIncubation()
-		{
-			spriteHandler.SetSprite(spriteHandler.Sprites[SMALL_SPRITE]);
-
-			if (freezeCycle)
-			{
-				yield break;
-			}
-
-			yield return WaitFor.Seconds(incubationTime / 2);
-			UpdateState(currentState == EggState.Growing ? EggState.Grown : currentState);
-		}
-
-		private IEnumerator FinishIncubation()
-		{
-			spriteHandler.SetSprite(spriteHandler.Sprites[BIG_SPRITE]);
-
-			if (freezeCycle)
-			{
-				yield break;
-			}
-
-			yield return WaitFor.Seconds(incubationTime / 2);
-			UpdateState(currentState == EggState.Grown ? EggState.Burst : currentState);
-		}
-
 		private IEnumerator OpenEgg()
 		{
 			spriteHandler.SetSprite(spriteHandler.Sprites[OPENING_SPRITE]);
 			yield return WaitFor.Seconds(OPENING_ANIM_TIME);
 			spriteHandler.SetSprite(spriteHandler.Sprites[HATCHED_SPRITE]);
-			Spawn.ServerPrefab(facehugger, gameObject.RegisterTile().WorldPositionServer);
 		}
 
 		private void Squish(HandApply interaction)
 		{
-			StopAllCoroutines();
 			SoundManager.PlayNetworkedAtPos(
 				"squish",
 				gameObject.RegisterTile().WorldPositionServer,
@@ -138,6 +158,7 @@ namespace Alien
 
 			UpdateState(EggState.Squished);
 			registerObject.Passable = true;
+			noLongerAlive = true;
 		}
 
 		[Server]

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -76,8 +76,6 @@ public partial class GameManager : MonoBehaviour
 	private bool loadedDirectlyToStation;
 	public bool LoadedDirectlyToStation => loadedDirectlyToStation;
 
-	public Queue<PlayerSpawnRequest> SpawnPlayerRequestQueue = new Queue<PlayerSpawnRequest>();
-
 	private bool QueueProcessing;
 
 	private float timeElapsedServer = 0;
@@ -101,8 +99,6 @@ public partial class GameManager : MonoBehaviour
 
 		//so respawn works when loading directly to outpost station
 		RespawnCurrentlyAllowed = RespawnAllowed;
-
-
 	}
 
 	private void OnEnable()
@@ -290,13 +286,6 @@ public partial class GameManager : MonoBehaviour
 			stationTime = stationTime.AddSeconds(Time.deltaTime);
 			roundTimer.text = stationTime.ToString("HH:mm");
 		}
-
-		timeElapsedServer += Time.deltaTime;
-		if (timeElapsedServer > 1f)
-		{
-			ProcessSpawnPlayerQueue();
-			timeElapsedServer = 0;
-		}
 	}
 
 	/// <summary>
@@ -457,40 +446,6 @@ public partial class GameManager : MonoBehaviour
 		CountdownTime = PreRoundTime;
 		waitForStart = true;
 		UpdateCountdownMessage.Send(waitForStart, CountdownTime);
-	}
-
-	public void ProcessSpawnPlayerQueue()
-	{
-		if (QueueProcessing) return;
-
-		while (SpawnPlayerRequestQueue.Count > 0)
-		{
-			QueueProcessing = true;
-
-			var player = SpawnPlayerRequestQueue.Peek();
-
-			int slotsTaken = GameManager.Instance.GetOccupationsCount(player.RequestedOccupation.JobType);
-			int slotsMax = GameManager.Instance.GetOccupationMaxCount(player.RequestedOccupation.JobType);
-			if (slotsTaken >= slotsMax)
-			{
-				SpawnPlayerRequestQueue.Dequeue();
-				continue;
-			}
-
-			//regardless of their chosen occupation, they might spawn as an antag instead.
-			//If they do, bypass the normal spawn logic.
-			if (GameManager.Instance.TrySpawnAntag(player))
-			{
-				SpawnPlayerRequestQueue.Dequeue();
-				continue;
-			}
-
-			PlayerSpawn.ServerSpawnPlayer(player);
-
-			SpawnPlayerRequestQueue.Dequeue();
-		}
-
-		QueueProcessing = false;
 	}
 
 	public int GetOccupationsCount(JobType jobType)

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -159,9 +159,11 @@ public class JoinedViewer : NetworkBehaviour
 		var spawnRequest =
 			PlayerSpawnRequest.RequestOccupation(this, GameManager.Instance.GetRandomFreeOccupation(jobType), characterSettings);
 
-		GameManager.Instance.SpawnPlayerRequestQueue.Enqueue(spawnRequest);
+		//regardless of their chosen occupation, they might spawn as an antag instead.
+		//If they do, bypass the normal spawn logic.
+		if (GameManager.Instance.TrySpawnAntag(spawnRequest)) return;
 
-		GameManager.Instance.ProcessSpawnPlayerQueue();
+		PlayerSpawn.ServerSpawnPlayer(spawnRequest);
 	}
 	/// <summary>
 	/// Command to spectate a round instead of spawning as a player

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/UnderFloorLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/UnderFloorLayer.cs
@@ -72,6 +72,19 @@ public class UnderFloorLayer : Layer
 			if (!Application.isPlaying) isServer = true;
 		}
 
+		//We do not want to duplicate under floor tiles if they are the same:
+		if (TileStore.ContainsKey(position.To2Int()))
+		{
+			foreach (var l in TileStore[position.To2Int()])
+			{
+				if (l == tile)
+				{
+					//duplicate found aborting
+					return;
+				}
+			}
+		}
+
 		if (isServer)
 		{
 			Vector2Int position2 = position.To2Int();


### PR DESCRIPTION
- reverted #4083 as it caused logging in issues for players and would crash servers
- Made it impossible to create duplication of wire tiles
- Fixed wire dupes on outpost
- Fixed egg code (not tested but separated server and client code preventing server methods being called on client)