### PR TITLE
Server NRE Fixes Part 2

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/All-In-One Grinder.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/All-In-One Grinder.prefab
@@ -210,6 +210,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  snapToGridOnStart: 1
   IsFixedMatrix: 0
 --- !u!114 &114489739355773536
 MonoBehaviour:
@@ -368,12 +369,13 @@ MonoBehaviour:
   - 50
   transferAmount: 50
   maxCapacity: 200
-  reactionSet: {fileID: 0}
+  reactionSet: {fileID: 11400000, guid: 2d5f766d9268838aa8d819bee2a442a7, type: 2}
   initialReagentMix:
     temperature: 273.15
     reagents:
       m_keys: []
       m_values: []
+  destroyOnEmpty: 0
 --- !u!82 &8790646442014020747
 AudioSource:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Input System/MouseInputController.cs
@@ -492,6 +492,10 @@ public class MouseInputController : MonoBehaviour
 
 		// TODO Prepare and send requestexaminemessage
 		// todo:  check if netid = 0.
+
+		//Shift clicking on space created NRE
+		if (!clickedObject) return;
+
 		RequestExamineMessage.Send(clickedObject.GetComponent<NetworkIdentity>().netId, MouseWorldPosition);
 	}
 

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestRespawnPlayer.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestRespawnPlayer.cs
@@ -22,6 +22,9 @@ public class RequestRespawnPlayer : ClientMessage
 		if (player != null)
 		{
 			var deadPlayer = PlayerList.Instance.GetByUserID(UserToRespawn);
+
+			if (deadPlayer == null || deadPlayer.Script == null) return;
+
 			if (deadPlayer.Script.playerHealth == null)
 			{
 				TryRespawn(deadPlayer, OccupationToRespawn);

--- a/UnityProject/Assets/Scripts/Messages/Client/NewPlayer/DoorNewPlayer.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/NewPlayer/DoorNewPlayer.cs
@@ -8,8 +8,12 @@ public class DoorNewPlayer: ClientMessage
 	public override void Process()
 	{
 		LoadNetworkObject(Door);
-		NetworkObject.GetComponent<DoorController>().UpdateNewPlayer(
-			SentByPlayer.Connection);
+		var doorController = NetworkObject.GetComponent<DoorController>();
+
+		if (doorController != null)
+		{
+			doorController.UpdateNewPlayer(SentByPlayer.Connection);
+		}
 	}
 
 	public static DoorNewPlayer Send(uint netId)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs
@@ -154,6 +154,12 @@ public class InteractableTiles : NetworkBehaviour, IClientInteractable<Positiona
 	{
 		// Get Tile at position
 		LayerTile tile = LayerTileAt(pos);
+
+		if (tile == null)
+		{
+			return "Space";
+		}
+
 		return "A " + tile.DisplayName;
 	}
 


### PR DESCRIPTION
<details>
<summary>Request Player Respawn NRE Fix</summary>
NullReferenceException: Object reference not set to an instance of an object
  at RequestRespawnPlayer.VerifyAdminStatus () [0x00035] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestRespawnPlayer.cs:25 
  at RequestRespawnPlayer.Process () [0x00001] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestRespawnPlayer.cs:16 
  at GameMessageBase.Process (Mirror.NetworkConnection sentBy) [0x00001] in /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:25 
  at ClientMessage.Process (Mirror.NetworkConnection sentBy) [0x00012] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs:14 
  at GameMessageBase.PreProcess (Mirror.NetworkConnection sentBy, GameMessageBase b) [0x00001] in /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:18 
  at Mirror.MessagePacker+<>c__DisplayClass6_0`2[T,C].<MessageHandler>b__0 (Mirror.NetworkConnection conn, Mirror.NetworkReader reader, System.Int32 channelId) [0x000c4] in /github/workspace/UnityProject/Assets/Mirror/Runtime/MessagePacker.cs:146 
  at Mirror.NetworkConnection.InvokeHandler (System.Int32 msgType, Mirror.NetworkReader reader, System.Int32 channelId) [0x00014] in /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:219 
  at Mirror.NetworkConnection.TransportReceive (System.ArraySegment`1[T] buffer, System.Int32 channelId) [0x00073] in /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:272 
</details>

<details>
<summary>Door New Player NRE Fix</summary>
NullReferenceException: Object reference not set to an instance of an object
  at DoorNewPlayer.Process () [0x0000e] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/NewPlayer/DoorNewPlayer.cs:11 
  at GameMessageBase.Process (Mirror.NetworkConnection sentBy) [0x00001] in /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:25 
  at ClientMessage.Process (Mirror.NetworkConnection sentBy) [0x00012] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs:14 
  at GameMessageBase.PreProcess (Mirror.NetworkConnection sentBy, GameMessageBase b) [0x00001] in /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:18 
  at Mirror.MessagePacker+<>c__DisplayClass6_0`2[T,C].<MessageHandler>b__0 (Mirror.NetworkConnection conn, Mirror.NetworkReader reader, System.Int32 channelId) [0x000c4] in /github/workspace/UnityProject/Assets/Mirror/Runtime/MessagePacker.cs:146 
  at Mirror.NetworkConnection.InvokeHandler (System.Int32 msgType, Mirror.NetworkReader reader, System.Int32 channelId) [0x00014] in /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:219 
  at Mirror.NetworkConnection.TransportReceive (System.ArraySegment`1[T] buffer, System.Int32 channelId) [0x00073] in /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:272 
  at Mirror.NetworkServer.OnDataReceived (System.Int32 connectionId, System.ArraySegment`1[T] data, System.Int32 channelId) [0x00013] in /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs:511 
  at (wrapper delegate-invoke) UnityEngine.Events.UnityAction`3[System.Int32,System.ArraySegment`1[System.Byte],System.Int32].invoke_void_T0_T1_T2(int,System.ArraySegment`1<byte>,int)
  at UnityEngine.Events.InvokableCall`3[T1,T2,T3].Invoke (T1 args0, T2 args1, T3 args2) [0x00010] in /home/builduser/buildslave/unity/build/Runtime/Export/UnityEvent/UnityEvent.cs:284 
  at UnityEngine.Events.UnityEvent`3[T0,T1,T2].Invoke (T0 arg0, T1 arg1, T2 arg2) [0x00025] in /home/builduser/buildslave/unity/build/Runtime/Export/UnityEvent/UnityEvent/UnityEvent_3.cs:58 
  at Mirror.TelepathyTransport.ProcessServerMessage () [0x00042] in /github/workspace/UnityProject/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs:159 
  at Mirror.TelepathyTransport.LateUpdate () [0x0001e] in /github/workspace/UnityProject/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs:121 
</details>

<details>
<summary>Reagent Container NRE fixed by adding reaction set to grinder prefab</summary>
NullReferenceException: Object reference not set to an instance of an object
  at Chemistry.Components.ReagentContainer.Add (Chemistry.ReagentMix addition) [0x000e7] in /github/workspace/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs:209 
  at AIOGrinder.GrindFood () [0x00024] in /github/workspace/UnityProject/Assets/Scripts/Machines/AIOGrinder.cs:62 
  at InteractableGrinder.ServerPerformInteraction (HandApply interaction) [0x000ba] in /github/workspace/UnityProject/Assets/Scripts/Objects/InteractableGrinder.cs:47 
  at RequestInteractMessage.ServerCheckAndTrigger[T] (T interaction, System.Collections.Generic.IEnumerable`1[T] interactables) [0x00046] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:333 
  at RequestInteractMessage.ProcessInteraction[T] (T interaction, UnityEngine.GameObject processorObj) [0x00251] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:315 
  at RequestInteractMessage.Process () [0x0018d] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:140 
  at GameMessageBase.Process (Mirror.NetworkConnection sentBy) [0x00001] in /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:25 
  at ClientMessage.Process (Mirror.NetworkConnection sentBy) [0x00012] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs:14 
</details>

<details>
<summary>Interactable Tiles NRE Fix</summary>
NullReferenceException: Object reference not set to an instance of an object
  at InteractableTiles.Examine (UnityEngine.Vector3 pos) [0x0000f] in /github/workspace/UnityProject/Assets/Scripts/Tilemaps/Behaviours/InteractableTiles.cs:157 
  at RequestExamineMessage.Process () [0x00068] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestExamineMessage.cs:45 
  at GameMessageBase.Process (Mirror.NetworkConnection sentBy) [0x00001] in /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:25 
  at ClientMessage.Process (Mirror.NetworkConnection sentBy) [0x00012] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs:14 
  at GameMessageBase.PreProcess (Mirror.NetworkConnection sentBy, GameMessageBase b) [0x00001] in /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:18 
</details>

-Also fixed shift clicking on space causing client side NRE.
