### PR TITLE
Escape shuttle now takes three minutes to leave after docking with the station.

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameManager.Escape.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.Escape.cs
@@ -85,9 +85,9 @@ public partial class GameManager
 			{
 				beenToStation = true;
 				SoundManager.PlayNetworked("ShuttleDocked");
-				Chat.AddSystemMsgToChat("<color=white>Escape shuttle has arrived! Crew has 1 minute to get on it.</color>", MatrixManager.MainStationMatrix);
+				Chat.AddSystemMsgToChat("<color=white>Escape shuttle has arrived! Crew has 3 minutes to get on it.</color>", MatrixManager.MainStationMatrix);
 				//should be changed to manual send later
-				StartCoroutine( SendEscapeShuttle( 60 ) );
+				StartCoroutine( SendEscapeShuttle( 180 ) );
 			}
 		} );
 	}


### PR DESCRIPTION
### Purpose
Title. Escape shuttle now takes three minutes to depart after leaving the station as in /tg/. This should give players a bit of extra time to on board and also do some other stuff. Localization for announcement was changed, and status displays properly show the time before departures.

Added in response to a poll.
![image](https://user-images.githubusercontent.com/38266309/85676712-b5781580-b67b-11ea-8a5c-9eeeb1868e45.png)


