### PR TITLE
PKA obtainable outside of lockers

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Mining/mining_machines_54.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Mining/mining_machines_54.prefab
@@ -215,6 +215,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8ed381a72f1e344bb8020dc181414b43, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  InitialVendorContent:
+  - Item: {fileID: 6700281191928912403, guid: 51db727353f37334c9bfdbb512f2d530, type: 3}
+    Stock: 5
+  - Item: {fileID: 2654578771155045139, guid: 5a7fa3c926dc42141889e9b72c5d314d, type: 3}
+    Stock: 5
+  - Item: {fileID: 2654578771155045139, guid: 82cb1c39112974a498a9756981eb07d0, type: 3}
+    Stock: 5
+  - Item: {fileID: 6507691273333881185, guid: 1488f67a55cb9b84098e095e65e5a2b3, type: 3}
+    Stock: 5
+  - Item: {fileID: 6507000735928756314, guid: 672dc44f4c052d746aefa06b301785bd, type: 3}
+    Stock: 5
+  HullColor: {r: 0.5882353, g: 0.4392157, b: 0.19607843, a: 1}
+  EjectObjects: 0
+  EjectDirection: 0
+  VendingSound: MachineVend
+  restockMessage: Items restocked.
+  noAccessMessage: Access denied!
   VendorContent:
   - Item: {fileID: 6700281191928912403, guid: 51db727353f37334c9bfdbb512f2d530, type: 3}
     Stock: 5
@@ -224,9 +241,6 @@ MonoBehaviour:
     Stock: 5
   - Item: {fileID: 6507691273333881185, guid: 1488f67a55cb9b84098e095e65e5a2b3, type: 3}
     Stock: 5
-  HullColor: {r: 0.5882353, g: 0.4392157, b: 0.19607843, a: 1}
-  EjectObjects: 0
-  EjectDirection: 0
 --- !u!114 &114030207048474028
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -259,6 +273,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  snapToGridOnStart: 1
   IsFixedMatrix: 0
 --- !u!114 &114774815397134544
 MonoBehaviour:
@@ -358,6 +373,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  forceHidden: 0

--- a/UnityProject/Assets/Scripts/UI/Cargo/CargoData.asset
+++ b/UnityProject/Assets/Scripts/UI/Cargo/CargoData.asset
@@ -306,6 +306,8 @@ MonoBehaviour:
       - {fileID: 2654578771155045139, guid: 5a7fa3c926dc42141889e9b72c5d314d, type: 3}
       - {fileID: 6507691273333881185, guid: 1488f67a55cb9b84098e095e65e5a2b3, type: 3}
       - {fileID: 6507691273333881185, guid: 1488f67a55cb9b84098e095e65e5a2b3, type: 3}
+      - {fileID: 6507000735928756314, guid: 672dc44f4c052d746aefa06b301785bd, type: 3}
+      - {fileID: 6507000735928756314, guid: 672dc44f4c052d746aefa06b301785bd, type: 3}
   - CategoryName: Uniform Sets
     Supplies:
     - OrderName: Assistant Set


### PR DESCRIPTION
5 Proto-Kinetic Accelerators were added to the mining tools vendor, and whenever cargo requests Mining Tools Crates then each crate should carry two as well.

### Purpose
-Changed mining_machines_54 prefab to contain Proto-Kinetic Accelerator prefab with an amount field of 5.
-Changed CargoData.asset's Mining field, the crate's item list array size was expanded by two. The mining tool crate now should contain two Proto-Kinetic Accelerators in addition to its previous contents