### PR TITLE
Added a Door Wedger component, allowing items to wedge open closed doors

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Crowbar.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Crowbar.prefab
@@ -1,5 +1,18 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &3214867194547515906
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8096842924384943973}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c5880da48629d4f086f5280f40e6e73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  openingDelay: 10
 --- !u!1001 &1177912565818634448
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -115,3 +128,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f709eab732189d6429ae3fa5beaf3fd3, type: 3}
+--- !u!1 &8096842924384943973 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6918947953705996213, guid: f709eab732189d6429ae3fa5beaf3fd3,
+    type: 3}
+  m_PrefabInstance: {fileID: 1177912565818634448}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Jaws of Life.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Jaws of Life.prefab
@@ -33,6 +33,19 @@ MonoBehaviour:
   variantIndex: -1
   variantType: 0
   hideClothingFlags: 0
+--- !u!114 &8280760454218284409
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6918947953705996213}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c5880da48629d4f086f5280f40e6e73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  openingDelay: 10
 --- !u!1001 &1691278609676860386
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Tool/DoorWedger.cs
+++ b/UnityProject/Assets/Scripts/Tool/DoorWedger.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DoorWedger : MonoBehaviour, IInteractable<HandApply>, ICheckedInteractable<HandApply>
+{
+    [SerializeField] [Tooltip("The time in seconds it takes to wedge open a door with this tool.")]
+    private float openingDelay = 10f;
+
+    public bool WillInteract(HandApply interaction, NetworkSide side)
+    {
+        if (!DefaultWillInteract.Default(interaction, side)) return false;
+
+        if (Validations.IsTarget(gameObject, interaction)) return false;
+        return true;
+    }
+    
+    public void ServerPerformInteraction(HandApply interaction)
+    {
+        var targetObject = interaction.TargetObject.GetComponent<DoorController>();
+
+        if (targetObject == null)
+        {
+            Chat.AddExamineMsgFromServer(interaction.Performer, "DEBUG: You hit NULL.");
+            return;
+        }
+
+        if (targetObject.IsWelded)
+        {
+            Chat.AddExamineMsgFromServer(interaction.Performer, $"You can't force this door open with your {gameObject.name}, it's welded shut!");
+        }
+
+        if (targetObject.IsClosed)
+        {
+            ToolUtils.ServerUseToolWithActionMessages(interaction, openingDelay,
+            "You start wedging open the door...",
+            $"{interaction.Performer.ExpensiveName()} starts wedging open the door...",
+            $"You force the door open with your {gameObject.name}!",
+            $"{interaction.Performer.ExpensiveName()} forces the door open!",
+            () =>
+            {
+                targetObject.ServerOpen();
+            });
+        }
+    }
+}

--- a/UnityProject/Assets/Scripts/Tool/DoorWedger.cs
+++ b/UnityProject/Assets/Scripts/Tool/DoorWedger.cs
@@ -21,7 +21,6 @@ public class DoorWedger : MonoBehaviour, IInteractable<HandApply>, ICheckedInter
 
         if (targetObject == null)
         {
-            Chat.AddExamineMsgFromServer(interaction.Performer, "DEBUG: You hit NULL.");
             return;
         }
 

--- a/UnityProject/Assets/Scripts/Tool/DoorWedger.cs
+++ b/UnityProject/Assets/Scripts/Tool/DoorWedger.cs
@@ -26,7 +26,7 @@ public class DoorWedger : MonoBehaviour, IInteractable<HandApply>, ICheckedInter
 
         if (targetObject.IsWelded)
         {
-            Chat.AddExamineMsgFromServer(interaction.Performer, $"You can't force this door open with your {gameObject.name}, it's welded shut!");
+            Chat.AddExamineMsgFromServer(interaction.Performer, $"You can't force this door open with your {gameObject.ExpensiveName()}, it's welded shut!");
         }
 
         if (targetObject.IsClosed)
@@ -34,7 +34,7 @@ public class DoorWedger : MonoBehaviour, IInteractable<HandApply>, ICheckedInter
             ToolUtils.ServerUseToolWithActionMessages(interaction, openingDelay,
             "You start wedging open the door...",
             $"{interaction.Performer.ExpensiveName()} starts wedging open the door...",
-            $"You force the door open with your {gameObject.name}!",
+            $"You force the door open with your {gameObject.ExpensiveName()}!",
             $"{interaction.Performer.ExpensiveName()} forces the door open!",
             () =>
             {

--- a/UnityProject/Assets/Scripts/Tool/DoorWedger.cs.meta
+++ b/UnityProject/Assets/Scripts/Tool/DoorWedger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c5880da48629d4f086f5280f40e6e73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
This PR adds a Door Wedger component, which can be applied to items in the Unity Editor to allow them to force open doors within the game. This PR relates to one of problems described in #4127

### Notes:
Because doors have no powered/unpowered state and this component has no sounds associated with it yet, it's not entirely finished and will probably need to be revisited in the future.
The time it takes for an item to wedge open a door can be changed on a per-item basis. I couldn't find out how long it took on /tg/ to wedge open a door, so I decided on 10 seconds by default for both the Crowbar and the Jaws of Life. Please change these values if needed.