### PR TITLE
Prevent progress bar actions from continuing on a despawned target

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -1,11 +1,11 @@
-﻿﻿using System;
- using System.Collections.Generic;
- using UnityEngine;
- using UnityEngine.Events;
- using Mirror;
- using UnityEngine.Serialization;
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+using Mirror;
+using UnityEngine.Serialization;
 
- public enum ObjectType
+public enum ObjectType
 {
 	Item,
 	Object,
@@ -115,6 +115,12 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 	/// </summary>
 	[NonSerialized]
 	public UnityEvent OnAppearClient = new UnityEvent();
+
+	/// <summary>
+	/// Invoked serverside when object is despawned
+	/// </summary>
+	[NonSerialized]
+	public UnityEvent OnDespawnedServer = new UnityEvent();
 
 
 	[SyncVar(hook = nameof(SyncNetworkedMatrixNetId))]
@@ -286,6 +292,8 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 				SpatialRelationship.ServerEnd(relationship);
 			}
 		}
+
+		OnDespawnedServer.Invoke();
 	}
 
 	public void SetElectricalData(ElectricalOIinheritance inElectricalData)

--- a/UnityProject/Assets/Scripts/UI/ProgressBar/StandardProgressAction.cs
+++ b/UnityProject/Assets/Scripts/UI/ProgressBar/StandardProgressAction.cs
@@ -163,10 +163,14 @@ public class StandardProgressAction : IProgressAction
 		{
 			eventRegistry.Register(welder.OnWelderOffServer, OnWelderOff);
 		}
-		//if targeting an object, interrupt if object moves away
+
 		if (startProgressInfo.Target.IsObject)
 		{
+			//if targeting an object, interrupt if object moves away
 			eventRegistry.Register(startProgressInfo.Target.Target.OnLocalPositionChangedServer, OnLocalPositionChanged);
+
+			//interrupt if target is despawned
+			eventRegistry.Register(startProgressInfo.Target.Target.OnDespawnedServer, OnDespawned);
 		}
 		//interrupt if active hand slot changes
 		var activeSlot = playerScript.ItemStorage.GetActiveHandSlot();
@@ -288,6 +292,11 @@ public class StandardProgressAction : IProgressAction
 	{
 		//if player or target moves at all, interrupt
 		InterruptProgress("performer or target moved");
+	}
+
+	private void OnDespawned()
+	{
+		InterruptProgress("target was despawned");
 	}
 
 	private void OnConsciousStateChange(ConsciousState oldState, ConsciousState newState)


### PR DESCRIPTION
### Purpose
Should fix #4345
Progress bar actions didn't track whether their targets still exist when they reach the end, they'd try to use a callback on an object which no longer exists.
Produced mass NREs on the server which break player movement
Now the progress bar will properly be cancelled the moment the target is despawned.

### Notes:
- [x] Tested in editor
- [x] Tested in build, headless server and client