### PR TITLE
Let mappers place items in exact positions

### DIFF
--- a/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Transform/CustomNetTransform.cs
@@ -8,6 +8,9 @@ using Mirror;
 
 public partial class CustomNetTransform : ManagedNetworkBehaviour, IPushable //see UpdateManager
 {
+	[SerializeField][Tooltip("When the scene loads, snap this to the middle of the nearest tile?")]
+	private bool snapToGridOnStart = true;
+
 	//I think this is valid server side only
 	public bool VisibleState {
 		get => ServerPosition != TransformState.HiddenPos;
@@ -221,9 +224,17 @@ public partial class CustomNetTransform : ManagedNetworkBehaviour, IPushable //s
 			{
 				serverState.MatrixId = matrixInfo.Id;
 			}
-			serverState.Position = ((Vector2)transform.localPosition).RoundToInt();
 
-		} else
+			if (snapToGridOnStart)
+			{
+				serverState.Position = ((Vector2)transform.localPosition).RoundToInt();
+			}
+			else
+			{
+				serverState.Position = ((Vector2)transform.localPosition);
+			}
+		}
+		else
 		{
 			serverState.MatrixId = 0;
 			Logger.LogWarning( $"{gameObject.name}: unable to detect MatrixId!", Category.Transform );


### PR DESCRIPTION
### Purpose
Mappers want to do this
![image](https://user-images.githubusercontent.com/7896673/82622849-b29a8880-9bd6-11ea-954e-ce384253b93d.png)

But currently everything snaps to the middle of a tile at runtime.
So I've added this (it's turned ON for everything by default)
![image](https://user-images.githubusercontent.com/7896673/82621742-e32cf300-9bd3-11ea-92f1-161223e87fb4.png)

Now they can uncheck that on stuff with a CustomNetTransform to make sure it stays where they put it.
![image](https://user-images.githubusercontent.com/7896673/82622328-64d15080-9bd5-11ea-8378-cf43799bb3f9.png)

### Notes
Maintaining object sorting order (see the gloves/multitool/vest) is a different issue that will also need fixing elsewhere.

- [x] The PR has been tested in editor
- [x] The PR has been tested in multiplayer (with 2 clients and late joiners)
- [x] The PR has been tested with round restarts.
- [x] The PR has been tested on a headless server.