### PR TITLE
Removes Pogstation from rotation

### DIFF
--- a/UnityProject/Assets/StreamingAssets/maps.json
+++ b/UnityProject/Assets/StreamingAssets/maps.json
@@ -1,1 +1,1 @@
-{"lowPopMaps":["Assets/scenes/OutpostStation.unity"],"highPopMaps":["Assets/scenes/BoxStationV1.unity"],"highPopMinLimit":40}
+{"lowPopMaps":["Assets/scenes/OutpostStation.unity"],"highPopMaps":["Assets/scenes/BoxStationV1.unity"],"highPopMinLimit":30}

--- a/UnityProject/Assets/StreamingAssets/maps.json
+++ b/UnityProject/Assets/StreamingAssets/maps.json
@@ -1,1 +1,1 @@
-{"lowPopMaps":["Assets/scenes/OutpostStation.unity","Assets/scenes/PogStation.unity"],"highPopMaps":["Assets/scenes/BoxStationV1.unity"],"highPopMinLimit":40}
+{"lowPopMaps":["Assets/scenes/PogStation.unity"],"highPopMaps":["Assets/scenes/BoxStationV1.unity"],"highPopMinLimit":40}

--- a/UnityProject/Assets/StreamingAssets/maps.json
+++ b/UnityProject/Assets/StreamingAssets/maps.json
@@ -1,1 +1,1 @@
-{"lowPopMaps":["Assets/scenes/PogStation.unity"],"highPopMaps":["Assets/scenes/BoxStationV1.unity"],"highPopMinLimit":40}
+{"lowPopMaps":["Assets/scenes/OutpostStation.unity"],"highPopMaps":["Assets/scenes/BoxStationV1.unity"],"highPopMinLimit":40}


### PR DESCRIPTION
### Purpose
It's not good and needs some work

See #4141 for details.

Also lowers boxstation pop requirement to 30 players.
