### PR TITLE
Remove access restrictions from YouTool.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/YouTool.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/YouTool.prefab
@@ -128,7 +128,6 @@ GameObject:
   - component: {fileID: 114775338284287122}
   - component: {fileID: 2621353704256442992}
   - component: {fileID: -4754010924819303601}
-  - component: {fileID: 6906766861460055973}
   m_Layer: 11
   m_Name: YouTool
   m_TagString: Untagged
@@ -454,16 +453,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &6906766861460055973
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1771454506785624}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 91b1f6111eb8ac243b137dc8a7e36d1a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  restriction: 32


### PR DESCRIPTION
### Purpose
This PR just removes the access restrictions from the YouTool so anyone can use it. It doesn't have access restrictions in /tg/.
![image](https://user-images.githubusercontent.com/38266309/84798930-66155380-afb0-11ea-9bd2-be151227ebda.png)
![image](https://user-images.githubusercontent.com/38266309/84799102-9ceb6980-afb0-11ea-8cef-98155709d368.png)

Notice how the YouTool in the top image doesn't have "req_access" while the EngiVend on the bottom does.