### PR TITLE
Gave the Jaws of Life a toggle when activated

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Jaws of Life.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Jaws of Life.prefab
@@ -18,6 +18,18 @@ MonoBehaviour:
   variantIndex: -1
   variantType: 0
   hideClothingFlags: 0
+--- !u!114 &6603776508560279397
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6918947953705996213}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1418c7e2d4af82eae90248862cf99f5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1691278609676860386
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -33,7 +45,7 @@ PrefabInstance:
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}
@@ -133,7 +145,7 @@ PrefabInstance:
         type: 3}
       propertyPath: initialTraits.Array.data[1]
       value: 
-      objectReference: {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644,
+      objectReference: {fileID: 11400000, guid: 5eafba0d7388d428c8e08ed1b5d5d260,
         type: 2}
     - target: {fileID: 8183094236644858677, guid: c9c58a9243d494537abcb4ee470efab0,
         type: 3}

--- a/UnityProject/Assets/Scripts/Tool/JawsOfLife.cs
+++ b/UnityProject/Assets/Scripts/Tool/JawsOfLife.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// some context behind this component: i'm making this as a start for my contributions
+// to unitystation, so there's probably going to be a lot of weird things here.
+// please let me know if you have any advice for my code.
+[RequireComponent(typeof(ItemAttributesV2))]
+public class JawsOfLife : MonoBehaviour, IInteractable<HandActivate>
+{
+	private ItemAttributesV2 itemAttributeComponent;
+	private int toolSetting = 0;	// set the Jaws of Life to "tool" 0, which will be defined below
+	
+	private void Awake()
+	{
+		itemAttributeComponent = GetComponent<ItemAttributesV2>();	// get ItemAttributesV2 from the object this component is attached to
+	}
+
+	public void ServerPerformInteraction(HandActivate interaction)
+	{
+		if (toolSetting == 0)
+		{
+			itemAttributeComponent.RemoveTrait(CommonTraits.Instance.Crowbar);
+			itemAttributeComponent.AddTrait(CommonTraits.Instance.Wirecutter);
+
+			Chat.AddExamineMsgFromServer(interaction.Performer,"You flick the Jaws of Life into Wirecutter mode" );	// TODO: not sure how this tool is meant to work in-game, so this description might not make sense
+			
+			toolSetting = 1;
+		}
+		else if (toolSetting == 1)
+		{
+			itemAttributeComponent.RemoveTrait(CommonTraits.Instance.Wirecutter);
+			itemAttributeComponent.AddTrait(CommonTraits.Instance.Crowbar);
+			
+			Chat.AddExamineMsgFromServer(interaction.Performer,"You flick the Jaws of Life into Crowbar mode" );	// TODO: like above, this description might not make sense
+			
+			toolSetting = 0;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Tool/JawsOfLife.cs.meta
+++ b/UnityProject/Assets/Scripts/Tool/JawsOfLife.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1418c7e2d4af82eae90248862cf99f5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
This PR adds toggle functionality to the Jaws of Life item. It solves one (but not all) of the problems described in #4127 
When selected in a hand, the player can now push Z or click the item to toggle it. A message will appear stating the Jaws of Life's new mode in which it is engaged.

### Notes:
This is my first PR, I've done my best to follow the coding standards laid out by the developers here. I've tested the new functionality on my end before submitting this PR, but please notify me if I made an oversight or there is a problem with the code. 
