### PR TITLE
makes the scotsman accent more authentic

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjects/Speech/Scotsman.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Speech/Scotsman.asset
@@ -11,82 +11,1041 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c302747b295f59d429cc78a122bcb51d, type: 3}
   m_Name: Scotsman
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
   activateReplacements: 1
   wordReplaceList:
-  - original: you
+  - original: about
     replaceWith:
-    - ye
-    - yah
-  - original: the
+    - aboot
+  - original: above
     replaceWith:
-    - tae
-  - original: yourself
+    - `boon
+  - original: account
     replaceWith:
-    - yersel
-  - original: would
+    - accoont
+  - original: across
     replaceWith:
-    - wid
-  - original: with
+    - o`er
+  - original: after
     replaceWith:
-    - wi
-  - original: of
+    - efter
+  - original: agree
     replaceWith:
-    - eh
-    - ae
-    - o
-  - original: not
+    - gree
+  - original: all
     replaceWith:
-    - no
-  - original: i
+    - a`
+  - original: almost
     replaceWith:
-    - a
-  - original: your
+    - a`maist
+  - original: along
     replaceWith:
-    - yer
+    - alang
+  - original: already
+    replaceWith:
+    - awready
+  - original: also
+    replaceWith:
+    - an` a`
+  - original: although
+    replaceWith:
+    - althoogh
+  - original: and
+    replaceWith:
+    - `n`
+  - original: another
+    replaceWith:
+    - anither
+  - original: any
+    replaceWith:
+    - ony
+  - original: anyone
+    replaceWith:
+    - a`body
+  - original: anything
+    replaceWith:
+    - anythin`
+  - original: argue
+    replaceWith:
+    - argie
+  - original: around
+    replaceWith:
+    - aroond
+  - original: available
+    replaceWith:
+    - free
+  - original: avoid
+    replaceWith:
+    - jook
+  - original: away
+    replaceWith:
+    - awa`
+  - original: baby
+    replaceWith:
+    - bairn
+  - original: bad
+    replaceWith:
+    - ill
+  - original: bag
+    replaceWith:
+    - poke
+  - original: ball
+    replaceWith:
+    - baw
+  - original: bar
+    replaceWith:
+    - boozer
+  - original: beautiful
+    replaceWith:
+    - bonny
+  - original: because
+    replaceWith:
+    - fur
+  - original: nap
+    replaceWith:
+    - kip
+  - original: before
+    replaceWith:
+    - afore
+  - original: believe
+    replaceWith:
+    - hawp
+  - original: between
+    replaceWith:
+    - atween
+  - original: big
+    replaceWith:
+    - muckle
+  - original: board
+    replaceWith:
+    - boord
+  - original: both
+    replaceWith:
+    - baith
+  - original: box
+    replaceWith:
+    - kist
+  - original: boy
+    replaceWith:
+    - laddie
+  - original: but
+    replaceWith:
+    - bit
+  - original: call
+    replaceWith:
+    - ca`
+  - original: can
+    replaceWith:
+    - kin
+  - original: car
+    replaceWith:
+    - motor
+  - original: card
+    replaceWith:
+    - caird
+  - original: career
+    replaceWith:
+    - joab
+  - original: case
+    replaceWith:
+    - trial
+  - original: century
+    replaceWith:
+    - hunner years
+  - original: change
+    replaceWith:
+    - chaynge
+  - original: child
+    replaceWith:
+    - bairn
+  - original: choose
+    replaceWith:
+    - wale
+  - original: church
+    replaceWith:
+    - kirk
+  - original: city
+    replaceWith:
+    - toon
+  - original: close
+    replaceWith:
+    - claise
+  - original: cold
+    replaceWith:
+    - cauld
+  - original: consumer
+    replaceWith:
+    - punter
+  - original: could
+    replaceWith:
+    - cuid
+  - original: country
+    replaceWith:
+    - land
+  - original: course
+    replaceWith:
+    - coorse
+  - original: culture
+    replaceWith:
+    - culchur
+  - original: customer
+    replaceWith:
+    - punter
+  - original: dark
+    replaceWith:
+    - mirk
+  - original: dead
+    replaceWith:
+    - deid
+  - original: debate
+    replaceWith:
+    - argie
+  - original: degree
+    replaceWith:
+    - gree
+  - original: difficult
+    replaceWith:
+    - pernicketie
+  - original: dinner
+    replaceWith:
+    - tea
+  - original: director
+    replaceWith:
+    - guider
+  - original: do
+    replaceWith:
+    - dae
+  - original: dog
+    replaceWith:
+    - dug
+  - original: down
+    replaceWith:
+    - doon
+  - original: drop
+    replaceWith:
+    - drap
+  - original: during
+    replaceWith:
+    - while
+  - original: each
+    replaceWith:
+    - ilk
+  - original: early
+    replaceWith:
+    - earlie
+  - original: eat
+    replaceWith:
+    - sloch
+  - original: edge
+    replaceWith:
+    - lip
+  - original: enjoy
+    replaceWith:
+    - gilravage
+  - original: evening
+    replaceWith:
+    - forenicht
+  - original: every
+    replaceWith:
+    - ilka
+  - original: everybody
+    replaceWith:
+    - a`body
+  - original: everyone
+    replaceWith:
+    - a`body
+  - original: eye
+    replaceWith:
+    - yak
+  - original: family
+    replaceWith:
+    - fowk
+  - original: fast
+    replaceWith:
+    - fleet
+  - original: father
+    replaceWith:
+    - faither
+  - original: fight
+    replaceWith:
+    - rammy
+  - original: film
+    replaceWith:
+    - picture
+  - original: find
+    replaceWith:
+    - fin`
+  - original: fine
+    replaceWith:
+    - braw
+  - original: first
+    replaceWith:
+    - foremaist
+  - original: floor
+    replaceWith:
+    - flair
+  - original: food
+    replaceWith:
+    - fairn
+  - original: for
+    replaceWith:
+    - fur
+  - original: forget
+    replaceWith:
+    - forgoat
+  - original: friend
+    replaceWith:
+    - mukker
+  - original: from
+    replaceWith:
+    - fae
+  - original: game
+    replaceWith:
+    - gam
+  - original: garden
+    replaceWith:
+    - back green
+  - original: get
+    replaceWith:
+    - git
   - original: girl
     replaceWith:
     - lassie
-    - lass
-    - burd
-  - original: need to
+  - original: give
     replaceWith:
-    - needty
-  - original: shit
+    - gie
+  - original: glass
     replaceWith:
-    - shite
-    - shet
-  - original: doing
+    - gless
+  - original: go
     replaceWith:
-    - dain
-  - original: out
+    - gang
+  - original: good
     replaceWith:
-    - oot
-  - original: you've
+    - guid
+  - original: great
     replaceWith:
-    - ye've
-  - original: i'll
+    - stoatin
+  - original: grow
     replaceWith:
-    - al
-  - original: off
+    - graw
+  - original: guess
     replaceWith:
-    - aff
+    - jalouse
+  - original: hair
+    replaceWith:
+    - locks
+  - original: half
+    replaceWith:
+    - hauf
+  - original: hand
+    replaceWith:
+    - haun
+  - original: hang
+    replaceWith:
+    - hing
+  - original: have
+    replaceWith:
+    - hae
+  - original: head
+    replaceWith:
+    - heid
+  - original: heart
+    replaceWith:
+    - hert
+  - original: help
+    replaceWith:
+    - hulp
+  - original: here
+    replaceWith:
+    - `ere
+  - original: high
+    replaceWith:
+    - heich
+  - original: himself
+    replaceWith:
+    - his-sel
+  - original: hit
+    replaceWith:
+    - skelp
+  - original: hold
+    replaceWith:
+    - haud
+  - original: home
+    replaceWith:
+    - hame
+  - original: hope
+    replaceWith:
+    - hawp
+  - original: hot
+    replaceWith:
+    - het
+  - original: hotel
+    replaceWith:
+    - change-hoose
+  - original: hour
+    replaceWith:
+    - oor
+  - original: house
+    replaceWith:
+    - hoose
+  - original: how
+    replaceWith:
+    - howfur
+  - original: husband
+    replaceWith:
+    - guidman
+  - original: image
+    replaceWith:
+    - photie
+  - original: imagine
+    replaceWith:
+    - jalouse
+  - original: including
+    replaceWith:
+    - anaw
+  - original: indicate
+    replaceWith:
+    - show
+  - original: information
+    replaceWith:
+    - speirins
   - original: into
     replaceWith:
     - intae
-    - inty
+  - original: its
+    replaceWith:
+    - tis
+  - original: job
+    replaceWith:
+    - jab
+  - original: join
+    replaceWith:
+    - jyne
+  - original: just
+    replaceWith:
+    - juist
+  - original: kid
+    replaceWith:
+    - bairn
+  - original: kill
+    replaceWith:
+    - murdurr
+  - original: kitchen
+    replaceWith:
+    - scullery
+  - original: know
+    replaceWith:
+    - ken
+  - original: language
+    replaceWith:
+    - leid
+  - original: large
+    replaceWith:
+    - lairge
+  - original: last
+    replaceWith:
+    - lest
+  - original: later
+    replaceWith:
+    - efter
+  - original: laugh
+    replaceWith:
+    - roar
+  - original: lawyer
+    replaceWith:
+    - advocate
+  - original: lead
+    replaceWith:
+    - leid
+  - original: leave
+    replaceWith:
+    - lea
+  - original: leg
+    replaceWith:
+    - shank
+  - original: life
+    replaceWith:
+    - lee
+  - original: like
+    replaceWith:
+    - lik`
+  - original: little
+    replaceWith:
+    - wee
+  - original: long
+    replaceWith:
+    - lang
+  - original: look
+    replaceWith:
+    - keek
+  - original: love
+    replaceWith:
+    - loue
+  - original: make
+    replaceWith:
+    - mak`
+  - original: man
+    replaceWith:
+    - jimmy
+  - original: manage
+    replaceWith:
+    - guide
+  - original: manager
+    replaceWith:
+    - high heid yin
+  - original: many
+    replaceWith:
+    - mony
+  - original: market
+    replaceWith:
+    - merkat
+  - original: marriage
+    replaceWith:
+    - mairriage
+  - original: matter
+    replaceWith:
+    - maiter
+  - original: maybe
+    replaceWith:
+    - mibbie
+  - original: meeting
+    replaceWith:
+    - meetin
+  - original: method
+    replaceWith:
+    - way
+  - original: might
+    replaceWith:
+    - micht
+  - original: mind
+    replaceWith:
+    - mynd
+  - original: miss
+    replaceWith:
+    - lassy
+  - original: money
+    replaceWith:
+    - dosh
+  - original: month
+    replaceWith:
+    - munth
+  - original: more
+    replaceWith:
+    - mair
+  - original: morning
+    replaceWith:
+    - mornin`
+  - original: most
+    replaceWith:
+    - maist
+  - original: mother
+    replaceWith:
+    - mither
+  - original: mouth
+    replaceWith:
+    - geggy
+  - original: move
+    replaceWith:
+    - shift
+  - original: much
+    replaceWith:
+    - muckle
+  - original: must
+    replaceWith:
+    - mist
+  - original: my
+    replaceWith:
+    - mah
+  - original: myself
+    replaceWith:
+    - masell
+  - original: network
+    replaceWith:
+    - netwurk
+  - original: never
+    replaceWith:
+    - ne`er
+  - original: new
+    replaceWith:
+    - freish
+  - original: news
+    replaceWith:
+    - speirins
+  - original: next
+    replaceWith:
+    - neist
+  - original: nice
+    replaceWith:
+    - crakin`
+  - original: night
+    replaceWith:
+    - nicht
+  - original: no
+    replaceWith:
+    - na
+  - original: not
+    replaceWith:
+    - nae
+  - original: now
+    replaceWith:
+    - noo
+  - original: number
+    replaceWith:
+    - batch
+  - original: of
+    replaceWith:
+    - o`
+  - original: off
+    replaceWith:
+    - aff
+  - original: office
+    replaceWith:
+    - affice
+  - original: officer
+    replaceWith:
+    - boaby
+  - original: oh
+    replaceWith:
+    - och
+  - original: ok
+    replaceWith:
+    - a`richt
+  - original: old
+    replaceWith:
+    - auld
+  - original: on
+    replaceWith:
+    - oan
+  - original: once
+    replaceWith:
+    - wance
+  - original: one
+    replaceWith:
+    - yin
+  - original: only
+    replaceWith:
+    - ainlie
+  - original: other
+    replaceWith:
+    - ither
+  - original: others
+    replaceWith:
+    - ithers
+  - original: our
+    replaceWith:
+    - oor
+  - original: out
+    replaceWith:
+    - oot
+  - original: outside
+    replaceWith:
+    - ootdoors
+  - original: over
+    replaceWith:
+    - ower
+  - original: own
+    replaceWith:
+    - ain
+  - original: owner
+    replaceWith:
+    - gaffer
+  - original: painting
+    replaceWith:
+    - pentin
+  - original: part
+    replaceWith:
+    - pairt
+  - original: partner
+    replaceWith:
+    - bidie
+  - original: party
+    replaceWith:
+    - pairtie
+  - original: pass
+    replaceWith:
+    - bygae
+  - original: past
+    replaceWith:
+    - bygane
+  - original: people
+    replaceWith:
+    - fowk
+  - original: perhaps
+    replaceWith:
+    - mibbie
+  - original: person
+    replaceWith:
+    - body
+  - original: phone
+    replaceWith:
+    - phane
+  - original: place
+    replaceWith:
+    - steid
+  - original: play
+    replaceWith:
+    - speil
+  - original: police
+    replaceWith:
+    - polis
+  - original: poor
+    replaceWith:
+    - brassic
+  - original: popular
+    replaceWith:
+    - weel-kent
+  - original: pretty
+    replaceWith:
+    - bonny
+  - original: price
+    replaceWith:
+    - cost
+  - original: probably
+    replaceWith:
+    - likelie
+  - original: problem
+    replaceWith:
+    - kinch
+  - original: professional
+    replaceWith:
+    - perfaissional
+  - original: program
+    replaceWith:
+    - progrum
+  - original: provide
+    replaceWith:
+    - gie
+  - original: put
+    replaceWith:
+    - pat
+  - original: question
+    replaceWith:
+    - quaistion
+  - original: quite
+    replaceWith:
+    - ferr
+  - original: radio
+    replaceWith:
+    - tranny
+  - original: rather
+    replaceWith:
+    - ower
+  - original: ready
+    replaceWith:
+    - duin
+  - original: really
+    replaceWith:
+    - pure
+  - original: red
+    replaceWith:
+    - rid
+  - original: relationship
+    replaceWith:
+    - kinship
+  - original: remember
+    replaceWith:
+    - mind
+  - original: right
+    replaceWith:
+    - richt
+  - original: role
+    replaceWith:
+    - part
+  - original: same
+    replaceWith:
+    - identical
+  - original: school
+    replaceWith:
+    - schuil
+  - original: score
+    replaceWith:
+    - hampden roar
+  - original: season
+    replaceWith:
+    - seezin
+  - original: second
+    replaceWith:
+    - seicont
+  - original: several
+    replaceWith:
+    - loads
+  - original: shake
+    replaceWith:
+    - shoogle
+  - original: should
+    replaceWith:
+    - shuid
+  - original: show
+    replaceWith:
+    - shaw
+  - original: since
+    replaceWith:
+    - sin
+  - original: small
+    replaceWith:
+    - wee
+  - original: so
+    replaceWith:
+    - sae
+  - original: soldier
+    replaceWith:
+    - fighter
+  - original: sometimes
+    replaceWith:
+    - whiles
+  - original: south
+    replaceWith:
+    - sooth
+  - original: staff
+    replaceWith:
+    - warkers
+  - original: stand
+    replaceWith:
+    - staun
+  - original: star
+    replaceWith:
+    - starn
+  - original: start
+    replaceWith:
+    - stairt
+  - original: stay
+    replaceWith:
+    - bade
+  - original: stop
+    replaceWith:
+    - stoap
+  - original: store
+    replaceWith:
+    - hain
+  - original: street
+    replaceWith:
+    - wynd
+  - original: strong
+    replaceWith:
+    - pure tough
+  - original: style
+    replaceWith:
+    - pure class
+  - original: such
+    replaceWith:
+    - sic
+  - original: table
+    replaceWith:
+    - buird
+  - original: take
+    replaceWith:
+    - tak`
+  - original: talk
+    replaceWith:
+    - blether
+  - original: task
+    replaceWith:
+    - hing
+  - original: team
+    replaceWith:
+    - gang
+  - original: television
+    replaceWith:
+    - tellybox
+  - original: the
+    replaceWith:
+    - th`
+  - original: their
+    replaceWith:
+    - thair
+  - original: them
+    replaceWith:
+    - thaim
+  - original: there
+    replaceWith:
+    - thare
+  - original: these
+    replaceWith:
+    - thae
+  - original: they
+    replaceWith:
+    - thay
+  - original: those
+    replaceWith:
+    - they
+  - original: through
+    replaceWith:
+    - thro`
+  - original: throughout
+    replaceWith:
+    - throo`oot
+  - original: to
+    replaceWith:
+    - tae
+  - original: today
+    replaceWith:
+    - th`day
+  - original: together
+    replaceWith:
+    - th`gither
+  - original: tonight
+    replaceWith:
+    - th`nicht
+  - original: too
+    replaceWith:
+    - tae
+  - original: top
+    replaceWith:
+    - tap
+  - original: total
+    replaceWith:
+    - tot
+  - original: town
+    replaceWith:
+    - toun
+  - original: trouble
+    replaceWith:
+    - trauchle
+  - original: turn
+    replaceWith:
+    - caw
+  - original: TV
+    replaceWith:
+    - telly
+  - original: two
+    replaceWith:
+    - twa
+  - original: understand
+    replaceWith:
+    - ken
+  - original: until
+    replaceWith:
+    - `til
+  - original: use
+    replaceWith:
+    - uise
+  - original: usually
+    replaceWith:
+    - forordinar
+  - original: very
+    replaceWith:
+    - gey
+  - original: victim
+    replaceWith:
+    - sittin` duck
+  - original: view
+    replaceWith:
+    - sicht
+  - original: walk
+    replaceWith:
+    - donder
+  - original: wall
+    replaceWith:
+    - dyke
+  - original: want
+    replaceWith:
+    - waant
+  - original: water
+    replaceWith:
+    - cooncil juice
+  - original: way
+    replaceWith:
+    - wey
+  - original: well
+    replaceWith:
+    - weel
+  - original: west
+    replaceWith:
+    - wast
+  - original: what
+    replaceWith:
+    - whit
+  - original: whatever
+    replaceWith:
+    - whitevur
+  - original: when
+    replaceWith:
+    - whin
+  - original: where
+    replaceWith:
+    - whaur
+  - original: whether
+    replaceWith:
+    - whither
+  - original: which
+    replaceWith:
+    - whilk
+  - original: who
+    replaceWith:
+    - wha
+  - original: whole
+    replaceWith:
+    - hail
+  - original: whom
+    replaceWith:
+    - wham
+  - original: whose
+    replaceWith:
+    - wha`s
+  - original: wife
+    replaceWith:
+    - guidwife
+  - original: will
+    replaceWith:
+    - wull
+  - original: wind
+    replaceWith:
+    - win`
+  - original: window
+    replaceWith:
+    - windae
+  - original: with
+    replaceWith:
+    - wi`
+  - original: within
+    replaceWith:
+    - wi`in
+  - original: without
+    replaceWith:
+    - wi`oot
+  - original: woman
+    replaceWith:
+    - wifie
+  - original: work
+    replaceWith:
+    - wirk
+  - original: would
+    replaceWith:
+    - wid
+  - original: yard
+    replaceWith:
+    - yaird
+  - original: yeah
+    replaceWith:
+    - aye
+  - original: yes
+    replaceWith:
+    - aye
+  - original: yet
+    replaceWith:
+    - yit
+  - original: you
+    replaceWith:
+    - ye
+  - original: your
+    replaceWith:
+    - yer
+  - original: yourself
+    replaceWith:
+    - yersel`
+  - original: i
+    replaceWith:
+    - a
+  - original: shit
+    replaceWith:
+    - shite
   - original: alright
     replaceWith:
-    - awryt
+    - a`richt
   - original: crazy
     replaceWith:
-    - a bampot
-  - original: great
-    replaceWith:
-    - crackin'
-  - original: awesome
-    replaceWith:
-    - crackin'
+    - doolally
   - original: idiot
     replaceWith:
     - eejit
@@ -96,68 +1055,32 @@ MonoBehaviour:
   - original: ugly
     replaceWith:
     - hackit
-  - original: is not
-    replaceWith:
-    - isnae
   - original: tired
     replaceWith:
     - knackert
   - original: gay
     replaceWith:
-    - a jessie
+    - bufty
   - original: testing
     replaceWith:
-    - testin'
+    - testin`
   - original: fuck
     replaceWith:
     - fook
   - original: fucking
     replaceWith:
-    - fookin'
+    - fookin`
     - feckin
   - original: fucker
     replaceWith:
     - fooker
-  - original: ones
-    replaceWith:
-    - wans
-  - original: on
-    replaceWith:
-    - oan
-  - original: his
-    replaceWith:
-    - es
-  - original: thought
-    replaceWith:
-    - thawt
-  - original: home
-    replaceWith:
-    - hame
-  - original: boy
-    replaceWith:
-    - lad
-    - laddie
   - original: mom
     replaceWith:
-    - mum
     - maw
     - mam
-  - original: head
-    replaceWith:
-    - heed
-  - original: my
-    replaceWith:
-    - me
-    - ma
-  - original: do not
-    replaceWith:
-    - dinny
   - original: throw
     replaceWith:
     - chuck
-  - original: window
-    replaceWith:
-    - windae
   - original: fucked
     replaceWith:
     - fooked
@@ -170,17 +1093,10 @@ MonoBehaviour:
     - arsed
   - original: dick
     replaceWith:
-    - dobber
+    - boaby
   - original: something
     replaceWith:
     - suhin
-  - original: around
-    replaceWith:
-    - round
-    - roond
-  - original: dead
-    replaceWith:
-    - deed
   - original: boys
     replaceWith:
     - lads
@@ -193,8 +1109,6 @@ MonoBehaviour:
   letterReplaceList: []
   activateAdditions: 1
   probability: 24
-  beginning:
-  - Oi!
   ending:
-  - Ya wee fooker?
+  - ye daft cunt
   customCode: {fileID: 0}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Speech/Scotsman.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Speech/Scotsman.asset
@@ -11,7 +11,7 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c302747b295f59d429cc78a122bcb51d, type: 3}
   m_Name: Scotsman
-  m_EditorClassIdentifier:
+  m_EditorClassIdentifier: 
   activateReplacements: 1
   wordReplaceList:
   - original: about
@@ -19,10 +19,10 @@ MonoBehaviour:
     - aboot
   - original: above
     replaceWith:
-    - `boon
-  - original: account
+    - '`boon'
+  - original: accounts
     replaceWith:
-    - accoont
+    - accoonts
   - original: across
     replaceWith:
     - o`er
@@ -52,7 +52,7 @@ MonoBehaviour:
     - althoogh
   - original: and
     replaceWith:
-    - `n`
+    - '`n`'
   - original: another
     replaceWith:
     - anither
@@ -62,9 +62,27 @@ MonoBehaviour:
   - original: anyone
     replaceWith:
     - a`body
+  - original: anybody
+    replaceWith:
+    - a`body
   - original: anything
     replaceWith:
     - anythin`
+  - original: arrested
+    replaceWith:
+    - liftit
+  - original: arrest
+    replaceWith:
+    - lift
+  - original: arrests
+    replaceWith:
+    - lifts
+  - original: argues
+    replaceWith:
+    - argies
+  - original: argued
+    replaceWith:
+    - argied
   - original: argue
     replaceWith:
     - argie
@@ -74,24 +92,51 @@ MonoBehaviour:
   - original: available
     replaceWith:
     - free
+  - original: avoiding
+    replaceWith:
+    - jookin
+  - original: avoided
+    replaceWith:
+    - jooked
   - original: avoid
     replaceWith:
     - jook
+  - original: ask
+    replaceWith:
+    - spir
+  - original: assistant
+    replaceWith:
+    - servand
+  - original: assistants
+    replaceWith:
+    - servands
+  - original: asking
+    replaceWith:
+    - spirin
+  - original: asked
+    replaceWith:
+    - spire'd
   - original: away
     replaceWith:
     - awa`
+  - original: babies
+    replaceWith:
+    - bairns
   - original: baby
     replaceWith:
     - bairn
   - original: bad
     replaceWith:
     - ill
-  - original: bag
+  - original: balls
     replaceWith:
-    - poke
+    - baws
   - original: ball
     replaceWith:
     - baw
+  - original: bars
+    replaceWith:
+    - boozers
   - original: bar
     replaceWith:
     - boozer
@@ -104,144 +149,333 @@ MonoBehaviour:
   - original: nap
     replaceWith:
     - kip
+  - original: napping
+    replaceWith:
+    - kipin'
   - original: before
     replaceWith:
     - afore
+  - original: believes
+    replaceWith:
+    - hawps
+  - original: believing
+    replaceWith:
+    - hawpin
   - original: believe
     replaceWith:
     - hawp
   - original: between
     replaceWith:
     - atween
-  - original: big
+  - original: boards
     replaceWith:
-    - muckle
+    - boords
   - original: board
     replaceWith:
     - boord
   - original: both
     replaceWith:
     - baith
+  - original: boxes
+    replaceWith:
+    - kists
   - original: box
     replaceWith:
     - kist
   - original: boy
     replaceWith:
     - laddie
+  - original: brother
+    replaceWith:
+    - brither
+  - original: brothers
+    replaceWith:
+    - brithers
   - original: but
     replaceWith:
     - bit
+  - original: bitch
+    replaceWith:
+    - cunt
+  - original: captain
+    replaceWith:
+    - caiptain
+  - original: cap
+    replaceWith:
+    - caip
+  - original: calling
+    replaceWith:
+    - ca`ing
+  - original: called
+    replaceWith:
+    - ca`ed
   - original: call
     replaceWith:
     - ca`
   - original: can
     replaceWith:
     - kin
+  - original: cars
+    replaceWith:
+    - motors
   - original: car
     replaceWith:
     - motor
+  - original: cared
+    replaceWith:
+    - car'd
+  - original: cards
+    replaceWith:
+    - cairds
   - original: card
     replaceWith:
     - caird
+  - original: careers
+    replaceWith:
+    - joabs
   - original: career
     replaceWith:
     - joab
-  - original: case
+  - original: cargo
     replaceWith:
-    - trial
+    - cargae
   - original: century
     replaceWith:
     - hunner years
+  - original: changed
+    replaceWith:
+    - chaynged
   - original: change
     replaceWith:
     - chaynge
+  - original: chaplain
+    replaceWith:
+    - priestheid
+  - original: chief
+    replaceWith:
+    - heid
   - original: child
     replaceWith:
-    - bairn
+    - wee'un
+  - original: childeren
+    replaceWith:
+    - wee'uns
+  - original: choosing
+    replaceWith:
+    - walin
   - original: choose
     replaceWith:
     - wale
+  - original: churches
+    replaceWith:
+    - kirks
   - original: church
     replaceWith:
     - kirk
   - original: city
     replaceWith:
     - toon
+  - original: cities
+    replaceWith:
+    - toons
+  - original: closer
+    replaceWith:
+    - claiser
+  - original: closest
+    replaceWith:
+    - claisest
   - original: close
     replaceWith:
     - claise
+  - original: clowns
+    replaceWith:
+    - clouns
+  - original: clown
+    replaceWith:
+    - cloun
+  - original: coats
+    replaceWith:
+    - coaties
+  - original: coat
+    replaceWith:
+    - coatie
+  - original: coldest
+    replaceWith:
+    - cauldest
+  - original: colder
+    replaceWith:
+    - caulder
   - original: cold
     replaceWith:
     - cauld
+  - original: cooks
+    replaceWith:
+    - keuks
+  - original: cook
+    replaceWith:
+    - keuk
   - original: consumer
     replaceWith:
     - punter
+  - original: consumers
+    replaceWith:
+    - punters
   - original: could
     replaceWith:
     - cuid
+  - original: countries
+    replaceWith:
+    - lands
   - original: country
     replaceWith:
     - land
   - original: course
     replaceWith:
     - coorse
+  - original: courses
+    replaceWith:
+    - coorses
+  - original: cultures
+    replaceWith:
+    - culchurs
   - original: culture
     replaceWith:
     - culchur
   - original: customer
     replaceWith:
     - punter
+  - original: customers
+    replaceWith:
+    - punters
+  - original: daddy
+    replaceWith:
+    - daddie
   - original: dark
     replaceWith:
     - mirk
   - original: dead
     replaceWith:
     - deid
+  - original: deaf
+    replaceWith:
+    - deav
+  - original: deafen
+    replaceWith:
+    - deave
+  - original: deafened
+    replaceWith:
+    - deaved
   - original: debate
     replaceWith:
     - argie
+  - original: debating
+    replaceWith:
+    - argiein
+  - original: debates
+    replaceWith:
+    - argies
+  - original: degrees
+    replaceWith:
+    - grees
   - original: degree
     replaceWith:
     - gree
+  - original: detectives
+    replaceWith:
+    - snoots
+  - original: detective
+    replaceWith:
+    - snoot
   - original: difficult
     replaceWith:
     - pernicketie
   - original: dinner
     replaceWith:
     - tea
+  - original: directors
+    replaceWith:
+    - guiders
   - original: director
     replaceWith:
     - guider
   - original: do
     replaceWith:
     - dae
+  - original: dogs
+    replaceWith:
+    - dugs
   - original: dog
     replaceWith:
     - dug
   - original: down
     replaceWith:
     - doon
+  - original: droped
+    replaceWith:
+    - draped
+  - original: drops
+    replaceWith:
+    - draps
   - original: drop
     replaceWith:
     - drap
+  - original: drink
+    replaceWith:
+    - drappie
+  - original: drinking
+    replaceWith:
+    - swillin'
+  - original: drank
+    replaceWith:
+    - swilled
+  - original: drunk
+    replaceWith:
+    - fou
   - original: during
     replaceWith:
     - while
+  - original: dying
+    replaceWith:
+    - deein'
   - original: each
     replaceWith:
     - ilk
   - original: early
     replaceWith:
     - earlie
+  - original: eating
+    replaceWith:
+    - slochin
+  - original: ate
+    replaceWith:
+    - sloched
   - original: eat
     replaceWith:
     - sloch
+  - original: edges
+    replaceWith:
+    - lips
   - original: edge
     replaceWith:
     - lip
+  - original: enjoys
+    replaceWith:
+    - gilravages
   - original: enjoy
     replaceWith:
     - gilravage
+  - original: engineer
+    replaceWith:
+    - navi
+  - original: engineering
+    replaceWith:
+    - ingineerin
+  - original: engineers
+    replaceWith:
+    - navies
+  - original: evenings
+    replaceWith:
+    - forenichts
   - original: evening
     replaceWith:
     - forenicht
@@ -256,22 +490,49 @@ MonoBehaviour:
     - a`body
   - original: eye
     replaceWith:
-    - yak
+    - ee
+  - original: eyes
+    replaceWith:
+    - e'ens
+  - original: face
+    replaceWith:
+    - physog
+  - original: famililies
+    replaceWith:
+    - fowks
   - original: family
     replaceWith:
     - fowk
   - original: fast
     replaceWith:
     - fleet
+  - original: fathers
+    replaceWith:
+    - faithers
   - original: father
     replaceWith:
     - faither
   - original: fight
     replaceWith:
     - rammy
+  - original: fighting
+    replaceWith:
+    - ramming
+  - original: fights
+    replaceWith:
+    - rammies
+  - original: films
+    replaceWith:
+    - pictures
   - original: film
     replaceWith:
     - picture
+  - original: finding
+    replaceWith:
+    - fin`ing
+  - original: found
+    replaceWith:
+    - fun
   - original: find
     replaceWith:
     - fin`
@@ -281,27 +542,45 @@ MonoBehaviour:
   - original: first
     replaceWith:
     - foremaist
+  - original: floors
+    replaceWith:
+    - flairs
   - original: floor
     replaceWith:
     - flair
+  - original: foods
+    replaceWith:
+    - fairns
   - original: food
     replaceWith:
     - fairn
   - original: for
     replaceWith:
-    - fur
+    - fer
   - original: forget
     replaceWith:
     - forgoat
+  - original: friends
+    replaceWith:
+    - mukkers
   - original: friend
     replaceWith:
-    - mukker
+    - pal
   - original: from
     replaceWith:
     - fae
+  - original: full
+    replaceWith:
+    - stowed oot
+  - original: games
+    replaceWith:
+    - gams
   - original: game
     replaceWith:
     - gam
+  - original: gardens
+    replaceWith:
+    - back greens
   - original: garden
     replaceWith:
     - back green
@@ -314,6 +593,9 @@ MonoBehaviour:
   - original: give
     replaceWith:
     - gie
+  - original: glasses
+    replaceWith:
+    - glesses
   - original: glass
     replaceWith:
     - gless
@@ -326,30 +608,63 @@ MonoBehaviour:
   - original: great
     replaceWith:
     - stoatin
+  - original: growing
+    replaceWith:
+    - grawing
+  - original: grown
+    replaceWith:
+    - grawn
   - original: grow
     replaceWith:
     - graw
+  - original: glared
+    replaceWith:
+    - glower'd
+  - original: glaring
+    replaceWith:
+    - glowrin'
   - original: guess
     replaceWith:
     - jalouse
+  - original: hairs
+    replaceWith:
+    - locks
   - original: hair
     replaceWith:
     - locks
+  - original: halfs
+    replaceWith:
+    - haufs
   - original: half
     replaceWith:
     - hauf
+  - original: hands
+    replaceWith:
+    - hauns
   - original: hand
     replaceWith:
     - haun
+  - original: hangs
+    replaceWith:
+    - hings
+  - original: hanging
+    replaceWith:
+    - hinging
   - original: hang
     replaceWith:
     - hing
   - original: have
     replaceWith:
     - hae
+  - original: heads
+    replaceWith:
+    - heids
   - original: head
     replaceWith:
     - heid
+  - original: hearts
+    replaceWith:
+    - herts
   - original: heart
     replaceWith:
     - hert
@@ -358,43 +673,67 @@ MonoBehaviour:
     - hulp
   - original: here
     replaceWith:
-    - `ere
+    - '`ere'
   - original: high
     replaceWith:
     - heich
   - original: himself
     replaceWith:
     - his-sel
-  - original: hit
+  - original: holding
     replaceWith:
-    - skelp
+    - hauding
   - original: hold
     replaceWith:
     - haud
+  - original: homes
+    replaceWith:
+    - hames
   - original: home
     replaceWith:
     - hame
+  - original: hopes
+    replaceWith:
+    - hawps
   - original: hope
     replaceWith:
     - hawp
+  - original: hoter
+    replaceWith:
+    - heter
+  - original: hotest
+    replaceWith:
+    - hetest
   - original: hot
     replaceWith:
     - het
+  - original: hotels
+    replaceWith:
+    - change-hooses
   - original: hotel
     replaceWith:
     - change-hoose
+  - original: hours
+    replaceWith:
+    - oors
   - original: hour
     replaceWith:
     - oor
   - original: house
     replaceWith:
     - hoose
+  - original: houses
+    replaceWith:
+    - hooses
   - original: how
     replaceWith:
     - howfur
   - original: husband
     replaceWith:
     - guidman
+  - original: images
+    replaceWith:
+    - photies
   - original: image
     replaceWith:
     - photie
@@ -404,9 +743,15 @@ MonoBehaviour:
   - original: including
     replaceWith:
     - anaw
+  - original: indicates
+    replaceWith:
+    - shows
   - original: indicate
     replaceWith:
     - show
+  - original: informations
+    replaceWith:
+    - speirins
   - original: information
     replaceWith:
     - speirins
@@ -416,30 +761,75 @@ MonoBehaviour:
   - original: its
     replaceWith:
     - tis
+  - original: janitors
+    replaceWith:
+    - jannies
+  - original: janitor
+    replaceWith:
+    - jannie
+  - original: jobs
+    replaceWith:
+    - jabs
   - original: job
     replaceWith:
     - jab
+  - original: joined
+    replaceWith:
+    - jyneed
+  - original: joins
+    replaceWith:
+    - jynes
   - original: join
     replaceWith:
     - jyne
   - original: just
     replaceWith:
     - juist
+  - original: kids
+    replaceWith:
+    - bairns
   - original: kid
     replaceWith:
     - bairn
+  - original: kills
+    replaceWith:
+    - murdurrs
+  - original: killer
+    replaceWith:
+    - murdurrur
+  - original: killed
+    replaceWith:
+    - murdurred
   - original: kill
     replaceWith:
     - murdurr
+  - original: kitchens
+    replaceWith:
+    - sculleries
   - original: kitchen
     replaceWith:
     - scullery
+  - original: knows
+    replaceWith:
+    - kens
   - original: know
     replaceWith:
     - ken
+  - original: known
+    replaceWith:
+    - kent
+  - original: languages
+    replaceWith:
+    - leids
   - original: language
     replaceWith:
     - leid
+  - original: larger
+    replaceWith:
+    - lairger
+  - original: largest
+    replaceWith:
+    - lairgest
   - original: large
     replaceWith:
     - lairge
@@ -449,21 +839,51 @@ MonoBehaviour:
   - original: later
     replaceWith:
     - efter
+  - original: laughing
+    replaceWith:
+    - roarin
   - original: laugh
     replaceWith:
     - roar
+  - original: lawyers
+    replaceWith:
+    - advocates
   - original: lawyer
     replaceWith:
     - advocate
   - original: lead
     replaceWith:
     - leid
+  - original: leading
+    replaceWith:
+    - leidin
+  - original: leaving
+    replaceWith:
+    - leaing
   - original: leave
     replaceWith:
     - lea
+  - original: let
+    replaceWith:
+    - loot
+  - original: legs
+    replaceWith:
+    - shanks
   - original: leg
     replaceWith:
     - shank
+  - original: lives
+    replaceWith:
+    - lees
+  - original: devil
+    replaceWith:
+    - deuce
+  - original: devils
+    replaceWith:
+    - deuces
+  - original: lying
+    replaceWith:
+    - liein
   - original: life
     replaceWith:
     - lee
@@ -473,45 +893,84 @@ MonoBehaviour:
   - original: little
     replaceWith:
     - wee
+  - original: longer
+    replaceWith:
+    - langer
+  - original: longest
+    replaceWith:
+    - langest
   - original: long
     replaceWith:
     - lang
+  - original: looking
+    replaceWith:
+    - keeking
+  - original: looked
+    replaceWith:
+    - keeked
   - original: look
     replaceWith:
     - keek
+  - original: loved
+    replaceWith:
+    - loued
+  - original: loving
+    replaceWith:
+    - louing
   - original: love
     replaceWith:
     - loue
+  - original: makes
+    replaceWith:
+    - mak`s
   - original: make
     replaceWith:
     - mak`
-  - original: man
+  - original: men
     replaceWith:
-    - jimmy
+    - jimmies
   - original: manage
     replaceWith:
     - guide
+  - original: managers
+    replaceWith:
+    - high heid yins
   - original: manager
     replaceWith:
     - high heid yin
   - original: many
     replaceWith:
     - mony
+  - original: markets
+    replaceWith:
+    - merkats
   - original: market
     replaceWith:
     - merkat
+  - original: marriages
+    replaceWith:
+    - mairriages
   - original: marriage
     replaceWith:
     - mairriage
+  - original: matters
+    replaceWith:
+    - maiters
   - original: matter
     replaceWith:
     - maiter
   - original: maybe
     replaceWith:
     - mibbie
+  - original: meetings
+    replaceWith:
+    - meetins
   - original: meeting
     replaceWith:
     - meetin
+  - original: methods
+    replaceWith:
+    - ways
   - original: method
     replaceWith:
     - way
@@ -521,30 +980,48 @@ MonoBehaviour:
   - original: mind
     replaceWith:
     - mynd
-  - original: miss
+  - original: miner
     replaceWith:
-    - lassy
+    - pickman
+  - original: miners
+    replaceWith:
+    - pickmen
   - original: money
     replaceWith:
     - dosh
+  - original: months
+    replaceWith:
+    - munths
   - original: month
     replaceWith:
     - munth
   - original: more
     replaceWith:
     - mair
+  - original: mornings
+    replaceWith:
+    - mornin`s
   - original: morning
     replaceWith:
     - mornin`
   - original: most
     replaceWith:
     - maist
+  - original: mothers
+    replaceWith:
+    - mithers
   - original: mother
     replaceWith:
     - mither
+  - original: mouths
+    replaceWith:
+    - geggies
   - original: mouth
     replaceWith:
     - geggy
+  - original: moves
+    replaceWith:
+    - shifts
   - original: move
     replaceWith:
     - shift
@@ -556,10 +1033,13 @@ MonoBehaviour:
     - mist
   - original: my
     replaceWith:
-    - mah
+    - ma
   - original: myself
     replaceWith:
     - masell
+  - original: networks
+    replaceWith:
+    - netwurks
   - original: network
     replaceWith:
     - netwurk
@@ -578,6 +1058,9 @@ MonoBehaviour:
   - original: nice
     replaceWith:
     - crakin`
+  - original: nights
+    replaceWith:
+    - nichts
   - original: night
     replaceWith:
     - nicht
@@ -587,9 +1070,15 @@ MonoBehaviour:
   - original: not
     replaceWith:
     - nae
+  - original: nothing
+    replaceWith:
+    - neithin'
   - original: now
     replaceWith:
     - noo
+  - original: numbers
+    replaceWith:
+    - batches
   - original: number
     replaceWith:
     - batch
@@ -599,9 +1088,15 @@ MonoBehaviour:
   - original: off
     replaceWith:
     - aff
+  - original: offices
+    replaceWith:
+    - affices
   - original: office
     replaceWith:
     - affice
+  - original: officers
+    replaceWith:
+    - boabies
   - original: officer
     replaceWith:
     - boaby
@@ -632,6 +1127,9 @@ MonoBehaviour:
   - original: others
     replaceWith:
     - ithers
+  - original: ours
+    replaceWith:
+    - oors
   - original: our
     replaceWith:
     - oor
@@ -644,18 +1142,33 @@ MonoBehaviour:
   - original: over
     replaceWith:
     - ower
+  - original: owns
+    replaceWith:
+    - ains
   - original: own
     replaceWith:
     - ain
+  - original: owners
+    replaceWith:
+    - gaffers
   - original: owner
     replaceWith:
     - gaffer
+  - original: paintings
+    replaceWith:
+    - pentins
   - original: painting
     replaceWith:
     - pentin
+  - original: parts
+    replaceWith:
+    - pairts
   - original: part
     replaceWith:
     - pairt
+  - original: partners
+    replaceWith:
+    - bidies
   - original: partner
     replaceWith:
     - bidie
@@ -668,6 +1181,9 @@ MonoBehaviour:
   - original: past
     replaceWith:
     - bygane
+  - original: peoples
+    replaceWith:
+    - fowks
   - original: people
     replaceWith:
     - fowk
@@ -677,12 +1193,21 @@ MonoBehaviour:
   - original: person
     replaceWith:
     - body
+  - original: phones
+    replaceWith:
+    - phanes
   - original: phone
     replaceWith:
     - phane
+  - original: places
+    replaceWith:
+    - steids
   - original: place
     replaceWith:
     - steid
+  - original: plays
+    replaceWith:
+    - speils
   - original: play
     replaceWith:
     - speil
@@ -698,33 +1223,57 @@ MonoBehaviour:
   - original: pretty
     replaceWith:
     - bonny
-  - original: price
-    replaceWith:
-    - cost
   - original: probably
     replaceWith:
     - likelie
+  - original: problems
+    replaceWith:
+    - kinches
   - original: problem
     replaceWith:
     - kinch
+  - original: professionals
+    replaceWith:
+    - perfaissionals
   - original: professional
     replaceWith:
     - perfaissional
+  - original: programs
+    replaceWith:
+    - progrums
   - original: program
     replaceWith:
     - progrum
+  - original: provides
+    replaceWith:
+    - gies
   - original: provide
     replaceWith:
     - gie
+  - original: prison
+    replaceWith:
+    - preeson
+  - original: Imprisonment
+    replaceWith:
+    - impreesonment
+  - original: prisoner
+    replaceWith:
+    - preesoner
   - original: put
     replaceWith:
     - pat
+  - original: questions
+    replaceWith:
+    - quaistions
   - original: question
     replaceWith:
     - quaistion
   - original: quite
     replaceWith:
     - ferr
+  - original: radios
+    replaceWith:
+    - trannies
   - original: radio
     replaceWith:
     - tranny
@@ -740,42 +1289,87 @@ MonoBehaviour:
   - original: red
     replaceWith:
     - rid
+  - original: relationships
+    replaceWith:
+    - kinships
   - original: relationship
     replaceWith:
     - kinship
   - original: remember
     replaceWith:
     - mind
+  - original: remembered
+    replaceWith:
+    - minded
+  - original: rights
+    replaceWith:
+    - richts
   - original: right
     replaceWith:
     - richt
+  - original: roles
+    replaceWith:
+    - parts
   - original: role
     replaceWith:
     - part
+  - original: round
+    replaceWith:
+    - ruund
   - original: same
     replaceWith:
     - identical
+  - original: schools
+    replaceWith:
+    - schuils
   - original: school
     replaceWith:
     - schuil
+  - original: scores
+    replaceWith:
+    - hampden roars
   - original: score
     replaceWith:
     - hampden roar
+  - original: scuffed
+    replaceWith:
+    - scotched
+  - original: seasons
+    replaceWith:
+    - seezins
   - original: season
     replaceWith:
     - seezin
+  - original: security
+    replaceWith:
+    - polis
+  - original: seconds
+    replaceWith:
+    - seiconts
   - original: second
     replaceWith:
     - seicont
   - original: several
     replaceWith:
     - loads
+  - original: shaked
+    replaceWith:
+    - shoogled
+  - original: shakes
+    replaceWith:
+    - shoogles
   - original: shake
     replaceWith:
     - shoogle
   - original: should
     replaceWith:
     - shuid
+  - original: shows
+    replaceWith:
+    - shaws
+  - original: showed
+    replaceWith:
+    - shawed
   - original: show
     replaceWith:
     - shaw
@@ -785,9 +1379,15 @@ MonoBehaviour:
   - original: small
     replaceWith:
     - wee
+  - original: spoke
+    replaceWith:
+    - spak
   - original: so
     replaceWith:
     - sae
+  - original: soldiers
+    replaceWith:
+    - fighters
   - original: soldier
     replaceWith:
     - fighter
@@ -797,33 +1397,60 @@ MonoBehaviour:
   - original: south
     replaceWith:
     - sooth
-  - original: staff
+  - original: sore
     replaceWith:
-    - warkers
+    - sair
+  - original: stands
+    replaceWith:
+    - stauns
   - original: stand
     replaceWith:
     - staun
+  - original: stars
+    replaceWith:
+    - starns
   - original: star
     replaceWith:
     - starn
+  - original: starts
+    replaceWith:
+    - stairts
   - original: start
     replaceWith:
     - stairt
+  - original: stays
+    replaceWith:
+    - bides
   - original: stay
     replaceWith:
     - bade
+  - original: stops
+    replaceWith:
+    - stoaps
   - original: stop
     replaceWith:
     - stoap
+  - original: stores
+    replaceWith:
+    - hains
   - original: store
     replaceWith:
     - hain
+  - original: struck
+    replaceWith:
+    - strak
+  - original: streets
+    replaceWith:
+    - wynds
   - original: street
     replaceWith:
     - wynd
   - original: strong
     replaceWith:
     - pure tough
+  - original: styles
+    replaceWith:
+    - pure classes
   - original: style
     replaceWith:
     - pure class
@@ -833,18 +1460,36 @@ MonoBehaviour:
   - original: table
     replaceWith:
     - buird
+  - original: tables
+    replaceWith:
+    - buirds
+  - original: takes
+    replaceWith:
+    - tak`s
   - original: take
     replaceWith:
     - tak`
+  - original: talks
+    replaceWith:
+    - blethers
   - original: talk
     replaceWith:
     - blether
+  - original: tasks
+    replaceWith:
+    - hings
   - original: task
     replaceWith:
     - hing
+  - original: teams
+    replaceWith:
+    - gangs
   - original: team
     replaceWith:
     - gang
+  - original: televisions
+    replaceWith:
+    - tellyboxes
   - original: television
     replaceWith:
     - tellybox
@@ -890,21 +1535,45 @@ MonoBehaviour:
   - original: too
     replaceWith:
     - tae
+  - original: told
+    replaceWith:
+    - telt
+  - original: tops
+    replaceWith:
+    - taps
   - original: top
     replaceWith:
     - tap
   - original: total
     replaceWith:
     - tot
+  - original: towns
+    replaceWith:
+    - touns
   - original: town
     replaceWith:
     - toun
+  - original: tough
+    replaceWith:
+    - hard
+  - original: traitors
+    replaceWith:
+    - quislings
+  - original: traitor
+    replaceWith:
+    - quisling
+  - original: troubles
+    replaceWith:
+    - trauchles
   - original: trouble
     replaceWith:
     - trauchle
   - original: turn
     replaceWith:
     - caw
+  - original: TVs
+    replaceWith:
+    - tellies
   - original: TV
     replaceWith:
     - telly
@@ -916,7 +1585,10 @@ MonoBehaviour:
     - ken
   - original: until
     replaceWith:
-    - `til
+    - '`til'
+  - original: uses
+    replaceWith:
+    - uises
   - original: use
     replaceWith:
     - uise
@@ -926,12 +1598,21 @@ MonoBehaviour:
   - original: very
     replaceWith:
     - gey
+  - original: victims
+    replaceWith:
+    - sittin` ducks
   - original: victim
     replaceWith:
     - sittin` duck
+  - original: views
+    replaceWith:
+    - sichts
   - original: view
     replaceWith:
     - sicht
+  - original: walks
+    replaceWith:
+    - donders
   - original: walk
     replaceWith:
     - donder
@@ -947,6 +1628,9 @@ MonoBehaviour:
   - original: way
     replaceWith:
     - wey
+  - original: warden
+    replaceWith:
+    - screw
   - original: well
     replaceWith:
     - weel
@@ -986,6 +1670,9 @@ MonoBehaviour:
   - original: wife
     replaceWith:
     - guidwife
+  - original: wives
+    replaceWith:
+    - guidwives
   - original: will
     replaceWith:
     - wull
@@ -995,6 +1682,9 @@ MonoBehaviour:
   - original: window
     replaceWith:
     - windae
+  - original: windows
+    replaceWith:
+    - windaes
   - original: with
     replaceWith:
     - wi`
@@ -1007,12 +1697,36 @@ MonoBehaviour:
   - original: woman
     replaceWith:
     - wifie
+  - original: women
+    replaceWith:
+    - Wummin
   - original: work
     replaceWith:
     - wirk
+  - original: words
+    replaceWith:
+    - Wurds
+  - original: world
+    replaceWith:
+    - warl
+  - original: worldly
+    replaceWith:
+    - war'ly
+  - original: working
+    replaceWith:
+    - wirkin
   - original: would
     replaceWith:
     - wid
+  - original: worse
+    replaceWith:
+    - waur
+  - original: ruined
+    replaceWith:
+    - clapped
+  - original: wrong
+    replaceWith:
+    - wrang
   - original: yard
     replaceWith:
     - yaird
@@ -1034,12 +1748,18 @@ MonoBehaviour:
   - original: yourself
     replaceWith:
     - yersel`
+  - original: quiet
+    replaceWith:
+    - cannie
   - original: i
     replaceWith:
     - a
   - original: shit
     replaceWith:
     - shite
+  - original: shitsec
+    replaceWith:
+    - shitesec
   - original: alright
     replaceWith:
     - a`richt
@@ -1050,8 +1770,14 @@ MonoBehaviour:
     replaceWith:
     - eejit
     - numpty
-    - fruitcake
+    - mongo
     - neep
+  - original: idiots
+    replaceWith:
+    - eejits
+    - numptys
+    - mongos
+    - neeps
   - original: ugly
     replaceWith:
     - hackit
@@ -1074,13 +1800,26 @@ MonoBehaviour:
   - original: fucker
     replaceWith:
     - fooker
+  - original: fuckers
+    replaceWith:
+    - fookers
   - original: mom
     replaceWith:
     - maw
     - mam
+  - original: moms
+    replaceWith:
+    - maws
+    - mams
   - original: throw
     replaceWith:
     - chuck
+  - original: throwing
+    replaceWith:
+    - chuckin
+  - original: threw
+    replaceWith:
+    - chucked
   - original: fucked
     replaceWith:
     - fooked
@@ -1088,15 +1827,24 @@ MonoBehaviour:
   - original: ass
     replaceWith:
     - arse
+  - original: asses
+    replaceWith:
+    - arses
   - original: bothered
     replaceWith:
     - arsed
   - original: dick
     replaceWith:
     - boaby
+  - original: dicks
+    replaceWith:
+    - boabys
   - original: something
     replaceWith:
     - suhin
+  - original: somethings
+    replaceWith:
+    - suhins
   - original: boys
     replaceWith:
     - lads
@@ -1108,7 +1856,8 @@ MonoBehaviour:
     - burds
   letterReplaceList: []
   activateAdditions: 1
-  probability: 24
+  probability: 2
+  beginning: []
   ending:
   - ye daft cunt
   customCode: {fileID: 0}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Speech/Scotsman.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Speech/Scotsman.asset.meta
@@ -4,5 +4,5 @@ NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0
   userData:
-  assetBundleName: 
-  assetBundleVariant:
+  assetBundleName:
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Speech/Scotsman.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Speech/Scotsman.asset.meta
@@ -3,6 +3,6 @@ guid: 9c9ccc21e0aee3b45a2463e8c42adc90
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0
-  userData: 
+  userData:
   assetBundleName: 
-  assetBundleVariant: 
+  assetBundleVariant:


### PR DESCRIPTION

### Purpose
changes the Scotsman accent to actually read like real Scots, has been tested in the editor.

### Notes:
introduces over 550 words.
Most of the ones that need it have been pluralized and conjugated. It uses mostly modern Scots but also borrows a few words from older Scots and has a few Scots-like words.
it also removes "oy" prefix and "ye wee fooker" suffix and introduces "ye wee cunt" suffix as a replacement, but turns the chances of it being suffixed to 2%

the two commits are the same cause the first time i forgot to save and missed about 200 words that had been added later.
