### PR TITLE
Add line gizmos from fire alarm to firelock and vice versa.

### DIFF
--- a/UnityProject/Assets/Scripts/Doors/FireLock.cs
+++ b/UnityProject/Assets/Scripts/Doors/FireLock.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.Events;
 
 public class FireLock : InteractableDoor
@@ -44,6 +44,16 @@ public class FireLock : InteractableDoor
 		metaNode = metaDataLayer.Get(registerTile.LocalPositionServer, false);
 		Controller.ServerOpen();
 	}
-
-
+	
+	//Copied over from LightSource.cs
+	void OnDrawGizmosSelected()
+	{
+		var sprite = GetComponentInChildren<SpriteRenderer>();
+		if (sprite == null)
+			return;
+		//Highlight associated fireAlarm.
+		Gizmos.color = new Color(1, 0.5f, 0, 1);
+		Gizmos.DrawLine(fireAlarm.transform.position, gameObject.transform.position);
+		Gizmos.DrawSphere(fireAlarm.transform.position, 0.25f);
+	}
 }

--- a/UnityProject/Assets/Scripts/Objects/FireAlarm.cs
+++ b/UnityProject/Assets/Scripts/Objects/FireAlarm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Mirror;
@@ -79,6 +79,24 @@ public class FireAlarm : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		else
 		{
 			SendCloseAlerts();
+		}
+	}
+	
+	//Copied over from LightSwitchV2.cs
+	void OnDrawGizmosSelected()
+	{
+		var sprite = GetComponentInChildren<SpriteRenderer>();
+		if (sprite == null)
+			return;
+
+		//Highlighting all controlled FireLocks
+		Gizmos.color = new Color(1, 0.5f, 0, 1);
+		for (int i = 0; i < FireLockList.Count; i++)
+		{
+			var FireLock = FireLockList[i];
+			if(FireLock == null) continue;
+			Gizmos.DrawLine(sprite.transform.position, FireLock.transform.position);
+			Gizmos.DrawSphere(FireLock.transform.position, 0.25f);
 		}
 	}
 


### PR DESCRIPTION
### Purpose
This PR makes it so that while gizmos are enabled, selecting a fire alarm will make lines appear from said alarm to whatever firelocks the alarm controls, and so that selecting a firelock makes a line appear from said firelock to the fire alarm that controls it.

That's it, really.

### Notes:
Gizmo code was taken from LightSource.cs and LightSwitchV2.cs, as is noted in the code comments.
