### PR TITLE
Custom editor inspector for Audio Clips Array

### DIFF
--- a/UnityProject/Assets/Scripts/Editor/Inspector/AudioClipsArrayInspector.cs
+++ b/UnityProject/Assets/Scripts/Editor/Inspector/AudioClipsArrayInspector.cs
@@ -1,0 +1,102 @@
+﻿using Audio.Containers;
+using UnityEditor;
+using UnityEngine;
+
+
+namespace CustomInspectors
+{
+	[CustomEditor(typeof(AudioClipsArray))]
+	public class AudioClipsArrayInspector : Editor
+	{
+		private SerializedProperty audioClips;
+		private AudioSource audioSource;
+		private int currentPickerWindow;
+		private bool isPickerWindowClosed = false;
+		private Object valueToAdd;
+
+		private void OnEnable()
+		{
+			audioClips = serializedObject.FindProperty("audioClips");
+			audioSource = EditorUtility.CreateGameObjectWithHideFlags("Audio preview",HideFlags.HideAndDontSave,typeof(AudioSource)).GetComponent<AudioSource>();
+		}
+
+		private void OnDisable()
+		{
+			DestroyImmediate(audioSource.gameObject);
+		}
+
+		public override void OnInspectorGUI()
+		{
+			serializedObject.Update();
+
+			for (int i = 0; i < audioClips.arraySize; i++)
+			{
+
+				EditorGUILayout.BeginHorizontal();
+
+				EditorGUILayout.LabelField(i.ToString(),GUILayout.MaxWidth(30), GUILayout.MaxHeight(20));
+
+				var objectReference = audioClips.GetArrayElementAtIndex(i).objectReferenceValue;
+				EditorGUILayout.ObjectField(objectReference, typeof(AudioClip),false,
+								GUILayout.MaxHeight(20));
+
+				if (GUILayout.Button("P", GUILayout.MaxWidth(20), GUILayout.MaxHeight(20)))
+				{
+					var audioClip = (AudioClip) objectReference;
+					audioSource.clip = audioClip;
+
+					audioSource.Play();
+				}
+
+				if (GUILayout.Button("S", GUILayout.MaxWidth(20), GUILayout.MaxHeight(20)))
+				{
+					audioSource.Stop();
+				}
+
+				if (GUILayout.Button("X", GUILayout.MaxWidth(20), GUILayout.MaxHeight(20)))
+				{
+					audioSource.Stop();
+					audioClips.DeleteArrayElementAtIndex(i);
+				}
+
+				EditorGUILayout.EndHorizontal();
+			}
+
+			if (GUILayout.Button("Add clip"))
+			{
+				//create a window picker control ID
+				currentPickerWindow = EditorGUIUtility.GetControlID(FocusType.Passive);
+
+				//use the ID you just created
+				EditorGUIUtility.ShowObjectPicker<AudioClip>(null,false,"",currentPickerWindow);
+				isPickerWindowClosed = false;
+			}
+
+			AddNewClipFromPickerWindow();
+
+			serializedObject.ApplyModifiedProperties();
+		}
+
+		private void AddNewClipFromPickerWindow()
+		{
+			var currentPickedValue = EditorGUIUtility.GetObjectPickerObject();
+
+			if (currentPickedValue != null)
+			{
+				valueToAdd = currentPickedValue;
+			}
+
+			if (Event.current.commandName == "ObjectSelectorClosed")
+			{
+				isPickerWindowClosed = true;
+			}
+
+			if (Event.current.type == EventType.Repaint && valueToAdd != null && isPickerWindowClosed)
+			{
+				audioClips.InsertArrayElementAtIndex(0);
+				audioClips.GetArrayElementAtIndex(0).objectReferenceValue = valueToAdd;
+				valueToAdd = null;
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Editor/Inspector/AudioClipsArrayInspector.cs.meta
+++ b/UnityProject/Assets/Scripts/Editor/Inspector/AudioClipsArrayInspector.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7b07abbd61bb4a5485e76ff176915dfb
+timeCreated: 1591953706


### PR DESCRIPTION
### Purpose
More friendly inspector for audio clips array.

Before:
![InspectorBefore](https://user-images.githubusercontent.com/42844726/84569315-41da2c80-ad8e-11ea-97b6-018da0c5a68d.PNG)

After:
![After](https://user-images.githubusercontent.com/42844726/84569323-4acafe00-ad8e-11ea-8cb8-c866f867e1ef.PNG)

### Notes:
- Button "P" to play the clip.
- Button "S" to stop. (Stops any clip)
- Button "X" to delete from array.
- Button "Add clip" opens PickerWindow with all AudioClips in the project. Double click or select and close the window to add the clip.