### PR TITLE
(bugfix) Welders don't automatically turn off when they run out of fuel.

### DIFF
--- a/UnityProject/Assets/Scripts/Tool/Welder.cs
+++ b/UnityProject/Assets/Scripts/Tool/Welder.cs
@@ -211,7 +211,7 @@ public class Welder : NetworkBehaviour, IInteractable<HandActivate>, IServerSpaw
 				reagentContainer.TakeReagents(.041f);
 
 				//Ran out of fuel
-				if (FuelAmount < 0f)
+				if (FuelAmount <= 0f)
 				{
 					SyncIsOn(isOn, false);
 				}


### PR DESCRIPTION
### Purpose
fixes #4340 

Welder check was looking for a value less than 0, it was changed to be less than or equal. Seemed like a straight forward fix and welders now properly turn off when they run out of fuel.

### Notes:
Any questions or concerns name in discord is Zasze
