### PR TITLE
nre check

### DIFF
--- a/UnityProject/Assets/Scripts/UI/AdminTools/AdminPlayersScrollView.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/AdminPlayersScrollView.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using DatabaseAPI;
 using UnityEngine;
@@ -52,6 +51,7 @@ namespace AdminTools
 
 		void RefreshPlayerList()
 		{
+			if (ServerData.UserID == null || PlayerList.Instance.AdminToken == null) return;
 			RequestAdminPlayerList.Send(ServerData.UserID, PlayerList.Instance.AdminToken);
 		}
 


### PR DESCRIPTION
<details>
<summary>RequestAdminPlayerList NRE</summary>
NullReferenceException: Object reference not set to an instance of an object
  at Telepathy.Server.GetClientAddress (System.Int32 connectionId) [0x00014] in /github/workspace/UnityProject/Assets/Mirror/Runtime/Transport/Telepathy/Server.cs:278 
  at Mirror.TelepathyTransport.ServerGetClientAddress (System.Int32 connectionId) [0x00002] in /github/workspace/UnityProject/Assets/Mirror/Runtime/Transport/TelepathyTransport.cs:178 
  at Mirror.NetworkConnectionToClient.get_address () [0x00000] in /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnectionToClient.cs:13 
  at AdminPlayerListRefreshMessage.GetAllPlayerStates (System.String adminID) [0x000bf] in /github/workspace/UnityProject/Assets/Scripts/Messages/Server/AdminTools/AdminPlayerListRefreshMessage.cs:58 
  at AdminPlayerListRefreshMessage.Send (UnityEngine.GameObject recipient, System.String adminID) [0x00007] in /github/workspace/UnityProject/Assets/Scripts/Messages/Server/AdminTools/AdminPlayerListRefreshMessage.cs:31 
  at RequestAdminPlayerList.VerifyAdminStatus () [0x00024] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminPlayerList.cs:24 
  at RequestAdminPlayerList.Process () [0x00001] in /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminPlayerList.cs:16 

</details>