### PR TITLE
Adjust spawning of high-capacity batteries in maintenance loot table.

### DIFF
--- a/UnityProject/Assets/Scripts/RandomItemPools/UncommonConstructionNCrafting.asset
+++ b/UnityProject/Assets/Scripts/RandomItemPools/UncommonConstructionNCrafting.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   pool:
   - prefab: {fileID: 229541522769283845, guid: b7b563c4ee7c20e459dbe3a9511a244d, type: 3}
-    maxAmount: 50
+    maxAmount: 1
     probability: 100
   - prefab: {fileID: 6254655335276451647, guid: 7543d187ee101c148ab143a796d9d175,
       type: 3}


### PR DESCRIPTION

### Purpose
This PR just changes a maint. loot table to only spawn one high-capacity battery instead of up to fifty. That is all.