### PR TITLE
Adding VSync options, update Options > Display

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/OptionsScreen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/OptionsScreen.prefab
@@ -771,7 +771,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -1.1099854, y: 4}
+  m_AnchoredPosition: {x: -1.1100159, y: 4}
   m_SizeDelta: {x: -197.65, y: 9.31}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3462330387591934867
@@ -844,7 +844,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -1.1099854, y: 4}
+  m_AnchoredPosition: {x: -1.1100159, y: 4}
   m_SizeDelta: {x: -197.65, y: 9.31}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2900600260597586642
@@ -1085,7 +1085,7 @@ RectTransform:
   - {fileID: 3273743420036181321}
   - {fileID: 8752297092432229972}
   m_Father: {fileID: 3595721449099993707}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1311,7 +1311,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -1436,7 +1436,7 @@ MonoBehaviour:
   m_MinValue: 0
   m_MaxValue: 0.25
   m_WholeNumbers: 0
-  m_Value: 1
+  m_Value: 0.25
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
@@ -1483,8 +1483,8 @@ RectTransform:
   m_Father: {fileID: 5331829392932256059}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 25, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -2442,6 +2442,81 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 'Fullscreen:'
+--- !u!1 &2615935905549909511
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 286697803962321592}
+  - component: {fileID: 8238620192420278497}
+  - component: {fileID: 8056414509009973188}
+  m_Layer: 5
+  m_Name: VSyncOption
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &286697803962321592
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2615935905549909511}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4759988053697032672}
+  - {fileID: 3961673489242558473}
+  m_Father: {fileID: 3595721449099993707}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8238620192420278497
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2615935905549909511}
+  m_CullTransparentMesh: 0
+--- !u!114 &8056414509009973188
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2615935905549909511}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.047058824}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2640249913619690146
 GameObject:
   m_ObjectHideFlags: 0
@@ -2478,7 +2553,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 715.77563, y: -384.1}
+  m_AnchoredPosition: {x: 715.77563, y: -386.12}
   m_SizeDelta: {x: 1431.5513, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4412926872037913403
@@ -2624,7 +2699,7 @@ RectTransform:
   - {fileID: 514559961916263796}
   - {fileID: 95570329513330584}
   m_Father: {fileID: 3595721449099993707}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2667,6 +2742,101 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3010809378314577650
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3961673489242558473}
+  - component: {fileID: 2242489747033056492}
+  m_Layer: 5
+  m_Name: Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3961673489242558473
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3010809378314577650}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6763061957159505239}
+  m_Father: {fileID: 286697803962321592}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5186986, y: 0.5}
+  m_AnchorMax: {x: 0.5186986, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -1.5074997}
+  m_SizeDelta: {x: 73.099976, y: 103}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2242489747033056492
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3010809378314577650}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5594219003606158749}
+  toggleTransition: 1
+  graphic: {fileID: 7749541345639191912}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4451116723230981298}
+        m_MethodName: OnVSyncToggle
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_IsOn: 1
 --- !u!1 &3083764650293778119
 GameObject:
   m_ObjectHideFlags: 0
@@ -3822,7 +3992,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -1.1099854, y: 4}
+  m_AnchoredPosition: {x: -1.1100159, y: 4}
   m_SizeDelta: {x: -197.65, y: 9.31}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4387267932823696763
@@ -3926,6 +4096,79 @@ MonoBehaviour:
       m_Calls: []
   m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
   m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4182604371085188169
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 448479671787005725}
+  - component: {fileID: 4895549845872379270}
+  - component: {fileID: 7749541345639191912}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &448479671787005725
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4182604371085188169}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6763061957159505239}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 30, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4895549845872379270
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4182604371085188169}
+  m_CullTransparentMesh: 0
+--- !u!114 &7749541345639191912
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4182604371085188169}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -4047,6 +4290,80 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 'Enable TTS:'
+--- !u!1 &4234669143815524131
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 998566937618842298}
+  - component: {fileID: 5722795410035240259}
+  - component: {fileID: 1557925231629852488}
+  m_Layer: 5
+  m_Name: VSyncWarning
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &998566937618842298
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4234669143815524131}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7701266124806256311}
+  m_Father: {fileID: 4476980803948650820}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 450, y: 50}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &5722795410035240259
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4234669143815524131}
+  m_CullTransparentMesh: 0
+--- !u!114 &1557925231629852488
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4234669143815524131}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.18245713, g: 0.19422856, b: 0.206, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4259822511952664219
 GameObject:
   m_ObjectHideFlags: 0
@@ -4079,8 +4396,8 @@ RectTransform:
   m_Father: {fileID: 7211730819058528063}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 25, y: -6}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -4380,11 +4697,11 @@ RectTransform:
   m_Father: {fileID: 1027084540189667700}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 25}
-  m_SizeDelta: {x: 0, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 50}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &8907790362344334631
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -5727,7 +6044,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -25}
+  m_AnchoredPosition: {x: 0, y: -24.999939}
   m_SizeDelta: {x: 0, y: -50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4663901235587051492
@@ -10196,7 +10513,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 3595721449099993707}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -10535,6 +10852,80 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6002666334109430146
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6763061957159505239}
+  - component: {fileID: 3677762709186001840}
+  - component: {fileID: 5594219003606158749}
+  m_Layer: 5
+  m_Name: InputBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6763061957159505239
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6002666334109430146}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.6854, y: 1.6854, z: 1.6854}
+  m_Children:
+  - {fileID: 448479671787005725}
+  m_Father: {fileID: 3961673489242558473}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -2, y: -0.00005722046}
+  m_SizeDelta: {x: 29.47998, y: 30.009995}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3677762709186001840
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6002666334109430146}
+  m_CullTransparentMesh: 0
+--- !u!114 &5594219003606158749
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6002666334109430146}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6067288764280770474
 GameObject:
   m_ObjectHideFlags: 0
@@ -10759,7 +11150,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -1.1099854, y: 4}
+  m_AnchoredPosition: {x: -1.1100159, y: 4}
   m_SizeDelta: {x: -197.65, y: 9.31}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8932357421984287414
@@ -10850,6 +11241,8 @@ MonoBehaviour:
   camZoomSlider: {fileID: 409163354096696072}
   scrollWheelZoomToggle: {fileID: 7401857623655751299}
   fullscreenToggle: {fileID: 5829766539079802346}
+  vSyncToggle: {fileID: 2242489747033056492}
+  vSyncWarning: {fileID: 4234669143815524131}
   frameRateTarget: {fileID: 4837674139496565793}
   chatBubbleSizeSlider: {fileID: 411084898738235156}
 --- !u!1 &6487944468741698383
@@ -10882,9 +11275,9 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 7433229492364204327}
-  - {fileID: 1027084540189667700}
+  - {fileID: 4476980803948650820}
   m_Father: {fileID: 3595721449099993707}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -11033,7 +11426,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -11315,6 +11708,69 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 99
+--- !u!1 &7547866002739229094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4476980803948650820}
+  - component: {fileID: 2771870620210193677}
+  m_Layer: 5
+  m_Name: Column2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4476980803948650820
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7547866002739229094}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1027084540189667700}
+  - {fileID: 998566937618842298}
+  m_Father: {fileID: 820807471610232660}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5186986, y: 0.5}
+  m_AnchorMax: {x: 0.5186986, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 73.099976, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2771870620210193677
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7547866002739229094}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 3
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
 --- !u!1 &7597910633178645888
 GameObject:
   m_ObjectHideFlags: 0
@@ -11410,6 +11866,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1593444944378468095}
+  - {fileID: 286697803962321592}
   - {fileID: 820807471610232660}
   - {fileID: 2251755938848169531}
   - {fileID: 4047231476509723958}
@@ -11448,6 +11905,83 @@ MonoBehaviour:
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
+--- !u!1 &7659464461173400081
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7701266124806256311}
+  - component: {fileID: 8952897636208171467}
+  - component: {fileID: 6751773666432232879}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7701266124806256311
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7659464461173400081}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 998566937618842298}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 450, y: 50}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &8952897636208171467
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7659464461173400081}
+  m_CullTransparentMesh: 0
+--- !u!114 &6751773666432232879
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7659464461173400081}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 0
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Not used with VSync on
 --- !u!1 &7746255338493639719
 GameObject:
   m_ObjectHideFlags: 0
@@ -11770,14 +12304,14 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 7838154960984482773}
-  m_Father: {fileID: 820807471610232660}
-  m_RootOrder: 1
+  m_Father: {fileID: 4476980803948650820}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 39, y: -40}
-  m_SizeDelta: {x: -1352.1, y: 80}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 50}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!1 &7887665672523097766
 GameObject:
   m_ObjectHideFlags: 0
@@ -12050,6 +12584,83 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8498399226186449526
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759988053697032672}
+  - component: {fileID: 2718180133744235357}
+  - component: {fileID: 3430667953576731569}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4759988053697032672
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8498399226186449526}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 286697803962321592}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.36560294, y: 1}
+  m_AnchoredPosition: {x: 28.25, y: 0.000030517578}
+  m_SizeDelta: {x: -55.899994, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2718180133744235357
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8498399226186449526}
+  m_CullTransparentMesh: 0
+--- !u!114 &3430667953576731569
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8498399226186449526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 0
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'VSync:'
 --- !u!1 &8557095183729252310
 GameObject:
   m_ObjectHideFlags: 0
@@ -12546,7 +13157,7 @@ RectTransform:
   - {fileID: 739238702041732506}
   - {fileID: 7391383987517615212}
   m_Father: {fileID: 3595721449099993707}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}

--- a/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/OptionsScreen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/OptionsScreen.prefab
@@ -11238,12 +11238,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6f3b5e426cb7ce444bf260a747524d36, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  camZoomSlider: {fileID: 409163354096696072}
-  scrollWheelZoomToggle: {fileID: 7401857623655751299}
   fullscreenToggle: {fileID: 5829766539079802346}
   vSyncToggle: {fileID: 2242489747033056492}
   vSyncWarning: {fileID: 4234669143815524131}
   frameRateTarget: {fileID: 4837674139496565793}
+  camZoomSlider: {fileID: 409163354096696072}
+  scrollWheelZoomToggle: {fileID: 7401857623655751299}
   chatBubbleSizeSlider: {fileID: 411084898738235156}
 --- !u!1 &6487944468741698383
 GameObject:
@@ -12187,6 +12187,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   screen: {fileID: 7597910633178645888}
+  displayOptions: {fileID: 4451116723230981298}
 --- !u!114 &3825634513002827830
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/PlayerPrefs/PlayerPrefKeys.cs
+++ b/UnityProject/Assets/Scripts/PlayerPrefs/PlayerPrefKeys.cs
@@ -66,4 +66,11 @@
 	/// Sets the normal chat bubble size preference
 	/// </summary>
 	public static string ChatBubbleSize = "ChatBubbleSize";
+
+	/// <summary>
+	/// VSync preference.
+	/// 0 = disabled
+	/// 1 = enabled, every VBlank
+	/// <summary>
+	public static string EnableVSync = "EnableVSync";
 }

--- a/UnityProject/Assets/Scripts/UI/CameraZoomHandler.cs
+++ b/UnityProject/Assets/Scripts/UI/CameraZoomHandler.cs
@@ -5,28 +5,43 @@ using UnityEngine.U2D;
 
 public class CameraZoomHandler : MonoBehaviour
 {
-    private int zoomLevel = 24;
-    public float ZoomLevel => zoomLevel;
-    private bool scrollWheelzoom = false;
-    public bool ScrollWheelZoom => scrollWheelzoom;
+	public float ZoomLevel => zoomLevel;
+	private int zoomLevel = DEFAULT_ZOOMLEVEL;
+	private const int DEFAULT_ZOOMLEVEL = 24;
+	
+	public bool ScrollWheelZoom => scrollWheelzoom;
+	private bool scrollWheelzoom = DEFAULT_SCROLLWHEELZOOM;
+	private const bool DEFAULT_SCROLLWHEELZOOM = true;
+
     private PixelPerfectCamera pixelPerfectCamera;
 
-    void Start()
-    {
-	    pixelPerfectCamera = Camera.main.GetComponent<PixelPerfectCamera>();
-        if (PlayerPrefs.HasKey(PlayerPrefKeys.CamZoomKey))
-        {
-            zoomLevel = PlayerPrefs.GetInt(PlayerPrefKeys.CamZoomKey);
-            scrollWheelzoom = PlayerPrefs.GetInt(PlayerPrefKeys.ScrollWheelZoom) == 1;
-        }
-        else
-        {
-            zoomLevel = 24;
-            PlayerPrefs.SetInt(PlayerPrefKeys.CamZoomKey, 24);
-            PlayerPrefs.SetInt(PlayerPrefKeys.ScrollWheelZoom, 1);
-            PlayerPrefs.Save();
-        }
+	void Awake()
+	{
+		pixelPerfectCamera = Camera.main.GetComponent<PixelPerfectCamera>();
 
+		if (PlayerPrefs.HasKey(PlayerPrefKeys.CamZoomKey))
+		{
+			zoomLevel = PlayerPrefs.GetInt(PlayerPrefKeys.CamZoomKey);
+		}
+		else
+		{
+			PlayerPrefs.SetInt(PlayerPrefKeys.CamZoomKey, DEFAULT_ZOOMLEVEL);
+			PlayerPrefs.Save();
+		}
+
+		if (PlayerPrefs.HasKey(PlayerPrefKeys.ScrollWheelZoom))
+		{
+			scrollWheelzoom = PlayerPrefs.GetInt(PlayerPrefKeys.ScrollWheelZoom) == 1;
+		}
+		else
+		{
+			PlayerPrefs.SetInt(PlayerPrefKeys.ScrollWheelZoom, DEFAULT_SCROLLWHEELZOOM ? 1 : 0);
+			PlayerPrefs.Save();
+		}
+	}
+
+	void Start()
+    {
         Refresh();
     }
 
@@ -109,23 +124,16 @@ public class CameraZoomHandler : MonoBehaviour
         SetZoomLevel(zoomLevel);
     }
 
-    public void ToggleScrollWheelZoom(bool activeState)
+    public void SetScrollWheelZoom(bool activeState)
     {
         scrollWheelzoom = activeState;
-        if (activeState)
-        {
-            PlayerPrefs.SetInt(PlayerPrefKeys.ScrollWheelZoom, 1);
-        }
-        else
-        {
-            PlayerPrefs.SetInt(PlayerPrefKeys.ScrollWheelZoom, 0);
-        }
+		PlayerPrefs.SetInt(PlayerPrefKeys.ScrollWheelZoom, activeState ? 1 : 0);
         PlayerPrefs.Save();
     }
 
     public void ResetDefaults()
     {
-        ToggleScrollWheelZoom(false);
-        SetZoomLevel(24);
+        SetScrollWheelZoom(DEFAULT_SCROLLWHEELZOOM);
+        SetZoomLevel(DEFAULT_ZOOMLEVEL);
     }
 }

--- a/UnityProject/Assets/Scripts/UI/OptionsMenu/DisplayOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/OptionsMenu/DisplayOptions.cs
@@ -5,64 +5,79 @@ using UnityEngine.UI;
 
 namespace Unitystation.Options
 {
-    /// <summary>
-    /// Controller for the display options view
-    /// <summary>
-    public class DisplayOptions : MonoBehaviour
-    {
-        [SerializeField]
-        private Slider camZoomSlider = null;
-        [SerializeField]
-        private Toggle scrollWheelZoomToggle = null;
+	/// <summary>
+	/// Controller for the display options view
+	/// <summary>
+	public class DisplayOptions : MonoBehaviour
+	{
+		[SerializeField]
+		private Slider camZoomSlider = null;
+		[SerializeField]
+		private Toggle scrollWheelZoomToggle = null;
 		[SerializeField]
 		private Toggle fullscreenToggle = null;
+		[SerializeField]
+		private Toggle vSyncToggle = null;
+		[SerializeField]
+		private GameObject vSyncWarning = null;
+
 		private CameraZoomHandler zoomHandler;
 		[SerializeField] private InputField frameRateTarget = null;
 		[SerializeField]
 		private Slider chatBubbleSizeSlider = null;
 
-        void OnEnable()
-        {
-            if (zoomHandler == null)
-            {
-                zoomHandler = FindObjectOfType<CameraZoomHandler>();
-            }
+		void OnEnable()
+		{
+			if (zoomHandler == null)
+			{
+				zoomHandler = FindObjectOfType<CameraZoomHandler>();
+			}
 
-            Refresh();
-        }
+			Refresh();
+		}
 
-        void Refresh()
-        {
-	        if (!PlayerPrefs.HasKey(PlayerPrefKeys.ChatBubbleSize))
-	        {
-		        PlayerPrefs.SetFloat(PlayerPrefKeys.ChatBubbleSize, 2f);
-		        PlayerPrefs.Save();
-	        }
+		void Refresh()
+		{
+			if (!PlayerPrefs.HasKey(PlayerPrefKeys.ChatBubbleSize))
+			{
+				PlayerPrefs.SetFloat(PlayerPrefKeys.ChatBubbleSize, 2f);
+				PlayerPrefs.Save();
+			}
+			if (!PlayerPrefs.HasKey(PlayerPrefKeys.EnableVSync))
+			{
+				PlayerPrefs.SetInt(PlayerPrefKeys.EnableVSync, 1);
+				PlayerPrefs.Save();
+			}
 
-	        chatBubbleSizeSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.ChatBubbleSize);
-	        camZoomSlider.value = zoomHandler.ZoomLevel / 8;
-            scrollWheelZoomToggle.isOn = zoomHandler.ScrollWheelZoom;
-            frameRateTarget.text = PlayerPrefs.GetInt(PlayerPrefKeys.TargetFrameRate).ToString();
-        }
+			int vSync = PlayerPrefs.GetInt(PlayerPrefKeys.EnableVSync);
+			vSyncToggle.isOn = vSync != 0;
+			vSyncWarning.SetActive(vSyncToggle.isOn);
+			QualitySettings.vSyncCount = vSync;
 
-        public void OnZoomLevelChange()
-        {
-	        zoomHandler.SetZoomLevel((int)camZoomSlider.value * 8);
-            Refresh();
-        }
+			chatBubbleSizeSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.ChatBubbleSize);
+			camZoomSlider.value = zoomHandler.ZoomLevel / 8;
+			scrollWheelZoomToggle.isOn = zoomHandler.ScrollWheelZoom;
+			frameRateTarget.text = PlayerPrefs.GetInt(PlayerPrefKeys.TargetFrameRate).ToString();
+		}
 
-        public void OnChatBubbleSizeChange()
-        {
+		public void OnZoomLevelChange()
+		{
+			zoomHandler.SetZoomLevel((int)camZoomSlider.value * 8);
+			Refresh();
+		}
+
+		public void OnChatBubbleSizeChange()
+		{
 			PlayerPrefs.SetFloat(PlayerPrefKeys.ChatBubbleSize, chatBubbleSizeSlider.value);
 			PlayerPrefs.Save();
-	        Refresh();
-        }
+			Refresh();
+		}
 
-        public void OnScrollWheelToggle()
-        {
-            zoomHandler.ToggleScrollWheelZoom(scrollWheelZoomToggle.isOn);
-            Refresh();
-        }
+		public void OnScrollWheelToggle()
+		{
+			zoomHandler.ToggleScrollWheelZoom(scrollWheelZoomToggle.isOn);
+			Refresh();
+		}
 
 		/// <summary>
 		/// Toggles fullscreen. Fullscreen uses native resolution, windowed always uses 720p.
@@ -70,32 +85,43 @@ namespace Unitystation.Options
 		public void OnFullscreenToggle()
 		{
 			int hRes = Screen.fullScreen ? 1280 : Display.main.systemWidth;
-			int vRes = Screen.fullScreen ? 720  : Display.main.systemHeight;
+			int vRes = Screen.fullScreen ? 720 : Display.main.systemHeight;
 			fullscreenToggle.isOn = !Screen.fullScreen; //This can't go into Refresh() because going fullscreen happens 1 too late
 			Screen.SetResolution(hRes, vRes, !Screen.fullScreen);
-
 		}
 
-        public void ResetDefaults()
-        {
-            ModalPanelManager.Instance.Confirm(
-                "Are you sure?",
-                () =>
-                {
-                    zoomHandler.ResetDefaults();
-                    Refresh();
-                },
-                "Reset"
-            );
-        }
+		/// <summary>
+		/// Toggles Vsync. Off or Every VBlank.
+		/// </summary>
+		public void OnVSyncToggle()
+		{
+			int vSync = vSyncToggle.isOn ? 1 : 0;
+			vSyncWarning.SetActive(vSyncToggle.isOn);
+			QualitySettings.vSyncCount = vSync;
+			PlayerPrefs.SetInt(PlayerPrefKeys.EnableVSync, vSync);
+			PlayerPrefs.Save();
+		}
 
-        public void OnFrameRateTargetEdit()
-        {
-	        int newTarget = 99;
-	        int.TryParse(frameRateTarget.text, out newTarget);
+		public void ResetDefaults()
+		{
+			ModalPanelManager.Instance.Confirm(
+				"Are you sure?",
+				() =>
+				{
+					zoomHandler.ResetDefaults();
+					Refresh();
+				},
+				"Reset"
+			);
+		}
+
+		public void OnFrameRateTargetEdit()
+		{
+			int newTarget = 99;
+			int.TryParse(frameRateTarget.text, out newTarget);
 			PlayerPrefs.SetInt(PlayerPrefKeys.TargetFrameRate, newTarget);
 			PlayerPrefs.Save();
 			Application.targetFrameRate = Mathf.Clamp(newTarget, 30, 144);
-        }
-    }
+		}
+	}
 }

--- a/UnityProject/Assets/Scripts/UI/OptionsMenu/DisplayOptions.cs
+++ b/UnityProject/Assets/Scripts/UI/OptionsMenu/DisplayOptions.cs
@@ -10,98 +10,117 @@ namespace Unitystation.Options
 	/// <summary>
 	public class DisplayOptions : MonoBehaviour
 	{
-		[SerializeField]
-		private Slider camZoomSlider = null;
-		[SerializeField]
-		private Toggle scrollWheelZoomToggle = null;
-		[SerializeField]
-		private Toggle fullscreenToggle = null;
-		[SerializeField]
-		private Toggle vSyncToggle = null;
-		[SerializeField]
-		private GameObject vSyncWarning = null;
+		private Color VALIDCOLOR = Color.white;
+		private Color INVALIDCOLOR = Color.red;
 
-		private CameraZoomHandler zoomHandler;
+		private const int DEFAULT_WINDOWWIDTH = 1280;
+		private const int DEFAULT_WINDOWHEIGHT = 720;
+
+		[SerializeField] private Toggle fullscreenToggle = null;
+
+		[SerializeField] private Toggle vSyncToggle = null;
+		[SerializeField] private GameObject vSyncWarning = null;
+		private const int DEFAULT_VSYNCENABLED = 1;
+
 		[SerializeField] private InputField frameRateTarget = null;
-		[SerializeField]
-		private Slider chatBubbleSizeSlider = null;
+		private const int DEFAULT_TARGETFRAMERATE = 99;
+		private const int MIN_TARGETFRAMERATE = 30;
+		private const int MAX_TARGETFRAMERATE = 144;
+
+		[SerializeField] private Slider camZoomSlider = null;
+		private CameraZoomHandler zoomHandler;
+
+		[SerializeField] private Toggle scrollWheelZoomToggle = null;
+
+		[SerializeField] private Slider chatBubbleSizeSlider = null;
+		private const float DEFAULT_CHATBUBBLESIZE = 2f;
 
 		void OnEnable()
 		{
-			if (zoomHandler == null)
-			{
-				zoomHandler = FindObjectOfType<CameraZoomHandler>();
-			}
-
-			Refresh();
+			RefreshForm();
 		}
 
-		void Refresh()
+		private void Awake()
 		{
-			if (!PlayerPrefs.HasKey(PlayerPrefKeys.ChatBubbleSize))
+			InitSettings();
+		}
+
+		private bool init = false;
+		/// <summary>
+		/// Set up this object, load and set up Display related PlayerPrefs,
+		/// then apply the settings to the current session
+		/// </summary>
+		public void InitSettings()
+		{
+			if (!init)
 			{
-				PlayerPrefs.SetFloat(PlayerPrefKeys.ChatBubbleSize, 2f);
-				PlayerPrefs.Save();
+				init = true;
+				if (zoomHandler == null)
+				{
+					zoomHandler = FindObjectOfType<CameraZoomHandler>();
+				}
+
+				SetupPrefs();
 			}
+		}
+
+		/// <summary>
+		/// Load and set up Display related PlayerPrefs,
+		/// then apply the settings to the current session
+		/// </summary>
+		void SetupPrefs()
+		{
 			if (!PlayerPrefs.HasKey(PlayerPrefKeys.EnableVSync))
 			{
-				PlayerPrefs.SetInt(PlayerPrefKeys.EnableVSync, 1);
-				PlayerPrefs.Save();
+				SetPrefDefaults(PlayerPrefKeys.EnableVSync);
 			}
+			else
+			{
+				ApplyEnableVSync();
+			}
+
+			if (!PlayerPrefs.HasKey(PlayerPrefKeys.TargetFrameRate))
+			{
+				SetPrefDefaults(PlayerPrefKeys.TargetFrameRate);
+			}
+			else
+			{
+				ApplyTargetFrameRate();
+			}
+
+			if (!PlayerPrefs.HasKey(PlayerPrefKeys.ChatBubbleSize))
+			{
+				SetPrefDefaults(PlayerPrefKeys.ChatBubbleSize);
+			}
+			// else Apply not required, just setting the pref is enough
+
+			RefreshForm();
+		}
+
+		/// <summary>
+		/// Update the form to match currently used values
+		/// </summary>
+		void RefreshForm()
+		{
+			fullscreenToggle.isOn = Screen.fullScreen;
 
 			int vSync = PlayerPrefs.GetInt(PlayerPrefKeys.EnableVSync);
 			vSyncToggle.isOn = vSync != 0;
 			vSyncWarning.SetActive(vSyncToggle.isOn);
-			QualitySettings.vSyncCount = vSync;
+
+			frameRateTarget.text = PlayerPrefs.GetInt(PlayerPrefKeys.TargetFrameRate).ToString();
+			frameRateTarget.textComponent.color = VALIDCOLOR;
+
+			camZoomSlider.value = zoomHandler.ZoomLevel / 8;
+
+			scrollWheelZoomToggle.isOn = zoomHandler.ScrollWheelZoom;
 
 			chatBubbleSizeSlider.value = PlayerPrefs.GetFloat(PlayerPrefKeys.ChatBubbleSize);
-			camZoomSlider.value = zoomHandler.ZoomLevel / 8;
-			scrollWheelZoomToggle.isOn = zoomHandler.ScrollWheelZoom;
-			frameRateTarget.text = PlayerPrefs.GetInt(PlayerPrefKeys.TargetFrameRate).ToString();
-		}
-
-		public void OnZoomLevelChange()
-		{
-			zoomHandler.SetZoomLevel((int)camZoomSlider.value * 8);
-			Refresh();
-		}
-
-		public void OnChatBubbleSizeChange()
-		{
-			PlayerPrefs.SetFloat(PlayerPrefKeys.ChatBubbleSize, chatBubbleSizeSlider.value);
-			PlayerPrefs.Save();
-			Refresh();
-		}
-
-		public void OnScrollWheelToggle()
-		{
-			zoomHandler.ToggleScrollWheelZoom(scrollWheelZoomToggle.isOn);
-			Refresh();
 		}
 
 		/// <summary>
-		/// Toggles fullscreen. Fullscreen uses native resolution, windowed always uses 720p.
+		/// Reset DisplayOptions settings to their default values and apply them
 		/// </summary>
-		public void OnFullscreenToggle()
-		{
-			int hRes = Screen.fullScreen ? 1280 : Display.main.systemWidth;
-			int vRes = Screen.fullScreen ? 720 : Display.main.systemHeight;
-			fullscreenToggle.isOn = !Screen.fullScreen; //This can't go into Refresh() because going fullscreen happens 1 too late
-			Screen.SetResolution(hRes, vRes, !Screen.fullScreen);
-		}
-
-		/// <summary>
-		/// Toggles Vsync. Off or Every VBlank.
-		/// </summary>
-		public void OnVSyncToggle()
-		{
-			int vSync = vSyncToggle.isOn ? 1 : 0;
-			vSyncWarning.SetActive(vSyncToggle.isOn);
-			QualitySettings.vSyncCount = vSync;
-			PlayerPrefs.SetInt(PlayerPrefKeys.EnableVSync, vSync);
-			PlayerPrefs.Save();
-		}
-
 		public void ResetDefaults()
 		{
 			ModalPanelManager.Instance.Confirm(
@@ -109,19 +128,159 @@ namespace Unitystation.Options
 				() =>
 				{
 					zoomHandler.ResetDefaults();
-					Refresh();
+					SetPrefDefaults();
+					// Skipping resetting fullscreen state
+					RefreshForm();
 				},
 				"Reset"
 			);
 		}
 
+		/// <summary>
+		/// Resets all Display playerPrefs to defaults, alternatively provide specific PlayerPrefKeys entries to only reset those. 
+		/// </summary>
+		/// <param name="playerPrefKeysEntries">Set of PlayerPrefKeys strings associated with a setting, to reset</param>
+		void SetPrefDefaults(params string[] playerPrefKeysEntries)
+		{
+			bool resetEnableVSync;
+			bool resetTargetFrameRate;
+			bool resetChatBubbleSize;
+
+			if (playerPrefKeysEntries.Length == 0)
+			{ // Set every display pref to be reset
+				resetEnableVSync = true;
+				resetTargetFrameRate = true;
+				resetChatBubbleSize = true;
+			}
+			else
+			{ // Reset any display pref listed in the params
+				List<string> prefEntries = new List<string>(playerPrefKeysEntries);
+
+				resetEnableVSync = prefEntries.Contains(PlayerPrefKeys.EnableVSync);
+				resetTargetFrameRate = prefEntries.Contains(PlayerPrefKeys.TargetFrameRate);
+				resetChatBubbleSize = prefEntries.Contains(PlayerPrefKeys.ChatBubbleSize);
+			}
+
+			if (resetEnableVSync)
+			{
+				SetEnableVSync(DEFAULT_VSYNCENABLED);
+			}
+			if (resetTargetFrameRate)
+			{
+				SetTargetFrameRate(DEFAULT_TARGETFRAMERATE);
+			}
+			if (resetChatBubbleSize)
+			{
+				SetChatBubbleSize(DEFAULT_CHATBUBBLESIZE);
+			}
+
+			RefreshForm();
+		}
+
+		/// <summary>
+		/// Set new EnableVSync PlayerPref and apply the change
+		/// </summary>
+		/// <param name="newValue">0 - Off, 1 - Every VBlank</param>
+		void SetEnableVSync(int newValue)
+		{
+			PlayerPrefs.SetInt(PlayerPrefKeys.EnableVSync, newValue);
+			PlayerPrefs.Save();
+			ApplyEnableVSync();
+		}
+
+		/// <summary>
+		/// Apply the VSync setting from PlayerPrefs
+		/// </summary>
+		void ApplyEnableVSync()
+		{
+			int vSync = PlayerPrefs.GetInt(PlayerPrefKeys.EnableVSync);
+			QualitySettings.vSyncCount = vSync;
+		}
+
+		/// <summary>
+		/// Set new TargetFrameRate PlayerPref and apply the change
+		/// </summary>
+		/// <param name="newValue">Target frame rate/></param>
+		void SetTargetFrameRate(int newValue)
+		{
+			PlayerPrefs.SetInt(PlayerPrefKeys.TargetFrameRate, newValue);
+			PlayerPrefs.Save();
+			ApplyTargetFrameRate();
+		}
+
+		/// <summary>
+		/// Apply the TargetFrameRate setting from PlayerPrefs
+		/// </summary>
+		void ApplyTargetFrameRate()
+		{
+			int target = PlayerPrefs.GetInt(PlayerPrefKeys.TargetFrameRate);
+			Application.targetFrameRate = Mathf.Clamp(target, MIN_TARGETFRAMERATE, MAX_TARGETFRAMERATE);
+		}
+
+		/// <summary>
+		/// Set new ChatBubbleSize PlayerPref
+		/// </summary>
+		/// <param name="newValue">New chat bubble size/></param>
+		void SetChatBubbleSize(float newValue)
+		{
+			PlayerPrefs.SetFloat(PlayerPrefKeys.ChatBubbleSize, newValue);
+			PlayerPrefs.Save();
+			// Apply not required, just setting the pref is enough
+		}
+
+		/// <summary>
+		/// Toggles fullscreen. Fullscreen uses native resolution, windowed uses a default resolution.
+		/// </summary>
+		public void OnFullscreenToggle()
+		{
+			if (fullscreenToggle.isOn != Screen.fullScreen)
+			{ // If the window fullscreen state was changed outside of this menu we won't do this
+				int hRes = fullscreenToggle.isOn ? Display.main.systemWidth : DEFAULT_WINDOWWIDTH;
+				int vRes = fullscreenToggle.isOn ? Display.main.systemHeight : DEFAULT_WINDOWHEIGHT;
+				Screen.SetResolution(hRes, vRes, fullscreenToggle.isOn);
+			}
+		}
+
+		/// <summary>
+		/// Sets a new VSync setting and shows the TargetFrameRate warning if enabled
+		/// </summary>
+		public void OnVSyncToggle()
+		{
+			int vSync = vSyncToggle.isOn ? 1 : 0;
+			SetEnableVSync(vSync);
+			vSyncWarning.SetActive(vSyncToggle.isOn);
+		}
+
+		/// <summary>
+		/// Validates FrameRateTarget input, indicated with colored text. Use the new value if valid.
+		/// </summary>
 		public void OnFrameRateTargetEdit()
 		{
-			int newTarget = 99;
-			int.TryParse(frameRateTarget.text, out newTarget);
-			PlayerPrefs.SetInt(PlayerPrefKeys.TargetFrameRate, newTarget);
-			PlayerPrefs.Save();
-			Application.targetFrameRate = Mathf.Clamp(newTarget, 30, 144);
+			if (int.TryParse(frameRateTarget.text, out int newTarget) && newTarget >= MIN_TARGETFRAMERATE && newTarget <= MAX_TARGETFRAMERATE)
+			{
+				frameRateTarget.textComponent.color = VALIDCOLOR;
+				SetTargetFrameRate(newTarget);
+			}
+			else
+			{
+				frameRateTarget.textComponent.color = INVALIDCOLOR;
+				return;
+			}
+		}
+
+		public void OnZoomLevelChange()
+		{
+			zoomHandler.SetZoomLevel((int)camZoomSlider.value * 8);
+		}
+
+		public void OnScrollWheelToggle()
+		{
+			zoomHandler.SetScrollWheelZoom(scrollWheelZoomToggle.isOn);
+		}
+
+		public void OnChatBubbleSizeChange()
+		{
+			SetChatBubbleSize(chatBubbleSizeSlider.value);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/OptionsMenu/OptionsMenu.cs
+++ b/UnityProject/Assets/Scripts/UI/OptionsMenu/OptionsMenu.cs
@@ -18,6 +18,8 @@ namespace Unitystation.Options
 		//All the nav buttons in the left column
 		private List<OptionsButton> optionButtons = new List<OptionsButton>();
 
+		[SerializeField] private DisplayOptions displayOptions = null;
+
 		void Awake()
 		{
 			if (Instance == null)
@@ -36,6 +38,7 @@ namespace Unitystation.Options
 		{
 			var btns = GetComponentsInChildren<OptionsButton>(true);
 			optionButtons = new List<OptionsButton>(btns);
+			displayOptions.InitSettings(); // Load display settings even if we don't turn on the options menu
 			screen.SetActive(false);
 		}
 

--- a/UnityProject/ProjectSettings/QualitySettings.asset
+++ b/UnityProject/ProjectSettings/QualitySettings.asset
@@ -26,7 +26,7 @@ QualitySettings:
     softVegetation: 1
     realtimeReflectionProbes: 0
     billboardsFaceCameraPosition: 0
-    vSyncCount: 0
+    vSyncCount: 1
     lodBias: 2
     maximumLODLevel: 0
     streamingMipmapsActive: 1


### PR DESCRIPTION
### Purpose
Adds Vsync, resolves #4314 

### Notes
- [x] make vsync every blank default quality setting
- [x] Create a toggle button in Options to disable vsync
- [x] Use player prefs to determine setting at start and set/toggle setting from options

Finished implementing the Reset button for all the Display options, only camera zoom was set up.
Target Framerate input box no longer gets squashed by different resolutions
Adds warning that Target Framerate doesn't work with VSync on

> [QualitySettings-vSyncCount](https://docs.unity3d.com/ScriptReference/QualitySettings-vSyncCount.html)
If this setting is set to a value other than 'Don't Sync' (0), the value of Application.targetFrameRate will be ignored.

Target Framerate already had a min and max value (30-144), so invalid input will now turn red
![image](https://user-images.githubusercontent.com/7896673/82695805-bae9d680-9c5d-11ea-9f6a-b1ee00dba425.png)
Moved a bunch of default values to constants

- [x] Tested in editor
- [x] Tested in build