### PR TITLE
feat(issue-4162): Fixing role names to display in a nicer format.

### DIFF
--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -191,7 +191,7 @@ public static class SweetExtensions
 	/// Good looking job name
 	public static string JobString(this JobType job)
 	{
-		return job.ToString().Equals("NULL") ? "*just joined" : textInfo.ToTitleCase(job.ToString().ToLower());
+		return job.ToString().Equals("NULL") ? "*just joined" : textInfo.ToTitleCase(job.ToString().ToLower()).Replace("_", " ");
 	}
 	//For job formatting purposes
 	private static readonly TextInfo textInfo = new CultureInfo("en-US", false).TextInfo;


### PR DESCRIPTION
# Purpose
Fixes #4162 
Formatting was taking the exact underscored name, this only seems to effect two roles and is incredibly minor.

### Notes:
Wanted to try my hand at contributing and picked one of the latest entries.

A more long term fix would be a lookup table with pretty names however the impact of the .replace seemed incredibly minor when testing on the existing format method.

Example
![image](https://user-images.githubusercontent.com/9701252/81359211-5c353200-908d-11ea-821d-111683be4112.png)
