### PR TITLE
Fix lost reference to character customisation window

### DIFF
--- a/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
+++ b/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
@@ -38,6 +38,7 @@ public class GUI_PreRoundWindow : MonoBehaviour
 	private GameObject mapLoadingPanel = null;
 
 	// Character objects
+	[SerializeField]
 	private GameObject characterCustomization = null;
 	[SerializeField]
 	private Button characterButton = null;


### PR DESCRIPTION
### Purpose
The Character button in game (not the main menu one) stopped functioning
Just re-adds a [SerializeField] attribute, the prefab `Windows (Put all window UI's in here).prefab` still knows what reference to put there.

### Notes
Issue is present on dev builds 2102-2106, you'll get an NRE trying to click it on staging