### PR TITLE
Changes to tile damage calculations by corp-0, and tweaks to armor and health values.

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -582,7 +582,7 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 			{
 				//window damage
 				SoundManager.PlayNetworkedAtPos("GlassHit", exposure.ExposedWorldPosition, Random.Range(0.9f, 1.1f));
-				AddWindowDamage(exposure.StandardDamage(), metaDataLayer.Get(cellPos), cellPos, exposure.ExposedWorldPosition, AttackType.Melee, false);
+				AddWindowDamage(exposure.StandardDamage(), metaDataLayer.Get(cellPos), cellPos, exposure.ExposedWorldPosition, AttackType.Fire, false);
 			}
 
 		}
@@ -595,7 +595,7 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 				if (metaTileMap.HasTile(cellPos, LayerType.Grills, true))
 				{
 					SoundManager.PlayNetworkedAtPos("GrillHit", exposure.ExposedWorldPosition, Random.Range(0.9f, 1.1f));
-					AddGrillDamage(exposure.StandardDamage(), metaDataLayer.Get(cellPos), cellPos, exposure.ExposedWorldPosition, AttackType.Melee, false);
+					AddGrillDamage(exposure.StandardDamage(), metaDataLayer.Get(cellPos), cellPos, exposure.ExposedWorldPosition, AttackType.Fire, false);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Serialization;
 using UnityEngine.Tilemaps;
-using Random = UnityEngine.Random;
 
 [Serializable]
 public struct TileState
@@ -34,7 +33,6 @@ public abstract class BasicTile : LayerTile
 	[SerializeField]
 	private OreCategory oreCategory;
 
-	public float MaxHealth;
 	public TileState[] HealthStates;
 
 	[Tooltip("Does this tile allow items / objects to pass through it?")]
@@ -56,12 +54,40 @@ public abstract class BasicTile : LayerTile
 	[SerializeField]
 	private PassableDictionary passableException = null;
 
-
 	[Tooltip("What is this tile's max health?")]
 	[FormerlySerializedAs("MaxHealth")]
 	[SerializeField]
 	private float maxHealth;
+	public float MaxHealth => maxHealth;
 
+	[Tooltip("Armor of this tile")]
+	[FormerlySerializedAs("Armor")]
+	[SerializeField]
+	private Armor armor = new Armor
+	{
+		Melee = 90,
+		Bullet = 90,
+		Laser = 90,
+		Energy = 90,
+		Bomb = 90,
+		Bio = 100,
+		Rad = 100,
+		Fire = 100,
+		Acid = 90
+	};
+
+	/// <summary>
+	/// Armor of this tile
+	/// </summary>
+	public Armor Armor => armor;
+
+	[Tooltip("Sound this tile makes when hit")] [SerializeField]
+	private string[] hitSounds = null;
+	public string[] HitSounds => hitSounds;
+
+	[Tooltip("Set the remains this tile can spawn once destroyed")] [SerializeField]
+	private List<TileDestroyedRemains> tileDestroyedRemains = null;
+	public List<TileDestroyedRemains> TileDestroyedRemains => tileDestroyedRemains;
 
 	[Tooltip("How does the tile change as its health changes?")]
 	[FormerlySerializedAs("HealthStates")]
@@ -76,15 +102,6 @@ public abstract class BasicTile : LayerTile
 	/// Resistances of this tile.
 	/// </summary>
 	public Resistances Resistances => resistances;
-
-	[Tooltip("Armor of this tile")]
-	[FormerlySerializedAs("Armor")]
-	[SerializeField]
-	private Armor armor = null;
-	/// <summary>
-	/// Armor of this tile
-	/// </summary>
-	public Armor Armor => armor;
 
 	[Tooltip("Interactions which can occur on this tile. They will be checked in the order they appear in this list (top to bottom).")]
 	[SerializeField]
@@ -103,7 +120,7 @@ public abstract class BasicTile : LayerTile
 	public GameObject SpawnOnDeconstruct => spawnOnDeconstruct;
 
 	[Tooltip("How much of the object to spawn when it's deconstructed. Defaults to 1 if" +
-			 " an object is specified and this is 0.")]
+	         " an object is specified and this is 0.")]
 	[SerializeField]
 	private int spawnAmountOnDeconstruct = 1;
 	/// <summary>
@@ -146,4 +163,16 @@ public abstract class BasicTile : LayerTile
 	{
 		return IsAtmosPassable() && !isSealed;
 	}
+}
+
+[Serializable]
+public class TileDestroyedRemains
+{
+	[Tooltip("What game object to spawn as a remain")]
+	public GameObject Object = null;
+	[Tooltip("Amount of said game object")]
+	public int Amount = 1;
+	[Tooltip("We will make a roll from 0,0 to 1,0. If the roll value is inside this range, we will spawn the game object")]
+	[NaughtyAttributes.MinMaxSlider(0,1)]
+	public Vector2 ProbabilityRange;
 }

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/CatWalk.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/CatWalk.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 50
+  armor:
+    Melee: 50
+    Bullet: 0
+    Laser: 0
+    Energy: 0
+    Bomb: 0
+    Rad: 0
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 0
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 10228000f4d0b45ccbe54926e21b9cb0, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Lattice.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Lattice.asset
@@ -16,18 +16,31 @@ MonoBehaviour:
   LayerType: 4
   TileType: 7
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 0
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 50
+  armor:
+    Melee: 50
+    Bullet: 0
+    Laser: 0
+    Energy: 0
+    Bomb: 0
+    Rad: 0
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 0
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -37,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 10228000f4d0b45ccbe54926e21b9cb0, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Plating.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/Plating.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid0.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid1.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid10.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid10.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid11.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid11.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid12.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid12.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid2.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid3.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: asteroid3
   m_EditorClassIdentifier: 
-  displayName: 
+  displayName: asteroid
   LayerType: 4
   TileType: 7
   RequiredTiles: []
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid4.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid5.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid6.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid7.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid8.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid8.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid9.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/asteroid9.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/grass.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/grass.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/platingdmg1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/platingdmg1.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/platingdmg2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/platingdmg2.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/platingdmg3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/platingdmg3.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic1.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic2.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic3.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic4.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic5.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic6.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic7.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic8.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic8.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic9.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Base/volcanic9.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 50
+    Bullet: 40
+    Laser: 10
+    Energy: 10
+    Bomb: 30
+    Rad: 100
+    Fire: 80
+    Acid: 50
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/Carpet.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/Carpet.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: bae9e1730d4424fbfa160f045597a604,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetBlack.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetBlack.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: cebaf0e2019143a419585accfe0bc2ba,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetBlue.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetBlue.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: ddb724c25a7371b4e98ed3781e9f8cf7,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetCyan.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetCyan.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 1ef9531cac6c1084b814425102e13772,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetGreen.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetGreen.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: e5cee1cf791d4ae44abd330269975110,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetOrange.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetOrange.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 2e430d66e310a994fb332ecfd2689647,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetPurple.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetPurple.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 19abb39bdcfe1374bad1e0ce822d1470,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetRed.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetRed.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 1fe58c6a869263d4697307856c72d3ae,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetRoyalBlack.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetRoyalBlack.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 50245e6f90e5bd341b27782ad9175c4d,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetRoyalBlue.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/CarpetRoyalBlue.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 9e7347df255ee314080349a3c7b88c65,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/Floor.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/Floor.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: f9ea48d86607369478d0ecfb2922b050, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L10.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L10.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L10
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: cc10c11eb6cea814a9ed8fade221f9a0, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L11.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L11.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L11
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 8e8e952d3a353f24e90c63a243396616, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L12.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L12.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L12
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 821164bd1ddc2a24ea421d264d0b041e, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L13.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L13.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L13
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 7302ebeb4e0613a4e88a14c46564f370, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L14.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L14.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L14
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 83b3213bfd1a39a4f825953065b95693, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 8ad87ecfc2fe50645ae7e921e8a468ad, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: ff8f169d5c351b44b8f0a48e3d36bb55, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L4.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L4
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 261920a758b702f4891e5d311f7f67bf, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L5.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L5
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 6d034aa9193dc7d4384cc15d91f49fec, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L6.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L6
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: e9116743b1d82ad48a6be9d985d19742, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L7.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L7
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 6e405f4a049286c42a123c7576e07f1e, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L8.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L8.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L8
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: e7b2085a5d5866048880c5870772b176, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L9.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/L9.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: L9
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 09ad3c23d0f5e7d41ad4b7a087181198, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ReinforcedFloor.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ReinforcedFloor.asset
@@ -17,23 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -43,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 3573a00d8b086489180e20299fd2a40f, type: 2}
   spawnOnDeconstruct: {fileID: 4519819786599941225, guid: 2a170fdb7187e38459de34c4d2b131ad,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienplating.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienplating.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod1_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod1_0.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod3_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod3_0.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod4_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod4_0.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod5_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod5_0.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod6_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod6_0.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod7_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod7_0.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod8_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod8_0.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod9_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienpod9_0.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienvault.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/alienvault.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrival_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrivalcorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrivalcorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrivalcorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrivalcorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrivalcorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrivalcorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrivalcorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/arrivalcorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_corner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_corner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_corner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_corner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_corner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_corner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_corner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_corner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_end_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_end_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_end_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_end_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_end_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_end_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_end_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ast_warn_end_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid0.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid1.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid10.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid10.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid11.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid11.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid12.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid12.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid2.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid3.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid4.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid5.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid6.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid7.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid8.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid8.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid9.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid9.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid_dug.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/asteroid_dug.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bananium.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bananium.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bananium_dam.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bananium_dam.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bar.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bar.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/barber.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/barber.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: cccc57b989501d148b644a31c6cd6c19, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: ade78dc1356cfdb4eb8a1d9bccdbba81, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt10.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt10.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt10
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: bb48f61b656983346ae3bb3414be9736, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt11.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt11.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt11
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: b4ef1ee584848d44cac4a6a68b7f3fa7, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt12.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt12.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt12
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 93c7fa74ca00aa240a3872988ec65e61, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt1_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt1_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt1_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 514eb1da9c9b7a241bb14e71f0d5603a, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt1_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt1_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt1_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 514eb1da9c9b7a241bb14e71f0d5603a, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt1_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt1_2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt1_2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300004, guid: 514eb1da9c9b7a241bb14e71f0d5603a, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt1_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt1_3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt1_3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300006, guid: 514eb1da9c9b7a241bb14e71f0d5603a, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt2_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt2_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt2_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 2823e40fdd9f06b49a0b1614173265f6, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt2_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt2_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt2_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 2823e40fdd9f06b49a0b1614173265f6, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt2_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt2_2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt2_2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300004, guid: 2823e40fdd9f06b49a0b1614173265f6, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt2_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt2_3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt2_3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300006, guid: 2823e40fdd9f06b49a0b1614173265f6, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt3_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt3_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt3_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: d52ebea02fde0d04d9ba4ac8fee7c888, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt3_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt3_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt3_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: d52ebea02fde0d04d9ba4ac8fee7c888, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt3_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt3_2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt3_2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300004, guid: d52ebea02fde0d04d9ba4ac8fee7c888, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt3_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt3_3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt3_3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300006, guid: d52ebea02fde0d04d9ba4ac8fee7c888, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt4.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt4
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 63a7c12e34c1f0a4d878879af098491e, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt5_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt5_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt5_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 3106ef7dd2f29ad4bbc5b5a2117f84e5, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt5_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt5_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt5_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 3106ef7dd2f29ad4bbc5b5a2117f84e5, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt5_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt5_2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt5_2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300004, guid: 3106ef7dd2f29ad4bbc5b5a2117f84e5, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt5_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt5_3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt5_3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300006, guid: 3106ef7dd2f29ad4bbc5b5a2117f84e5, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt6.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt6
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 1a0274cba61326b43a57fadec933bc3a, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt7.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt7
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: e037890e98bed3e42825335d67532310, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt8.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt8.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt8
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 363efa2ed064d0046aadfdbbc186a885, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt9_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt9_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt9_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: ef097f81f3d311845afe59591a12a577, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt9_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt9_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt9_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: ef097f81f3d311845afe59591a12a577, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt9_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt9_2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt9_2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300004, guid: ef097f81f3d311845afe59591a12a577, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt9_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt9_3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt9_3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300006, guid: ef097f81f3d311845afe59591a12a577, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt_dug.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/basalt_dug.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: basalt_dug
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 77b0349438f45894b9c65265a69a4af5, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bcircuit.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bcircuit.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bcircuitoff.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bcircuitoff.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blue_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluecorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluecorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluecorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluecorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluecorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluecorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluecorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluecorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluefull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluefull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bluered_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blueyellowfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/blueyellowfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brown_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncornerold_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncornerold_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncornerold_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncornerold_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncornerold_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncornerold_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncornerold_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/browncornerold_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/brownold_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bus.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/bus.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cafeteria.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cafeteria.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_6.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/caution_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cautioncorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cautioncorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cautioncorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cautioncorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cautioncorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cautioncorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cautioncorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cautioncorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/chapel_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/clockwork_floor.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/clockwork_floor.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cmo.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cmo.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cult.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cult.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/cultdamage7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/damaged1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/damaged1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/damaged2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/damaged2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/damaged3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/damaged3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/damaged4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/damaged4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/damaged5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/damaged5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/dark.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/dark.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkblue_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbluecorners_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbluecorners_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbluecorners_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbluecorners_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbluecorners_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbluecorners_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbluecorners_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbluecorners_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbluefull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbluefull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrown_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrowncorners_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrowncorners_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrowncorners_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrowncorners_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrowncorners_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrowncorners_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrowncorners_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrowncorners_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrownfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkbrownfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreen_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreencorners_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreencorners_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreencorners_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreencorners_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreencorners_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreencorners_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreencorners_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreencorners_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreenfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkgreenfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurple_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurplecorners_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurplecorners_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurplecorners_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurplecorners_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurplecorners_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurplecorners_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurplecorners_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurplecorners_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurplefull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkpurplefull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkred_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkredcorners_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkredcorners_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkredcorners_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkredcorners_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkredcorners_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkredcorners_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkredcorners_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkredcorners_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkredfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkredfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellow_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellowcorners_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellowcorners_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellowcorners_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellowcorners_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellowcorners_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellowcorners_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellowcorners_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellowcorners_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellowfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/darkyellowfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/decals_warn_box_Horizontal.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/decals_warn_box_Horizontal.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/decals_warn_box_vertical.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/decals_warn_box_vertical.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/delivery.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/delivery.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: delivery
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 98d39d817ace60f418830bb5d6a3f009, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 78a9ba7623ddd3b49801e5d27237a196, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict10.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict10.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict10
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 1d1064ec4713c97429fc63026dfcf048, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict11.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict11.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict11
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 9385569d84f8dc44090c7bba48a2a6b5, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict12.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict12.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict12
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: fcb05cc4aa8154f468a665c3019943e2, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict13.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict13.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict13
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 1149014148e29d546acc713afdb79e37, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict14.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict14.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict14
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: e40a3ce0abcfc0746925c884b939f964, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict15.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict15.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict15
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 619ddf7e3dcba3e4a84981a8202544ab, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict16.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict16.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict16
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 513637826077cc542bfa7b7433348f2b, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 441ecfba74ba06343a527765c52b92c7, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 6cadfbfef4c99a74d947a68de3bfa066, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict4.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict4
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: daf9faa58a75fa042be2991e67a3c698, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict5.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict5
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: b99fdcc74cc04b64facb3fdc8f6834db, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict6.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict6
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: a2c95216be4212f48a0becbdf06312f0, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict7.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict7
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 0bb0b9b989da2da488c2a4b4a3b84354, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict8.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict8.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict8
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 7f502ec36c720a149b238cd8b659b6ff, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict9.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/derelict9.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: derelict9
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 9ecf0aab5c4a1c943bdc9edb5369b0f7, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/diamond.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/diamond.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/diamond_dam.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/diamond_dam.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/elevatorshaft.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/elevatorshaft.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/engine.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/engine.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/escape_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/floorscorched1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/floorscorched1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/floorscorched2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/floorscorched2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/freezerfloor.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/freezerfloor.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gcircuit.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gcircuit.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gcircuitanim_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gcircuitanim_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gcircuitanim_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gcircuitanim_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gcircuitanim_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gcircuitanim_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gcircuitanim_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gcircuitanim_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gcircuitoff.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gcircuitoff.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gold_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gold_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gold_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gold_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gold_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gold_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gold_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gold_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gold_dam.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/gold_dam.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/grass.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/grass.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/green_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenblue_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenbluefull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenbluefull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greencorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greencorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greencorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greencorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greencorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greencorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greencorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greencorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellow_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellowfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/greenyellowfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/grimy.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/grimy.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/hierophant1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/hierophant1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: hierophant1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 615c5f230a08ed24c9d8927e66a37bd1, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/hierophant2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/hierophant2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: hierophant2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 79ec0dea7801fbe468ab3a0563d1562f, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand1.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand10.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand10.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand11.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand11.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand12.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand12.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand13.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand13.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand14.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand14.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand15.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand15.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand2.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand3.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand4.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand5.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand6.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand7.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand8.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand8.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand9.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand9.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7532420ce3464b348b4018420cba3044, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand_dug.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/ironsand_dug.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_0.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_1.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_2.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_3.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_4.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_5.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_6.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/lava_7.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_broken.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_broken.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_broken
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: aaaefd5988ba9064695b1bf4d92609ee, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_off.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_off.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_off
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 80fcc11b6658a2c4ea70f49c6ab9cbe4, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-b_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-b_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-b_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 97025a09776adf243b031e5bd11eb537, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-b_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-b_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-b_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 97025a09776adf243b031e5bd11eb537, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-g_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-g_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-g_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 769e8e0e2697f584f9ec91c577d839ab, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-g_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-g_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-g_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 769e8e0e2697f584f9ec91c577d839ab, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-o_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-o_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-o_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: cd823d193ec6ff64abf166167638cf3b, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-o_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-o_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-o_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: cd823d193ec6ff64abf166167638cf3b, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-p_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-p_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-p_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 6220adebd12f4c940924fde419d5cb62, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-p_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-p_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-p_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 6220adebd12f4c940924fde419d5cb62, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-r_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-r_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-r_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: ceb70526b92126e40a541763b766b412, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-r_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-r_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-r_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: ceb70526b92126e40a541763b766b412, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_10.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_10.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_10
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300020, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_11.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_11.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_11
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300022, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_12.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_12.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_12
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300024, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_13.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_13.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_13
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300026, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300004, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300006, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_4.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_4
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300008, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_5.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_5
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300010, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_6.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_6
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300012, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_7.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_7
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300014, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_8.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_8.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_8
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300016, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_9.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-s_9.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-s_9
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300018, guid: 9135ddd3e244bf04c865e9e87a8299be, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-w_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-w_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-w_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 5a534659725e9cf4d9511b5f223b539f, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-w_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-w_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-w_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 5a534659725e9cf4d9511b5f223b539f, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-y_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-y_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-y_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: c0affdbf9572582439afe754a43864b1, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-y_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on-y_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on-y_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: c0affdbf9572582439afe754a43864b1, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 87b4764280f07c2448508974f6ab13e5, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 87b4764280f07c2448508974f6ab13e5, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_10.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_10.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_10
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300020, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_11.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_11.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_11
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300022, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_12.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_12.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_12
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300024, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_13.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_13.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_13
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300026, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_14.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_14.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_14
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300028, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_15.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_15.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_15
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300030, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300004, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300006, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_4.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_4
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300008, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_5.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_5
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300010, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_6.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_6
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300012, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_7.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_7
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300014, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_8.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_8.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_8
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300016, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_9.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/light_on_broken_9.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: light_on_broken_9
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300018, guid: e01f88f8e4d87654bbeb75548442ec51, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/loadingarea_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/loadingarea_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: loadingarea_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 86cd0997d36f9494abd65c2f75b3ea69, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/loadingarea_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/loadingarea_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: loadingarea_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 86cd0997d36f9494abd65c2f75b3ea69, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/loadingarea_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/loadingarea_2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: loadingarea_2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300004, guid: 86cd0997d36f9494abd65c2f75b3ea69, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/loadingarea_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/loadingarea_3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: loadingarea_3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300006, guid: 86cd0997d36f9494abd65c2f75b3ea69, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: necro1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: f273d40714a6c0943a5e213162a27a92, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro2_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro2_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: necro2_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 05cfd4c2c5c9cdb4ab0690bab1aeb8dd, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro2_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro2_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: necro2_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 05cfd4c2c5c9cdb4ab0690bab1aeb8dd, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro2_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro2_2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: necro2_2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300004, guid: 05cfd4c2c5c9cdb4ab0690bab1aeb8dd, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro2_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro2_3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: necro2_3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300006, guid: 05cfd4c2c5c9cdb4ab0690bab1aeb8dd, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro3_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro3_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: necro3_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 6eb6e2a31db0e2a40b063c1bcbc8d32a, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro3_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro3_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: necro3_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 6eb6e2a31db0e2a40b063c1bcbc8d32a, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro3_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro3_2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: necro3_2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300004, guid: 6eb6e2a31db0e2a40b063c1bcbc8d32a, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro3_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro3_3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: necro3_3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300006, guid: 6eb6e2a31db0e2a40b063c1bcbc8d32a, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro3_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro3_4.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: necro3_4
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300008, guid: 6eb6e2a31db0e2a40b063c1bcbc8d32a, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro3_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/necro3_5.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: necro3_5
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300010, guid: 6eb6e2a31db0e2a40b063c1bcbc8d32a, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/noslip-damaged1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/noslip-damaged1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/noslip-damaged2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/noslip-damaged2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/noslip-damaged3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/noslip-damaged3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/noslip-scorched1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/noslip-scorched1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/noslip-scorched2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/noslip-scorched2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/noslip.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/noslip.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orange_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orangecorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orangecorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orangecorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orangecorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orangecorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orangecorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orangecorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orangecorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orangefull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/orangefull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/panelscorched.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/panelscorched.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: panelscorched
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 1141bb0109095da41b6cee9116f0aa53, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/paperfloor.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/paperfloor.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: paperfloor
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: f1d740d9beee82540ad023cd1e37d286, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/pinkblack.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/pinkblack.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/plaque.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/plaque.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: plaque
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: c534fe707ed4555418d16247cb99d9ed, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/plasma.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/plasma.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/plasma_dam.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/plasma_dam.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/podfloor.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/podfloor.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/podfloor_dark.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/podfloor_dark.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/podfloor_light.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/podfloor_light.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purple_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purplecorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purplecorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purplecorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purplecorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purplecorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purplecorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purplecorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purplecorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purplefull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/purplefull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuit.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuit.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_10.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_10.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_11.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_11.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_12.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_12.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_13.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_13.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_14.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_14.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_15.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_15.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_8.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_8.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_9.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rcircuitanim_9.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/recharge_floor_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/recharge_floor_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/recharge_floor_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/recharge_floor_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/recharge_floor_asteroid_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/recharge_floor_asteroid_0.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 1
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/recharge_floor_asteroid_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/recharge_floor_asteroid_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/red_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redblue_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redbluefull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redbluefull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redcorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redcorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redcorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redcorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redcorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redcorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redcorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redcorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreen_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreenfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redgreenfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellow_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellowfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/redyellowfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rockvault.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/rockvault.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/sand.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/sand.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/sandstonevault.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/sandstonevault.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/sepia.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/sepia.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/showroomfloor.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/showroomfloor.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor2_dam.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor2_dam.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor3_dam.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor3_dam.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/shuttlefloor5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/silver.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/silver.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/silver_dam.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/silver_dam.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/solarpanel.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/solarpanel.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: solarpanel
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 98ce64ae76b028b45b96e795219ac021, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/stage_bleft.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/stage_bleft.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/stairs-l.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/stairs-l.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: stairs-l
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: b39b56477a527294b961de86cb3cebc9, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/stairs-m.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/stairs-m.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: stairs-m
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 985376b52b524bc48a4960ef2bfb7c91, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/stairs-old.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/stairs-old.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: stairs-old
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: d38d591c687e2964fbf839d5b68022ae, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/stairs-r.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/stairs-r.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: stairs-r
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 8066f79bb31a1b146a5b0965b113ae5c, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/stairs.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/stairs.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: stairs
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 68207c4917fae75488469fe1695ec7ea, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/uranium.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/uranium.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/uranium_dam.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/uranium_dam.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warn_end_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warn_end_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: warn_end_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 927e2b0b240c99d40a9a008a5ffdffc6, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warn_end_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warn_end_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: warn_end_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 927e2b0b240c99d40a9a008a5ffdffc6, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warn_end_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warn_end_2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: warn_end_2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300004, guid: 927e2b0b240c99d40a9a008a5ffdffc6, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warn_end_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warn_end_3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: warn_end_3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300006, guid: 927e2b0b240c99d40a9a008a5ffdffc6, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_0.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: warningline_0
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300000, guid: 32e1df63d7301224f9c3555bb323b106, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_1.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: warningline_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300002, guid: 32e1df63d7301224f9c3555bb323b106, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_2.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: warningline_2
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300004, guid: 32e1df63d7301224f9c3555bb323b106, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_3.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: warningline_3
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300006, guid: 32e1df63d7301224f9c3555bb323b106, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_4.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: warningline_4
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300008, guid: 32e1df63d7301224f9c3555bb323b106, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_5.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: warningline_5
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300010, guid: 32e1df63d7301224f9c3555bb323b106, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_6.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: warningline_6
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300012, guid: 32e1df63d7301224f9c3555bb323b106, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/warningline_7.asset
@@ -12,19 +12,46 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c576ac449c2d45d99890dcfa21598645, type: 3}
   m_Name: warningline_7
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 3
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 1
-  IsSealed: 1
-  Passable: 1
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 1
+  isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 1
+  mineable: 0
+  passableException:
     m_keys: 01000000
     m_values: 00
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   sprite: {fileID: 21300014, guid: 32e1df63d7301224f9c3555bb323b106, type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/white.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/white.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteblue_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitebluecorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitebluecorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitebluecorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitebluecorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitebluecorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitebluecorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitebluecorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitebluecorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitebluefull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitebluefull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitecorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitecorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitecorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitecorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitecorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitecorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitecorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitecorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreen_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreencorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreencorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreencorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreencorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreencorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreencorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreencorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreencorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreenfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitegreenfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitehall_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurple_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurplecorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurplecorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurplecorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurplecorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurplecorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurplecorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurplecorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurplecorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurplefull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitepurplefull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whitered_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteredcorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteredcorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteredcorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteredcorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteredcorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteredcorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteredcorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteredcorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteredfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteredfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellow_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellowcorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellowcorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellowcorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellowcorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellowcorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellowcorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellowcorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellowcorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellowfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/whiteyellowfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: b72fa05149b4449b79ffe7363b7dd252,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken2.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: b72fa05149b4449b79ffe7363b7dd252,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken3.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: b72fa05149b4449b79ffe7363b7dd252,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken4.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: b72fa05149b4449b79ffe7363b7dd252,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken5.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: b72fa05149b4449b79ffe7363b7dd252,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken6.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: b72fa05149b4449b79ffe7363b7dd252,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood-broken7.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: b72fa05149b4449b79ffe7363b7dd252,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/wood.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 1
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: b72fa05149b4449b79ffe7363b7dd252,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellow_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcorner_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcorner_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcorner_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcorner_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcorner_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcorner_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcorner_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcorner_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcornersiding_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcornersiding_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcornersiding_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcornersiding_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcornersiding_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcornersiding_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcornersiding_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowcornersiding_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowfull.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowfull.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_0.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_0.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_1.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_2.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_3.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_3.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_4.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_4.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_5.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_5.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_6.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_6.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_7.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Floors/yellowsiding_7.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 3
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 01000000
     m_values: 00
-  maxHealth: 0
+  maxHealth: 70
+  armor:
+    Melee: 50
+    Bullet: 50
+    Laser: 50
+    Energy: 50
+    Bomb: 10
+    Rad: 100
+    Fire: 0
+    Acid: 0
+    Magic: 0
+    Bio: 50
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 7b6820d9f95c544a8bf274f9125b4941, type: 2}
   spawnOnDeconstruct: {fileID: 7602444472548548205, guid: 28ccdf7c9ebf84198bf4b8bd543f4ce8,

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/Grill.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/Grill.asset
@@ -22,23 +22,13 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 50
   armor:
     Melee: 50
     Bullet: 70
@@ -50,6 +40,17 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 8e5b0c6f1995489408133f815f767c27, type: 2}
   - {fileID: 11400000, guid: 107560a7c6045ac478f5555e9487ba89, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/GrillDestroyed.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Grills/GrillDestroyed.asset
@@ -22,23 +22,13 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 50
   armor:
     Melee: 50
     Bullet: 70
@@ -50,6 +40,17 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 10228000f4d0b45ccbe54926e21b9cb0, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/Reinforced Table/table_reinforced.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/Reinforced Table/table_reinforced.asset
@@ -16,23 +16,31 @@ MonoBehaviour:
   LayerType: 2
   TileType: 4
   RequiredTiles: []
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 02000000
     m_values: 01
-  maxHealth: 0
+  maxHealth: 200
+  armor:
+    Melee: 10
+    Bullet: 30
+    Laser: 100
+    Energy: 0
+    Bomb: 20
+    Rad: 0
+    Fire: 80
+    Acid: 0
+    Magic: 0
+    Bio: 70
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -42,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 8f2e4e0e18ab3504eb00dfca3d459901, type: 2}
   - {fileID: 11400000, guid: fc968a68963834c05a67838fe15fedec, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/Reinforced Table/table_reinforced_unwelded.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/Reinforced Table/table_reinforced_unwelded.asset
@@ -16,23 +16,31 @@ MonoBehaviour:
   LayerType: 2
   TileType: 4
   RequiredTiles: []
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 02000000
     m_values: 01
-  maxHealth: 0
+  maxHealth: 200
+  armor:
+    Melee: 10
+    Bullet: 30
+    Laser: 100
+    Energy: 0
+    Bomb: 20
+    Rad: 0
+    Fire: 80
+    Acid: 0
+    Magic: 0
+    Bio: 70
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -42,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: b2ed86334f60cfebe9c02f326c550bfd, type: 2}
   - {fileID: 11400000, guid: 02a799c7125ad1d44b6a5c98cf8353e6, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/Table.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/Table.asset
@@ -16,23 +16,31 @@ MonoBehaviour:
   LayerType: 2
   TileType: 4
   RequiredTiles: []
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 02000000
     m_values: 01
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 0
+    Bullet: 0
+    Laser: 0
+    Energy: 0
+    Bomb: 0
+    Rad: 0
+    Fire: 50
+    Acid: 50
+    Magic: 0
+    Bio: 0
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -42,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 60c558a8dfbf4ee4e8225a3484933424, type: 2}
   - {fileID: 11400000, guid: fc968a68963834c05a67838fe15fedec, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/table_glass.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/table_glass.asset
@@ -16,28 +16,18 @@ MonoBehaviour:
   LayerType: 2
   TileType: 4
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 02000000
     m_values: 01
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 70
   armor:
     Melee: 0
     Bullet: 0
@@ -45,10 +35,21 @@ MonoBehaviour:
     Energy: 0
     Bomb: 0
     Rad: 0
-    Fire: 0
-    Acid: 0
+    Fire: 80
+    Acid: 100
     Magic: 0
     Bio: 0
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 1
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 60c558a8dfbf4ee4e8225a3484933424, type: 2}
   - {fileID: 11400000, guid: fc968a68963834c05a67838fe15fedec, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/table_poker.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/table_poker.asset
@@ -16,32 +16,18 @@ MonoBehaviour:
   LayerType: 2
   TileType: 4
   RequiredTiles: []
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 02000000
     m_values: 01
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 70
   armor:
     Melee: 0
     Bullet: 0
@@ -53,6 +39,17 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 60c558a8dfbf4ee4e8225a3484933424, type: 2}
   - {fileID: 11400000, guid: fc968a68963834c05a67838fe15fedec, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/table_wood.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/table_wood.asset
@@ -16,32 +16,18 @@ MonoBehaviour:
   LayerType: 2
   TileType: 4
   RequiredTiles: []
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 02000000
     m_values: 01
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 70
   armor:
     Melee: 0
     Bullet: 0
@@ -53,6 +39,17 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 60c558a8dfbf4ee4e8225a3484933424, type: 2}
   - {fileID: 11400000, guid: fc968a68963834c05a67838fe15fedec, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/AdminWall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/AdminWall.asset
@@ -17,23 +17,31 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -43,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 1
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Bananium Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Bananium Ore.asset
@@ -16,19 +16,31 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 1
   oreCategory: 9
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 1
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 5776497215191974577, guid: 8a4e65d27933f8d4688717312b9181dc,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/BlueSpace Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/BlueSpace Ore.asset
@@ -16,12 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 1
   oreCategory: 6
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 1
@@ -29,6 +28,19 @@ MonoBehaviour:
     m_keys: 
     m_values: 
   maxHealth: 0
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 5776497215191974577, guid: be53c6a65b80e884a9157a2ecd204dd5,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Diamond ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Diamond ore.asset
@@ -16,12 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 1
   oreCategory: 8
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 1
@@ -29,6 +28,19 @@ MonoBehaviour:
     m_keys: 
     m_values: 
   maxHealth: 0
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 5776497215191974577, guid: 1598cca5ce449de40b71631377e13b53,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Gold Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Gold Ore.asset
@@ -16,12 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 1
   oreCategory: 4
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 1
@@ -29,6 +28,19 @@ MonoBehaviour:
     m_keys: 
     m_values: 
   maxHealth: 0
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 5776497215191974577, guid: 6f3e10ec6d1918e40be5fde77ed90705,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Iron Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Iron Ore.asset
@@ -16,12 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 1
   oreCategory: 1
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 1
@@ -29,6 +28,19 @@ MonoBehaviour:
     m_keys: 
     m_values: 
   maxHealth: 0
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 5776497215191974577, guid: 9ac648da14e680a4a9873997a26aff32,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Plasma Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Plasma Ore.asset
@@ -16,12 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 1
   oreCategory: 2
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 1
@@ -29,6 +28,19 @@ MonoBehaviour:
     m_keys: 
     m_values: 
   maxHealth: 0
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 5776497215191974577, guid: a5f18b97ee713da448320f98b86a9892,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Silver Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Silver Ore.asset
@@ -16,12 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 1
   oreCategory: 3
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 1
@@ -29,6 +28,19 @@ MonoBehaviour:
     m_keys: 
     m_values: 
   maxHealth: 0
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 5776497215191974577, guid: 250ca2e271f85f14bb775ad6b2f0a290,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Titanium Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Titanium Ore.asset
@@ -16,12 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 1
   oreCategory: 7
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 1
@@ -29,6 +28,19 @@ MonoBehaviour:
     m_keys: 
     m_values: 
   maxHealth: 0
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 5776497215191974577, guid: a0fd72833524583409f55b3e4453611c,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Uranium Ore.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ORES/Uranium Ore.asset
@@ -16,12 +16,11 @@ MonoBehaviour:
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 1
   oreCategory: 5
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 1
@@ -29,6 +28,19 @@ MonoBehaviour:
     m_keys: 
     m_values: 
   maxHealth: 0
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 5776497215191974577, guid: 34f7d74d5d846bd4a8f3960a42f298f3,
     type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWallAnchorBolts.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWallAnchorBolts.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: e7dbaec31525647378209f60c5769d78, type: 2}
   - {fileID: 11400000, guid: a98a88e95993e4baa9b8a1ac0581371f, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWallCover.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWallCover.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 755e9178883ca42078adcafed89a098e, type: 2}
   - {fileID: 11400000, guid: 35adc0f539c6c4c93af01c6244984d8e, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWallCutCover.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWallCutCover.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 80fa3856a932643f38b929bd7e371344, type: 2}
   - {fileID: 11400000, guid: af5d9791dd6ca4ba2a75443eae419653, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWallSheath.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWallSheath.asset
@@ -17,23 +17,31 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -43,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 2aeef0d30efdc4806a2269f5b9870cf6, type: 2}
   - {fileID: 11400000, guid: ed81a2062dacd4535b82f9374790ff9c, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWallSupportLines.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWallSupportLines.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 9a5b0e5a36e3340cfb333db3a756a8c6, type: 2}
   - {fileID: 11400000, guid: 7cfed025aab5449ec880953a33d4d8b1, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWallSupportRods.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/RWallSupportRods.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: 4c0e26fe41a85429ea69f01523c76cc5, type: 2}
   - {fileID: 11400000, guid: 14798733b170b464a9172271406ea016, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ReinforcedWall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/ReinforcedWall.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: df2824a08f89f459e90d745b5e8e07a2, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/Wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/Wall.asset
@@ -17,14 +17,31 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 90
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -34,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: bb76dc79372e14705abf68e3caa3e0f9, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/abductor_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/abductor_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: abductor_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/bananium_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/bananium_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: bananium_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/clockwork_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/clockwork_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: clockwork_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/cult_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/cult_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: cult_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/diamond_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/diamond_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: diamond_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/false_open.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/false_open.asset
@@ -17,18 +17,31 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 1
   isSealed: 1
+  SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 1
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions:
   - {fileID: 11400000, guid: bb76dc79372e14705abf68e3caa3e0f9, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/gold_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/gold_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: gold_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/hierophant_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/hierophant_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: hierophant_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/iron_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/iron_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: iron_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plasma_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plasma_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: plasma_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall.asset
@@ -22,14 +22,26 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall_corner.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/plastitanium_wall_corner.asset
@@ -21,14 +21,26 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -38,17 +50,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/pod_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/pod_wall.asset
@@ -17,23 +17,31 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
-  BarefootWalkingSoundCategory: 0
-  ClawFootstepSoundCategory: 0
-  HeavyFootstepSoundCategory: 0
-  ClownFootstepSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -43,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 1

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/resin_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/resin_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: resin_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rock_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rock_wall.asset
@@ -17,19 +17,31 @@ MonoBehaviour:
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  WalkingSoundCategory: 0
+  floorTileType: 0
   atmosPassable: 0
   isSealed: 0
   SpawnWithNoAir: 1
   oreCategory: 2
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 1
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
   healthStates: []
   resistances:
     LavaProof: 0
@@ -39,17 +51,6 @@ MonoBehaviour:
     AcidProof: 0
     Indestructable: 0
     FreezeProof: 0
-  armor:
-    Melee: 0
-    Bullet: 0
-    Laser: 0
-    Energy: 0
-    Bomb: 0
-    Rad: 0
-    Fire: 0
-    Acid: 0
-    Magic: 0
-    Bio: 0
   tileInteractions: []
   spawnOnDeconstruct: {fileID: 0}
   spawnAmountOnDeconstruct: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rusty_reinforced_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rusty_reinforced_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: rusty_reinforced_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rusty_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/rusty_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: rusty_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/sandstone_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/sandstone_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: sandstone_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 90
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: shuttle_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 90
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall_corner.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/shuttle_wall_corner.asset
@@ -12,20 +12,47 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: shuttle_wall_corner
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles: []
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 90
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/silver_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/silver_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: silver_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 90
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/smooth_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/smooth_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: smooth_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 90
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/snow_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/snow_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: snow_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 90
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/survival_pod_walls.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/survival_pod_walls.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: survival_pod_walls
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 90
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/uranium_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/uranium_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: uranium_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 90
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/wood_wall.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Walls/wood_wall.asset
@@ -12,21 +12,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad263680d73c8c54ba53262044a57d04, type: 3}
   m_Name: wood_wall
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 0
   TileType: 1
   RequiredTiles:
   - {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f, type: 2}
-  AtmosPassable: 0
-  IsSealed: 0
-  Passable: 0
-  PassableException:
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  oreCategory: 0
+  HealthStates: []
+  passable: 0
+  mineable: 0
+  passableException:
     m_keys: 
     m_values: 
-  MaxHealth: 0
-  HealthStates: []
-  ItemSpawn: {fileID: 0}
-  amount: 0
-  DestroyedTile: {fileID: 0}
+  maxHealth: 100
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 90
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 0
+    Indestructable: 0
+    FreezeProof: 0
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
   connectCategory: 0
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced.asset
@@ -22,23 +22,13 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 1
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 75
   armor:
     Melee: 80
     Bullet: 0
@@ -50,6 +40,17 @@ MonoBehaviour:
     Acid: 100
     Magic: 0
     Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 1
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: d5be8b3cdb39edf449d5d7770fcaf55a, type: 2}
   - {fileID: 11400000, guid: 4635ca63f127a4b1cb58c7ff9de5695a, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced_Unsecuring_Step_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced_Unsecuring_Step_1.asset
@@ -21,23 +21,13 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 1
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 75
   armor:
     Melee: 80
     Bullet: 0
@@ -49,6 +39,17 @@ MonoBehaviour:
     Acid: 100
     Magic: 0
     Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 1
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 50443094b78a109479ae69d71ba210a6, type: 2}
   - {fileID: 11400000, guid: 56202775cd46ef44593ac9f8dc26c961, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced_Unsecuring_Step_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced_Unsecuring_Step_2.asset
@@ -21,23 +21,13 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 1
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 75
   armor:
     Melee: 80
     Bullet: 0
@@ -49,6 +39,17 @@ MonoBehaviour:
     Acid: 100
     Magic: 0
     Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 1
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 63475e1665725c54c99244d0499e9ea8, type: 2}
   - {fileID: 11400000, guid: a25ba21001ad22247994b5f3e90c5f52, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Window.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Window.asset
@@ -22,23 +22,13 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 1
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 25
   armor:
     Melee: 0
     Bullet: 0
@@ -50,6 +40,17 @@ MonoBehaviour:
     Acid: 100
     Magic: 0
     Bio: 0
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 1
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 4635ca63f127a4b1cb58c7ff9de5695a, type: 2}
   - {fileID: 11400000, guid: 2d0f8701c6446414a87a614f7a51afef, type: 2}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowPlastitanium.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowPlastitanium.asset
@@ -21,23 +21,13 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 1
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 200
   armor:
     Melee: 95
     Bullet: 0
@@ -49,6 +39,17 @@ MonoBehaviour:
     Acid: 100
     Magic: 0
     Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 1
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 4635ca63f127a4b1cb58c7ff9de5695a, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowPod.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowPod.asset
@@ -21,23 +21,13 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 1
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 150
   armor:
     Melee: 90
     Bullet: 0
@@ -49,6 +39,17 @@ MonoBehaviour:
     Acid: 100
     Magic: 0
     Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 1
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 4635ca63f127a4b1cb58c7ff9de5695a, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowShuttle.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowShuttle.asset
@@ -21,23 +21,13 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 1
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 150
   armor:
     Melee: 90
     Bullet: 0
@@ -48,7 +38,18 @@ MonoBehaviour:
     Fire: 80
     Acid: 100
     Magic: 0
-    Bio: 0
+    Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 1
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 4635ca63f127a4b1cb58c7ff9de5695a, type: 2}
   spawnOnDeconstruct: {fileID: 0}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowTinted.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowTinted.asset
@@ -21,23 +21,13 @@ MonoBehaviour:
   isSealed: 0
   SpawnWithNoAir: 0
   oreCategory: 0
-  MaxHealth: 0
   HealthStates: []
   passable: 0
   mineable: 0
   passableException:
     m_keys: 
     m_values: 
-  maxHealth: 0
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 1
-    Indestructable: 0
-    FreezeProof: 0
+  maxHealth: 75
   armor:
     Melee: 80
     Bullet: 0
@@ -49,6 +39,17 @@ MonoBehaviour:
     Acid: 100
     Magic: 0
     Bio: 100
+  hitSounds: []
+  tileDestroyedRemains: []
+  healthStates: []
+  resistances:
+    LavaProof: 0
+    FireProof: 0
+    Flammable: 0
+    UnAcidable: 0
+    AcidProof: 1
+    Indestructable: 0
+    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 4635ca63f127a4b1cb58c7ff9de5695a, type: 2}
   spawnOnDeconstruct: {fileID: 0}


### PR DESCRIPTION
### Purpose
This PR contains tweaks to TilemapDamage.cs and BasicTile.cs **by corp-0** so that there are no longer hardcoded values for armor and resistances for all kinds of tiles. Changes to the aforementioned scripts also make fire deal fire damage to windows and grilles instead of melee damage, for some reason.

This PR also tweaks the armor, health, and resistance values of **many** tiles in their assets now that said values are no longer hardcoded. I used /tg/ values where applicable, and used the old hardcoded values if /tg/ values were not available.

May or may not resolve #4137.

### Notes:
**Again, the changes to scripts were done by corp-0 (Gilles on Discord). I just inserted values into the assets for all the tiles.**

Also, fires still break windows within seconds. Most windows should actually break even faster since the health (integrity) values I added are lower than the hardcoded ones.
