### PR TITLE
Fix item spawner .prefab references, add check to RandomItemSpot.cs.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/2%XenoEgg.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/2%XenoEgg.prefab
@@ -21,7 +21,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[0].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 157fb9a92fe7905449e7f9e32c78e95f,
+      objectReference: {fileID: 11400000, guid: a5b6eaca848bbdb4abc640f8f63e35ca,
         type: 2}
     - target: {fileID: 2708525666452541148, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/ArmoryContrabandGunSpawner.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/ArmoryContrabandGunSpawner.prefab
@@ -21,7 +21,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[0].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 7da4a2b658ba05b498641fddeb6119d3,
+      objectReference: {fileID: 11400000, guid: e6cf430be6c79c741b31a401292072ad,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -32,8 +32,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[1].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 6f38e1fcd4adc9c4d904d6b2d391afe1,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: poolList.Array.data[2].probability
@@ -43,8 +42,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[2].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 2c4d1cecba62e4e42a694d900c765fb4,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: poolList.Array.data[3].probability
@@ -54,8 +52,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[3].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: bef2cdf6314a23245a45cf8d7069c7a7,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: poolList.Array.data[4].probability
@@ -65,8 +62,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[4].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 11e3be478d8ef8a4ba263d9ee8dd08b3,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: poolList.Array.data[5].probability
@@ -76,8 +72,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[5].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 7722af163801ab84ba6ffd4ed45a5cc3,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: poolList.Array.data[6].probability
@@ -87,8 +82,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[6].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: e04fdca3e848109499e2cd897792deea,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: poolList.Array.data[7].probability
@@ -98,8 +92,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[7].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 7ec6dedfb200e7e4b9387da053683b1f,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: poolList.Array.data[8].probability
@@ -109,8 +102,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[8].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 7e88f18ca08669f4986d1b20d06f7991,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: poolList.Array.data[9].probability
@@ -120,8 +112,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[9].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: a023f7a7adb344941b8032b016639640,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: poolList.Array.data[10].probability
@@ -131,8 +122,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[10].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 1ecac083f128b5348bcdc25a13f4bb4a,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 2806690048445349940, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLoot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/MaintLoot.prefab
@@ -21,7 +21,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[0].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: acbf77ee963f2464bbc6d07ac57f8805,
+      objectReference: {fileID: 11400000, guid: 22131c9e2fcff2a4285f9e919baea526,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -32,7 +32,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[1].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 6f38e1fcd4adc9c4d904d6b2d391afe1,
+      objectReference: {fileID: 11400000, guid: d7cc7a991fbe2f14e96933a0dba00a88,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -43,7 +43,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[2].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 2c4d1cecba62e4e42a694d900c765fb4,
+      objectReference: {fileID: 11400000, guid: 3c9854fd844d22a46a5e872819a122e2,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -54,7 +54,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[3].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: bef2cdf6314a23245a45cf8d7069c7a7,
+      objectReference: {fileID: 11400000, guid: 1c01408aa4ff95845b57e06bb1b437ea,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -65,7 +65,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[4].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 11e3be478d8ef8a4ba263d9ee8dd08b3,
+      objectReference: {fileID: 11400000, guid: 1f22494d2c1842c41a3dfd7e2ab79599,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -76,7 +76,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[5].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 7722af163801ab84ba6ffd4ed45a5cc3,
+      objectReference: {fileID: 11400000, guid: 76c76e380eb6fa3499016440dcdd92be,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -87,7 +87,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[6].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: e04fdca3e848109499e2cd897792deea,
+      objectReference: {fileID: 11400000, guid: 877efeea58acb6d468781c1223659e4d,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -98,7 +98,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[7].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 7ec6dedfb200e7e4b9387da053683b1f,
+      objectReference: {fileID: 11400000, guid: f863081c2a3733b48af42cd4fc0d6123,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -109,7 +109,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[8].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 7e88f18ca08669f4986d1b20d06f7991,
+      objectReference: {fileID: 11400000, guid: 834fd2e77374a9846890391442dfcff3,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -120,7 +120,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[9].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: a023f7a7adb344941b8032b016639640,
+      objectReference: {fileID: 11400000, guid: 834fd2e77374a9846890391442dfcff3,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -131,7 +131,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[10].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 1ecac083f128b5348bcdc25a13f4bb4a,
+      objectReference: {fileID: 11400000, guid: eb91a22b242bb4543b8a312a249582c9,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -142,7 +142,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[11].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: e56423ec3363f8443890e256d53a5470,
+      objectReference: {fileID: 11400000, guid: de596418d301ffc46b3c7355bded1f9b,
         type: 2}
     - target: {fileID: 2806690048445349940, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomCrowbar.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomCrowbar.prefab
@@ -21,7 +21,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[0].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 03c8a85f84af1574cb697cea96c20b57,
+      objectReference: {fileID: 11400000, guid: c34b740e688061f4d93e01fcff2b546d,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -32,8 +32,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[1].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: bad350ee11e13f9448abcf9ee6bb2566,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: poolList.Array.data[2].probability
@@ -43,8 +42,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[2].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: bad350ee11e13f9448abcf9ee6bb2566,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 2708525666452541148, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomGloves.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomGloves.prefab
@@ -21,7 +21,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[0].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 7ec6dedfb200e7e4b9387da053683b1f,
+      objectReference: {fileID: 11400000, guid: f863081c2a3733b48af42cd4fc0d6123,
         type: 2}
     - target: {fileID: 2708525666452541148, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomHeadset.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomHeadset.prefab
@@ -21,7 +21,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[0].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 1fe262b0d1927df489163775af4e9c0b,
+      objectReference: {fileID: 11400000, guid: 79b27f79a1ad15842af3420faa3b3045,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -32,7 +32,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[1].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: a788815c46dad624ba8fecc3f75ad697,
+      objectReference: {fileID: 11400000, guid: 60ed3a7ff50b64c4e84a3fbae182b713,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -43,7 +43,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[2].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: bad350ee11e13f9448abcf9ee6bb2566,
+      objectReference: {fileID: 11400000, guid: bf6ffb027c9ec5f4fa11045ada138460,
         type: 2}
     - target: {fileID: 2708525666452541148, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomTool.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomTool.prefab
@@ -16,13 +16,13 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[0].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: e04fdca3e848109499e2cd897792deea,
+      objectReference: {fileID: 11400000, guid: 877efeea58acb6d468781c1223659e4d,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: poolList.Array.data[1].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 1ecac083f128b5348bcdc25a13f4bb4a,
+      objectReference: {fileID: 11400000, guid: eb91a22b242bb4543b8a312a249582c9,
         type: 2}
     - target: {fileID: 1158969463323420989, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomVendor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/RandomVendor.prefab
@@ -21,7 +21,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[0].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 6d3ada036cd73c8429dd27a9a67488fb,
+      objectReference: {fileID: 11400000, guid: f9fbdb83313c1da479ed1e97a37397be,
         type: 2}
     - target: {fileID: 2708525666452541148, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Spawners/TrashOrGrille.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Spawners/TrashOrGrille.prefab
@@ -21,7 +21,7 @@ PrefabInstance:
         type: 3}
       propertyPath: poolList.Array.data[0].randomItemPool
       value: 
-      objectReference: {fileID: 11400000, guid: 4f93cf8c461ab57409926fd5a5c257df,
+      objectReference: {fileID: 11400000, guid: b51ec59e44a7ca44883947bdffa98e04,
         type: 2}
     - target: {fileID: 2708525666452541148, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
@@ -37,7 +37,7 @@ PrefabInstance:
     - target: {fileID: 2839352587806555520, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}
       propertyPath: m_Name
-      value: ThrashOrGrille
+      value: TrashOrGrille
       objectReference: {fileID: 0}
     - target: {fileID: 2843154561411039476, guid: abff3ae0227731244b0814b2055fa6f0,
         type: 3}

--- a/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/RandomItemSpot.cs
@@ -65,6 +65,15 @@ namespace Items
 		private void SpawnItems(PoolData poolData)
 		{
 			if (poolData == null) return;
+
+            var itemPool = poolData.RandomItemPool;
+
+            if (itemPool == null)
+			{
+				Debug.LogError($"Item pool was null in {gameObject.name}");
+				return;
+			}
+
 			var item = poolData.RandomItemPool.Pool.PickRandom();
 			var spread = fanOut ? Random.Range(-0.5f,0.5f) : (float?) null;
 


### PR DESCRIPTION
### Purpose
- Fix references in random item spawner .prefabs because they all broke after #4501 due to .meta guID shenanigans.
- Add a check for empty references to RandomItemSpot.cs. **Code done by ThatDaniel**.
