### PR TITLE
Making spawn aware of stackables, recipe crafting rework

### DIFF
--- a/UnityProject/Assets/Hatchet.cs
+++ b/UnityProject/Assets/Hatchet.cs
@@ -30,34 +30,9 @@ public class Hatchet : MonoBehaviour, ICheckedInteractable<InventoryApply>
 	}
 	public void ServerPerformInteraction(InventoryApply interaction)
 	{
-
-		//is the target item chopable?
-		ItemAttributesV2 attr = interaction.TargetObject.GetComponent<ItemAttributesV2>();
-		Ingredient ingredient = new Ingredient(attr.ArticleName);
-		GameObject cut = CraftingManager.Logs.FindRecipe(new List<Ingredient> { ingredient });
-		if (cut)
+		if (!CraftingManager.InventoryApplyInteraction(interaction, CraftingManager.Logs))
 		{
-			Inventory.ServerDespawn(interaction.TargetSlot);
-
-			SpawnResult spwn = Spawn.ServerPrefab(CraftingManager.Logs.FindOutputMeal(cut.name), 
-			SpawnDestination.At(), 1);
-
-			if (spwn.Successful)
-			{
-				
-				//foreach (GameObject obj in spwn.GameObjects)
-				//{
-				//	Inventory.ServerAdd(obj,interaction.TargetSlot);
-				//}
-
-				Inventory.ServerAdd(spwn.GameObject ,interaction.TargetSlot);
-
-			}
-
-		} else {
-
 			Chat.AddExamineMsgFromServer(interaction.Performer, "You can't chop this.");
 		}
-
 	}
 }

--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -202,10 +202,10 @@ namespace IngameDebugConsole
 			foreach (ConnectedPlayer player in PlayerList.Instance.InGamePlayers) {
 				Vector3 playerPos = player.Script.WorldPos;
 				Vector3 spawnPos = playerPos + new Vector3( 0, 2, 0 );
-				GameObject mealPrefab = CraftingManager.Meals.FindOutputMeal("Meat Steak");
+				Recipe mealRecipe = CraftingManager.Meals.FindRecipeFromOutput("Meat Steak");
 				var slabs = new List<CustomNetTransform>();
 				for ( int i = 0; i < 5; i++ ) {
-					slabs.Add( Spawn.ServerPrefab(mealPrefab, spawnPos).GameObject.GetComponent<CustomNetTransform>() );
+					slabs.Add( Spawn.ServerPrefab(mealRecipe.Output, spawnPos).GameObject.GetComponent<CustomNetTransform>() );
 				}
 				for ( var i = 0; i < slabs.Count; i++ ) {
 					Vector3 vector3 = i%2 == 0 ? new Vector3(i,-i,0) : new Vector3(-i,i,0);

--- a/UnityProject/Assets/IngredientMarker.cs
+++ b/UnityProject/Assets/IngredientMarker.cs
@@ -31,39 +31,6 @@ public class IngredientMarker : MonoBehaviour, ICheckedInteractable<InventoryApp
 	}
 	public void ServerPerformInteraction(InventoryApply interaction)
 	{
-		//is the target item another ingredient?
-		ItemAttributesV2 attr = interaction.TargetObject.GetComponent<ItemAttributesV2>();
-		ItemAttributesV2 selfattr = interaction.UsedObject.GetComponent<ItemAttributesV2>();
-		Ingredient ingredient = new Ingredient(attr.ArticleName);
-		Ingredient self = new Ingredient(selfattr.ArticleName);
-		GameObject cut = CraftingManager.SimpleMeal.FindRecipe(new List<Ingredient> { ingredient, self });
-		GameObject cut2 = CraftingManager.SimpleMeal.FindRecipe(new List<Ingredient> { self, ingredient });
-		if (cut)
-		{
-			Inventory.ServerDespawn(interaction.TargetObject);
-			Inventory.ServerDespawn(interaction.UsedObject);
-
-			SpawnResult spwn = Spawn.ServerPrefab(CraftingManager.SimpleMeal.FindOutputMeal(cut.name),
-			SpawnDestination.At(), 1);
-
-			if (spwn.Successful)
-			{
-				Inventory.ServerAdd(spwn.GameObject, interaction.TargetSlot);
-			}
-		}
-		else if (cut2)
-		{
-			Inventory.ServerDespawn(interaction.TargetSlot);
-			Inventory.ServerDespawn(interaction.Performer);
-
-			SpawnResult spwn = Spawn.ServerPrefab(CraftingManager.SimpleMeal.FindOutputMeal(cut2.name),
-			SpawnDestination.At(), 1);
-
-			if (spwn.Successful)
-			{
-				Inventory.ServerAdd(spwn.GameObject, interaction.TargetSlot);
-			}
-
-		}
+		CraftingManager.MergeInteraction(interaction, CraftingManager.SimpleMeal);
 	}
 }

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Alien Steak.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/food/Alien Steak.prefab
@@ -1,5 +1,17 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-411641939036542691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6128081887975298069}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 421c3b18959bb624f8fe705eaad88216, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &6128081887975217483
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -25,6 +37,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
       propertyPath: initialName
       value: Suspicious Steak
       objectReference: {fileID: 0}
@@ -33,6 +50,12 @@ PrefabInstance:
       propertyPath: initialDescription
       value: This doesn't look healthy.
       objectReference: {fileID: 0}
+    - target: {fileID: 667038178532149417, guid: 9e24daf3783555e42b00f94e49d98357,
+        type: 3}
+      propertyPath: initialTraits.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: f4bf367b42a325c4dbf26b76591e0ef1,
+        type: 2}
     - target: {fileID: 963106870793376919, guid: 9e24daf3783555e42b00f94e49d98357,
         type: 3}
       propertyPath: m_Sprite
@@ -111,3 +134,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9e24daf3783555e42b00f94e49d98357, type: 3}
+--- !u!1 &6128081887975298069 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1129366686127204299, guid: 9e24daf3783555e42b00f94e49d98357,
+    type: 3}
+  m_PrefabInstance: {fileID: 6128081887975217483}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/ScriptableObjects/FoodRecipes/Alien Cutlets.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/FoodRecipes/Alien Cutlets.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   - requiredAmount: 1
     ingredientName: Strange Meat
   Output: {fileID: 6532193109441330816, guid: 26bedbdf41b93724698f98566254680b, type: 3}
+  OutputAmount: 3

--- a/UnityProject/Assets/Resources/ScriptableObjects/FoodRecipes/Meat Cutlets.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/FoodRecipes/Meat Cutlets.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   - requiredAmount: 1
     ingredientName: Meat
   Output: {fileID: 6532193109441330816, guid: f06058cd7ca4b944aa68f64125386e28, type: 3}
+  OutputAmount: 3

--- a/UnityProject/Assets/Scripts/Crafting/CraftingDatabase.cs
+++ b/UnityProject/Assets/Scripts/Crafting/CraftingDatabase.cs
@@ -8,66 +8,27 @@ public class CraftingDatabase
 {
 	public Recipe[] recipeList;
 
-	public GameObject FindRecipe(List<Ingredient> ingredients)
+	public Recipe FindRecipeFromIngredients(List<ItemAttributesV2> ingredients)
 	{
 		foreach (Recipe recipe in recipeList)
 		{
-			if (recipe.Check(ingredients))
+			if (recipe.CanMakeRecipeWith(ingredients))
 			{
-				return recipe.Output;
+				return recipe;
 			}
-		
 		}
 		return null;
 	}
 
-	public GameObject FindOutputMeal(string mealName)
+	public Recipe FindRecipeFromOutput(string mealName)
 	{
 		foreach (Recipe recipe in recipeList)
 		{
 			if (recipe.Output.name == mealName)
 			{
-				return recipe.Output;
+				return recipe;
 			}
 		}
 		return null;
-	}
-}
-[Serializable]
-public class GrinderDatabase
-{
-	public GrinderRecipe[] grinderRecipeList;
-	public Chemistry.Reagent FindOutputReagent(string reagentName)
-	{
-		foreach (GrinderRecipe recipe in grinderRecipeList)
-		{
-			if (recipe.Output.Name == reagentName)
-			{
-				return recipe.Output;
-			}
-		}
-		return null;
-	}
-	public Chemistry.Reagent FindReagentRecipe(List<Ingredient> ingredients)
-	{
-		foreach (GrinderRecipe recipe in grinderRecipeList)
-		{
-			if (recipe.Check(ingredients))
-			{
-				return recipe.Output;
-			}
-		}
-		return null;
-	}
-	public int FindReagentAmount(List<Ingredient> ingredients)
-	{
-		foreach (GrinderRecipe recipe in grinderRecipeList)
-		{
-			if (recipe.Check(ingredients))
-			{
-				return recipe.resultingAmount;
-			}
-		}
-		return 0;
 	}
 }

--- a/UnityProject/Assets/Scripts/Crafting/GrinderDatabase.cs
+++ b/UnityProject/Assets/Scripts/Crafting/GrinderDatabase.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+[Serializable]
+public class GrinderDatabase
+{
+	public GrinderRecipe[] grinderRecipeList;
+	public Chemistry.Reagent FindOutputReagent(string reagentName)
+	{
+		foreach (GrinderRecipe recipe in grinderRecipeList)
+		{
+			if (recipe.Output.Name == reagentName)
+			{
+				return recipe.Output;
+			}
+		}
+		return null;
+	}
+	public Chemistry.Reagent FindReagentRecipe(List<Ingredient> ingredients)
+	{
+		foreach (GrinderRecipe recipe in grinderRecipeList)
+		{
+			if (recipe.Check(ingredients))
+			{
+				return recipe.Output;
+			}
+		}
+		return null;
+	}
+	public int FindReagentAmount(List<Ingredient> ingredients)
+	{
+		foreach (GrinderRecipe recipe in grinderRecipeList)
+		{
+			if (recipe.Check(ingredients))
+			{
+				return recipe.resultingAmount;
+			}
+		}
+		return 0;
+	}
+}

--- a/UnityProject/Assets/Scripts/Crafting/GrinderDatabase.cs.meta
+++ b/UnityProject/Assets/Scripts/Crafting/GrinderDatabase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b43b644493ac4eb4fb12ca80786a68e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Crafting/Recipe.cs
+++ b/UnityProject/Assets/Scripts/Crafting/Recipe.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 [CreateAssetMenu(fileName = "Recipe", menuName = "ScriptableObjects/Recipe/GenericRecipe")]
 [Serializable]
@@ -10,14 +9,91 @@ public class Recipe : ScriptableObject
 	public string Name;
 	public Ingredient[] Ingredients;
 	public GameObject Output;
+	public int OutputAmount = 1;
 
-	public bool Check(List<Ingredient> other)
+	public bool CanMakeRecipeWith(List<ItemAttributesV2> other)
 	{
-		foreach (Ingredient ingredient in Ingredients)
+		foreach (Ingredient recipeIngredient in Ingredients)
 		{
-			if (!other.Contains(ingredient))
+			int ingredientCount = 0;
+
+			foreach (ItemAttributesV2 ingredientOffered in other)
+			{
+				if (ingredientOffered.ArticleName == recipeIngredient.ingredientName)
+				{
+					Stackable stck = ingredientOffered.GetComponent<Stackable>();
+					if (stck != null)
+					{
+						ingredientCount += stck.Amount;
+					}
+					else
+					{
+						ingredientCount++;
+					}
+				}
+			}
+
+			if (ingredientCount < recipeIngredient.requiredAmount)
 			{
 				return false;
+			}
+		}
+		return true;
+	}
+
+	public int AmountOfIngredientNeeded(ItemAttributesV2 ingredient)
+	{
+		foreach (Ingredient recipeIngredient in Ingredients)
+		{
+			if (ingredient.ArticleName == recipeIngredient.ingredientName)
+			{
+				return recipeIngredient.requiredAmount;
+			}
+		}
+
+		return 0;
+	}
+
+	public bool Consume(List<ItemAttributesV2> ingredients, out List<ItemAttributesV2> remains)
+	{
+		remains = new List<ItemAttributesV2>(ingredients);
+		if (!CanMakeRecipeWith(ingredients))
+		{
+			return false;
+		}
+
+		foreach (Ingredient recipeIngredient in Ingredients)
+		{
+			int amountToConsume = recipeIngredient.requiredAmount;
+
+			List<ItemAttributesV2> current = new List<ItemAttributesV2>(remains);
+			foreach (ItemAttributesV2 ingredientOffered in current)
+			{
+				if (ingredientOffered.ArticleName == recipeIngredient.ingredientName)
+				{
+					Stackable stck = ingredientOffered.GetComponent<Stackable>();
+					if (stck != null)
+					{
+						int amt = Mathf.Min(stck.Amount, amountToConsume);
+						if (amt == stck.Amount)
+						{
+							remains.Remove(ingredientOffered);
+						}
+						stck.ServerConsume(amt);
+						amountToConsume -= amt;
+					}
+					else
+					{
+						Inventory.ServerDespawn(ingredientOffered.gameObject);
+						remains.Remove(ingredientOffered);
+						amountToConsume--;
+					}
+
+					if (amountToConsume <= 0)
+					{
+						break;
+					}
+				}
 			}
 		}
 		return true;

--- a/UnityProject/Assets/Scripts/Food/RawMeat.cs
+++ b/UnityProject/Assets/Scripts/Food/RawMeat.cs
@@ -20,7 +20,13 @@ public class RawMeat : MonoBehaviour
 	private void OnBurnUpServer(DestructionInfo info)
 	{
 		//cook the meat by destroying this meat and spawning a meat steak
-		Spawn.ServerPrefab(meatSteakPrefab, registerTile.WorldPosition, transform.parent);
+		Stackable stck = gameObject.GetComponent<Stackable>();
+		int numResults = 1;
+		if (stck != null)
+		{
+			numResults = stck.Amount;
+		}
+		Spawn.ServerPrefab(meatSteakPrefab, registerTile.WorldPosition, transform.parent, count: numResults);
 		Despawn.ServerSingle(gameObject);
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Others/Knife.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Knife.cs
@@ -11,7 +11,6 @@ public class Knife : MonoBehaviour, ICheckedInteractable<InventoryApply>
 	//check if item is being applied to offhand with cuttable object on it.
 	public bool WillInteract(InventoryApply interaction, NetworkSide side)
 	{
-
 		//can the player act at all?
 		if (!DefaultWillInteract.Default(interaction, side)) return false;
 
@@ -21,44 +20,15 @@ public class Knife : MonoBehaviour, ICheckedInteractable<InventoryApply>
 		//if the item isn't a butcher knife, no go.
 		if (!Validations.HasUsedItemTrait(interaction, CommonTraits.Instance.Knife)) return false;
 
-
 		//TargetSlot must not be empty.
 		if (interaction.TargetSlot.Item == null) return false;
 
 		return true;
 	}
+
 	public void ServerPerformInteraction(InventoryApply interaction)
 	{
-		//is the target item cuttable?
-		ItemAttributesV2 attr = interaction.TargetObject.GetComponent<ItemAttributesV2>();
-		Ingredient ingredient = new Ingredient(attr.ArticleName);
-		GameObject cut = CraftingManager.Cuts.FindRecipe(new List<Ingredient> { ingredient });
-		if (cut && interaction.TargetObject.GetComponent<Stackable>() != null && ingredient.requiredAmount
-			== interaction.TargetObject.GetComponent<Stackable>().Amount)
-		{
-			Inventory.ServerDespawn(interaction.TargetSlot);
-
-			SpawnResult spwn = Spawn.ServerPrefab(CraftingManager.Cuts.FindOutputMeal(cut.name),
-			SpawnDestination.At(), 1);
-
-			if (spwn.Successful)
-			{
-				Inventory.ServerAdd(spwn.GameObject, interaction.TargetSlot);
-			}
-		}
-		else if (cut)
-		{
-			Inventory.ServerDespawn(interaction.TargetSlot);
-
-			SpawnResult spwn = Spawn.ServerPrefab(CraftingManager.Cuts.FindOutputMeal(cut.name),
-			SpawnDestination.At(), 1);
-
-			if (spwn.Successful)
-			{
-				Inventory.ServerAdd(spwn.GameObject, interaction.TargetSlot);
-			}
-		}
-		else
+		if (!CraftingManager.InventoryApplyInteraction(interaction, CraftingManager.Cuts))
 		{
 			Chat.AddExamineMsgFromServer(interaction.Performer, "You can't cut this.");
 		}

--- a/UnityProject/Assets/Scripts/Items/Others/RollingPin.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/RollingPin.cs
@@ -27,30 +27,12 @@ public class RollingPin : MonoBehaviour, ICheckedInteractable<InventoryApply>
 
 		return true;
 	}
+
 	public void ServerPerformInteraction(InventoryApply interaction)
 	{
-
-		//is the target item cuttable?
-		ItemAttributesV2 attr = interaction.TargetObject.GetComponent<ItemAttributesV2>();
-		Ingredient ingredient = new Ingredient(attr.ArticleName);
-		GameObject roll = CraftingManager.Roll.FindRecipe(new List<Ingredient> { ingredient });
-		if (roll)
+		if (!CraftingManager.InventoryApplyInteraction(interaction, CraftingManager.Roll))
 		{
-			Inventory.ServerDespawn(interaction.TargetSlot);
-
-			SpawnResult spwn = Spawn.ServerPrefab(CraftingManager.Roll.FindOutputMeal(roll.name), 
-			SpawnDestination.At(), 1);
-
-			if (spwn.Successful)
-			{
-				Inventory.ServerAdd(spwn.GameObject ,interaction.TargetSlot);
-
-			}
-
-		} else {
-
 			Chat.AddExamineMsgFromServer(interaction.Performer, "You can't roll this out.");
 		}
-
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -20,8 +20,8 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	private int maxAmount = 50;
 
 	[Tooltip("Other prefabs which can stack with this object. By default a stackable can stack with its own" +
-	         " prefab, but if you create any variants which have a different initial amount you can assign them" +
-	         " in this list on either prefab to allow it to recognize that it's stackable with the parent.")]
+			 " prefab, but if you create any variants which have a different initial amount you can assign them" +
+			 " in this list on either prefab to allow it to recognize that it's stackable with the parent.")]
 	[SerializeField]
 	private List<GameObject> stacksWith;
 
@@ -98,7 +98,8 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 
 	public override void OnStartServer()
 	{
-		SyncAmount(amount, this.amount);
+		SyncAmount(amount, initialAmount);
+		amountInit = true;
 	}
 
 	public bool IsFull()
@@ -110,8 +111,6 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 	{
 		Logger.LogTraceFormat("Spawning {0}", Category.Inventory, GetInstanceID());
 		InitStacksWith();
-		SyncAmount(amount, initialAmount);
-		amountInit = true;
 		//check for stacking with things on the ground
 		ServerStackOnGround(registerTile.LocalPositionServer);
 	}
@@ -231,7 +230,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		if (!StacksWith(toAdd))
 		{
 			Logger.LogErrorFormat("toAdd {0} doesn't stack with this {2}, cannot combine. Consider adding" +
-			                      " this prefab to stacksWith if these really should be stackable.",
+								  " this prefab to stacksWith if these really should be stackable.",
 				Category.Inventory, toAdd, this);
 			return;
 		}

--- a/UnityProject/Assets/Scripts/Managers/CraftingManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CraftingManager.cs
@@ -1,5 +1,5 @@
 ﻿using UnityEngine;
-using UnityEngine.SceneManagement;
+using System.Collections.Generic;
 
 public class CraftingManager : MonoBehaviour
 {
@@ -31,6 +31,63 @@ public class CraftingManager : MonoBehaviour
 
 			return craftingManager;
 		}
+	}
+
+	private static GameObject Craft(List<ItemAttributesV2> ingredients, CraftingDatabase databaseToCheck, out List<ItemAttributesV2> remains)
+	{
+		Recipe recipe = databaseToCheck.FindRecipeFromIngredients(ingredients);
+		if (recipe != null)
+		{
+			SpawnResult spwn = Spawn.ServerPrefab(recipe.Output, SpawnDestination.At(), recipe.OutputAmount);
+
+			if (spwn.Successful)
+			{
+				recipe.Consume(ingredients, out remains);
+				return spwn.GameObject;
+			}
+		}
+
+		remains = new List<ItemAttributesV2>(ingredients);
+		return null;
+	}
+
+	public static bool MergeInteraction(InventoryApply iApply, CraftingDatabase databaseToCheck)
+	{
+		ItemAttributesV2 toSlot = iApply.TargetObject.GetComponent<ItemAttributesV2>();
+		ItemAttributesV2 fromSlot = iApply.UsedObject.GetComponent<ItemAttributesV2>();
+
+		List<ItemAttributesV2> ingredients = new List<ItemAttributesV2>() { toSlot, fromSlot };
+		GameObject result = Craft(ingredients, databaseToCheck, out List<ItemAttributesV2> remains);
+		if (result != null)
+		{
+			if (!remains.Contains(toSlot))
+			{
+				Inventory.ServerAdd(result, iApply.TargetSlot);
+			}
+			else if (!remains.Contains(fromSlot))
+			{
+				Inventory.ServerAdd(result, iApply.FromSlot);
+			}
+			return true;
+		}
+		return false;
+	}
+
+	public static bool InventoryApplyInteraction(InventoryApply iApply, CraftingDatabase databaseToCheck)
+	{
+		ItemAttributesV2 toSlot = iApply.TargetObject.GetComponent<ItemAttributesV2>();
+
+		List<ItemAttributesV2> ingredients = new List<ItemAttributesV2>() { toSlot };
+		GameObject result = Craft(ingredients, databaseToCheck, out List<ItemAttributesV2> remains);
+		if (result != null)
+		{
+			if (!remains.Contains(toSlot))
+			{
+				Inventory.ServerAdd(result, iApply.TargetSlot);
+			}
+			return true;
+		}
+		return false;
 	}
 
 	public Techweb techweb;


### PR DESCRIPTION
### Purpose
When spawning something which is stackable you wouldn't get the amount you asked for, you'd get that amount times by the Stackable initialAmount.
This is probably part of why we have things like two versions of each wire prefab with 1 or 30 in the stack.
Spawn now looks at their Stackable and correctly sets their amounts.

Recipe crafting has been updated to match the new functionality
- Crafting attempts now properly use the recipe, making sure to use and produce the correct amounts
- Reduced a bunch of code copy+paste

### TODO?

Currently considering a better place to put the new CraftingManager code and the Recipe.Consume, particularly because they can't be marked as [Server] where they are.

The grinder has its own Recipe and CraftingDatabase classes, wondering if that can be made unnecessary.

Should be able to add a spawn amount to the admin spawner/cloner with this.

Need to do a comment pass

## Tests
Find any places stackables might be spawned and make sure they are working correctly
See where changes can be made to use the new spawning
- [x] Crafting recipes
- [x] Construction / Deconstruction / Destruction
- [ ] Admin spawner
- [ ] Vending machines
- [x] Map placed items
- [ ] Bags/Belts + Lockers + Cargo orders
- [ ] More I haven't thought of