### PR TITLE
Admin Teleport

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/AdminTools/AdminTools.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/AdminTools/AdminTools.prefab
@@ -398,6 +398,83 @@ MonoBehaviour:
   m_CaretBlinkRate: 0.85
   m_CaretWidth: 5
   m_ReadOnly: 0
+--- !u!1 &318831297132330163
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4542703396048777450}
+  - component: {fileID: 4631041905605678156}
+  - component: {fileID: 4833728137354659657}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4542703396048777450
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 318831297132330163}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5723466169221834917}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4631041905605678156
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 318831297132330163}
+  m_CullTransparentMesh: 0
+--- !u!114 &4833728137354659657
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 318831297132330163}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.98823535, g: 0.98823535, b: 0.98823535, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 20
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 2
+    m_MaxSize: 20
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Teleport Admin To Player - Aghost
 --- !u!1 &325021019328161987
 GameObject:
   m_ObjectHideFlags: 0
@@ -573,8 +650,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 152.54498, y: -336.035}
-  m_SizeDelta: {x: 180.05, y: 119.3}
+  m_AnchoredPosition: {x: 461.76, y: -74.19998}
+  m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1093371403546201424
 CanvasRenderer:
@@ -1543,6 +1620,83 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: KICK
+--- !u!1 &975855305819485646
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1120847261795524150}
+  - component: {fileID: 4387454821847920189}
+  - component: {fileID: 6036270691547626326}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1120847261795524150
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975855305819485646}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5185232339583884655}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4387454821847920189
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975855305819485646}
+  m_CullTransparentMesh: 0
+--- !u!114 &6036270691547626326
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975855305819485646}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 20
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 2
+    m_MaxSize: 20
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Teleport Admin To Player
 --- !u!1 &1159973385265942778
 GameObject:
   m_ObjectHideFlags: 0
@@ -1745,6 +1899,135 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1285762283856049918
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5185232339583884655}
+  - component: {fileID: 3473849101460219364}
+  - component: {fileID: 6155682185304467250}
+  - component: {fileID: 5320481274553130716}
+  m_Layer: 5
+  m_Name: TeleportAdminToPlayer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5185232339583884655
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285762283856049918}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1120847261795524150}
+  m_Father: {fileID: 1743105774368683888}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 102.84, y: -454.39996}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3473849101460219364
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285762283856049918}
+  m_CullTransparentMesh: 0
+--- !u!114 &6155682185304467250
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285762283856049918}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 00b9f947b2ed79743a4a1d83880a5901, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5320481274553130716
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285762283856049918}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6155682185304467250}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3838275868867218214}
+        m_MethodName: OnTeleportAdminToPlayer
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &1324796412596208898
 GameObject:
   m_ObjectHideFlags: 0
@@ -2150,7 +2433,6 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1743105774368683888}
-  - {fileID: 5241895889754527550}
   m_Father: {fileID: 4427713382983301975}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2177,6 +2459,9 @@ MonoBehaviour:
   respawnBtn: {fileID: 6648542095557804186}
   respawnAsBtn: {fileID: 8805674663035658561}
   adminJobsDropdown: {fileID: 5142037760516971008}
+  teleportAdminToPlayer: {fileID: 5320481274553130716}
+  teleportPlayerToAdmin: {fileID: 2428868581691071586}
+  teleportAdminToPlayerAghost: {fileID: 5713380019150669197}
 --- !u!1 &1577184765888699447
 GameObject:
   m_ObjectHideFlags: 0
@@ -2569,7 +2854,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 723.91003, y: -174.805}
+  m_AnchoredPosition: {x: 204.88998, y: -384.205}
   m_SizeDelta: {x: 180.05, y: 119.3}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &9143061363295099683
@@ -3212,6 +3497,83 @@ MonoBehaviour:
   - {fileID: 0}
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2454346669898557897
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8021917845160475843}
+  - component: {fileID: 7260727336803753339}
+  - component: {fileID: 5339505763434647447}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8021917845160475843
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2454346669898557897}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3755087979155411765}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7260727336803753339
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2454346669898557897}
+  m_CullTransparentMesh: 0
+--- !u!114 &5339505763434647447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2454346669898557897}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9607844, g: 0.9607844, b: 0.9607844, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 20
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 2
+    m_MaxSize: 20
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Teleport Player To Admin
 --- !u!1 &2464125070694631880
 GameObject:
   m_ObjectHideFlags: 0
@@ -4098,13 +4460,14 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2900833249516902360}
+  - {fileID: 5241895889754527550}
   m_Father: {fileID: 1743105774368683888}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 412.055, y: -336.035}
-  m_SizeDelta: {x: 180.05, y: 119.3}
+  m_AnchoredPosition: {x: 102.84, y: -264.3}
+  m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5395226812823623218
 CanvasRenderer:
@@ -4793,12 +5156,12 @@ RectTransform:
   - {fileID: 4361548709419195067}
   - {fileID: 6184256359795788896}
   - {fileID: 7051972171869476254}
-  m_Father: {fileID: 2705851631137214661}
+  m_Father: {fileID: 1542399247138976064}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 759.67, y: -455.59}
+  m_AnchoredPosition: {x: 56, y: -142}
   m_SizeDelta: {x: 177.47, y: 40.89}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &5835069370026545696
@@ -5225,6 +5588,135 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Search by Unicloth, Hier, or Prefab Name
+--- !u!1 &3930880883924070210
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3755087979155411765}
+  - component: {fileID: 8498005133307530148}
+  - component: {fileID: 2627839132491900420}
+  - component: {fileID: 2428868581691071586}
+  m_Layer: 5
+  m_Name: TeleportPlayerToAdmin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3755087979155411765
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3930880883924070210}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8021917845160475843}
+  m_Father: {fileID: 1743105774368683888}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 282.3, y: -264.3}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8498005133307530148
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3930880883924070210}
+  m_CullTransparentMesh: 0
+--- !u!114 &2627839132491900420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3930880883924070210}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 00b9f947b2ed79743a4a1d83880a5901, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2428868581691071586
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3930880883924070210}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2627839132491900420}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3838275868867218214}
+        m_MethodName: OnTeleportPlayerToAdmin
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &3964877443630982805
 GameObject:
   m_ObjectHideFlags: 0
@@ -5382,13 +5874,16 @@ RectTransform:
   - {fileID: 3226595742494241600}
   - {fileID: 8560776635561198632}
   - {fileID: 1542399247138976064}
+  - {fileID: 3755087979155411765}
+  - {fileID: 5723466169221834917}
+  - {fileID: 5185232339583884655}
   m_Father: {fileID: 2705851631137214661}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 166.29999, y: 29.862}
-  m_SizeDelta: {x: 564.6, y: 462.67}
+  m_AnchoredPosition: {x: 166.3, y: -3.1}
+  m_SizeDelta: {x: 564.6, y: 528.6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2978044118273273289
 MonoBehaviour:
@@ -5410,7 +5905,7 @@ MonoBehaviour:
   m_ChildAlignment: 4
   m_StartCorner: 0
   m_StartAxis: 0
-  m_CellSize: {x: 180.05, y: 119.3}
+  m_CellSize: {x: 100, y: 100}
   m_Spacing: {x: 79.46, y: 90.1}
   m_Constraint: 0
   m_ConstraintCount: 2
@@ -7814,8 +8309,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 412.055, y: -126.635}
-  m_SizeDelta: {x: 180.05, y: 119.3}
+  m_AnchoredPosition: {x: 282.3, y: -74.19998}
+  m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7450100925885238376
 CanvasRenderer:
@@ -8250,6 +8745,135 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5717816400329970477
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5723466169221834917}
+  - component: {fileID: 2101963399624187744}
+  - component: {fileID: 7207339889736903316}
+  - component: {fileID: 5713380019150669197}
+  m_Layer: 5
+  m_Name: TeleportAdminToPlayer - Aghost
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5723466169221834917
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5717816400329970477}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4542703396048777450}
+  m_Father: {fileID: 1743105774368683888}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 461.76, y: -264.3}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2101963399624187744
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5717816400329970477}
+  m_CullTransparentMesh: 0
+--- !u!114 &7207339889736903316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5717816400329970477}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 00b9f947b2ed79743a4a1d83880a5901, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5713380019150669197
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5717816400329970477}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7207339889736903316}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3838275868867218214}
+        m_MethodName: OnTeleportAdminToPlayerAghost
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &5743863903887078973
 GameObject:
   m_ObjectHideFlags: 0
@@ -11520,7 +12144,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1272676827458379016}
   m_HandleRect: {fileID: 3835727200826391243}
   m_Direction: 3
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -12432,8 +13056,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 152.54498, y: -126.635}
-  m_SizeDelta: {x: 180.05, y: 119.3}
+  m_AnchoredPosition: {x: 102.84, y: -74.19998}
+  m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5585972740863931781
 CanvasRenderer:

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/AdminTools/AdminTools.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/AdminTools/AdminTools.prefab
@@ -151,6 +151,135 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &164017820276573491
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1675726846448114705}
+  - component: {fileID: 611348971243797575}
+  - component: {fileID: 7210780937216237321}
+  - component: {fileID: 889364241311585945}
+  m_Layer: 5
+  m_Name: TeleportALLPlayersToPlayer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1675726846448114705
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 164017820276573491}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5409708021132150829}
+  m_Father: {fileID: 1743105774368683888}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 282.3, y: -454.39996}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &611348971243797575
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 164017820276573491}
+  m_CullTransparentMesh: 0
+--- !u!114 &7210780937216237321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 164017820276573491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 00b9f947b2ed79743a4a1d83880a5901, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &889364241311585945
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 164017820276573491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7210780937216237321}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3838275868867218214}
+        m_MethodName: OnTeleportAllPlayersToPlayer
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &204198262122931395
 GameObject:
   m_ObjectHideFlags: 0
@@ -1931,11 +2060,11 @@ RectTransform:
   m_Children:
   - {fileID: 1120847261795524150}
   m_Father: {fileID: 1743105774368683888}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 102.84, y: -454.39996}
+  m_AnchoredPosition: {x: 461.76, y: -264.3}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3473849101460219364
@@ -2462,6 +2591,7 @@ MonoBehaviour:
   teleportAdminToPlayer: {fileID: 5320481274553130716}
   teleportPlayerToAdmin: {fileID: 2428868581691071586}
   teleportAdminToPlayerAghost: {fileID: 5713380019150669197}
+  teleportAllPlayersToPlayer: {fileID: 889364241311585945}
 --- !u!1 &1577184765888699447
 GameObject:
   m_ObjectHideFlags: 0
@@ -5620,11 +5750,11 @@ RectTransform:
   m_Children:
   - {fileID: 8021917845160475843}
   m_Father: {fileID: 1743105774368683888}
-  m_RootOrder: 5
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 282.3, y: -264.3}
+  m_AnchoredPosition: {x: 102.84, y: -454.39996}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8498005133307530148
@@ -5874,9 +6004,10 @@ RectTransform:
   - {fileID: 3226595742494241600}
   - {fileID: 8560776635561198632}
   - {fileID: 1542399247138976064}
-  - {fileID: 3755087979155411765}
   - {fileID: 5723466169221834917}
   - {fileID: 5185232339583884655}
+  - {fileID: 3755087979155411765}
+  - {fileID: 1675726846448114705}
   m_Father: {fileID: 2705851631137214661}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -8777,11 +8908,11 @@ RectTransform:
   m_Children:
   - {fileID: 4542703396048777450}
   m_Father: {fileID: 1743105774368683888}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 461.76, y: -264.3}
+  m_AnchoredPosition: {x: 282.3, y: -264.3}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2101963399624187744
@@ -9824,6 +9955,83 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Option A
+--- !u!1 &6164530522928518326
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5409708021132150829}
+  - component: {fileID: 4136605421880876937}
+  - component: {fileID: 4165076768981622004}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5409708021132150829
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6164530522928518326}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1675726846448114705}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4136605421880876937
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6164530522928518326}
+  m_CullTransparentMesh: 0
+--- !u!114 &4165076768981622004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6164530522928518326}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 10
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 20
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Teleport <color=red>ALL</color> Players To Player
 --- !u!1 &6184138863785233666
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -426,7 +426,7 @@ public partial class PlayerList
 				}
 				else
 				{
-					message = $"{ServerData.ServerConfig.ServerName}\nPlayer: {p.Name}, has been kicked for {banMinutes}";
+					message = $"{ServerData.ServerConfig.ServerName}\nPlayer: {p.Name}, has been kicked.";
 				}
 
 				DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookAnnouncementURL, message, "");

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs
@@ -1,0 +1,102 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Mirror;
+using UnityEngine;
+
+public class RequestAdminTeleport : ClientMessage
+{
+	public string Userid;
+	public string AdminToken;
+	public string UserToTeleport;
+	public string UserToTeleportTo;
+	public bool IsAdminToPlayer;
+
+	public override void Process()
+	{
+		if (IsAdminToPlayer)
+		{
+			DoAdminToPlayerTeleport();
+		}
+		else
+		{
+			DoPlayerToAdminTeleport();
+		}
+	}
+
+	private void DoPlayerToAdminTeleport()
+	{
+		PlayerSync userToTeleport = null;
+
+		foreach (var player in PlayerList.Instance.AllPlayers)
+		{
+			if (player.UserId == UserToTeleport)
+			{
+				userToTeleport = player.Script.PlayerSync;
+
+				break;
+			}
+		}
+
+		if (userToTeleport == null) return;
+
+		userToTeleport.SetPosition(SentByPlayer.Script.AssumedWorldPos);
+	}
+
+	private void DoAdminToPlayerTeleport()
+	{
+		PlayerScript userToTeleportTo = null;
+
+		foreach (var player in PlayerList.Instance.AllPlayers)
+		{
+			if (player.UserId == UserToTeleportTo)
+			{
+				userToTeleportTo = player.Script;
+
+				break;
+			}
+		}
+
+		if (userToTeleportTo == null) return;
+
+		var playerScript = SentByPlayer.Script;
+
+		if (playerScript == null) return;
+
+		playerScript.PlayerSync.SetPosition(userToTeleportTo.AssumedWorldPos);
+	}
+
+	public static RequestAdminTeleport Send(string userId, string adminToken, string userToTeleport, string userToTelportTo, bool isAdminToPlayer)
+	{
+		RequestAdminTeleport msg = new RequestAdminTeleport
+		{
+			Userid = userId,
+			AdminToken = adminToken,
+			UserToTeleport = userToTeleport,
+			UserToTeleportTo = userToTelportTo,
+			IsAdminToPlayer = isAdminToPlayer
+		};
+		msg.Send();
+		return msg;
+	}
+
+	public override void Deserialize(NetworkReader reader)
+	{
+		base.Deserialize(reader);
+		Userid = reader.ReadString();
+		AdminToken = reader.ReadString();
+		UserToTeleport = reader.ReadString();
+		UserToTeleportTo = reader.ReadString();
+		IsAdminToPlayer = reader.ReadBoolean();
+	}
+
+	public override void Serialize(NetworkWriter writer)
+	{
+		base.Serialize(writer);
+		writer.WriteString(Userid);
+		writer.WriteString(AdminToken);
+		writer.WriteString(UserToTeleport);
+		writer.WriteString(UserToTeleportTo);
+		writer.WriteBoolean(IsAdminToPlayer);
+	}
+}

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs
@@ -18,17 +18,17 @@ public class RequestAdminTeleport : ClientMessage
 
 	public override void Process()
 	{
-		if (OpperationNumber == 1)
+		switch (OpperationNumber)
 		{
-			DoAdminToPlayerTeleport();
-		}
-		else if (OpperationNumber == 2)
-		{
-			DoPlayerToAdminTeleport();
-		}
-		else if (OpperationNumber == 3)
-		{
-			DoAllPlayersToPlayerTeleport();
+			case (int)OpperationList.AdminToPlayer:
+				DoAdminToPlayerTeleport();
+				return;
+			case (int)OpperationList.PlayerToAdmin:
+				DoPlayerToAdminTeleport();
+				return;
+			case (int)OpperationList.AllPlayersToPlayer:
+				DoAllPlayersToPlayerTeleport();
+				return;
 		}
 	}
 
@@ -132,6 +132,7 @@ public class RequestAdminTeleport : ClientMessage
 			else if (destinationPlayer.IsGhost)
 			{
 				//if the  destination player player is a ghost the system breaks as for some reason ghost position is not accurate on server.
+				//To test for future reference: test coord on headless, works fine in editor.
 				//if admin is ghost top condition is used as the admin can pass their position from client to server.
 				return;
 			}
@@ -146,7 +147,7 @@ public class RequestAdminTeleport : ClientMessage
 		UIManager.Instance.adminChatWindows.adminToAdminChat.ServerAddChatRecord(msg, Userid);
 	}
 
-	public static RequestAdminTeleport Send(string userId, string adminToken, string userToTeleport, string userToTelportTo, int opperationNumber, bool isAghost, Vector3 Coord)
+	public static RequestAdminTeleport Send(string userId, string adminToken, string userToTeleport, string userToTelportTo, OpperationList opperation, bool isAghost, Vector3 Coord)
 	{
 		RequestAdminTeleport msg = new RequestAdminTeleport
 		{
@@ -154,7 +155,7 @@ public class RequestAdminTeleport : ClientMessage
 			AdminToken = adminToken,
 			UserToTeleport = userToTeleport,
 			UserToTeleportTo = userToTelportTo,
-			OpperationNumber = opperationNumber,
+			OpperationNumber = (int)opperation,
 			IsAghost = isAghost,
 			vectorX = Coord.x,
 			vectorY = Coord.y,
@@ -164,31 +165,10 @@ public class RequestAdminTeleport : ClientMessage
 		return msg;
 	}
 
-	public override void Deserialize(NetworkReader reader)
+	public enum OpperationList
 	{
-		base.Deserialize(reader);
-		Userid = reader.ReadString();
-		AdminToken = reader.ReadString();
-		UserToTeleport = reader.ReadString();
-		UserToTeleportTo = reader.ReadString();
-		OpperationNumber = reader.ReadInt32();
-		IsAghost = reader.ReadBoolean();
-		vectorX = reader.ReadSingle();
-		vectorY = reader.ReadSingle();
-		vectorZ = reader.ReadSingle();
-	}
-
-	public override void Serialize(NetworkWriter writer)
-	{
-		base.Serialize(writer);
-		writer.WriteString(Userid);
-		writer.WriteString(AdminToken);
-		writer.WriteString(UserToTeleport);
-		writer.WriteString(UserToTeleportTo);
-		writer.WriteInt32(OpperationNumber);
-		writer.WriteBoolean(IsAghost);
-		writer.WriteSingle(vectorX);
-		writer.WriteSingle(vectorY);
-		writer.WriteSingle(vectorZ);
+		AdminToPlayer = 1,
+		PlayerToAdmin = 2,
+		AllPlayersToPlayer = 3
 	}
 }

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs
@@ -41,7 +41,18 @@ public class RequestAdminTeleport : ClientMessage
 
 		if (userToTeleport == null) return;
 
-		userToTeleport.PlayerSync.SetPosition(SentByPlayer.Script.AssumedWorldPos);
+		Vector3 pos;
+
+		if (SentByPlayer.Script.pushPull == null)
+		{
+			pos = SentByPlayer.Script.WorldPos;
+		}
+		else
+		{
+			pos = SentByPlayer.Script.AssumedWorldPos;
+		}
+
+		userToTeleport.PlayerSync.SetPosition(pos);
 
 		UIManager.Instance.adminChatWindows.adminToAdminChat.ServerAddChatRecord(
 				$"{SentByPlayer.Username} teleported {userToTeleport.playerName} to themselves", Userid);
@@ -67,7 +78,18 @@ public class RequestAdminTeleport : ClientMessage
 
 		if (playerScript == null) return;
 
-		playerScript.PlayerSync.SetPosition(userToTeleportTo.AssumedWorldPos);
+		Vector3 pos;
+
+		if (userToTeleportTo.pushPull == null)
+		{
+			pos = userToTeleportTo.WorldPos;
+		}
+		else
+		{
+			pos = userToTeleportTo.AssumedWorldPos;
+		}
+
+		playerScript.PlayerSync.SetPosition(pos);
 
 		string msg;
 

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs
@@ -10,7 +10,7 @@ public class RequestAdminTeleport : ClientMessage
 	public string AdminToken;
 	public string UserToTeleport;
 	public string UserToTeleportTo;
-	public bool IsAdminToPlayer;
+	public int OpperationNumber;
 	public bool IsAghost;
 	public float vectorX;
 	public float vectorY;
@@ -18,13 +18,17 @@ public class RequestAdminTeleport : ClientMessage
 
 	public override void Process()
 	{
-		if (IsAdminToPlayer)
+		if (OpperationNumber == 1)
 		{
 			DoAdminToPlayerTeleport();
 		}
-		else
+		else if (OpperationNumber == 2)
 		{
 			DoPlayerToAdminTeleport();
+		}
+		else if (OpperationNumber == 3)
+		{
+			DoAllPlayersToPlayerTeleport();
 		}
 	}
 
@@ -136,7 +140,7 @@ public class RequestAdminTeleport : ClientMessage
 		UIManager.Instance.adminChatWindows.adminToAdminChat.ServerAddChatRecord(msg, Userid);
 	}
 
-	public static RequestAdminTeleport Send(string userId, string adminToken, string userToTeleport, string userToTelportTo, bool isAdminToPlayer, bool isAghost, Vector3 Coord)
+	public static RequestAdminTeleport Send(string userId, string adminToken, string userToTeleport, string userToTelportTo, int opperationNumber, bool isAghost, Vector3 Coord)
 	{
 		RequestAdminTeleport msg = new RequestAdminTeleport
 		{
@@ -144,7 +148,7 @@ public class RequestAdminTeleport : ClientMessage
 			AdminToken = adminToken,
 			UserToTeleport = userToTeleport,
 			UserToTeleportTo = userToTelportTo,
-			IsAdminToPlayer = isAdminToPlayer,
+			OpperationNumber = opperationNumber,
 			IsAghost = isAghost,
 			vectorX = Coord.x,
 			vectorY = Coord.y,
@@ -161,7 +165,7 @@ public class RequestAdminTeleport : ClientMessage
 		AdminToken = reader.ReadString();
 		UserToTeleport = reader.ReadString();
 		UserToTeleportTo = reader.ReadString();
-		IsAdminToPlayer = reader.ReadBoolean();
+		OpperationNumber = reader.ReadInt32();
 		IsAghost = reader.ReadBoolean();
 		vectorX = reader.ReadSingle();
 		vectorY = reader.ReadSingle();
@@ -175,7 +179,7 @@ public class RequestAdminTeleport : ClientMessage
 		writer.WriteString(AdminToken);
 		writer.WriteString(UserToTeleport);
 		writer.WriteString(UserToTeleportTo);
-		writer.WriteBoolean(IsAdminToPlayer);
+		writer.WriteInt32(OpperationNumber);
 		writer.WriteBoolean(IsAghost);
 		writer.WriteSingle(vectorX);
 		writer.WriteSingle(vectorY);

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs
@@ -10,7 +10,7 @@ public class RequestAdminTeleport : ClientMessage
 	public string AdminToken;
 	public string UserToTeleport;
 	public string UserToTeleportTo;
-	public int OpperationNumber;
+	public OpperationList OpperationNumber;
 	public bool IsAghost;
 	public float vectorX;
 	public float vectorY;
@@ -20,13 +20,13 @@ public class RequestAdminTeleport : ClientMessage
 	{
 		switch (OpperationNumber)
 		{
-			case (int)OpperationList.AdminToPlayer:
+			case OpperationList.AdminToPlayer:
 				DoAdminToPlayerTeleport();
 				return;
-			case (int)OpperationList.PlayerToAdmin:
+			case OpperationList.PlayerToAdmin:
 				DoPlayerToAdminTeleport();
 				return;
-			case (int)OpperationList.AllPlayersToPlayer:
+			case OpperationList.AllPlayersToPlayer:
 				DoAllPlayersToPlayerTeleport();
 				return;
 		}
@@ -155,7 +155,7 @@ public class RequestAdminTeleport : ClientMessage
 			AdminToken = adminToken,
 			UserToTeleport = userToTeleport,
 			UserToTeleportTo = userToTelportTo,
-			OpperationNumber = (int)opperation,
+			OpperationNumber = opperation,
 			IsAghost = isAghost,
 			vectorX = Coord.x,
 			vectorY = Coord.y,

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs
@@ -129,6 +129,12 @@ public class RequestAdminTeleport : ClientMessage
 
 				userToTeleport.PlayerSync.SetPosition(coord, true);
 			}
+			else if (destinationPlayer.IsGhost)
+			{
+				//if the  destination player player is a ghost the system breaks as for some reason ghost position is not accurate on server.
+				//if admin is ghost top condition is used as the admin can pass their position from client to server.
+				return;
+			}
 			else
 			{
 				userToTeleport.PlayerSync.SetPosition(destinationPlayer.gameObject.AssumedWorldPosServer(), true);

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs.meta
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminTeleport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf433d72b4f48ee48a97e7b450309396
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -290,12 +290,12 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 
 	bool checkWallMountOverlay()
 	{
-		var handItem = UIManager.Hands.CurrentSlot.ItemObject;
-		if (handItem == null)
+		var handItem = UIManager.Hands.CurrentSlot;
+		if (handItem == null || handItem.ItemObject == null)
 		{
 			return false;
 		}
-		var wallMount = handItem.GetComponent<WallMountHandApplySpawn>();
+		var wallMount = handItem.ItemObject.GetComponent<WallMountHandApplySpawn>();
 		if (wallMount == null)
 		{
 			return false;
@@ -312,7 +312,4 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 			Highlight.DeHighlight();
 		}
 	}
-
-
-
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -265,7 +265,7 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 
 	public void OnHover()
 	{
-		if (checkWallMountOverlay())
+		if (CheckWallMountOverlay())
 		{
 			Vector2 cameraPos = Camera.main.ScreenToWorldPoint(CommonInput.mousePosition);
 			var tilePos = cameraPos.RoundToInt();
@@ -288,7 +288,7 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 		}
 	}
 
-	bool checkWallMountOverlay()
+	private bool CheckWallMountOverlay()
 	{
 		var handItem = UIManager.Hands.CurrentSlot;
 		if (handItem == null || handItem.ItemObject == null)

--- a/UnityProject/Assets/Scripts/UI/AdminTools/PlayerManagePage.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/PlayerManagePage.cs
@@ -13,6 +13,9 @@ namespace AdminTools
 		[SerializeField] private Button respawnBtn = null;
 		[SerializeField] private Button respawnAsBtn = null;
 		[SerializeField] private Dropdown adminJobsDropdown = null;
+		[SerializeField] private Button teleportAdminToPlayer = null;
+		[SerializeField] private Button teleportPlayerToAdmin = null;
+		[SerializeField] private Button teleportAdminToPlayerAghost = null;
 		private AdminPlayerEntry playerEntry;
 
 		public override void OnPageRefresh(AdminPageRefreshData adminPageData)
@@ -120,6 +123,63 @@ namespace AdminTools
 				occupation);
 
 			RefreshPage();
+		}
+
+		public void OnTeleportAdminToPlayer()
+		{
+			adminTools.areYouSurePage.SetAreYouSurePage(
+				$"Teleport yourself to: {playerEntry.PlayerData.name}?",
+				SendTeleportAdminToPlayerRequest);
+		}
+
+		private void SendTeleportAdminToPlayerRequest()
+		{
+
+			RequestAdminTeleport.Send(
+				ServerData.UserID,
+				PlayerList.Instance.AdminToken,
+				null,
+				playerEntry.PlayerData.uid,
+				true
+				);
+		}
+
+		public void OnTeleportPlayerToAdmin()
+		{
+			adminTools.areYouSurePage.SetAreYouSurePage(
+				$"Teleport {playerEntry.PlayerData.name} to you?",
+				SendTeleportPlayerToAdmin);
+		}
+
+		private void SendTeleportPlayerToAdmin()
+		{
+			RequestAdminTeleport.Send(
+				ServerData.UserID,
+				PlayerList.Instance.AdminToken,
+				playerEntry.PlayerData.uid,
+				null,
+				false
+				);
+		}
+
+		public void OnTeleportAdminToPlayerAghost()
+		{
+			adminTools.areYouSurePage.SetAreYouSurePage(
+				$"Teleport yourself to: {playerEntry.PlayerData.name} as a ghost?",
+				SendTeleportAdminToPlayerAghost);
+		}
+
+		private void SendTeleportAdminToPlayerAghost()
+		{
+			PlayerManager.LocalPlayerScript.playerNetworkActions.CmdAGhost(ServerData.UserID, PlayerList.Instance.AdminToken);
+
+			RequestAdminTeleport.Send(
+				ServerData.UserID,
+				PlayerList.Instance.AdminToken,
+				null,
+				playerEntry.PlayerData.uid,
+				true
+				);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/AdminTools/PlayerManagePage.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/PlayerManagePage.cs
@@ -141,7 +141,7 @@ namespace AdminTools
 				PlayerList.Instance.AdminToken,
 				null,
 				playerEntry.PlayerData.uid,
-				1,
+				RequestAdminTeleport.OpperationList.AdminToPlayer,
 				false,
 				new Vector3(0, 0, 0)
 				);
@@ -161,7 +161,7 @@ namespace AdminTools
 				PlayerList.Instance.AdminToken,
 				playerEntry.PlayerData.uid,
 				null,
-				2,
+				RequestAdminTeleport.OpperationList.PlayerToAdmin,
 				false,
 				PlayerManager.LocalPlayerScript.PlayerSync.ClientPosition
 				);
@@ -186,7 +186,7 @@ namespace AdminTools
 				PlayerList.Instance.AdminToken,
 				null,
 				playerEntry.PlayerData.uid,
-				1,
+				RequestAdminTeleport.OpperationList.AdminToPlayer,
 				true,
 				new Vector3 (0,0,0)
 				);
@@ -221,7 +221,7 @@ namespace AdminTools
 				PlayerList.Instance.AdminToken,
 				null,
 				playerEntry.PlayerData.uid,
-				3,
+				RequestAdminTeleport.OpperationList.AllPlayersToPlayer,
 				isAghost,
 				coord
 				);

--- a/UnityProject/Assets/Scripts/UI/AdminTools/PlayerManagePage.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/PlayerManagePage.cs
@@ -16,6 +16,7 @@ namespace AdminTools
 		[SerializeField] private Button teleportAdminToPlayer = null;
 		[SerializeField] private Button teleportPlayerToAdmin = null;
 		[SerializeField] private Button teleportAdminToPlayerAghost = null;
+		[SerializeField] private Button teleportAllPlayersToPlayer = null;
 		private AdminPlayerEntry playerEntry;
 
 		public override void OnPageRefresh(AdminPageRefreshData adminPageData)
@@ -141,7 +142,8 @@ namespace AdminTools
 				null,
 				playerEntry.PlayerData.uid,
 				true,
-				false
+				false,
+				new Vector3(0, 0, 0)
 				);
 		}
 
@@ -160,7 +162,8 @@ namespace AdminTools
 				playerEntry.PlayerData.uid,
 				null,
 				false,
-				false
+				false,
+				PlayerManager.LocalPlayerScript.PlayerSync.ClientPosition
 				);
 		}
 
@@ -184,7 +187,43 @@ namespace AdminTools
 				null,
 				playerEntry.PlayerData.uid,
 				true,
-				true
+				true,
+				new Vector3 (0,0,0)
+				);
+		}
+
+		public void OnTeleportAllPlayersToPlayer()
+		{
+			adminTools.areYouSurePage.SetAreYouSurePage(
+				$"Teleport EVERYONE to {playerEntry.PlayerData.name}?",
+				SendTeleportAllPlayersToPlayer);
+		}
+
+		private void SendTeleportAllPlayersToPlayer()
+		{
+			Vector3 coord;
+
+			bool isAghost;
+
+			if (PlayerManager.LocalPlayerScript.IsGhost && playerEntry.PlayerData.uid == ServerData.UserID)
+			{
+				coord = PlayerManager.LocalPlayerScript.PlayerSync.ClientPosition;
+				isAghost = true;
+			}
+			else
+			{
+				coord = new Vector3(0, 0, 0);
+				isAghost = false;
+			}
+
+			RequestAdminTeleport.Send(
+				ServerData.UserID,
+				PlayerList.Instance.AdminToken,
+				null,
+				playerEntry.PlayerData.uid,
+				true,
+				isAghost,
+				coord
 				);
 		}
 	}

--- a/UnityProject/Assets/Scripts/UI/AdminTools/PlayerManagePage.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/PlayerManagePage.cs
@@ -173,7 +173,10 @@ namespace AdminTools
 
 		private void SendTeleportAdminToPlayerAghost()
 		{
-			PlayerManager.LocalPlayerScript.playerNetworkActions.CmdAGhost(ServerData.UserID, PlayerList.Instance.AdminToken);
+			if (!PlayerManager.LocalPlayerScript.IsGhost)
+			{
+				PlayerManager.LocalPlayerScript.playerNetworkActions.CmdAGhost(ServerData.UserID, PlayerList.Instance.AdminToken);
+			}
 
 			RequestAdminTeleport.Send(
 				ServerData.UserID,

--- a/UnityProject/Assets/Scripts/UI/AdminTools/PlayerManagePage.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/PlayerManagePage.cs
@@ -128,7 +128,7 @@ namespace AdminTools
 		public void OnTeleportAdminToPlayer()
 		{
 			adminTools.areYouSurePage.SetAreYouSurePage(
-				$"Teleport yourself to: {playerEntry.PlayerData.name}?",
+				$"Teleport yourself to {playerEntry.PlayerData.name}?",
 				SendTeleportAdminToPlayerRequest);
 		}
 
@@ -140,7 +140,8 @@ namespace AdminTools
 				PlayerList.Instance.AdminToken,
 				null,
 				playerEntry.PlayerData.uid,
-				true
+				true,
+				false
 				);
 		}
 
@@ -158,6 +159,7 @@ namespace AdminTools
 				PlayerList.Instance.AdminToken,
 				playerEntry.PlayerData.uid,
 				null,
+				false,
 				false
 				);
 		}
@@ -165,7 +167,7 @@ namespace AdminTools
 		public void OnTeleportAdminToPlayerAghost()
 		{
 			adminTools.areYouSurePage.SetAreYouSurePage(
-				$"Teleport yourself to: {playerEntry.PlayerData.name} as a ghost?",
+				$"Teleport yourself to {playerEntry.PlayerData.name} as a ghost?",
 				SendTeleportAdminToPlayerAghost);
 		}
 
@@ -178,6 +180,7 @@ namespace AdminTools
 				PlayerList.Instance.AdminToken,
 				null,
 				playerEntry.PlayerData.uid,
+				true,
 				true
 				);
 		}

--- a/UnityProject/Assets/Scripts/UI/AdminTools/PlayerManagePage.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/PlayerManagePage.cs
@@ -141,7 +141,7 @@ namespace AdminTools
 				PlayerList.Instance.AdminToken,
 				null,
 				playerEntry.PlayerData.uid,
-				true,
+				1,
 				false,
 				new Vector3(0, 0, 0)
 				);
@@ -161,7 +161,7 @@ namespace AdminTools
 				PlayerList.Instance.AdminToken,
 				playerEntry.PlayerData.uid,
 				null,
-				false,
+				2,
 				false,
 				PlayerManager.LocalPlayerScript.PlayerSync.ClientPosition
 				);
@@ -186,7 +186,7 @@ namespace AdminTools
 				PlayerList.Instance.AdminToken,
 				null,
 				playerEntry.PlayerData.uid,
-				true,
+				1,
 				true,
 				new Vector3 (0,0,0)
 				);
@@ -221,7 +221,7 @@ namespace AdminTools
 				PlayerList.Instance.AdminToken,
 				null,
 				playerEntry.PlayerData.uid,
-				true,
+				3,
 				isAghost,
 				coord
 				);

--- a/UnityProject/Assets/Scripts/UI/Cargo/CargoData.asset
+++ b/UnityProject/Assets/Scripts/UI/Cargo/CargoData.asset
@@ -689,7 +689,7 @@ MonoBehaviour:
   - CategoryName: Materials
     Supplies:
     - OrderName: Metal Crate
-      CreditsCost: 700
+      CreditsCost: 850
       Crate: {fileID: 658481186047158928, guid: 7703bcfa4ada3480095b5c7b68673f61,
         type: 3}
       Items:
@@ -754,7 +754,7 @@ MonoBehaviour:
       - {fileID: 6254655335276451647, guid: ab486d104d39e584e935c8a5459a967c, type: 3}
       - {fileID: 6254655335276451647, guid: ab486d104d39e584e935c8a5459a967c, type: 3}
     - OrderName: Glass Crate
-      CreditsCost: 700
+      CreditsCost: 850
       Crate: {fileID: 658481186047158928, guid: 7703bcfa4ada3480095b5c7b68673f61,
         type: 3}
       Items:


### PR DESCRIPTION
Adds: 

-Admin to player teleport

-Admin to player teleport but as Aghost

-Player to Admin teleport

-Teleport ALL players to any other player, (can only teleport to ghosts IF it an admin ghost who does the action)

-Fixes NRE with wallmounts

-kick message fix.

-rebalanced glass and metal crates buy cost to 850 from 700, as you could sell for 800.

Code problem discovered: ghosts position cannot be found using usual methods on headless, it just produces the same coord each time not matter what position, which is why only admins can do the all players to them when ghost as i had to send their client coord to the server.