### PR TITLE
Removing dependency on Time.deltaTime in GameManager.

### DIFF
--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -79,9 +79,7 @@ public class JoinedViewer : NetworkBehaviour
 		{
 			if (GameManager.Instance.waitForStart)
 			{
-				// Calculate when the countdown will end relative to the NetworkTime
-				double endTime = NetworkTime.time + GameManager.Instance.CountdownTime;
-				TargetSyncCountdown(connectionToClient, GameManager.Instance.waitForStart, endTime);
+				TargetSyncCountdown(connectionToClient, GameManager.Instance.waitForStart, GameManager.Instance.CountdownEndTime);
 			}
 			else
 			{


### PR DESCRIPTION
### Purpose
This fixes #4322 , where a job couldn't be chosen after the countdown ended. This seems to be due to Time.deltaTime not being updated properly when loading stuff (I think mainly SubScenes).

Fix:
Changing CountdownTime to CountdownEndTime, i.e. setting at which time the count down will be finished in respect to NetworkTime.time. This will prevent the countdown to be longer than expected.

### Notes:
I am not sure how reliable NetworkTime itself is, it works fine on my end.
