### PR TITLE
Fix microwaves losing stackable meals, cutlet cooking works again

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjects/FoodRecipes/Cooked Cutlets.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/FoodRecipes/Cooked Cutlets.asset
@@ -15,5 +15,5 @@ MonoBehaviour:
   Name: Cooked Cutlets
   Ingredients:
   - requiredAmount: 1
-    ingredientName: Meat Cutlets
+    ingredientName: Meat Cutlet
   Output: {fileID: 6532193109441330816, guid: dcb198c42e70def43a450ef925a6b4b5, type: 3}

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -32,6 +32,8 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 
 	public int MaxAmount => maxAmount;
 
+	public int SpareCapacity => MaxAmount - Amount;
+
 	/// <summary>
 	/// amount currently in the stack
 	/// </summary>
@@ -147,48 +149,57 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	/// Consumes the specified amount of quantity from this stack. Despawns if entirely consumed.
 	/// Does nothing if consumed is greater than the amount in this stack.
 	/// </summary>
-	/// <param name="consumed"></param>
+	/// <param name="consumed">Amount to consume</param>
+	/// <returns>If stackable contained enough stacks and they were consumed</returns>
 	[Server]
-	public void ServerConsume(int consumed)
+	public bool ServerConsume(int consumed)
 	{
 		if (consumed > amount)
 		{
-			Logger.LogErrorFormat("Consumed amount {0} is greater than amount in this stack {1}, will not consume.",
-				 Category.Inventory, consumed, amount);
-			return;
+			Logger.LogErrorFormat("Consumed amount {0} is greater than amount in this stack {1}, will not consume.", Category.Inventory, consumed, amount);
+			return false;
 		}
 		SyncAmount(amount, amount - consumed);
 		if (amount <= 0)
 		{
 			Despawn.ServerSingle(gameObject);
 		}
+		return true;
 	}
 
 	/// <summary>
 	/// Increments the amount by a specified quantity, does not go above the max.
-	/// Do not perform if max is already reached.
+	/// Cannot be used to reduce stacks
 	/// </summary>
-	/// <param name="increase"></param>
+	/// <param name="increase">Amount to add</param>
+	/// <returns>The remaining number of stacks which could not fit in the stackable</returns>
 	[Server]
-	public void ServerIncrease(int increase)
+	public int ServerIncrease(int increase)
 	{
-		if (amount == maxAmount)
-			return;
+		if (increase == 0)
+		{
+			return 0;
+		}
 
-		if (increase > maxAmount)
+		if (increase < 0)
+		{
+			Logger.LogErrorFormat("Attempted to increase stacks by a negative value, ignored", Category.Inventory);
+			return 0;
+		}
+
+		int overflow = increase - SpareCapacity;
+
+		if (overflow > 0)
 		{
 			Logger.LogErrorFormat("Increased amount {0} will overfill stack, filled to max",
 				 Category.Inventory, increase);
+
+			SyncAmount(amount, MaxAmount);
+			return overflow;
 		}
 
-		int add = increase;
-		if (amount + increase > maxAmount)
-		{
-			//If increase would push stack above maximum amount, make add equal the difference
-			//to reach max stack.
-			add = increase+amount-maxAmount;
-		}
-		SyncAmount(amount, amount + add);
+		SyncAmount(amount, amount + increase);
+		return 0;
 	}
 
 	/// <summary>
@@ -224,7 +235,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 				Category.Inventory, toAdd, this);
 			return;
 		}
-		var amountToConsume = Math.Min(toAdd.amount, maxAmount - amount);
+		var amountToConsume = Math.Min(toAdd.amount, SpareCapacity);
 		if (amountToConsume <= 0) return;
 		Logger.LogTraceFormat("Combining {0} <- {1}", Category.Inventory, GetInstanceID(), toAdd.GetInstanceID());
 		toAdd.ServerConsume(amountToConsume);

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -13,6 +13,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	[Tooltip("Amount initially in the stack when this is spawned.")]
 	[SerializeField]
 	private int initialAmount = 1;
+	public int InitialAmount => initialAmount;
 
 	[Tooltip("Max amount allowed in the stack.")]
 	[SerializeField]

--- a/UnityProject/Assets/Scripts/Machines/Microwave.cs
+++ b/UnityProject/Assets/Scripts/Machines/Microwave.cs
@@ -135,33 +135,23 @@ public class Microwave : NetworkBehaviour
 
 			if (stck != null)   // If the meal has a stackable component, set the correct number of meals
 			{
-				int spawnedSoFar = stck.InitialAmount;
+				int mealDeficit = mealCount - stck.InitialAmount;
 
-				while (spawnedSoFar < mealCount)
+				while (mealDeficit > 0)
 				{
-					int spaceInStack = stck.MaxAmount - stck.Amount;
+					mealDeficit = stck.ServerIncrease(mealDeficit);
 
-					if (spaceInStack > 0)
-					{
-						// Add all the missing meals to the stack, or as many as the stack can contain
-						int mealDeficit = mealCount - spawnedSoFar;
-						int stacksToAdd = Mathf.Min(spaceInStack, mealDeficit);
-						stck.ServerIncrease(stacksToAdd);
-						spawnedSoFar += stacksToAdd;
-					}
-
-					if (spawnedSoFar < mealCount) // Still not enough meals
+					if (mealDeficit > 0)
 					{
 						result = Spawn.ServerPrefab(mealPrefab, spawnPosition, transform.parent);
 						stck = result.GameObject.GetComponent<Stackable>();
-						spawnedSoFar += stck.InitialAmount;
+						mealDeficit -= stck.InitialAmount;
 					}
 				}
 
-				if (spawnedSoFar > mealCount) // Reduce the stack if our last spawned stackable results in too many meals
+				if (mealDeficit < 0) // Reduce the stack if our last spawned stackable results in too many meals
 				{
-					int mealSurplus = spawnedSoFar - mealCount;
-					stck.ServerConsume(mealSurplus);
+					stck.ServerConsume(-mealDeficit);
 				}
 			}
 			else if (mealCount > 1) // Spawn non-stackable meals

--- a/UnityProject/Assets/Scripts/Machines/Microwave.cs
+++ b/UnityProject/Assets/Scripts/Machines/Microwave.cs
@@ -124,29 +124,49 @@ public class Microwave : NetworkBehaviour
 	private void FinishCooking()
 	{
 		spriteRenderer.sprite = SPRITE_OFF;
-		if (isServer)
+
+		if (isServer && mealCount > 0)
 		{
 			GameObject mealPrefab = CraftingManager.Meals.FindOutputMeal(meal);
-			SpawnResult result = Spawn.ServerPrefab(mealPrefab, GetComponent<RegisterTile>().WorldPosition, transform.parent);
+			Vector3Int spawnPosition = GetComponent<RegisterTile>().WorldPosition;
 
-			//If the resulting meal has a stackable component, set the amount to mealCount to ensure that food in = food out.
+			SpawnResult result = Spawn.ServerPrefab(mealPrefab, spawnPosition, transform.parent);
 			Stackable stck = result.GameObject.GetComponent<Stackable>();
 
-			if (stck != null && mealCount != 0)
+			if (stck != null)   // If the meal has a stackable component, set the correct number of meals
 			{
-				//Get difference between new item's initial amount and the amount held by mealCount (amount of ingredient).
-				int stckChanger = mealCount-stck.Amount;
+				int spawnedSoFar = stck.InitialAmount;
 
-				//If stckChanger is 0, do nothing.
-				//If stckChanger is positive, add to stack.
-				if (stckChanger > 0)
+				while (spawnedSoFar < mealCount)
 				{
-					stck.ServerIncrease(stckChanger);
-				} else if (stckChanger < 0)
-				{
-					//If stckChanger is positive, remove stack.
-					stck.ServerConsume(-stckChanger);
+					int spaceInStack = stck.MaxAmount - stck.Amount;
+
+					if (spaceInStack > 0)
+					{
+						// Add all the missing meals to the stack, or as many as the stack can contain
+						int mealDeficit = mealCount - spawnedSoFar;
+						int stacksToAdd = Mathf.Min(spaceInStack, mealDeficit);
+						stck.ServerIncrease(stacksToAdd);
+						spawnedSoFar += stacksToAdd;
+					}
+
+					if (spawnedSoFar < mealCount) // Still not enough meals
+					{
+						result = Spawn.ServerPrefab(mealPrefab, spawnPosition, transform.parent);
+						stck = result.GameObject.GetComponent<Stackable>();
+						spawnedSoFar += stck.InitialAmount;
+					}
 				}
+
+				if (spawnedSoFar > mealCount) // Reduce the stack if our last spawned stackable results in too many meals
+				{
+					int mealSurplus = spawnedSoFar - mealCount;
+					stck.ServerConsume(mealSurplus);
+				}
+			}
+			else if (mealCount > 1) // Spawn non-stackable meals
+			{
+				Spawn.ServerPrefab(mealPrefab, spawnPosition, transform.parent, count: mealCount - 1);
 			}
 		}
 		meal = null;

--- a/UnityProject/Assets/Scripts/Objects/InteractableMicrowave.cs
+++ b/UnityProject/Assets/Scripts/Objects/InteractableMicrowave.cs
@@ -37,10 +37,13 @@ public class InteractableMicrowave : MonoBehaviour, ICheckedInteractable<HandApp
 			// Check if the player is holding food that can be cooked
 			ItemAttributesV2 attr = interaction.HandObject.GetComponent<ItemAttributesV2>();
 			Ingredient ingredient = new Ingredient(attr.ArticleName);
+
 			GameObject meal = CraftingManager.Meals.FindRecipe(new List<Ingredient> { ingredient });
 
 			if (meal)
 			{
+				// HACK: Currently DOES NOT check how many items are used per meal
+				// Blindly assumes each single item in a stack produces a meal
 
 				//If food item is stackable, set output amount to equal input amount.
 				Stackable stck = interaction.HandObject.GetComponent<Stackable>();
@@ -48,7 +51,10 @@ public class InteractableMicrowave : MonoBehaviour, ICheckedInteractable<HandApp
 				{
 					microwave.ServerSetOutputStackAmount(stck.Amount);
 				}
-
+				else
+				{
+					microwave.ServerSetOutputStackAmount(1);
+				}
 
 				microwave.ServerSetOutputMeal(meal.name);
 				Despawn.ServerSingle(interaction.HandObject);


### PR DESCRIPTION
### Purpose
Fixes #3999 , Fixes #4341
Stackable objects stack with other items on spawn, microwave was doing calculations to adjust the output stacks without realizing this happens

### Notes:
Microwave spawning is more robust and will better handle non-Stackable outputs, differences in maximum stack amounts between input and output

Current microwave behavior gives you a number of meals equal to the stacks of ingredient in your hand, mostly ignoring the recipe.
This works currently but will likely need work in the future, ideally adding code to CraftingDatabase.cs/Recipe.cs
Spawn.cs could also benefit from being aware of Stackable and handling stack counts instead

However these are out of scope for this fix