### PR TITLE
Add stock parts to loot tables and autolathe.

### DIFF
--- a/UnityProject/Assets/Scripts/Machines/Autolathe/AutolatheProducts.asset
+++ b/UnityProject/Assets/Scripts/Machines/Autolathe/AutolatheProducts.asset
@@ -153,6 +153,22 @@ MonoBehaviour:
       productionTime: 4
   - categoryName: Construction
     products:
+    - name: Metal
+      product: {fileID: 6254655335276451647, guid: ab486d104d39e584e935c8a5459a967c,
+        type: 3}
+      materialToAmounts:
+        m_keys:
+        - {fileID: 11400000, guid: 80c7380282adee649aa0c255f79bc5f2, type: 2}
+        m_values: d0070000
+      productionTime: 0.5
+    - name: Glass
+      product: {fileID: 5680136605834777345, guid: ea07289ba72453444a4ff1202b47a57d,
+        type: 3}
+      materialToAmounts:
+        m_keys:
+        - {fileID: 11400000, guid: cde83a8cd1e2083479c40e5e1c19292b, type: 2}
+        m_values: d0070000
+      productionTime: 0.5
     - name: Reinforced Glass
       product: {fileID: 5680136605834777345, guid: 4549e37f0d4967848a5f07a0913869fa,
         type: 3}
@@ -161,7 +177,7 @@ MonoBehaviour:
         - {fileID: 11400000, guid: 80c7380282adee649aa0c255f79bc5f2, type: 2}
         - {fileID: 11400000, guid: cde83a8cd1e2083479c40e5e1c19292b, type: 2}
         m_values: e8030000d0070000
-      productionTime: 4
+      productionTime: 0.5
     - name: Metal Rod
       product: {fileID: 4519819786599941225, guid: 2a170fdb7187e38459de34c4d2b131ad,
         type: 3}
@@ -169,7 +185,23 @@ MonoBehaviour:
         m_keys:
         - {fileID: 11400000, guid: 80c7380282adee649aa0c255f79bc5f2, type: 2}
         m_values: e8030000
-      productionTime: 4
+      productionTime: 0.5
+    - name: Light Tube
+      product: {fileID: 2419386692754613975, guid: 55cd86212b6c71d468c98ff09f7bbd8a,
+        type: 3}
+      materialToAmounts:
+        m_keys:
+        - {fileID: 11400000, guid: cde83a8cd1e2083479c40e5e1c19292b, type: 2}
+        m_values: 64000000
+      productionTime: 1
+    - name: Light Bulb
+      product: {fileID: 2419386692754613975, guid: ae09a5f5cfaa8134cbf8800bab7e0739,
+        type: 3}
+      materialToAmounts:
+        m_keys:
+        - {fileID: 11400000, guid: cde83a8cd1e2083479c40e5e1c19292b, type: 2}
+        m_values: 64000000
+      productionTime: 1
   - categoryName: Security
     products:
     - name: Beanbag Slug
@@ -234,11 +266,80 @@ MonoBehaviour:
         m_values: f4010000
       productionTime: 4
   - categoryName: Electronics
-    products: []
+    products:
+    - name: APC Module
+      product: {fileID: 7187812193856883994, guid: eb83c6edf05d1f24188f4c09edc90e47,
+        type: 3}
+      materialToAmounts:
+        m_keys:
+        - {fileID: 11400000, guid: 80c7380282adee649aa0c255f79bc5f2, type: 2}
+        - {fileID: 11400000, guid: cde83a8cd1e2083479c40e5e1c19292b, type: 2}
+        m_values: 6400000064000000
+      productionTime: 4
   - categoryName: T-Comm
-    products: []
+    products:
+    - name: Remote Signaling Device
+      product: {fileID: 8610387204673337071, guid: c9d03be44229a74469be1b6738941ec3,
+        type: 3}
+      materialToAmounts:
+        m_keys:
+        - {fileID: 11400000, guid: 80c7380282adee649aa0c255f79bc5f2, type: 2}
+        - {fileID: 11400000, guid: cde83a8cd1e2083479c40e5e1c19292b, type: 2}
+        m_values: 9001000078000000
+      productionTime: 4
+    - name: Radio Headset
+      product: {fileID: 835768756810601639, guid: 3d08b6dbf08774e8681378945dec4edf,
+        type: 3}
+      materialToAmounts:
+        m_keys:
+        - {fileID: 11400000, guid: 80c7380282adee649aa0c255f79bc5f2, type: 2}
+        m_values: 4b000000
+      productionTime: 4
   - categoryName: Machinery
-    products: []
+    products:
+    - name: Basic Capacitor
+      product: {fileID: 2527188313238870147, guid: bb147b9bf5a66eb40b94bd8853aaf9ea,
+        type: 3}
+      materialToAmounts:
+        m_keys:
+        - {fileID: 11400000, guid: 80c7380282adee649aa0c255f79bc5f2, type: 2}
+        - {fileID: 11400000, guid: cde83a8cd1e2083479c40e5e1c19292b, type: 2}
+        m_values: 6400000064000000
+      productionTime: 0.8
+    - name: Basic Scanning Module
+      product: {fileID: 2527188313238870147, guid: 45433567aa3e67f44a4bf6ad15bc6c04,
+        type: 3}
+      materialToAmounts:
+        m_keys:
+        - {fileID: 11400000, guid: 80c7380282adee649aa0c255f79bc5f2, type: 2}
+        - {fileID: 11400000, guid: cde83a8cd1e2083479c40e5e1c19292b, type: 2}
+        m_values: 6400000032000000
+      productionTime: 0.8
+    - name: Micro Manipulator
+      product: {fileID: 2527188313238870147, guid: 73792b6d5257dfe4e85247bd61979cef,
+        type: 3}
+      materialToAmounts:
+        m_keys:
+        - {fileID: 11400000, guid: 80c7380282adee649aa0c255f79bc5f2, type: 2}
+        m_values: 64000000
+      productionTime: 0.8
+    - name: Basic Micro-Laser
+      product: {fileID: 2527188313238870147, guid: 12e1033504f11d342867225fade01e88,
+        type: 3}
+      materialToAmounts:
+        m_keys:
+        - {fileID: 11400000, guid: 80c7380282adee649aa0c255f79bc5f2, type: 2}
+        - {fileID: 11400000, guid: cde83a8cd1e2083479c40e5e1c19292b, type: 2}
+        m_values: 6400000032000000
+      productionTime: 0.8
+    - name: Basic Matter Bin
+      product: {fileID: 2527188313238870147, guid: 1ca8c26ca2f61444bb8d374104ed2a02,
+        type: 3}
+      materialToAmounts:
+        m_keys:
+        - {fileID: 11400000, guid: 80c7380282adee649aa0c255f79bc5f2, type: 2}
+        m_values: 64000000
+      productionTime: 0.8
   - categoryName: Misc
     products:
     - name: Earmuffs

--- a/UnityProject/Assets/Scripts/RandomItemPools/CommonConstructionNCrafting.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/CommonConstructionNCrafting.asset
@@ -12,12 +12,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
   m_Name: CommonConstructionNCrafting
   m_EditorClassIdentifier: 
-  lootCount: 1
-  fanOut: 0
   pool:
   - prefab: {fileID: 5680136605834777345, guid: c3e6805b264a935428b0de415ea57943,
       type: 3}
     maxAmount: 5
+    probability: 100
+  - prefab: {fileID: 2527188313238870147, guid: d84851eeb2ee38b4fab01c7a2cea13a5,
+      type: 3}
+    maxAmount: 1
     probability: 100
   - prefab: {fileID: 6254655335276451647, guid: ab486d104d39e584e935c8a5459a967c,
       type: 3}
@@ -28,6 +30,14 @@ MonoBehaviour:
     maxAmount: 25
     probability: 100
   - prefab: {fileID: 6254655335276451647, guid: 70a15a1bc92d10944878d2f52dfe2be0,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8610387204673337071, guid: c9d03be44229a74469be1b6738941ec3,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 3506820747392627008, guid: 1fa9f2d6fbcfef845bb2f5903ffcfd23,
       type: 3}
     maxAmount: 1
     probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/Tier1StockParts.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/Tier1StockParts.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
+  m_Name: UncommonTools
+  m_EditorClassIdentifier: 
+  pool:
+  - prefab: {fileID: 6989221924687263735, guid: b735ab74dab174a4f90c79558cd51e43,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 970193913688544828, guid: 32fcd56a575fd884ebae6deb79a43656, type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8127442588295923452, guid: 706cc1f035332384c96f001de4760563,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 8568672687853555390, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
+      type: 3}
+    maxAmount: 1
+    probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/Tier1StockParts.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/Tier1StockParts.asset
@@ -10,21 +10,26 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ce108c02d022d1940bc023ceca025d81, type: 3}
-  m_Name: UncommonTools
+  m_Name: Tier1StockParts
   m_EditorClassIdentifier: 
   pool:
-  - prefab: {fileID: 6989221924687263735, guid: b735ab74dab174a4f90c79558cd51e43,
+  - prefab: {fileID: 2527188313238870147, guid: bb147b9bf5a66eb40b94bd8853aaf9ea,
       type: 3}
     maxAmount: 1
     probability: 100
-  - prefab: {fileID: 970193913688544828, guid: 32fcd56a575fd884ebae6deb79a43656, type: 3}
-    maxAmount: 1
-    probability: 100
-  - prefab: {fileID: 8127442588295923452, guid: 706cc1f035332384c96f001de4760563,
+  - prefab: {fileID: 2527188313238870147, guid: 45433567aa3e67f44a4bf6ad15bc6c04,
       type: 3}
     maxAmount: 1
     probability: 100
-  - prefab: {fileID: 8568672687853555390, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
+  - prefab: {fileID: 2527188313238870147, guid: 73792b6d5257dfe4e85247bd61979cef,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 2527188313238870147, guid: 12e1033504f11d342867225fade01e88,
+      type: 3}
+    maxAmount: 1
+    probability: 100
+  - prefab: {fileID: 2527188313238870147, guid: 1ca8c26ca2f61444bb8d374104ed2a02,
       type: 3}
     maxAmount: 1
     probability: 100

--- a/UnityProject/Assets/Scripts/RandomItemPools/Tier1StockParts.asset.meta
+++ b/UnityProject/Assets/Scripts/RandomItemPools/Tier1StockParts.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e56423ec3363f8443890e256d53a5470
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
This PR adds a loot table for just basic stock parts, makes some basic stock parts spawn in the construction loot tables, and adds basic stock parts to the autolathe. Some other items were also added to the autolathe, such as light tubes, signalers (also added to maint loot tables), and basic radio headsets.

### Notes:
The Tier1StockParts.asset is not used in any .prefabs at the moment due to the lockdown. I will need to add them at a later point.
