### PR TITLE
Temporarily buff window tile fire armor from 80 to 99.

### DIFF
--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced.asset
@@ -36,7 +36,7 @@ MonoBehaviour:
     Energy: 0
     Bomb: 25
     Rad: 100
-    Fire: 80
+    Fire: 99
     Acid: 100
     Magic: 0
     Bio: 100

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced_Unsecuring_Step_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced_Unsecuring_Step_1.asset
@@ -35,7 +35,7 @@ MonoBehaviour:
     Energy: 0
     Bomb: 25
     Rad: 100
-    Fire: 80
+    Fire: 99
     Acid: 100
     Magic: 0
     Bio: 100

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced_Unsecuring_Step_2.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Reinforced Window/WindowReinforced_Unsecuring_Step_2.asset
@@ -35,7 +35,7 @@ MonoBehaviour:
     Energy: 0
     Bomb: 25
     Rad: 100
-    Fire: 80
+    Fire: 99
     Acid: 100
     Magic: 0
     Bio: 100

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Window.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/Window.asset
@@ -36,7 +36,7 @@ MonoBehaviour:
     Energy: 0
     Bomb: 0
     Rad: 0
-    Fire: 80
+    Fire: 99
     Acid: 100
     Magic: 0
     Bio: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowPlastitanium.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowPlastitanium.asset
@@ -35,7 +35,7 @@ MonoBehaviour:
     Energy: 0
     Bomb: 50
     Rad: 100
-    Fire: 80
+    Fire: 99
     Acid: 100
     Magic: 0
     Bio: 100

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowPod.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowPod.asset
@@ -35,7 +35,7 @@ MonoBehaviour:
     Energy: 0
     Bomb: 50
     Rad: 100
-    Fire: 80
+    Fire: 99
     Acid: 100
     Magic: 0
     Bio: 100

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowShuttle.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowShuttle.asset
@@ -35,7 +35,7 @@ MonoBehaviour:
     Energy: 0
     Bomb: 50
     Rad: 100
-    Fire: 80
+    Fire: 99
     Acid: 100
     Magic: 0
     Bio: 100

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowTinted.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Windows/WindowTinted.asset
@@ -35,7 +35,7 @@ MonoBehaviour:
     Energy: 0
     Bomb: 25
     Rad: 100
-    Fire: 80
+    Fire: 99
     Acid: 100
     Magic: 0
     Bio: 100


### PR DESCRIPTION
### Purpose
As stated in the title, this PR tweaks window tile fire armor from 80 to 99 so that fire doesn't chew through them immediately but so that windows can still break after enough time. 

This is meant to be temporary and should be reverted should anyone make fires more sane when it come to damaging tiles such as windows.