### PR TITLE
Server NRE fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/Assassinate.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/Assassinate.cs
@@ -45,11 +45,10 @@ namespace Antagonists
 			}
 
 			// Pick a random target and add them to the targeted list
-			// If null try once more
-			Target = playerPool.PickRandom().Script ?? playerPool.PickRandom().Script;
+			Target = playerPool.PickRandom().Script;
 
 			//If still null then its a free objective
-			if(Target == null)
+			if(Target == null || Target.mind.occupation == null)
 			{
 				FreeObjective();
 				return;

--- a/UnityProject/Assets/Scripts/Chat/DiscordWebhookMessage.cs
+++ b/UnityProject/Assets/Scripts/Chat/DiscordWebhookMessage.cs
@@ -170,13 +170,13 @@ namespace DiscordWebhook
 			for (var i = 1; i <= count; i++)
 			{
 				//Discord character limit is 2000
-				if (msg.Length > 1950)
+				if (msg.Length > 1970)
 				{
-					msg = msg.Substring(0, 1950);
+					msg = msg.Substring(0, 1970);
 					break;
 				}
 
-				if (msg.Length + queue.Peek().Length > 1950)
+				if (msg.Length + queue.Peek().Length > 1970)
 				{
 					break;
 				}
@@ -252,6 +252,8 @@ namespace DiscordWebhook
 			{
 				ErrorMessageHashSet.Add(stackTrace);
 
+				if(logString.Contains("Can't get home directory!")) return;
+
 				var logToSend = $"{logString}\n{stackTrace}";
 
 				//Discord character limit is 2000
@@ -259,6 +261,8 @@ namespace DiscordWebhook
 				{
 					logToSend = logToSend.Substring(0, 1950);
 				}
+
+				logToSend = $"```\n{logToSend}\n```\n";
 
 				AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookErrorLogURL, logToSend, "");
 			}

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
@@ -206,7 +206,10 @@ namespace Chemistry.Components
 			// add addition to reagent mix
 			CurrentReagentMix.Add(addition);
 			//Reactions happen here
-			ReactionSet.Apply(this, CurrentReagentMix);
+			if (ReactionSet != null)
+			{
+				ReactionSet.Apply(this, CurrentReagentMix);
+			}
 
 			// get mix total after all reactions
 			var afterReactionTotal = CurrentReagentMix.Total;

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -303,6 +303,7 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		{
 			//spawn a new one and put it into the from slot with a stack size of 1
 			var single = Spawn.ServerPrefab(prefab).GameObject;
+			if (single == null || single.GetComponent<Stackable>() == null) return;
 			single.GetComponent<Stackable>().SyncAmount(amount, 1);
 			Inventory.ServerAdd(single, interaction.FromSlot);
 			ServerConsume(1);

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs
@@ -308,6 +308,7 @@ public class RequestInteractMessage : ClientMessage
 			//check the target object if there is one
 			if (interaction is TargetedInteraction targetedInteraction)
 			{
+				if(targetedInteraction.TargetObject == null) return;
 				var interactables = targetedInteraction.TargetObject.GetComponents<IInteractable<T>>()
 					.Where(c => c != null && (c as MonoBehaviour)?.enabled == true);
 				Logger.LogTraceFormat("Server checking which component to trigger for {0} on object {1}", Category.Interaction,

--- a/UnityProject/Assets/Scripts/UI/Action/ActionControlInventory.cs
+++ b/UnityProject/Assets/Scripts/UI/Action/ActionControlInventory.cs
@@ -12,9 +12,10 @@ public class ActionControlInventory : MonoBehaviour, IClientInventoryMove
 
 	public void OnInventoryMoveClient(ClientInventoryMove info)
 	{
+		if(PlayerManager.LocalPlayerScript == null) return;
 		var pna = PlayerManager.LocalPlayerScript.playerNetworkActions;
 		var showAlert = pna.GetActiveHandItem() == gameObject ||
-						pna.GetOffHandItem() == gameObject;
+		                pna.GetOffHandItem() == gameObject;
 		foreach (var _IActionGUI in ControllingActions)
 		{
 			UIActionManager.ToggleLocal(_IActionGUI, showAlert);


### PR DESCRIPTION
-Cleans up the error log webhook, excludes the no home directory error.

-Fixes these NREs:
```
NullReferenceException: Object reference not set to an instance of an object
RequestInteractMessage.ProcessInteraction[T] (T interaction, UnityEngine.GameObject processorObj) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:311)
RequestInteractMessage.Process () (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:140)
GameMessageBase.Process (Mirror.NetworkConnection sentBy) (at /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:25)
ClientMessage.Process (Mirror.NetworkConnection sentBy) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs:14)
GameMessageBase.PreProcess (Mirror.NetworkConnection sentBy, GameMessageBase b) (at /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:18)
Mirror.MessagePacker+<>cDisplayClass6_0`2[T,C].<MessageHandler>b0 (Mirror.NetworkConnection conn, Mirror.NetworkReader reader, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/MessagePacker.cs:146)
Mirror.NetworkConnection.InvokeHandler (System.Int32 msgType, Mirror.NetworkReader reader, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:219)
Mirror.NetworkConnection.TransportReceive (System.ArraySegment1[T] buffer, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:272)
Mirror.NetworkServer.OnDataReceived (System.Int32 connectionId, System.ArraySegment1[T] data, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs:511)
```
```
NullReferenceException: Object reference not set to an instance of an object
ActionControlInventory.OnInventoryMoveClient (ClientInventoryMove info) (at /github/workspace/UnityProject/Assets/Scripts/UI/Action/ActionControlInventory.cs:15)
ItemSlot._ServerSetItem (Pickupable newItem) (at /github/workspace/UnityProject/Assets/Scripts/Inventory/ItemSlot.cs:266)
ItemSlot._ServerRemoveItem () (at /github/workspace/UnityProject/Assets/Scripts/Inventory/ItemSlot.cs:291)
Inventory.ServerPerformRemove (InventoryMove toPerform, Pickupable pickupable) (at /github/workspace/UnityProject/Assets/Scripts/Inventory/Inventory.cs:315)
Inventory.ServerPerform (InventoryMove toPerform) (at /github/workspace/UnityProject/Assets/Scripts/Inventory/Inventory.cs:196)
Inventory.ServerDrop (ItemSlot fromSlot, System.Nullable1[T] worldTargetVector) (at /github/workspace/UnityProject/Assets/Scripts/Inventory/Inventory.cs:100)
ClosetControl.ServerPerformInteraction (HandApply interaction) (at /github/workspace/UnityProject/Assets/Scripts/Closets/ClosetControl.cs:400)
RequestInteractMessage.ServerCheckAndTrigger[T] (T interaction, System.Collections.Generic.IEnumerable1[T] interactables) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:333)
RequestInteractMessage.ProcessInteraction[T] (T interaction, UnityEngine.GameObject processorObj) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:315)
RequestInteractMessage.Process () (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:140)
GameMessageBase.Process (Mirror.NetworkConnection sentBy) (at /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:25)
ClientMessage.Process (Mirror.NetworkConnection sentBy) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs:14)
```

```
NullReferenceException: Object reference not set to an instance of an object
Stackable.ServerPerformInteraction (InventoryApply interaction) (at /github/workspace/UnityProject/Assets/Scripts/Items/Stackable.cs:306)
RequestInteractMessage.ServerCheckAndTrigger[T] (T interaction, System.Collections.Generic.IEnumerable1[T] interactables) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:333)
RequestInteractMessage.ProcessInteraction[T] (T interaction, UnityEngine.GameObject processorObj) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:315)
RequestInteractMessage.Process () (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:206)
GameMessageBase.Process (Mirror.NetworkConnection sentBy) (at /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:25)
ClientMessage.Process (Mirror.NetworkConnection sentBy) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs:14)
GameMessageBase.PreProcess (Mirror.NetworkConnection sentBy, GameMessageBase b) (at /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:18)
Mirror.MessagePacker+<>c__DisplayClass6_02[T,C].<MessageHandler>b__0 (Mirror.NetworkConnection conn, Mirror.NetworkReader reader, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/MessagePacker.cs:146)
Mirror.NetworkConnection.InvokeHandler (System.Int32 msgType, Mirror.NetworkReader reader, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:219)
Mirror.NetworkConnection.TransportReceive (System.ArraySegment1[T] buffer, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:272)
```

```
NullReferenceException: Object reference not set to an instance of an object
Antagonists.Assassinate.Setup () (at /github/workspace/UnityProject/Assets/Scripts/Antagonists/Objectives/Assassinate.cs:59)
Antagonists.Objective.DoSetup (Mind owner) (at /github/workspace/UnityProject/Assets/Scripts/Antagonists/Objective.cs:61)
Antagonists.AntagData.GenerateObjectives (PlayerScript player, Antagonists.Antagonist antag) (at /github/workspace/UnityProject/Assets/Scripts/Antagonists/AntagData.cs:81)
Antagonists.AntagManager.ServerSpawnAntag (Antagonists.Antagonist chosenAntag, PlayerSpawnRequest spawnRequest) (at /github/workspace/UnityProject/Assets/Scripts/Antagonists/AntagManager.cs:87)
GameMode.SpawnAntag (PlayerSpawnRequest playerSpawnRequest) (at /github/workspace/UnityProject/Assets/Scripts/GameModes/GameMode.cs:251)
GameMode.TrySpawnAntag (PlayerSpawnRequest spawnRequest) (at /github/workspace/UnityProject/Assets/Scripts/GameModes/GameMode.cs:176)
GameManager.TrySpawnAntag (PlayerSpawnRequest spawnRequest) (at /github/workspace/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs:125)
GameManager.ProcessSpawnPlayerQueue () (at /github/workspace/UnityProject/Assets/Scripts/Managers/GameManager.cs:501)
JoinedViewer.CallCmdRequestJob (JobType jobType, System.String jsonCharSettings) (at /github/workspace/UnityProject/Assets/Scripts/Player/JoinedViewer.cs:189)
JoinedViewer.InvokeCmdCmdRequestJob (Mirror.NetworkBehaviour obj, Mirror.NetworkReader reader) (at <542137971a9d4f6f84dc16b5130b0ec2>:0)
Mirror.NetworkBehaviour.InvokeHandlerDelegate (System.Int32 cmdHash, Mirror.MirrorInvokeType invokeType, Mirror.NetworkReader reader) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkBehaviour.cs:449)
```

```
NullReferenceException: Object reference not set to an instance of an object
Chemistry.Components.ReagentContainer.Add (Chemistry.ReagentMix addition) (at /github/workspace/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs:209)
Chemistry.Components.ReagentContainer.TransferTo (System.Single amount, Chemistry.Components.ReagentContainer target) (at /github/workspace/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs:363)
Chemistry.Components.ReagentContainer.MoveReagentsTo (System.Single amount, Chemistry.Components.ReagentContainer target) (at /github/workspace/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs:333)
Chemistry.Components.ReagentContainer.ServerTransferInteraction (Chemistry.Components.ReagentContainer objectInHands, Chemistry.Components.ReagentContainer target, UnityEngine.GameObject performer) (at /github/workspace/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs:314)
Chemistry.Components.ReagentContainer.ServerPerformInteraction (HandApply interaction) (at /github/workspace/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.TransferInteraction.cs:157)
RequestInteractMessage.ServerCheckAndTrigger[T] (T interaction, System.Collections.Generic.IEnumerable`1[T] interactables) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:333)
RequestInteractMessage.ProcessInteraction[T] (T interaction, UnityEngine.GameObject processorObj) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:303)
RequestInteractMessage.Process () (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:140)
```