### PR TITLE
Fix MetaTileMap bounds calculation

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -498,6 +498,10 @@ public class MetaTileMap : MonoBehaviour
 		for (var i = 0; i < LayersValues.Length; i++)
 		{
 			BoundsInt layerBounds = LayersValues[i].Bounds;
+			if (layerBounds.x == 0 && layerBounds.y == 0)
+			{
+				continue; // Has no tiles
+			}
 
 			minPosition = Vector3Int.Min(layerBounds.min, minPosition);
 			maxPosition = Vector3Int.Max(layerBounds.max, maxPosition);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -485,9 +485,10 @@ public class MetaTileMap : MonoBehaviour
 	{
 		var bounds = GetBounds();
 		//???
-		var min = CellToWorld( bounds.min ).RoundToInt();
-		var max = CellToWorld( bounds.max ).RoundToInt();
-		return new BoundsInt(min, max - min);
+		var min = CellToWorld(bounds.min);
+		var max = CellToWorld(bounds.max);
+
+		return new BoundsInt(min.RoundToInt(), (max - min).RoundToInt());
 	}
 
 	public BoundsInt GetBounds()


### PR DESCRIPTION
### Purpose
MetaTileMap GetBounds() would treat an empty layer as a single tile at the origin, causing bounds problems with maps drawn off-center.
Changes the calculation to skip them.

Also fixes an int rounding error in GetWorldBounds() which could result in bounds dimensions being off by 1.
![image](https://user-images.githubusercontent.com/7896673/82843440-078b1700-9ed5-11ea-93b2-c7e7c1cdeda0.png)

### Notes:
Allows proper compression of bounds on stations like Pog, or those trailing bounds behind shuttles.
![image](https://user-images.githubusercontent.com/7896673/82842785-c09c2200-9ed2-11ea-9796-b14577c13168.png)