### PR TITLE
Job Selection Queue

### DIFF
--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -186,11 +186,9 @@ public class JoinedViewer : NetworkBehaviour
 		var spawnRequest =
 			PlayerSpawnRequest.RequestOccupation(this, GameManager.Instance.GetRandomFreeOccupation(jobType), characterSettings);
 
-		//regardless of their chosen occupation, they might spawn as an antag instead.
-		//If they do, bypass the normal spawn logic.
-		if (GameManager.Instance.TrySpawnAntag(spawnRequest)) return;
+		GameManager.Instance.SpawnPlayerRequestQueue.Enqueue(spawnRequest);
 
-		PlayerSpawn.ServerSpawnPlayer(spawnRequest);
+		GameManager.Instance.ProcessSpawnPlayerQueue();
 	}
 
 	public void Spectate()


### PR DESCRIPTION
Readds #4083 and #4095 and should work properly this time.

-Adds queue to after round job select to stop people spawning more of the same job than allowed.

~Still testing.~

Tested on headless, late joining and readying up, no errors works good.

Should have a robust staging test, just to make sure it all works ok.