### PR TITLE
Fixed Spectate ghosts having no name, fixed a log output in Playerlist

### DIFF
--- a/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Lifecycle/PlayerSpawn.cs
@@ -313,7 +313,7 @@ public static class PlayerSpawn
 	/// <summary>
 	/// Spawns as a ghost for spectating the Round
 	/// </summary>
-	public static void ServerSpawnGhost(JoinedViewer joinedViewer)
+	public static void ServerSpawnGhost(JoinedViewer joinedViewer, CharacterSettings characterSettings)
 	{
 		//Hard coding to assistant
 		Vector3Int spawnPosition = GetSpawnForJob(JobType.ASSISTANT).transform.position.CutToInt();
@@ -327,8 +327,7 @@ public static class PlayerSpawn
 
 		//Create the mind without a job refactor this to make it as a ghost mind
 		Mind.Create(newPlayer);
-		ServerTransferPlayer(joinedViewer.connectionToClient, newPlayer, null, EVENT.GhostSpawned, PlayerManager.CurrentCharacterSettings);
-
+		ServerTransferPlayer(joinedViewer.connectionToClient, newPlayer, null, EVENT.GhostSpawned, characterSettings);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -169,7 +169,7 @@ public partial class PlayerList : NetworkBehaviour
 		if (loggedOffClient  != null)
 		{
 			Logger.Log(
-				$"ConnectedPlayer {player} already exists in this server's PlayerList as {loggedOff}. " +
+				$"ConnectedPlayer Username({player.Username}) already exists in this server's PlayerList as Character({loggedOffClient.Name}) " +
 				$"Will update existing player instead of adding this new connected player.");
 
 			if (loggedOffClient.GameObject == null)

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -192,13 +192,21 @@ public class JoinedViewer : NetworkBehaviour
 
 		PlayerSpawn.ServerSpawnPlayer(spawnRequest);
 	}
+
+	public void Spectate()
+	{
+		var jsonCharSettings = JsonConvert.SerializeObject(PlayerManager.CurrentCharacterSettings);
+		CmdSpectate(jsonCharSettings);
+	}
+
 	/// <summary>
 	/// Command to spectate a round instead of spawning as a player
 	/// </summary>
 	[Command]
-	public void CmdSpectate()
+	public void CmdSpectate(string jsonCharSettings)
 	{
-		PlayerSpawn.ServerSpawnGhost(this);
+		var characterSettings = JsonConvert.DeserializeObject<CharacterSettings>(jsonCharSettings);
+		PlayerSpawn.ServerSpawnGhost(this, characterSettings);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
+++ b/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
@@ -171,7 +171,7 @@ public class GUI_PlayerJobs : MonoBehaviour
 		occupationGO.GetComponent<Image>().color = Color.white;
 		occupationGO.GetComponentInChildren<TextMeshProUGUI>().text = "Spectate";
 		occupationGO.transform.localScale = new Vector3(1.0f, 1f, 1.0f);
-		occupationGO.GetComponent<Button>().onClick.AddListener(() => { PlayerManager.LocalViewerScript.CmdSpectate(); });
+		occupationGO.GetComponent<Button>().onClick.AddListener(() => { PlayerManager.LocalViewerScript.Spectate(); });
 
 	}
 }


### PR DESCRIPTION
### Purpose
Fixes #3983
Spectate ghost spawn was using the local CharacterSettings of the server.
They're now correctly passed from the client.

Also a small fix to a log entry in Playerlist.

### Notes:
- [x] Tested in editor (though spectating on the server doesn't have the error)
- [x] Tested in build, headless server and client