### PR TITLE
IF2 - allow clients to defer to the server when determining which interact to trigger

### DIFF
--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/InteractionUtils.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/InteractionUtils.cs
@@ -38,7 +38,6 @@ public static class InteractionUtils
 	/// </summary>
 	/// <param name="interactable"></param>
 	/// <param name="interaction"></param>
-	/// <param name="side"></param>
 	/// <typeparam name="T"></typeparam>
 	/// <returns>true if an interaction was triggered (even if it was clientside-only)</returns>
 	public static bool ClientCheckAndTrigger<T>(this IBaseInteractable<T> interactable, T interaction) where T: Interaction

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/InteractionUtils.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/InteractionUtils.cs
@@ -23,7 +23,7 @@ public static class InteractionUtils
 	/// <param name="interaction">interaction to perform</param>
 	/// <param name="interactableComponent">component to handle the interaction, null
 	/// if the server should determine which component will trigger from the interaction</param>
-	/// <typeparam name="T"></typeparam>
+	/// <typeparam name="T">type of interaction</typeparam>
 	public static void RequestInteract<T>(T interaction, IBaseInteractable<T> interactableComponent = null)
 		where T : Interaction
 	{
@@ -36,9 +36,9 @@ public static class InteractionUtils
 	/// Checks if this component would trigger and sends the interaction request to the server if it does. Doesn't
 	/// send a message if it only triggered an IClientInteractable (client side only) interaction.
 	/// </summary>
-	/// <param name="interactable"></param>
-	/// <param name="interaction"></param>
-	/// <typeparam name="T"></typeparam>
+	/// <param name="interactable">component to check / trigger</param>
+	/// <param name="interaction">interaction attempting to be performed</param>
+	/// <typeparam name="T">interaction type</typeparam>
 	/// <returns>true if an interaction was triggered (even if it was clientside-only)</returns>
 	public static bool ClientCheckAndTrigger<T>(this IBaseInteractable<T> interactable, T interaction) where T: Interaction
 	{
@@ -65,9 +65,9 @@ public static class InteractionUtils
 	/// triggers an interaction, null if none are triggered. Messages the server to request an interaction for the interaction that
 	/// was triggered (if any). Doesn't message the server if only a clientside interaction was triggered.
 	/// </summary>
-	/// <param name="interactables"></param>
-	/// <param name="interaction"></param>
-	/// <typeparam name="T"></typeparam>
+	/// <param name="interactables">component to check</param>
+	/// <param name="interaction">interaction attempting to be performed</param>
+	/// <typeparam name="T">type of interaction being checked</typeparam>
 	/// <returns></returns>
 	public static IBaseInteractable<T> ClientCheckAndTrigger<T>(IEnumerable<IBaseInteractable<T>> interactables, T interaction)
 		where T : Interaction
@@ -142,9 +142,9 @@ public static class InteractionUtils
 	/// <summary>
 	/// Checks if this component should trigger based on server-side logic.
 	/// </summary>
-	/// <param name="interactable"></param>
-	/// <param name="interaction"></param>
-	/// <typeparam name="T"></typeparam>
+	/// <param name="interactable">component to check</param>
+	/// <param name="interaction">interaction attempting to be performed</param>
+	/// <typeparam name="T">type of interaction</typeparam>
 	/// <returns>true if an interaction would be triggered.</returns>
 	public static bool ServerCheckInteract<T>(this IBaseInteractable<T> interactable, T interaction)
 		where T : Interaction

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/InteractionUtils.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/InteractionUtils.cs
@@ -14,7 +14,7 @@ public static class InteractionUtils
 	/// Use this on client side to request an interaction. This can be used to trigger
 	/// interactions manually outside of the normal interaction logic.
 	/// Request the server to perform the indicated interaction using the specified
-	/// component (or whichever component triggers if interactableComponent is null). The server will still validate the interaction and only perform
+	/// component (or let the server determine the component if interactableComponent is null). The server will still validate the interaction and only perform
 	/// it if it validates.
 	///
 	/// Note that if interactableComponent implements IClientSideInteractable for this interaction type,

--- a/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
@@ -362,12 +362,12 @@ public class MouseInputController : MonoBehaviour
 				if (handAppliable is IBaseInteractable<HandApply>)
 				{
 					var hap = handAppliable as IBaseInteractable<HandApply>;
-					if (hap.ClientCheckAndRequestInteract(handApply)) return true;
+					if (hap.ClientCheckAndTrigger(handApply)) return true;
 				}
 				else
 				{
 					var hap = handAppliable as IBaseInteractable<PositionalHandApply>;
-					if (hap.ClientCheckAndRequestInteract(posHandApply)) return true;
+					if (hap.ClientCheckAndTrigger(posHandApply)) return true;
 				}
 			}
 		}
@@ -380,12 +380,12 @@ public class MouseInputController : MonoBehaviour
 			if (targetHandAppliable is IBaseInteractable<HandApply>)
 			{
 				var hap = targetHandAppliable as IBaseInteractable<HandApply>;
-				if (hap.ClientCheckAndRequestInteract(handApply)) return true;
+				if (hap.ClientCheckAndTrigger(handApply)) return true;
 			}
 			else
 			{
 				var hap = targetHandAppliable as IBaseInteractable<PositionalHandApply>;
-				if (hap.ClientCheckAndRequestInteract(posHandApply)) return true;
+				if (hap.ClientCheckAndTrigger(posHandApply)) return true;
 			}
 		}
 
@@ -435,7 +435,7 @@ public class MouseInputController : MonoBehaviour
 				secondsSinceLastAimApplyTrigger += Time.deltaTime;
 				if (secondsSinceLastAimApplyTrigger > AimApplyInterval)
 				{
-					if (triggeredAimApply.ClientCheckAndRequestInteract(aimApplyInfo))
+					if (triggeredAimApply.ClientCheckAndTrigger(aimApplyInfo))
 					{
 						//only reset timer if it was actually triggered
 						secondsSinceLastAimApplyTrigger = 0;

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs
@@ -11,6 +11,15 @@ using UnityEngine;
 /// </summary>
 public class RequestInteractMessage : ClientMessage
 {
+
+	/**
+	 * this is sent as the componentID when the client doesn't know
+	 * exactly which interaction should be triggered. In this case,
+	 * the server will check each interaction of the given interaction type
+	 * to see which should occur.
+	 */
+	private static readonly ushort UNKNOWN_COMPONENT_TYPE_ID = ushort.MaxValue;
+
 	//these are always populated
 	public Type ComponentType;
 	public Type InteractionType;
@@ -41,8 +50,6 @@ public class RequestInteractMessage : ClientMessage
 	public int SlotIndex;
 	//named slot targeted in storage
 	public NamedSlot NamedSlot;
-
-	public int TileInteractionIndex;
 
 	private static readonly Dictionary<ushort, Type> componentIDToComponentType = new Dictionary<ushort, Type>();
 	private static readonly Dictionary<Type, ushort> componentTypeToComponentID = new Dictionary<Type, ushort>();
@@ -202,8 +209,9 @@ public class RequestInteractMessage : ClientMessage
 			var usedObject = clientStorage.GetActiveHandSlot().ItemObject;
 			LoadNetworkObject(ProcessorObject);
 			var processorObj = NetworkObject;
-			processorObj.GetComponent<InteractableTiles>().ServerProcessInteraction(TileInteractionIndex,
-				SentByPlayer.GameObject, TargetVector, processorObj, usedSlot, usedObject, Intent, TileApply.ApplyType.HandApply);
+			processorObj.GetComponent<InteractableTiles>().ServerProcessInteraction(SentByPlayer.GameObject,
+				TargetVector, processorObj, usedSlot, usedObject, Intent,
+				TileApply.ApplyType.HandApply);
 		}
 		else if(InteractionType == typeof(TileMouseDrop))
 		{
@@ -213,8 +221,9 @@ public class RequestInteractMessage : ClientMessage
 
 			var usedObj = NetworkObjects[0];
 			var processorObj = NetworkObjects[1];
-			processorObj.GetComponent<InteractableTiles>().ServerProcessInteraction(TileInteractionIndex,
-				SentByPlayer.GameObject, TargetVector, processorObj, null, usedObj, Intent, TileApply.ApplyType.MouseDrop);
+			processorObj.GetComponent<InteractableTiles>().ServerProcessInteraction(SentByPlayer.GameObject,
+				TargetVector, processorObj, null, usedObj, Intent,
+				TileApply.ApplyType.MouseDrop);
 		}
 	}
 
@@ -226,43 +235,85 @@ public class RequestInteractMessage : ClientMessage
 			Logger.LogWarning("processorObj is null, action will not be performed.", Category.Interaction);
 			return;
 		}
-		//find the indicated component
-		var component = processorObj.GetComponent(ComponentType);
-		if (component == null)
+		//find the indicated component if one was indicated
+		if (ComponentType != null)
 		{
-			Logger.LogWarningFormat("No component found of requested type {0} on {1}," +
-			                        " action will not be performed.",
-				Category.Interaction, ComponentType.Name, processorObj.name);
-			return;
-		}
-		if (!(component is IInteractable<T>))
-		{
-			Logger.LogWarningFormat("Component of type {0} doesn't implement IInteractable" +
-			                        " for interaction type {1} on {2}," +
-			                        " action will not be performed.",
-				Category.Interaction, ComponentType.Name, typeof(T).Name, processorObj.name);
-			return;
-		}
-
-		var interactable = (component as IInteractable<T>);
-		//server side interaction check and cooldown check, and start the cooldown
-		if (interactable.ServerCheckInteract(interaction) &&
-		    Cooldowns.TryStartServer(interaction, CommonCooldowns.Instance.Interaction))
-		{
-			//perform
-			interactable.ServerPerformInteraction(interaction);
+			var component = processorObj.GetComponent(ComponentType);
+			if (component == null)
+			{
+				Logger.LogWarningFormat("No component found of requested type {0} on {1}," +
+				                        " action will not be performed.",
+					Category.Interaction, ComponentType.Name, processorObj.name);
+				return;
+			}
+			if (!(component is IInteractable<T>))
+			{
+				Logger.LogWarningFormat("Component of type {0} doesn't implement IInteractable" +
+				                        " for interaction type {1} on {2}," +
+				                        " action will not be performed.",
+					Category.Interaction, ComponentType.Name, typeof(T).Name, processorObj.name);
+				return;
+			}
+			var interactable = (component as IInteractable<T>);
+			//server side interaction check and cooldown check, and start the cooldown
+			if (interactable.ServerCheckInteract(interaction) &&
+			    Cooldowns.TryStartServer(interaction, CommonCooldowns.Instance.Interaction))
+			{
+				//perform
+				interactable.ServerPerformInteraction(interaction);
+			}
+			else
+			{
+				//rollback if this component implements it
+				if (component is IPredictedInteractable<T> predictedInteractable)
+				{
+					predictedInteractable.ServerRollbackClient(interaction);
+				}
+			}
 		}
 		else
 		{
-			//rollback if this component implements it
-			if (component is IPredictedInteractable<T> predictedInteractable)
+			// client wasn't sure which component should be triggered, check them in the proper order
+			// and trigger the first one that should happen, rolling back any that shouldn't happen.
+			var interactables = processorObj.GetComponents<IInteractable<T>>()
+				.Where(c => c != null && (c as MonoBehaviour).enabled);
+			Logger.LogTraceFormat("Server checking which component to trigger for {0} on object {1}", Category.Interaction,
+				typeof(T).Name, processorObj.name);
+			foreach (var interactable in interactables.Reverse())
 			{
-				predictedInteractable.ServerRollbackClient(interaction);
+				if (interactable.ServerCheckInteract(interaction))
+				{
+					//perform if not on cooldown
+					if (Cooldowns.TryStartServer(interaction, CommonCooldowns.Instance.Interaction))
+					{
+						interactable.ServerPerformInteraction(interaction);
+					}
+					else
+					{
+						//stop all checking for this interaction, we hit a cooldown
+						//rollback if this component implements it, in case they tried to predict it
+						if (interactable is IPredictedInteractable<T> predictedInteractable)
+						{
+							predictedInteractable.ServerRollbackClient(interaction);
+						}
+						break;
+					}
+				}
+				else
+				{
+					//rollback if this component implements it, in case they tried to predict it
+					if (interactable is IPredictedInteractable<T> predictedInteractable)
+					{
+						predictedInteractable.ServerRollbackClient(interaction);
+					}
+				}
 			}
 		}
 	}
 
 	//only intended to be used by core if2 classes, please use InteractionUtils.RequestInteract instead.
+	//pass null for interactableComponent if you want the server to determine which component should be triggered.
+	//(which can be useful when client doesn't have enough info to know which one to trigger)
 	public static void Send<T>(T interaction, IBaseInteractable<T> interactableComponent)
 		where T : Interaction
 	{
@@ -303,7 +354,7 @@ public class RequestInteractMessage : ClientMessage
 		var comp = interactableComponent as Component;
 		var msg = new RequestInteractMessage()
 		{
-			ComponentType = interactableComponent.GetType(),
+			ComponentType = interactableComponent == null ? null : interactableComponent.GetType(),
 			InteractionType = typeof(T),
 			ProcessorObject = comp.GetComponent<NetworkIdentity>().netId,
 			Intent = interaction.Intent
@@ -347,7 +398,7 @@ public class RequestInteractMessage : ClientMessage
 	}
 
 	//only intended to be used by core if2 classes
-	public static void SendTileApply(TileApply tileApply, InteractableTiles interactableTiles, TileInteraction tileInteraction, int tileInteractionIndex)
+	public static void SendTileApply(TileApply tileApply, InteractableTiles interactableTiles, TileInteraction tileInteraction)
 	{
 		//if we are client and the interaction has client prediction, trigger it.
 		//Note that client prediction is not triggered for server player.
@@ -370,8 +421,7 @@ public class RequestInteractMessage : ClientMessage
 			InteractionType = typeof(TileApply),
 			ProcessorObject = interactableTiles.GetComponent<NetworkIdentity>().netId,
 			Intent = tileApply.Intent,
-			TargetVector = tileApply.TargetVector,
-			TileInteractionIndex = tileInteractionIndex
+			TargetVector = tileApply.TargetVector
 		};
 		msg.Send();
 	}
@@ -393,8 +443,7 @@ public class RequestInteractMessage : ClientMessage
 			ProcessorObject = interactableTiles.GetComponent<NetworkIdentity>().netId,
 			Intent = mouseDrop.Intent,
 			UsedObject = mouseDrop.UsedObject.NetId(),
-			TargetVector = mouseDrop.TargetVector,
-			TileInteractionIndex = tileInteractionIndex
+			TargetVector = mouseDrop.TargetVector
 		};
 		msg.Send();
 	}
@@ -403,7 +452,18 @@ public class RequestInteractMessage : ClientMessage
 	{
 
 		base.Deserialize(reader);
-		ComponentType = componentIDToComponentType[reader.ReadUInt16()];
+		var componentID = reader.ReadUInt16();
+		if (componentID == UNKNOWN_COMPONENT_TYPE_ID)
+		{
+			//client didn't know which to trigger, leave ComponentType null
+			ComponentType = null;
+		}
+		else
+		{
+			//client requested a specific component.
+			ComponentType = componentIDToComponentType[reader.ReadUInt16()];
+		}
+
 		InteractionType = interactionIDToInteractionType[reader.ReadByte()];
 		ProcessorObject = reader.ReadUInt32();
 		Intent = (Intent) reader.ReadByte();
@@ -441,20 +501,26 @@ public class RequestInteractMessage : ClientMessage
 		else if (InteractionType == typeof(TileApply))
 		{
 			TargetVector = reader.ReadVector2();
-			TileInteractionIndex = reader.ReadByte();
 		}
 		else if(InteractionType == typeof(TileMouseDrop))
 		{
 			UsedObject = reader.ReadUInt32();
 			TargetVector = reader.ReadVector2();
-			TileInteractionIndex = reader.ReadByte();
 		}
 	}
 
 	public override void Serialize(NetworkWriter writer)
 	{
 		base.Serialize(writer);
-		writer.WriteUInt16(componentTypeToComponentID[ComponentType]);
+		// indicate unknown component if client requested it
+		if (ComponentType == null)
+		{
+			writer.WriteUInt16(UNKNOWN_COMPONENT_TYPE_ID);
+		}
+		else
+		{
+			writer.WriteUInt16(componentTypeToComponentID[ComponentType]);
+		}
 		writer.WriteByte(interactionTypeToInteractionID[InteractionType]);
 		writer.WriteUInt32(ProcessorObject);
 		writer.WriteByte((byte) Intent);
@@ -492,13 +558,11 @@ public class RequestInteractMessage : ClientMessage
 		else if (InteractionType == typeof(TileApply))
 		{
 			writer.WriteVector2(TargetVector);
-			writer.WriteByte((byte) TileInteractionIndex);
 		}
 		else if(InteractionType == typeof(TileMouseDrop))
 		{
 			writer.WriteUInt32(UsedObject);
 			writer.WriteVector2(TargetVector);
-			writer.WriteByte((byte)TileInteractionIndex);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -215,11 +215,13 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 					}
 					else
 					{
-						//don't interact at all, stop all checking - we hit a cooldown
-						//rollback in case they tried to predict it
+						//hit a cooldown, rollback in case client tried to predict it
 						tileInteraction.ServerRollbackClient(tileApply);
-						break;
 					}
+
+					// interaction should've triggered and did or we hit a cooldown, so we're
+					// done processing this request.
+					break;
 				}
 				else
 				{
@@ -239,19 +241,16 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 		{
 			var tileApply = new TileApply(interaction.Performer, interaction.UsedObject, interaction.Intent, (Vector2Int)WorldToCell(interaction.ShadowWorldLocation), this, basicTile, null, -((Vector2)interaction.Performer.transform.position - interaction.ShadowWorldLocation), TileApply.ApplyType.MouseDrop);
 			var tileMouseDrop = new TileMouseDrop(interaction.Performer, interaction.UsedObject, interaction.Intent, (Vector2Int)WorldToCell(interaction.ShadowWorldLocation), this, basicTile, -((Vector2)interaction.Performer.transform.position - interaction.ShadowWorldLocation));
-			var i = 0;
 			foreach (var tileInteraction in basicTile.TileInteractions)
 			{
 				if (tileInteraction == null) continue;
 				if (tileInteraction.WillInteract(tileApply, NetworkSide.Client) &&
 					Cooldowns.TryStartClient(interaction, CommonCooldowns.Instance.Interaction))
 				{
-					//request the tile interaction with this index
-					RequestInteractMessage.SendTileMouseDrop(tileMouseDrop, this, i);
+					//request the tile interaction because we think one will happen
+					RequestInteractMessage.SendTileMouseDrop(tileMouseDrop, this);
 					return true;
 				}
-
-				i++;
 			}
 		}
 


### PR DESCRIPTION
### Purpose
Fixes #2579 

Now when triggering a normal IF2 interaction, the client defers to the server to decide which component is triggered. Previously the client would tell the server the exact component it wanted to trigger, and if the server said no, nothing happened. This allows clients to trigger interactions without having the full knowledge that the server has w.r.t. which component should actually trigger.

Clients are still able to manually trigger specific interactions (such as for right click menu).

Also applies to Tile interactions.

The main entry point for the changes is in RequestInteractMessage (particularly ProcessInteraction) and InteractableTiles.ServerProcessInteraction
