### PR TITLE
Cargo crate value checker

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -560,25 +560,33 @@ namespace IngameDebugConsole
 					{
 						if(item == null) continue;
 
-						if (item.GetComponent<ItemAttributesV2>() != null)
+						var itemAttribute = item.GetComponent<ItemAttributesV2>();
+
+						if (itemAttribute != null)
 						{
-							value += item.GetComponent<ItemAttributesV2>().ExportCost;
+							value += itemAttribute.ExportCost;
 						}
 
-						if (item.GetComponent<ObjectAttributes>() != null)
+						var objectAttribute = item.GetComponent<ObjectAttributes>();
+
+						if (objectAttribute != null)
 						{
-							value += item.GetComponent<ObjectAttributes>().ExportCost;
+							value += objectAttribute.ExportCost;
 						}
 					}
 
-					if (items.Crate != null && items.Crate.GetComponent<ItemAttributesV2>() != null)
+					var itemAttributeCrate = items.Crate.GetComponent<ItemAttributesV2>();
+
+					if (items.Crate != null && itemAttributeCrate != null)
 					{
-						value += items.Crate.GetComponent<ItemAttributesV2>().ExportCost;
+						value += itemAttributeCrate.ExportCost;
 					}
 
-					if (items.Crate != null && items.Crate.GetComponent<ObjectAttributes>() != null)
+					var objectAttributesCrate = items.Crate.GetComponent<ObjectAttributes>();
+
+					if (items.Crate != null && objectAttributesCrate != null)
 					{
-						value += items.Crate.GetComponent<ObjectAttributes>().ExportCost;
+						value += objectAttributesCrate.ExportCost;
 					}
 
 					items.TotalCreditExport = value;

--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -547,5 +547,52 @@ namespace IngameDebugConsole
 
 			PlayerList.Instance.ProcessAdminEnableRequest(ServerData.UserID, userIDToPromote);
 		}
+#if UNITY_EDITOR
+		[MenuItem("Networking/Calculate Cargo Export Costs")]
+		private static void SetCargoExportValues()
+		{
+			foreach (var cargoDataList in CargoManager.Instance.CargoData.Supplies)
+			{
+				foreach (var items in cargoDataList.Supplies)
+				{
+					int value = 0;
+					foreach (var item in items.Items)
+					{
+						if(item == null) continue;
+
+						if (item.GetComponent<ItemAttributesV2>() != null)
+						{
+							value += item.GetComponent<ItemAttributesV2>().ExportCost;
+						}
+
+						if (item.GetComponent<ObjectAttributes>() != null)
+						{
+							value += item.GetComponent<ObjectAttributes>().ExportCost;
+						}
+					}
+
+					if (items.Crate != null && items.Crate.GetComponent<ItemAttributesV2>() != null)
+					{
+						value += items.Crate.GetComponent<ItemAttributesV2>().ExportCost;
+					}
+
+					if (items.Crate != null && items.Crate.GetComponent<ObjectAttributes>() != null)
+					{
+						value += items.Crate.GetComponent<ObjectAttributes>().ExportCost;
+					}
+
+					items.TotalCreditExport = value;
+
+					if (value > items.CreditsCost)
+					{
+						Debug.LogError($"{items.OrderName}'s credit cost: {items.CreditsCost} is less than its export value: {value}, exploit possible!");
+					}
+
+					Debug.Log($"value: {value}, cost: {items.CreditsCost}, {items.OrderName}");
+				}
+			}
+			Debug.Log("Cost Calculation Complete");
+		}
+#endif
 	}
 }

--- a/UnityProject/Assets/Resources/ScriptableObjects/Machines/CargoData.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Machines/CargoData.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
       - {fileID: 1150524617746403880, guid: 8293bf9edcadf604f82121a421203d88, type: 3}
       - {fileID: 1150524617746403880, guid: 8293bf9edcadf604f82121a421203d88, type: 3}
       - {fileID: 1150524617746403880, guid: 8293bf9edcadf604f82121a421203d88, type: 3}
+      TotalCreditExport: 600
     - OrderName: Meat kit
       CreditsCost: 600
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -35,6 +36,7 @@ MonoBehaviour:
       - {fileID: 6532193109441330816, guid: 08f2ed80656ab8548b303e79671a18e8, type: 3}
       - {fileID: 6532193109441330816, guid: 08f2ed80656ab8548b303e79671a18e8, type: 3}
       - {fileID: 7781396554342910705, guid: 229f1c93e0e4ada439cfe4b781f65997, type: 3}
+      TotalCreditExport: 500
     - OrderName: Knife kit
       CreditsCost: 500
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -43,8 +45,9 @@ MonoBehaviour:
       - {fileID: 7781396554342910705, guid: 229f1c93e0e4ada439cfe4b781f65997, type: 3}
       - {fileID: 7781396554342910705, guid: 229f1c93e0e4ada439cfe4b781f65997, type: 3}
       - {fileID: 7781396554342910705, guid: 229f1c93e0e4ada439cfe4b781f65997, type: 3}
+      TotalCreditExport: 500
     - OrderName: Energy Crate
-      CreditsCost: 500
+      CreditsCost: 525
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
         type: 3}
       Items:
@@ -53,6 +56,7 @@ MonoBehaviour:
       - {fileID: 6602018046170396259, guid: 6744be6888ba21549a52eefcc270e0d5, type: 3}
       - {fileID: 6602018046170396259, guid: 6744be6888ba21549a52eefcc270e0d5, type: 3}
       - {fileID: 6602018046170396259, guid: 6744be6888ba21549a52eefcc270e0d5, type: 3}
+      TotalCreditExport: 525
     - OrderName: Better Eyes Crate
       CreditsCost: 600
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -63,6 +67,7 @@ MonoBehaviour:
       - {fileID: 6602018046170396259, guid: 3f42bf93060678d43b3858247bc0696f, type: 3}
       - {fileID: 6602018046170396259, guid: 3f42bf93060678d43b3858247bc0696f, type: 3}
       - {fileID: 6602018046170396259, guid: 3f42bf93060678d43b3858247bc0696f, type: 3}
+      TotalCreditExport: 525
   - CategoryName: Security
     Supplies:
     - OrderName: Handcuffs  Crate
@@ -75,6 +80,7 @@ MonoBehaviour:
       - {fileID: 8127442588295923452, guid: 706cc1f035332384c96f001de4760563, type: 3}
       - {fileID: 8127442588295923452, guid: 706cc1f035332384c96f001de4760563, type: 3}
       - {fileID: 8127442588295923452, guid: 706cc1f035332384c96f001de4760563, type: 3}
+      TotalCreditExport: 515
     - OrderName: Batons Crate
       CreditsCost: 1500
       Crate: {fileID: 3603551487888253092, guid: 19f122548a008234c96c29eceea0b0fc,
@@ -83,6 +89,7 @@ MonoBehaviour:
       - {fileID: 7781396554342910705, guid: 6ec2cf5e4acf23543ba1612545d2fca4, type: 3}
       - {fileID: 7781396554342910705, guid: 6ec2cf5e4acf23543ba1612545d2fca4, type: 3}
       - {fileID: 7781396554342910705, guid: 6ec2cf5e4acf23543ba1612545d2fca4, type: 3}
+      TotalCreditExport: 750
     - OrderName: Shotgun Crate
       CreditsCost: 5000
       Crate: {fileID: 1915535976018001213, guid: d059b46ee78dde84b963769ba89d24cc,
@@ -91,6 +98,7 @@ MonoBehaviour:
       - {fileID: 8582594776399167655, guid: 8aa9c1617fcf44905b26d836feca524f, type: 3}
       - {fileID: 8582594776399167655, guid: 8aa9c1617fcf44905b26d836feca524f, type: 3}
       - {fileID: 8582594776399167655, guid: 8aa9c1617fcf44905b26d836feca524f, type: 3}
+      TotalCreditExport: 1650
     - OrderName: machine-gun Crate
       CreditsCost: 5000
       Crate: {fileID: 1915535976018001213, guid: d059b46ee78dde84b963769ba89d24cc,
@@ -99,6 +107,7 @@ MonoBehaviour:
       - {fileID: 8582594776399167655, guid: a74cbb38ab9ab7c459eef728c98b21f0, type: 3}
       - {fileID: 8582594776399167655, guid: a74cbb38ab9ab7c459eef728c98b21f0, type: 3}
       - {fileID: 8582594776399167655, guid: a74cbb38ab9ab7c459eef728c98b21f0, type: 3}
+      TotalCreditExport: 750
     - OrderName: Laser Gun Crate
       CreditsCost: 4500
       Crate: {fileID: 1915535976018001213, guid: d059b46ee78dde84b963769ba89d24cc,
@@ -107,6 +116,7 @@ MonoBehaviour:
       - {fileID: 6507000735928756314, guid: c8db81d5fc87fc5409a6f7c00e5ebc96, type: 3}
       - {fileID: 6507000735928756314, guid: c8db81d5fc87fc5409a6f7c00e5ebc96, type: 3}
       - {fileID: 6507000735928756314, guid: c8db81d5fc87fc5409a6f7c00e5ebc96, type: 3}
+      TotalCreditExport: 750
     - OrderName: Laser Pistol Crate
       CreditsCost: 4000
       Crate: {fileID: 1915535976018001213, guid: d059b46ee78dde84b963769ba89d24cc,
@@ -115,6 +125,7 @@ MonoBehaviour:
       - {fileID: 6507000735928756314, guid: 66e26e048c0ee0448878c27b37dc685f, type: 3}
       - {fileID: 6507000735928756314, guid: 66e26e048c0ee0448878c27b37dc685f, type: 3}
       - {fileID: 6507000735928756314, guid: 66e26e048c0ee0448878c27b37dc685f, type: 3}
+      TotalCreditExport: 750
   - CategoryName: Medical
     Supplies:
     - OrderName: First Aid Kit Crate
@@ -125,6 +136,7 @@ MonoBehaviour:
       - {fileID: 8635195139948178778, guid: d0eb5dacbdcd4844e8c76aabde50434f, type: 3}
       - {fileID: 8635195139948178778, guid: d0eb5dacbdcd4844e8c76aabde50434f, type: 3}
       - {fileID: 8635195139948178778, guid: d0eb5dacbdcd4844e8c76aabde50434f, type: 3}
+      TotalCreditExport: 500
     - OrderName: Burn Kit Crate
       CreditsCost: 800
       Crate: {fileID: 4501350970557495462, guid: e90789a74f1a247b585694b4a51e2ecb,
@@ -133,6 +145,7 @@ MonoBehaviour:
       - {fileID: 1693542147258265400, guid: da48d3ea930b7f747b15cd3314c86fd0, type: 3}
       - {fileID: 1693542147258265400, guid: da48d3ea930b7f747b15cd3314c86fd0, type: 3}
       - {fileID: 1693542147258265400, guid: da48d3ea930b7f747b15cd3314c86fd0, type: 3}
+      TotalCreditExport: 500
     - OrderName: Body Bag Crate
       CreditsCost: 800
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -140,6 +153,7 @@ MonoBehaviour:
       Items:
       - {fileID: 6354141011021534515, guid: de5178dc540b92244acea8e15022313a, type: 3}
       - {fileID: 6354141011021534515, guid: de5178dc540b92244acea8e15022313a, type: 3}
+      TotalCreditExport: 500
     - OrderName: Beaker Box Crate
       CreditsCost: 700
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -148,6 +162,7 @@ MonoBehaviour:
       - {fileID: 5162418143041738271, guid: f25a6f263584e6848819e145b53ee65b, type: 3}
       - {fileID: 5162418143041738271, guid: f25a6f263584e6848819e145b53ee65b, type: 3}
       - {fileID: 5162418143041738271, guid: f25a6f263584e6848819e145b53ee65b, type: 3}
+      TotalCreditExport: 500
   - CategoryName: Science
     Supplies:
     - OrderName: Chemistry kit Crate
@@ -160,6 +175,7 @@ MonoBehaviour:
       - {fileID: 7374481989050852271, guid: 1fada2a01fe5e49208acb17e93095002, type: 3}
       - {fileID: 7516689663430431150, guid: 8aa459a6447baed4a95b189f4950f59f, type: 3}
       - {fileID: 5162418143041738271, guid: f25a6f263584e6848819e145b53ee65b, type: 3}
+      TotalCreditExport: 550
   - CategoryName: Engineering
     Supplies:
     - OrderName: Tool Crate
@@ -171,6 +187,7 @@ MonoBehaviour:
       - {fileID: 20384307089368758, guid: 371b9c216382844659c05791957b28c8, type: 3}
       - {fileID: 7331803544451838430, guid: d554409601a0f744090f24e47955cb9a, type: 3}
       - {fileID: 7331803544451838430, guid: d554409601a0f744090f24e47955cb9a, type: 3}
+      TotalCreditExport: 500
     - OrderName: Low voltage cable Crate
       CreditsCost: 800
       Crate: {fileID: 6439324441883113404, guid: 4ff388f72fc794b1fab838a88a5d115e,
@@ -179,6 +196,7 @@ MonoBehaviour:
       - {fileID: 7657921970005526780, guid: 7f32e42309899114b9c122f261161bc5, type: 3}
       - {fileID: 7657921970005526780, guid: 7f32e42309899114b9c122f261161bc5, type: 3}
       - {fileID: 7657921970005526780, guid: 7f32e42309899114b9c122f261161bc5, type: 3}
+      TotalCreditExport: 500
     - OrderName: Cable Crate
       CreditsCost: 800
       Crate: {fileID: 6439324441883113404, guid: 4ff388f72fc794b1fab838a88a5d115e,
@@ -187,6 +205,7 @@ MonoBehaviour:
       - {fileID: 5680136605834777345, guid: c3e6805b264a935428b0de415ea57943, type: 3}
       - {fileID: 5680136605834777345, guid: c3e6805b264a935428b0de415ea57943, type: 3}
       - {fileID: 5680136605834777345, guid: c3e6805b264a935428b0de415ea57943, type: 3}
+      TotalCreditExport: 500
     - OrderName: High voltage cable Crate
       CreditsCost: 700
       Crate: {fileID: 6439324441883113404, guid: 4ff388f72fc794b1fab838a88a5d115e,
@@ -195,6 +214,7 @@ MonoBehaviour:
       - {fileID: 1431646644770877665, guid: 288980126acf5f441841169958c31630, type: 3}
       - {fileID: 1431646644770877665, guid: 288980126acf5f441841169958c31630, type: 3}
       - {fileID: 1431646644770877665, guid: 288980126acf5f441841169958c31630, type: 3}
+      TotalCreditExport: 500
     - OrderName: Circuit board Crate
       CreditsCost: 800
       Crate: {fileID: 6439324441883113404, guid: 4ff388f72fc794b1fab838a88a5d115e,
@@ -206,12 +226,14 @@ MonoBehaviour:
       - {fileID: 728401503887791882, guid: 5bcdb263d27704d17bee5ce7e474f028, type: 3}
       - {fileID: 728401503887791882, guid: 549cd6443fca249c3a3399a36f1197f0, type: 3}
       - {fileID: 728401503887791882, guid: 6f38690aacaa94594b183a38b76111d6, type: 3}
+      TotalCreditExport: 500
     - OrderName: 'Plasma generator '
       CreditsCost: 1000
       Crate: {fileID: 6439324441883113404, guid: 4ff388f72fc794b1fab838a88a5d115e,
         type: 3}
       Items:
       - {fileID: 1853426429102140, guid: 69c27c4a07b053d458c6fec363e66403, type: 3}
+      TotalCreditExport: 500
     - OrderName: Reactor Starting Rod Crate
       CreditsCost: 1000
       Crate: {fileID: 3701635295295868414, guid: d2e38660b0ae0450ab25b2a61ac10c46,
@@ -219,6 +241,7 @@ MonoBehaviour:
       Items:
       - {fileID: 1562249808724683428, guid: 90d47e2251b9b6943b78a010f6b58909, type: 3}
       - {fileID: 1562249808724683428, guid: 90d47e2251b9b6943b78a010f6b58909, type: 3}
+      TotalCreditExport: 1000
     - OrderName: Reactor Control Rod Crate
       CreditsCost: 2000
       Crate: {fileID: 3701635295295868414, guid: d2e38660b0ae0450ab25b2a61ac10c46,
@@ -230,6 +253,7 @@ MonoBehaviour:
       - {fileID: 6658728792277159638, guid: f035a877ddd6fa8458a3ad86fd4069ee, type: 3}
       - {fileID: 6658728792277159638, guid: f035a877ddd6fa8458a3ad86fd4069ee, type: 3}
       - {fileID: 6658728792277159638, guid: f035a877ddd6fa8458a3ad86fd4069ee, type: 3}
+      TotalCreditExport: 1400
     - OrderName: Reactor Fuel Rod Crate
       CreditsCost: 2500
       Crate: {fileID: 3701635295295868414, guid: d2e38660b0ae0450ab25b2a61ac10c46,
@@ -240,6 +264,7 @@ MonoBehaviour:
       - {fileID: 70068185008237990, guid: 2c62bf4b8bd1b13409822a00ad8cb214, type: 3}
       - {fileID: 70068185008237990, guid: 2c62bf4b8bd1b13409822a00ad8cb214, type: 3}
       - {fileID: 70068185008237990, guid: 2c62bf4b8bd1b13409822a00ad8cb214, type: 3}
+      TotalCreditExport: 1000
   - CategoryName: Service
     Supplies:
     - OrderName: Cleaning supplies Crate
@@ -251,6 +276,7 @@ MonoBehaviour:
       - {fileID: 2419386692754613975, guid: 72539a60f847bd248bec932a82058e0b, type: 3}
       - {fileID: 359432221073519209, guid: 4dddcb74ff9a3ee4ca69bc6d757dca03, type: 3}
       - {fileID: 7516689663430431150, guid: 8aa459a6447baed4a95b189f4950f59f, type: 3}
+      TotalCreditExport: 500
     - OrderName: Wet floor signs Crate
       CreditsCost: 800
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -266,6 +292,7 @@ MonoBehaviour:
       - {fileID: 2419386692754613975, guid: 6603caafe8df84b4da1c797343cdf8c6, type: 3}
       - {fileID: 2419386692754613975, guid: 6603caafe8df84b4da1c797343cdf8c6, type: 3}
       - {fileID: 2419386692754613975, guid: 6603caafe8df84b4da1c797343cdf8c6, type: 3}
+      TotalCreditExport: 500
     - OrderName: ID Crate
       CreditsCost: 550
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -281,6 +308,7 @@ MonoBehaviour:
       - {fileID: 2462507587837783305, guid: dd36cfd4f55a00d4ab4190d869297198, type: 3}
       - {fileID: 2462507587837783305, guid: dd36cfd4f55a00d4ab4190d869297198, type: 3}
       - {fileID: 2462507587837783305, guid: dd36cfd4f55a00d4ab4190d869297198, type: 3}
+      TotalCreditExport: 500
     - OrderName: Replacement Lights
       CreditsCost: 1000
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -289,6 +317,7 @@ MonoBehaviour:
       - {fileID: 8062332028689852436, guid: 8edc1f3642b9f28429c21e6c30566791, type: 3}
       - {fileID: 8062332028689852436, guid: 8edc1f3642b9f28429c21e6c30566791, type: 3}
       - {fileID: 8062332028689852436, guid: 8edc1f3642b9f28429c21e6c30566791, type: 3}
+      TotalCreditExport: 500
   - CategoryName: Botany
     Supplies:
     - OrderName: Hydroponics Crate
@@ -306,6 +335,7 @@ MonoBehaviour:
       - {fileID: 7929132545395035327, guid: 6b278dfd25eca3a458046704b9670b4c, type: 3}
       - {fileID: 3611557936377049867, guid: 61c1ba86edcb8f745b758d73ea4725d4, type: 3}
       - {fileID: 326547609064969591, guid: ed3cf51f5ac908c428c083a07596e441, type: 3}
+      TotalCreditExport: 750
   - CategoryName: Mining
     Supplies:
     - OrderName: Mining Tools Crate
@@ -321,6 +351,7 @@ MonoBehaviour:
       - {fileID: 6507691273333881185, guid: 1488f67a55cb9b84098e095e65e5a2b3, type: 3}
       - {fileID: 6507000735928756314, guid: 672dc44f4c052d746aefa06b301785bd, type: 3}
       - {fileID: 6507000735928756314, guid: 672dc44f4c052d746aefa06b301785bd, type: 3}
+      TotalCreditExport: 500
   - CategoryName: Uniform Sets
     Supplies:
     - OrderName: Assistant Set
@@ -340,6 +371,7 @@ MonoBehaviour:
       - {fileID: 835768756810601639, guid: 3d08b6dbf08774e8681378945dec4edf, type: 3}
       - {fileID: 835768756810601639, guid: 3d08b6dbf08774e8681378945dec4edf, type: 3}
       - {fileID: 835768756810601639, guid: 3d08b6dbf08774e8681378945dec4edf, type: 3}
+      TotalCreditExport: 500
     - OrderName: Cook Set
       CreditsCost: 650
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -350,6 +382,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
       - {fileID: 7636118406116123594, guid: c1986e2665f9a413694ce37f09e0f17e, type: 3}
       - {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
+      TotalCreditExport: 500
     - OrderName: Bartender Set
       CreditsCost: 600
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -360,6 +393,7 @@ MonoBehaviour:
       - {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
       - {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
       - {fileID: 3011710637427380133, guid: c842b429251c54792a95e292b838d034, type: 3}
+      TotalCreditExport: 500
     - OrderName: Janitor Set
       CreditsCost: 2000
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -371,6 +405,7 @@ MonoBehaviour:
       - {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
       - {fileID: 7106618204054676533, guid: 7a2370ed5124e4897ba86392a2d9052b, type: 3}
       - {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
+      TotalCreditExport: 500
     - OrderName: Botanist Set
       CreditsCost: 700
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -381,6 +416,7 @@ MonoBehaviour:
       - {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
       - {fileID: 3921521694364753778, guid: 34840ba56d91a4e4bb5c615fe3c2b1f3, type: 3}
       - {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
+      TotalCreditExport: 500
     - OrderName: Clown Set
       CreditsCost: 600
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -391,6 +427,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: 026678bf2f4d34e7a8aa23aab0a96c64, type: 3}
       - {fileID: 6404652678407139925, guid: abed35e9cfa734a00815cf8cda62687a, type: 3}
       - {fileID: 3011710637427380133, guid: a08b3d5119d894fcb917204c9c820035, type: 3}
+      TotalCreditExport: 500
     - OrderName: Mime Set
       CreditsCost: 700
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -402,6 +439,7 @@ MonoBehaviour:
       - {fileID: 6404652678407139925, guid: 82493ba3850304e50a7d25606a4f59f1, type: 3}
       - {fileID: 3921521694364753778, guid: 625759ec27e444592b12922a179ac340, type: 3}
       - {fileID: 3011710637427380133, guid: 57b4739d8947544f387d028cd2dd59b9, type: 3}
+      TotalCreditExport: 500
     - OrderName: Lawyer Set
       CreditsCost: 700
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -411,6 +449,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
       - {fileID: 3708231617607487601, guid: dcb36ae56960eb34a8988e485be4515e, type: 3}
       - {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
+      TotalCreditExport: 500
     - OrderName: Chaplain Set
       CreditsCost: 600
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -420,6 +459,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
       - {fileID: 835768756810601639, guid: 3d08b6dbf08774e8681378945dec4edf, type: 3}
       - {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
+      TotalCreditExport: 500
     - OrderName: Curator Set
       CreditsCost: 600
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -431,6 +471,7 @@ MonoBehaviour:
       - {fileID: 7636118406116123594, guid: 6fe473acd28e04fafba497e02a994da8, type: 3}
       - {fileID: 3921521694364753778, guid: b67b665e16e3047c28f852c453112321, type: 3}
       - {fileID: 3011710637427380133, guid: aacc30d5087d94ec7a4764c686da7e57, type: 3}
+      TotalCreditExport: 500
     - OrderName: Quartermaster Set
       CreditsCost: 1000
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -442,6 +483,7 @@ MonoBehaviour:
       - {fileID: 3431291279286482953, guid: 0c3e7a0b25eff4d33a4f511cfc36b5d9, type: 3}
       - {fileID: 3011710637427380133, guid: c9cafc4cfdf774b66b6d76a563646fd7, type: 3}
       - {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
+      TotalCreditExport: 500
     - OrderName: Cargo Technician Set
       CreditsCost: 700
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -452,6 +494,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
       - {fileID: 835768756810601639, guid: 455167e17d2dd4f24b32aaafea5e7fb2, type: 3}
       - {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
+      TotalCreditExport: 500
     - OrderName: Shaft Miner Set
       CreditsCost: 800
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -462,6 +505,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: afe0b0cc9e24249c1aaf8b7b2c4b3a3c, type: 3}
       - {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
       - {fileID: 3011710637427380133, guid: c8281f12859404623bffaa7c78584fb5, type: 3}
+      TotalCreditExport: 500
     - OrderName: Chief Medical Officer Set
       CreditsCost: 2000
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -472,6 +516,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
       - {fileID: 7374481989050852271, guid: cee5c0303ff564c76a3a323d2646b47e, type: 3}
       - {fileID: 3011710637427380133, guid: 6ab2f9c28085a419ca49eda6e97a06cf, type: 3}
+      TotalCreditExport: 500
     - OrderName: Chemist Set
       CreditsCost: 800
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -482,6 +527,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
       - {fileID: 7374481989050852271, guid: 1fada2a01fe5e49208acb17e93095002, type: 3}
       - {fileID: 3011710637427380133, guid: 54c252491fc58478aac029a841777c90, type: 3}
+      TotalCreditExport: 500
     - OrderName: Medical Doctor Set
       CreditsCost: 800
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -492,6 +538,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
       - {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226, type: 3}
       - {fileID: 3011710637427380133, guid: 604161a1d792749539a5f1b0eb6e4749, type: 3}
+      TotalCreditExport: 500
     - OrderName: Geneticist Set
       CreditsCost: 600
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -502,6 +549,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
       - {fileID: 7374481989050852271, guid: 1eabf8d0cc67b4d04926dd8eb07bf946, type: 3}
       - {fileID: 3011710637427380133, guid: 05d3054c3617b467ea8e086e2969e172, type: 3}
+      TotalCreditExport: 500
     - OrderName: Virologist Set
       CreditsCost: 800
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -512,6 +560,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
       - {fileID: 7374481989050852271, guid: 22ce62e388fa84ff098d72a7856ea506, type: 3}
       - {fileID: 3011710637427380133, guid: aab6051d13dac4be8a3ca172d9b74051, type: 3}
+      TotalCreditExport: 500
     - OrderName: Research Director Set
       CreditsCost: 2000
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -522,6 +571,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
       - {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226, type: 3}
       - {fileID: 3011710637427380133, guid: 14673e0d9505d4a20ba67712d7358daa, type: 3}
+      TotalCreditExport: 500
     - OrderName: Scientist Set
       CreditsCost: 800
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -532,6 +582,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
       - {fileID: 7374481989050852271, guid: d45ca61e9864044ebb02cf9d0d01f986, type: 3}
       - {fileID: 3011710637427380133, guid: d39638a7abcdf4a25b189fa975eab5e7, type: 3}
+      TotalCreditExport: 500
     - OrderName: Roboticist Set
       CreditsCost: 800
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -543,6 +594,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
       - {fileID: 3011710637427380133, guid: 2a2d871db32f24302b1aeb03f3652c48, type: 3}
       - {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
+      TotalCreditExport: 500
     - OrderName: Chief Engineer Set
       CreditsCost: 2000
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -554,6 +606,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: 67eaf03d3dc08490c85f77c1aedf4a15, type: 3}
       - {fileID: 1052293997073687485, guid: 4d1d96d4187b0497a91fd915d358d354, type: 3}
       - {fileID: 3011710637427380133, guid: 10db9e28e42d145e9bbb1b151ee172de, type: 3}
+      TotalCreditExport: 500
     - OrderName: Station Engineer Set
       CreditsCost: 900
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -564,6 +617,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: 67eaf03d3dc08490c85f77c1aedf4a15, type: 3}
       - {fileID: 7636118406116123594, guid: 64e430f828cfc465ea88b8d6e6fecda4, type: 3}
       - {fileID: 3011710637427380133, guid: 669c8831af14a4225968399b65b23461, type: 3}
+      TotalCreditExport: 500
     - OrderName: Atmospheric Technician Set
       CreditsCost: 900
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -573,6 +627,7 @@ MonoBehaviour:
       - {fileID: 3011710637427380133, guid: 7836d5b8852b74938820fb198f01e5ba, type: 3}
       - {fileID: 835768756810601639, guid: ce8ad09737e5d47c0876505a3366d37d, type: 3}
       - {fileID: 7106618204054676533, guid: 67eaf03d3dc08490c85f77c1aedf4a15, type: 3}
+      TotalCreditExport: 500
     - OrderName: Head of Security Set
       CreditsCost: 4000
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -586,6 +641,7 @@ MonoBehaviour:
       - {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
       - {fileID: 7636118406116123594, guid: 8a05cb3da796e42e89e13a0963de6953, type: 3}
       - {fileID: 3921521694364753778, guid: cc01ce86e44f441a0a39be6164acd40e, type: 3}
+      TotalCreditExport: 500
     - OrderName: Security Officer Set
       CreditsCost: 800
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -597,6 +653,7 @@ MonoBehaviour:
       - {fileID: 3431291279286482953, guid: 0c3e7a0b25eff4d33a4f511cfc36b5d9, type: 3}
       - {fileID: 7106618204054676533, guid: eaeac5365190b4842bedb2b846ff15da, type: 3}
       - {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
+      TotalCreditExport: 500
     - OrderName: Warden Set
       CreditsCost: 1000
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -610,6 +667,7 @@ MonoBehaviour:
       - {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
       - {fileID: 7636118406116123594, guid: 77556be90466a4737b39e556f8ff1d41, type: 3}
       - {fileID: 3921521694364753778, guid: 012d5b9e077cf4eda9c65f01d1ff5b57, type: 3}
+      TotalCreditExport: 500
     - OrderName: Detective Set
       CreditsCost: 600
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -623,6 +681,7 @@ MonoBehaviour:
       - {fileID: 7636118406116123594, guid: 5dd96f5e685214da19f65b06f2463aa2, type: 3}
       - {fileID: 3921521694364753778, guid: 02d871d46281a42d1820f9b47a8124c6, type: 3}
       - {fileID: 3011710637427380133, guid: de7c66806376e49fd871dfce32fb6d26, type: 3}
+      TotalCreditExport: 500
     - OrderName: Head of Personnel Set
       CreditsCost: 5000
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -634,6 +693,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
       - {fileID: 7636118406116123594, guid: aec4b97408d594f4d91c03418d9a457f, type: 3}
       - {fileID: 3011710637427380133, guid: cda0c7d60b6a643279489d6c9a64d208, type: 3}
+      TotalCreditExport: 500
     - OrderName: Captain Set
       CreditsCost: 10000
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -647,6 +707,7 @@ MonoBehaviour:
       - {fileID: 7636118406116123594, guid: 97b4b6e6d0aac46f6ad3fb58fb826008, type: 3}
       - {fileID: 3921521694364753778, guid: 1f5c642823aec460a8c4867390c89849, type: 3}
       - {fileID: 3011710637427380133, guid: 9c0ae44adb2c14e9bae919e9e0f844fc, type: 3}
+      TotalCreditExport: 500
     - OrderName: Prisoner Uniform Set
       CreditsCost: 500
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -658,6 +719,7 @@ MonoBehaviour:
       - {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
       - {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
       - {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+      TotalCreditExport: 500
   - CategoryName: Emergency
     Supplies:
     - OrderName: Internals Crate
@@ -674,6 +736,7 @@ MonoBehaviour:
       - {fileID: 132773863777131159, guid: 7a4abc9d5e36bb14cb203248884ef037, type: 3}
       - {fileID: 132773863777131159, guid: 7a4abc9d5e36bb14cb203248884ef037, type: 3}
       - {fileID: 132773863777131159, guid: 7a4abc9d5e36bb14cb203248884ef037, type: 3}
+      TotalCreditExport: 500
     - OrderName: Firefighting Crate
       CreditsCost: 1000
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -687,6 +750,7 @@ MonoBehaviour:
       - {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb, type: 3}
       - {fileID: 7914350351518715449, guid: 908afbc5b9f871148b5ccd0b81bd147f, type: 3}
       - {fileID: 7914350351518715449, guid: 908afbc5b9f871148b5ccd0b81bd147f, type: 3}
+      TotalCreditExport: 540
     - OrderName: EVA crate
       CreditsCost: 800
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -698,6 +762,7 @@ MonoBehaviour:
       - {fileID: 5285738701257476823, guid: 5b03000bed50be045b14e7dc9186fd97, type: 3}
       - {fileID: 7106618204054676533, guid: afe0b0cc9e24249c1aaf8b7b2c4b3a3c, type: 3}
       - {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
+      TotalCreditExport: 500
     - OrderName: Radiation Protection crate
       CreditsCost: 800
       Crate: {fileID: 3701635295295868414, guid: d2e38660b0ae0450ab25b2a61ac10c46,
@@ -711,6 +776,7 @@ MonoBehaviour:
       - {fileID: 3921521694364753778, guid: e3a0238ef8323eb4caadcb2e19bbcf41, type: 3}
       - {fileID: 4705670883515168300, guid: 46cceb9511b6bba4cb747e67a7f2b70d, type: 3}
       - {fileID: 4705670883515168300, guid: 46cceb9511b6bba4cb747e67a7f2b70d, type: 3}
+      TotalCreditExport: 600
   - CategoryName: Materials
     Supplies:
     - OrderName: Metal Crate
@@ -778,6 +844,7 @@ MonoBehaviour:
       - {fileID: 6254655335276451647, guid: ab486d104d39e584e935c8a5459a967c, type: 3}
       - {fileID: 6254655335276451647, guid: ab486d104d39e584e935c8a5459a967c, type: 3}
       - {fileID: 6254655335276451647, guid: ab486d104d39e584e935c8a5459a967c, type: 3}
+      TotalCreditExport: 500
     - OrderName: Glass Crate
       CreditsCost: 850
       Crate: {fileID: 658481186047158928, guid: 7703bcfa4ada3480095b5c7b68673f61,
@@ -843,6 +910,7 @@ MonoBehaviour:
       - {fileID: 5680136605834777345, guid: ea07289ba72453444a4ff1202b47a57d, type: 3}
       - {fileID: 5680136605834777345, guid: ea07289ba72453444a4ff1202b47a57d, type: 3}
       - {fileID: 5680136605834777345, guid: ea07289ba72453444a4ff1202b47a57d, type: 3}
+      TotalCreditExport: 500
     - OrderName: Solid Plasma Crate
       CreditsCost: 3000
       Crate: {fileID: 1102147915931524473, guid: 15783568e89845c45b49764f003fabe4,
@@ -852,6 +920,7 @@ MonoBehaviour:
       - {fileID: 6254655335276451647, guid: 70a15a1bc92d10944878d2f52dfe2be0, type: 3}
       - {fileID: 6254655335276451647, guid: 70a15a1bc92d10944878d2f52dfe2be0, type: 3}
       - {fileID: 6254655335276451647, guid: 70a15a1bc92d10944878d2f52dfe2be0, type: 3}
+      TotalCreditExport: 750
     - OrderName: Plasteel Crate
       CreditsCost: 800
       Crate: {fileID: 658481186047158928, guid: 7703bcfa4ada3480095b5c7b68673f61,
@@ -887,12 +956,14 @@ MonoBehaviour:
       - {fileID: 3642454299424425929, guid: 7d23f839f141d4c99a6bfe9c8bfceca1, type: 3}
       - {fileID: 3642454299424425929, guid: 7d23f839f141d4c99a6bfe9c8bfceca1, type: 3}
       - {fileID: 3642454299424425929, guid: 7d23f839f141d4c99a6bfe9c8bfceca1, type: 3}
+      TotalCreditExport: 500
     - OrderName: Vending Resupply
       CreditsCost: 1500
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
         type: 3}
       Items:
       - {fileID: 266178104534119887, guid: 1aff7456d9fe31693a6705676cb722f6, type: 3}
+      TotalCreditExport: 500
   - CategoryName: Miscellaneous
     Supplies:
     - OrderName: Monkey Crate
@@ -906,6 +977,7 @@ MonoBehaviour:
       - {fileID: 7785875528613525472, guid: 4569acb573d85cc4d851531fdaedc4d2, type: 3}
       - {fileID: 7785875528613525472, guid: 4569acb573d85cc4d851531fdaedc4d2, type: 3}
       - {fileID: 7785875528613525472, guid: 4569acb573d85cc4d851531fdaedc4d2, type: 3}
+      TotalCreditExport: 500
     - OrderName: Robusting Crate
       CreditsCost: 1000
       Crate: {fileID: 7179535571258370003, guid: 44071f490693c439896528fb8aca8917,
@@ -919,3 +991,4 @@ MonoBehaviour:
       - {fileID: 7331803544451838430, guid: d554409601a0f744090f24e47955cb9a, type: 3}
       - {fileID: 7331803544451838430, guid: d554409601a0f744090f24e47955cb9a, type: 3}
       - {fileID: 7331803544451838430, guid: d554409601a0f744090f24e47955cb9a, type: 3}
+      TotalCreditExport: 500

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using NaughtyAttributes;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.SceneManagement;
@@ -28,6 +29,8 @@ public class CargoManager : MonoBehaviour
 
 	[SerializeField]
 	private CargoData cargoData = null;
+
+	public CargoData CargoData => cargoData;
 
 	[SerializeField]
 	private float shuttleFlyDuration = 10f;
@@ -386,6 +389,9 @@ public class CargoOrder
 	public int CreditsCost = 1000;
 	public GameObject Crate = null;
 	public List<GameObject> Items = new List<GameObject>();
+
+	[ReadOnly]
+	public int TotalCreditExport = 0;
 }
 
 [System.Serializable]


### PR DESCRIPTION
Adds a checker for cargo crate values and export costs.

To run the checker you **must** be in to play mode in editor.

But the check can be saved in the SO, so currently the export values are up to data as they've been committed.

To use the checker:

Go to the networking tab at the top of the editor and run the "Calculate Cargo Export Costs" tool.

It will generate debug messages for all the items and Error messages if there's an exploit possible.
