### PR TITLE
Fixes subscene restart round issues

### DIFF
--- a/UnityProject/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -829,22 +829,23 @@ namespace Mirror
         /// <returns>true when overwriting so that Mirror knows that we wanted to rebuild observers ourselves. otherwise it uses built in rebuild.</returns>
         public virtual bool OnRebuildObservers(HashSet<NetworkConnection> observers, bool initialize)
         {
-	        return false;
+	        foreach (var obs in NetworkServer.observerSceneList)
+	        {
+		        if (obs.Key == null) continue;
+		        if (gameObject.scene == SceneManager.GetActiveScene())
+		        {
+			        observers.Add(obs.Key);
+		        }
+		        else
+		        {
+			        if (obs.Value.Contains(gameObject.scene))
+			        {
+				        observers.Add(obs.Key);
+			        }
+		        }
+			}
 
-	        //TODO: We are not doing observer rebuilds yet. will come back to visibility stuff later
-	        // foreach(var n in NetworkIdentity.spawned)
-	        // {
-	        //  if (n.Value != null && n.Value.connectionToClient != null)
-	        //  {
-	        //   if (n.Value.gameObject.scene == gameObject.scene
-	        //       || SceneManager.GetActiveScene() == gameObject.scene)
-	        //   {
-	        //    observers.Add(n.Value.connectionToClient);
-	        //   }
-	        //  }
-	        // }
-	        //
-	        // return true;
+	        return true;
         }
 
         /// <summary>

--- a/UnityProject/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -855,6 +855,8 @@ namespace Mirror
         /// <param name="visible">New visibility state.</param>
         public virtual void OnSetHostVisibility(bool visible)
         {
+	        //We are not using mirrors visibity methods
+	        return;
 	        foreach (Renderer rend in GetComponentsInChildren<Renderer>())
 		        rend.enabled = visible;
         }
@@ -867,6 +869,12 @@ namespace Mirror
         /// <returns>True if the player can see this object.</returns>
         public virtual bool OnCheckObserver(NetworkConnection conn)
         {
+	        if (NetworkServer.observerSceneList.ContainsKey(conn) &&
+	            NetworkServer.observerSceneList[conn].Contains(gameObject.scene))
+	        {
+		        return true;
+	        }
+
 	        return SceneManager.GetActiveScene() == gameObject.scene;
         }
     }

--- a/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Mirror
 {
@@ -18,6 +19,11 @@ namespace Mirror
     {
         static bool initialized;
         static int maxConnections;
+
+        /// <summary>
+        /// The definitive list of scenes that a client connection is allowed to observe (Server only)
+        /// </summary>
+        public static Dictionary<NetworkConnection, List<Scene>> observerSceneList = new Dictionary<NetworkConnection, List<Scene>>();
 
         /// <summary>
         /// The connection to the host mode client (if any).

--- a/UnityProject/Assets/Scripts/Managers/GameData.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameData.cs
@@ -215,6 +215,7 @@ public class GameData : MonoBehaviour
 
 	private void OnLevelFinishedLoading(Scene oldScene, Scene newScene)
 	{
+		Resources.UnloadUnusedAssets();
 		if (newScene.name == "Lobby")
 		{
 			IsInGame = false;

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -170,6 +170,7 @@ public class CustomNetworkManager : NetworkManager
 
 		Logger.LogFormat("Client connecting to server {0}", Category.Connections, conn);
 		base.OnServerAddPlayer(conn);
+		SubSceneManager.Instance.AddNewObserverScenePermissions(conn);
 		UpdateRoundTimeMessage.Send(GameManager.Instance.stationTime.ToString("O"));
 	}
 

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.Server.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.Server.cs
@@ -114,6 +114,8 @@ public partial class SubSceneManager
 			SceneType = SceneType.AwaySite
 		});
 
+		netIdentity.isDirty = true;
+
 		yield return WaitFor.Seconds(0.1f);
 		UIManager.Display.preRoundWindow.CloseMapLoadingPanel();
 

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using Mirror;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -7,18 +8,7 @@ public partial class SubSceneManager : NetworkBehaviour
 {
 	private static SubSceneManager subSceneManager;
 
-	public static SubSceneManager Instance
-	{
-		get
-		{
-			if (subSceneManager == null)
-			{
-				subSceneManager = FindObjectOfType<SubSceneManager>();
-			}
-
-			return subSceneManager;
-		}
-	}
+	public static SubSceneManager Instance;
 
 	public AwayWorldListSO awayWorldList;
 	[SerializeField] private MainStationListSO mainStationList = null;
@@ -28,6 +18,18 @@ public partial class SubSceneManager : NetworkBehaviour
 
 	public bool AwaySiteLoaded { get; private set; }
 	public bool MainStationLoaded { get; private set; }
+
+	void Awake()
+	{
+		if (Instance == null)
+		{
+			Instance = this;
+		}
+		else
+		{
+			Destroy(gameObject);
+		}
+	}
 
 	void Update()
 	{
@@ -55,6 +57,7 @@ public partial class SubSceneManager : NetworkBehaviour
 		if (isServer)
 		{
 			NetworkServer.SpawnObjects();
+			yield return WaitFor.Seconds(0.1f);
 		}
 		else
 		{
@@ -62,6 +65,7 @@ public partial class SubSceneManager : NetworkBehaviour
 			yield return WaitFor.EndOfFrame;
 			RequestObserverRefresh.Send(sceneName);
 		}
+		yield return WaitFor.EndOfFrame;
 	}
 
 	public static void ProcessObserverRefreshReq(ConnectedPlayer connectedPlayer, Scene sceneContext)

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.cs
@@ -100,10 +100,28 @@ public enum SceneType
 }
 
 [System.Serializable]
-public struct SceneInfo
+public struct SceneInfo : IEquatable<SceneInfo>
 {
 	public string SceneName;
 	public SceneType SceneType;
+
+	public bool Equals(SceneInfo other)
+	{
+		return SceneName == other.SceneName && SceneType == other.SceneType;
+	}
+
+	public override bool Equals(object obj)
+	{
+		return obj is SceneInfo other && Equals(other);
+	}
+
+	public override int GetHashCode()
+	{
+		unchecked
+		{
+			return ((SceneName != null ? SceneName.GetHashCode() : 0) * 397) ^ (int) SceneType;
+		}
+	}
 }
 
 [System.Serializable]

--- a/UnityProject/Assets/Sounds/Ambient/-Sector11_MashedByMachines.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/-Sector11_MashedByMachines.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Bug Band Loop_Visager.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Bug Band Loop_Visager.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/CaveWaterAmbience.wav.meta
+++ b/UnityProject/Assets/Sounds/Ambient/CaveWaterAmbience.wav.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Clown Title_Admiral Hippie.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Clown Title_Admiral Hippie.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Clownman Redial_Onulle.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Clownman Redial_Onulle.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Comet Haley_Stellardrone.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Comet Haley_Stellardrone.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/DarkJungleAmbience.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/DarkJungleAmbience.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Endless Space_Solus.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Endless Space_Solus.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/FemurBreaking Horrible Scream.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/FemurBreaking Horrible Scream.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/FlipFlap_X-CEED.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/FlipFlap_X-CEED.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/GBC Robocop Title Theme_Cboyardee (Remix).ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/GBC Robocop Title Theme_Cboyardee (Remix).ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Journey of the Sorcerer_Admiral Hippie (Remix).mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Journey of the Sorcerer_Admiral Hippie (Remix).mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Marhaba_Ian Alex Mac.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Marhaba_Ian Alex Mac.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Miniboss Fight_Skidrow.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Miniboss Fight_Skidrow.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Music for manatees_Kevin MacLeod.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Music for manatees_Kevin MacLeod.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Shyguy SCP Scream.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Shyguy SCP Scream.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Silent Honk 2 Clon Ending_WanderingShow.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Silent Honk 2 Clon Ending_WanderingShow.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/SmallHeartbeat.wav.meta
+++ b/UnityProject/Assets/Sounds/Ambient/SmallHeartbeat.wav.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Space Asshole_Chris Remo.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Space Asshole_Chris Remo.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/The Challenge_Komiku.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/The Challenge_Komiku.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/The Settler_Chris Remo.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/The Settler_Chris Remo.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/The Wizard_Chris Remo.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/The Wizard_Chris Remo.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/TimCurrySPAACE.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/TimCurrySPAACE.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Tintin on the Moon_Admiral Hippie (Remix).ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Tintin on the Moon_Admiral Hippie (Remix).ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/Tintin on the Moon_Cuboos (Remix).ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/Tintin on the Moon_Cuboos (Remix).ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: 18e13ce0b3d9d45adb4b8024927c864f
-timeCreated: 1493801081
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Ambient/ambiatm1.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambiatm1.ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: 047b5149a61444d8cb605ef3eeb80e86
-timeCreated: 1500116145
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Ambient/ambicha2.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambicha2.ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: 6e671e0f7195e4cf7a0870fb1cb99726
-timeCreated: 1500116187
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Ambient/ambicha3.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambicha3.ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: de158abd8cf5d4ac18c2426a2628c9f8
-timeCreated: 1500116202
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Ambient/ambicha4.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambicha4.ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: eecaece8f9b8e42a49f8a045c95ce987
-timeCreated: 1500116215
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Ambient/ambigen14.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambigen14.ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: c2185574c7d54debb83dc0aaab7386aa
-timeCreated: 1478642044
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Ambient/ambigen8.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambigen8.ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: c9e3ed57f05fa44079d8c9ddecdea939
-timeCreated: 1500117825
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Ambient/ambilava.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambilava.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/ambimaint1.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambimaint1.ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: d15dedb5e80714f51a71f57dc8f4236d
-timeCreated: 1500117710
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Ambient/ambimaint2.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambimaint2.ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: 94bbd9f85a6ea4f7babdf3b70f8a1c71
-timeCreated: 1500117733
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Ambient/ambimaint3.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambimaint3.ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: c22b3802466ef43d7a550d8e3beb83e2
-timeCreated: 1500117749
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Ambient/ambimine.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambimine.ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: d9f773021a5634c4abfe072fae35f52e
-timeCreated: 1500117788
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Ambient/ambispace.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambispace.ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: 694a700a2c1f34736ab9a8203c8f3182
-timeCreated: 1500116317
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Ambient/ambispace2.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/ambispace2.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/another drone_the semen incident.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/another drone_the semen incident.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/h-o-n-k-e-r-s_Onulle.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/h-o-n-k-e-r-s_Onulle.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/honkman_Onulle.mp3.meta
+++ b/UnityProject/Assets/Sounds/Ambient/honkman_Onulle.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Ambient/shipambience.ogg.meta
+++ b/UnityProject/Assets/Sounds/Ambient/shipambience.ogg.meta
@@ -1,11 +1,10 @@
 fileFormatVersion: 2
 guid: 60c47d2a95fe456b8f3da5fa60e88b89
-timeCreated: 1478642166
-licenseType: Pro
 AudioImporter:
+  externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
@@ -16,6 +15,7 @@ AudioImporter:
   normalize: 1
   preloadAudioData: 1
   loadInBackground: 0
+  ambisonic: 0
   3D: 1
   userData: 
   assetBundleName: 

--- a/UnityProject/Assets/Sounds/Effects/hyperspace_begin.ogg.meta
+++ b/UnityProject/Assets/Sounds/Effects/hyperspace_begin.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Effects/hyperspace_end.ogg.meta
+++ b/UnityProject/Assets/Sounds/Effects/hyperspace_end.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/UnityProject/Assets/Sounds/Effects/hyperspace_progress.ogg.meta
+++ b/UnityProject/Assets/Sounds/Effects/hyperspace_progress.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1


### PR DESCRIPTION
- Creates a dedicated dictionary on NetworkServer that lists what scenes the NetworkConnection is allowed to observe. This is then used by OnRebuildObservers and OnCheckObserver methods on NetworkBehaviour

- Ensures the scene list is properly synced

- Sets all music to streaming to save mem usage

Fixes more stuff in #4184 
