### PR TITLE
Prevents random loot from doing an occasional infinite loop

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
@@ -51,6 +51,11 @@ namespace Items
 					}
 				}
 
+				if (pool == null)
+				{
+					return;
+				}
+
 				SpawnItems(pool);
 			}
 

--- a/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
@@ -37,7 +37,7 @@ namespace Items
 
 					if (rollAttempt >= MaxAmountRolls)
 					{
-						continue;
+						break;
 					}
 
 					var tryPool = poolList.PickRandom();


### PR DESCRIPTION
Hot fix for a very stupid error that could end with an infinite loop on every round start.

This implementation will be dropped eventually for a real weighted random selection, once I find a good approach.