### PR TITLE
Fire now does fire attacks on people, fixed by Gilles/corp-0.

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -438,7 +438,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 				if (fireStacks > 0)
 				{
 					//TODO: Burn clothes (see species.dm handle_fire)
-					ApplyDamageToBodypart(null, fireStacks * DAMAGE_PER_FIRE_STACK, AttackType.Internal, DamageType.Burn);
+					ApplyDamageToBodypart(null, fireStacks * DAMAGE_PER_FIRE_STACK, AttackType.Fire, DamageType.Burn);
 					//gradually deplete fire stacks
 					SyncFireStacks(fireStacks, fireStacks-0.1f);
 					//instantly stop burning if there's no oxygen at this location


### PR DESCRIPTION
### Purpose
This PR makes it so fire now does fire attacks on people instead of internal attacks. This makes it so that fire resistances on clothing actually reduce the amount of damage done by fire. This means firesuits are actually useful now, and other stuff.

**Fixed by Gilles/corp-0 on Discord, He just told me to PR his fix since he's doing something important.**

### Notes
You will still get notifications that the area is too hot while wearing fire-resistant/proofed armor, but you won't take any damage from the heat it would appear.