### PR TITLE
infinite fire stack issue + fire state tracking 

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -105,6 +105,8 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	//can go up or down based on possible sources of being on fire. Max seems to be 20 in tg.
 	[SyncVar(hook=nameof(SyncFireStacks))]
 	private float fireStacks;
+	private float maxFireStacks = 20f;
+	private bool isOnFire = false;
 
 	/// <summary>
 	/// How on fire we are. Exists client side - synced with server.
@@ -379,7 +381,16 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 
 		if (attackType == AttackType.Fire)
 		{
-			SyncFireStacks(fireStacks, fireStacks+1);
+			if (fireStacks <= maxFireStacks && !isOnFire)
+			{
+				SyncFireStacks(fireStacks, fireStacks+1);
+				isOnFire = true;
+			}
+
+			if (fireStacks <= 0f)
+			{
+				isOnFire = false;
+			}
 		}
 
 		//For special effects spawning like blood:

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -381,17 +381,19 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 
 		if (attackType == AttackType.Fire)
 		{
-			// TODO: issue here is that fire stacks need to apply freely when inside a fire source but not forever from self sources
+			// fire stacks should not exceed 20, and not apply if already at the cap
 			if (fireStacks <= maxFireStacks && !maxFireStacksReached)
 			{
 				SyncFireStacks(fireStacks, fireStacks+1);
 			}
 
+			// fire stacks should not exceed max fire stacks
 			if (fireStacks >= maxFireStacks)
 			{
 				maxFireStacksReached = true;
 			}
 
+			// fire stacks hit 0 remove flag
 			if (fireStacks <= 0f)
 			{
 				maxFireStacksReached = false;

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -106,7 +106,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	[SyncVar(hook=nameof(SyncFireStacks))]
 	private float fireStacks;
 	private float maxFireStacks = 20f;
-	private bool isOnFire = false;
+	private bool maxFireStacksReached = false;
 
 	/// <summary>
 	/// How on fire we are. Exists client side - synced with server.
@@ -381,15 +381,20 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 
 		if (attackType == AttackType.Fire)
 		{
-			if (fireStacks <= maxFireStacks && !isOnFire)
+			// TODO: issue here is that fire stacks need to apply freely when inside a fire source but not forever from self sources
+			if (fireStacks <= maxFireStacks && !maxFireStacksReached)
 			{
 				SyncFireStacks(fireStacks, fireStacks+1);
-				isOnFire = true;
+			}
+
+			if (fireStacks >= maxFireStacks)
+			{
+				maxFireStacksReached = true;
 			}
 
 			if (fireStacks <= 0f)
 			{
-				isOnFire = false;
+				maxFireStacksReached = false;
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -105,7 +105,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	//can go up or down based on possible sources of being on fire. Max seems to be 20 in tg.
 	[SyncVar(hook=nameof(SyncFireStacks))]
 	private float fireStacks;
-	private float maxFireStacks = 20f;
+	private float maxFireStacks = 5f;
 	private bool maxFireStacksReached = false;
 
 	/// <summary>


### PR DESCRIPTION
### Purpose
Fixes #4343  
two main issues are 
* That there was no fire stack cap so that's been added, stacks will continue to tick up forever and  probably cause issues down the line.
* When someone is on fire they are themselves a source of fire and will just add new stacks to themselves faster than the fire stack decay rate.

I am working on a better way to implement fire state tracking to prevent someone in fire proof clothing from being an infinite source of new fire stacks even if they are now capped.

### Notes:
Any questions or comments msg Zasze on discord
