### PR TITLE
Enables dark theme for everyone and adds a neat sidebar

### DIFF
--- a/UnityProject/Packages/manifest.json
+++ b/UnityProject/Packages/manifest.json
@@ -16,6 +16,7 @@
     "com.unity.timeline": "1.2.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.xr.legacyinputhelpers": "2.1.1",
+    "com.xeleh.enhancer": "https://github.com/xeleh/enhancer.git",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
@@ -59,6 +60,10 @@
     "com.dbrizov.naughtyattributes": {
       "revision": "upm",
       "hash": "b46e9e8fde10448accd59ecabd09fbe296ef62f7"
+    },
+    "com.xeleh.enhancer": {
+      "revision": "HEAD",
+      "hash": "78e062bf5467bb3a4caae6315aaf74352050d116"
     }
   }
 }

--- a/UnityProject/ProjectSettings/Packages/com.xeleh.enhancer/Settings.asset
+++ b/UnityProject/ProjectSettings/Packages/com.xeleh.enhancer/Settings.asset
@@ -1,0 +1,51 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 61
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7233115e949fc48bb917a51ec59fb0cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  theme:
+    foldout: 1
+    darkEnabled: 1
+    autoEnable: 1
+  sidebar:
+    foldout: 1
+    enabled: 1
+    dockingSide: 1
+    backColor: {r: 1, g: 1, b: 1, a: 1}
+    verticalPadding: 8
+    items:
+    - icon: {fileID: 2800000, guid: 35001c30dca274d6baf7a5b7b5352da7, type: 3}
+      function: 1
+      layoutName: 
+      menuPath: Window/General/Test Runner
+    - icon: {fileID: 2800000, guid: b7c8febef39ef424ab31ec71f625325c, type: 3}
+      function: 2
+      layoutName: 
+      menuPath: 
+    - icon: {fileID: 2800000, guid: 015154da0beca2f4d8d122b9d269f1b3, type: 3}
+      function: 1
+      layoutName: 
+      menuPath: Window/2D/Tile Palette
+    - icon: {fileID: 2800000, guid: 3ed9ddd3a906e83489904773243ea87e, type: 3}
+      function: 1
+      layoutName: 
+      menuPath: Window/Matrix Check
+    - icon: {fileID: 2800000, guid: 89396edced8dc405d87684a582ab87bd, type: 3}
+      function: 1
+      layoutName: 
+      menuPath: Logger/Adjust Log Levels
+    - icon: {fileID: 2800000, guid: 7949afa9fd64c31408a479bec5ee97fb, type: 3}
+      function: 1
+      layoutName: 
+      menuPath: Window/Pixel Art Editor
+    playModeLayout: 
+    saveLayoutOnChange: 0


### PR DESCRIPTION
Engineers rejoice
<img width="1158" alt="Scr 2020-06-12 в 12 48 10" src="https://user-images.githubusercontent.com/10403536/84489856-fef35880-acaa-11ea-8968-cb42bf1866d9.png">

Adds Editor Enhancer that enables dark mode for 2019.3 versions below 2019.3.15 and adds a customizable sidebar that I pre-filled with some actions