### PR TITLE
Vendor updates

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/DinnerWareVendor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Kitchen/DinnerWareVendor.prefab
@@ -131,7 +131,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1000013211423706}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -7, y: 4, z: -0.1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -226,13 +226,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 7781396554342910705, guid: 229f1c93e0e4ada439cfe4b781f65997, type: 3}
+  - ItemName: Knife
+    Item: {fileID: 7781396554342910705, guid: 229f1c93e0e4ada439cfe4b781f65997, type: 3}
     Stock: 5
-  - Item: {fileID: 7188868217503671157, guid: d90196f4e6b6a4e4a949960b6fafb464, type: 3}
+  - ItemName: Salt Shaker
+    Item: {fileID: 7188868217503671157, guid: d90196f4e6b6a4e4a949960b6fafb464, type: 3}
     Stock: 5
-  - Item: {fileID: 7188868217503671157, guid: ecdfcc2ad92d8b846a04f0b050fdf377, type: 3}
+  - ItemName: Pepper Shaker
+    Item: {fileID: 7188868217503671157, guid: ecdfcc2ad92d8b846a04f0b050fdf377, type: 3}
     Stock: 5
-  - Item: {fileID: 7781396554342910705, guid: fd2b975bb2d60fb429c193f9ef1d31b0, type: 3}
+  - ItemName: Rolling Pin
+    Item: {fileID: 7781396554342910705, guid: fd2b975bb2d60fb429c193f9ef1d31b0, type: 3}
+    Stock: 5
+  - ItemName: Mixing Bowl
+    Item: {fileID: 7516689663430431150, guid: 1bbe7e45a9c8b9a4da41c797e24ffc8d, type: 3}
+    Stock: 5
+  - ItemName: Drinking Glass
+    Item: {fileID: 5426160498802093876, guid: 73832b33f58924a40b5c771587f9707e, type: 3}
     Stock: 5
   HullColor: {r: 0.42745098, g: 0.62352943, b: 0.7529412, a: 1}
   EjectObjects: 0
@@ -241,13 +251,17 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 7781396554342910705, guid: 229f1c93e0e4ada439cfe4b781f65997, type: 3}
+  - ItemName: 
+    Item: {fileID: 7781396554342910705, guid: 229f1c93e0e4ada439cfe4b781f65997, type: 3}
     Stock: 5
-  - Item: {fileID: 7188868217503671157, guid: d90196f4e6b6a4e4a949960b6fafb464, type: 3}
+  - ItemName: 
+    Item: {fileID: 7188868217503671157, guid: d90196f4e6b6a4e4a949960b6fafb464, type: 3}
     Stock: 5
-  - Item: {fileID: 7188868217503671157, guid: ecdfcc2ad92d8b846a04f0b050fdf377, type: 3}
+  - ItemName: 
+    Item: {fileID: 7188868217503671157, guid: ecdfcc2ad92d8b846a04f0b050fdf377, type: 3}
     Stock: 5
-  - Item: {fileID: 7781396554342910705, guid: fd2b975bb2d60fb429c193f9ef1d31b0, type: 3}
+  - ItemName: 
+    Item: {fileID: 7781396554342910705, guid: fd2b975bb2d60fb429c193f9ef1d31b0, type: 3}
     Stock: 5
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/AtmosDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/AtmosDrobe.prefab
@@ -97,23 +97,32 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 3
-  - Item: {fileID: 2814261017750131953, guid: 3d586d5738df167469974943cd4a69ff, type: 3}
+  - ItemName: Industrial Duffel Bag
+    Item: {fileID: 2814261017750131953, guid: 3d586d5738df167469974943cd4a69ff, type: 3}
     Stock: 3
-  - Item: {fileID: 6682071155640065413, guid: 99480f95d67c6cc4c852e3e388dc70df, type: 3}
+  - ItemName: Industrial Satchel
+    Item: {fileID: 6682071155640065413, guid: 99480f95d67c6cc4c852e3e388dc70df, type: 3}
     Stock: 3
-  - Item: {fileID: 6527078367214184808, guid: 9ece9b1c0b01fa46ab120b1b423b1739, type: 3}
+  - ItemName: Industrial Backpack
+    Item: {fileID: 6527078367214184808, guid: 9ece9b1c0b01fa46ab120b1b423b1739, type: 3}
     Stock: 3
-  - Item: {fileID: 7775834299501801313, guid: eb6e678136f03fe4896e35207b70e1cc, type: 3}
+  - ItemName: 
+    Item: {fileID: 7775834299501801313, guid: eb6e678136f03fe4896e35207b70e1cc, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: 7836d5b8852b74938820fb198f01e5ba, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 7836d5b8852b74938820fb198f01e5ba, type: 3}
     Stock: 3
-  - Item: {fileID: 3893929246494869355, guid: 6c0b4e12999405741b9fd74d47c66001, type: 3}
+  - ItemName: 
+    Item: {fileID: 3893929246494869355, guid: 6c0b4e12999405741b9fd74d47c66001, type: 3}
     Stock: 3
-  - Item: {fileID: 7106618204054676533, guid: 67eaf03d3dc08490c85f77c1aedf4a15, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 67eaf03d3dc08490c85f77c1aedf4a15, type: 3}
     Stock: 3
-  - Item: {fileID: 835768756810601639, guid: ce8ad09737e5d47c0876505a3366d37d, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: ce8ad09737e5d47c0876505a3366d37d, type: 3}
     Stock: 3
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -122,23 +131,32 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 3
-  - Item: {fileID: 2814261017750131953, guid: 3d586d5738df167469974943cd4a69ff, type: 3}
+  - ItemName: 
+    Item: {fileID: 2814261017750131953, guid: 3d586d5738df167469974943cd4a69ff, type: 3}
     Stock: 3
-  - Item: {fileID: 6682071155640065413, guid: 99480f95d67c6cc4c852e3e388dc70df, type: 3}
+  - ItemName: 
+    Item: {fileID: 6682071155640065413, guid: 99480f95d67c6cc4c852e3e388dc70df, type: 3}
     Stock: 3
-  - Item: {fileID: 6527078367214184808, guid: 9ece9b1c0b01fa46ab120b1b423b1739, type: 3}
+  - ItemName: 
+    Item: {fileID: 6527078367214184808, guid: 9ece9b1c0b01fa46ab120b1b423b1739, type: 3}
     Stock: 3
-  - Item: {fileID: 7775834299501801313, guid: eb6e678136f03fe4896e35207b70e1cc, type: 3}
+  - ItemName: 
+    Item: {fileID: 7775834299501801313, guid: eb6e678136f03fe4896e35207b70e1cc, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: 7836d5b8852b74938820fb198f01e5ba, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 7836d5b8852b74938820fb198f01e5ba, type: 3}
     Stock: 3
-  - Item: {fileID: 3893929246494869355, guid: 6c0b4e12999405741b9fd74d47c66001, type: 3}
+  - ItemName: 
+    Item: {fileID: 3893929246494869355, guid: 6c0b4e12999405741b9fd74d47c66001, type: 3}
     Stock: 3
-  - Item: {fileID: 7106618204054676533, guid: 67eaf03d3dc08490c85f77c1aedf4a15, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 67eaf03d3dc08490c85f77c1aedf4a15, type: 3}
     Stock: 3
-  - Item: {fileID: 835768756810601639, guid: ce8ad09737e5d47c0876505a3366d37d, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: ce8ad09737e5d47c0876505a3366d37d, type: 3}
     Stock: 3
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/AutoDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/AutoDrobe.prefab
@@ -96,341 +96,500 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 3921521694364753778, guid: a13fbe8edd77fac409d1ce7543dee807, type: 3}
+  - ItemName: Street Judges Uniform
+    Item: {fileID: 3921521694364753778, guid: a13fbe8edd77fac409d1ce7543dee807, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 5a2c36e5029b04a45a559c20eea57600, type: 3}
+  - ItemName: Street Judges Helmet
+    Item: {fileID: 7636118406116123594, guid: 5a2c36e5029b04a45a559c20eea57600, type: 3}
     Stock: 1
-  - Item: {fileID: 482378326749940947, guid: aa9224525bbbd5a59922f2fd2e4215bb, type: 3}
+  - ItemName: Main Outfit Blue
+    Item: {fileID: 482378326749940947, guid: aa9224525bbbd5a59922f2fd2e4215bb, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 65a378878b1d64f428bb7a05510b9092, type: 3}
+  - ItemName: Werewolf Suit
+    Item: {fileID: 3921521694364753778, guid: 65a378878b1d64f428bb7a05510b9092, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 185e8f1981e885b47a92b5e69ca88f1d, type: 3}
+  - ItemName: Warewolf Mask
+    Item: {fileID: 7636118406116123594, guid: 185e8f1981e885b47a92b5e69ca88f1d, type: 3}
     Stock: 1
-  - Item: {fileID: 6595718230816168079, guid: a9799cb5acad5a44fa29b2eb0f75c5c0, type: 3}
+  - ItemName: Odd Werewolf Suit
+    Item: {fileID: 6595718230816168079, guid: a9799cb5acad5a44fa29b2eb0f75c5c0, type: 3}
     Stock: 1
-  - Item: {fileID: 3955254198958978278, guid: faa0112f6ce89384e8aa4545fe64fb0a, type: 3}
+  - ItemName: Odd Werewol Mask
+    Item: {fileID: 3955254198958978278, guid: faa0112f6ce89384e8aa4545fe64fb0a, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: a731bca6e7803034eaf73a1ff169485b, type: 3}
+  - ItemName: Chicken Suit
+    Item: {fileID: 3921521694364753778, guid: a731bca6e7803034eaf73a1ff169485b, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 3864fa9dd4aa14c4c83805082e402fc2, type: 3}
+  - ItemName: Chicken Suit Head
+    Item: {fileID: 7636118406116123594, guid: 3864fa9dd4aa14c4c83805082e402fc2, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 90c2bcb8434d2c442a4c22a235bd6ff1, type: 3}
+  - ItemName: Monkey Suit
+    Item: {fileID: 3921521694364753778, guid: 90c2bcb8434d2c442a4c22a235bd6ff1, type: 3}
     Stock: 1
-  - Item: {fileID: 6632660008125443998, guid: 2d19dbdc797a03a43b454ba27020415b, type: 3}
+  - ItemName: Monkey Mask
+    Item: {fileID: 6632660008125443998, guid: 2d19dbdc797a03a43b454ba27020415b, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: ba41c95ddca00aa4ca99feeed566e1d9, type: 3}
+  - ItemName: Mummy Wrapping
+    Item: {fileID: 3011710637427380133, guid: ba41c95ddca00aa4ca99feeed566e1d9, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: f7c0d4c0fca38674a8e3d778edfb1a7e, type: 3}
+  - ItemName: Mummy Mask
+    Item: {fileID: 6404652678407139925, guid: f7c0d4c0fca38674a8e3d778edfb1a7e, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: d26ae7b210f3fc840a5dc1647d95344a, type: 3}
+  - ItemName: Scarecrow Clothes
+    Item: {fileID: 3011710637427380133, guid: d26ae7b210f3fc840a5dc1647d95344a, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 40c0513d984473e48a1393a33244bc46, type: 3}
+  - ItemName: Sack Mask
+    Item: {fileID: 6404652678407139925, guid: 40c0513d984473e48a1393a33244bc46, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: e021575b277d72e4bbcd1365adf65f5b, type: 3}
+  - ItemName: Scarecrow Hat
+    Item: {fileID: 7636118406116123594, guid: e021575b277d72e4bbcd1365adf65f5b, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 35a07bc0cd215c24888e3ed416359c43, type: 3}
+  - ItemName: Goldola Suit
+    Item: {fileID: 3011710637427380133, guid: 35a07bc0cd215c24888e3ed416359c43, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 74ff45c24da2a354c926a07813318a1c, type: 3}
+  - ItemName: Gondola Mask
+    Item: {fileID: 6404652678407139925, guid: 74ff45c24da2a354c926a07813318a1c, type: 3}
     Stock: 1
-  - Item: {fileID: 1656165686329110666, guid: 2a3ca69e5f8019e4388af8a531a8c4c8, type: 3}
+  - ItemName: Blue Clown Suit
+    Item: {fileID: 1656165686329110666, guid: 2a3ca69e5f8019e4388af8a531a8c4c8, type: 3}
     Stock: 1
-  - Item: {fileID: 1656165686329110666, guid: c6d7c947c93bd6a479c7197367cf6675, type: 3}
+  - ItemName: Green Clown Suit
+    Item: {fileID: 1656165686329110666, guid: c6d7c947c93bd6a479c7197367cf6675, type: 3}
     Stock: 1
-  - Item: {fileID: 1656165686329110666, guid: 6626f7059fcde804aa7d3e5bc015f9e3, type: 3}
+  - ItemName: Yellow Clown Suit
+    Item: {fileID: 1656165686329110666, guid: 6626f7059fcde804aa7d3e5bc015f9e3, type: 3}
     Stock: 1
-  - Item: {fileID: 1656165686329110666, guid: 8de7067b2153d394990fd2f38f51eb31, type: 3}
+  - ItemName: Orange Clown Suit
+    Item: {fileID: 1656165686329110666, guid: 8de7067b2153d394990fd2f38f51eb31, type: 3}
     Stock: 1
-  - Item: {fileID: 1656165686329110666, guid: 4bd6816b9935b6948a33c5fd9f1f562f, type: 3}
+  - ItemName: Purple Clown Suit
+    Item: {fileID: 1656165686329110666, guid: 4bd6816b9935b6948a33c5fd9f1f562f, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 362e418a402e61647802081d06826f88, type: 3}
+  - ItemName: Gladiators Uniform
+    Item: {fileID: 3011710637427380133, guid: 362e418a402e61647802081d06826f88, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: a5c2833832604a146bb01b103de9174e, type: 3}
+  - ItemName: Gladiator Helmet
+    Item: {fileID: 7636118406116123594, guid: a5c2833832604a146bb01b103de9174e, type: 3}
     Stock: 1
-  - Item: {fileID: 6127118939752068930, guid: b9ea9931e8b07a140ab790d555cace98, type: 3}
+  - ItemName: Green Suit
+    Item: {fileID: 6127118939752068930, guid: b9ea9931e8b07a140ab790d555cace98, type: 3}
     Stock: 1
-  - Item: {fileID: 2834735550645104383, guid: 51fa4efb14c93714ea1ff2121835d6cc, type: 3}
+  - ItemName: Green Suit Skirt
+    Item: {fileID: 2834735550645104383, guid: 51fa4efb14c93714ea1ff2121835d6cc, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 63587900698efce47a648bd987aef283, type: 3}
+  - ItemName: Flat Cap
+    Item: {fileID: 7636118406116123594, guid: 63587900698efce47a648bd987aef283, type: 3}
     Stock: 1
-  - Item: {fileID: 2647627343863631382, guid: 786f07174bf918c48a2388cbfa400fde, type: 3}
+  - ItemName: The Mads Labcoat
+    Item: {fileID: 2647627343863631382, guid: 786f07174bf918c48a2388cbfa400fde, type: 3}
     Stock: 1
-  - Item: {fileID: 7106618204054676533, guid: eaeac5365190b4842bedb2b846ff15da, type: 3}
+  - ItemName: Jack Boots
+    Item: {fileID: 7106618204054676533, guid: eaeac5365190b4842bedb2b846ff15da, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: d87ab69a913cab84592eef571ad4b258, type: 3}
+  - ItemName: Blue Schoolgirl Uniform
+    Item: {fileID: 3011710637427380133, guid: d87ab69a913cab84592eef571ad4b258, type: 3}
     Stock: 1
-  - Item: {fileID: 1433422093498208896, guid: 5cda432cc1acd554188a8e36173c2e80, type: 3}
+  - ItemName: Red Schoolgirl Uniform
+    Item: {fileID: 1433422093498208896, guid: 5cda432cc1acd554188a8e36173c2e80, type: 3}
     Stock: 1
-  - Item: {fileID: 1433422093498208896, guid: 79e10a657cef67c4b97b317574b8d768, type: 3}
+  - ItemName: Green Schoolgirl Uniform
+    Item: {fileID: 1433422093498208896, guid: 79e10a657cef67c4b97b317574b8d768, type: 3}
     Stock: 1
-  - Item: {fileID: 1433422093498208896, guid: d00739bfeb2f2ac44b71c2a0d42f4ddd, type: 3}
+  - ItemName: Orange Schoolgirl Uniform
+    Item: {fileID: 1433422093498208896, guid: d00739bfeb2f2ac44b71c2a0d42f4ddd, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 5a6e2e3a0a44146198136e4fa2798db5, type: 3}
+  - ItemName: Kitty Ears
+    Item: {fileID: 7636118406116123594, guid: 5a6e2e3a0a44146198136e4fa2798db5, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: c61b0ba80af0439449f9a47dfcbdd8a4, type: 3}
+  - ItemName: Rabbit Ears
+    Item: {fileID: 7636118406116123594, guid: c61b0ba80af0439449f9a47dfcbdd8a4, type: 3}
     Stock: 1
-  - Item: {fileID: 4795735908449438376, guid: 64a0d2d91b5c1d24596fcac46075e587, type: 3}
+  - ItemName: Black Skirt
+    Item: {fileID: 4795735908449438376, guid: 64a0d2d91b5c1d24596fcac46075e587, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 9445628fd16314b7388c7086f5fd2f26, type: 3}
+  - ItemName: Beret
+    Item: {fileID: 7636118406116123594, guid: 9445628fd16314b7388c7086f5fd2f26, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
+  - ItemName: Waistcoat
+    Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: dff9b7e8f22ff9b4cb9e2f035702e875, type: 3}
+  - ItemName: Black Suit
+    Item: {fileID: 3011710637427380133, guid: dff9b7e8f22ff9b4cb9e2f035702e875, type: 3}
     Stock: 1
-  - Item: {fileID: 1268281847278913779, guid: 73a102ba242379c4b92c25800ea7976a, type: 3}
+  - ItemName: Black Suit Skirt
+    Item: {fileID: 1268281847278913779, guid: 73a102ba242379c4b92c25800ea7976a, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 489b0e24de7b7dc4ea31a401aadb3779, type: 3}
+  - ItemName: Top Hat
+    Item: {fileID: 7636118406116123594, guid: 489b0e24de7b7dc4ea31a401aadb3779, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 6aeac73f4196c0a92a6db19aa7d06391, type: 3}
+  - ItemName: Kilt
+    Item: {fileID: 3011710637427380133, guid: 6aeac73f4196c0a92a6db19aa7d06391, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 9445628fd16314b7388c7086f5fd2f26, type: 3}
+  - ItemName: Vintage Beret
+    Item: {fileID: 6980020022460415521, guid: 2e40dad0882daeb4bbd61afc69196ac1, type: 3}
     Stock: 1
-  - Item: {fileID: 6980020022460415521, guid: 2e40dad0882daeb4bbd61afc69196ac1, type: 3}
+  - ItemName: Archaic Beret
+    Item: {fileID: 6980020022460415521, guid: e00d12849f2494441989ee85ea7ed5c8, type: 3}
     Stock: 1
-  - Item: {fileID: 6980020022460415521, guid: e00d12849f2494441989ee85ea7ed5c8, type: 3}
+  - ItemName: Black Beret
+    Item: {fileID: 6980020022460415521, guid: 9c308081529a1fa43850db366eb71631, type: 3}
     Stock: 1
-  - Item: {fileID: 6980020022460415521, guid: 9c308081529a1fa43850db366eb71631, type: 3}
+  - ItemName: Monocle
+    Item: {fileID: 3431291279286482953, guid: 5c940802546a18f46af0e10ee4ddc95b, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 3431291279286482953, guid: 5c940802546a18f46af0e10ee4ddc95b, type: 3}
+  - ItemName: Amish Suit
+    Item: {fileID: 5480900738568975519, guid: 48285da19a755284693023b1c12c153e, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: Fake Moustache
+    Item: {fileID: 6404652678407139925, guid: 404a54992896a5d4caacc205764bf058, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: Plague Doctor Suit
+    Item: {fileID: 4546394627455633865, guid: 706adbdc94f3ee04ea1d02ddbb027dae, type: 3}
     Stock: 1
-  - Item: {fileID: 5480900738568975519, guid: 48285da19a755284693023b1c12c153e, type: 3}
+  - ItemName: Plague Doctors Hat
+    Item: {fileID: 7636118406116123594, guid: 593845527b97851419727b6919afa92e, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 404a54992896a5d4caacc205764bf058, type: 3}
+  - ItemName: Plague Doctors Mask
+    Item: {fileID: 7701271712345465664, guid: 6b1fe6ba2d6dfb44e86f0594af87dd36, type: 3}
     Stock: 1
-  - Item: {fileID: 4546394627455633865, guid: 706adbdc94f3ee04ea1d02ddbb027dae, type: 3}
+  - ItemName: Owl Cloak
+    Item: {fileID: 3921521694364753778, guid: 36659b70ab02933438ae211235aeb67e, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 593845527b97851419727b6919afa92e, type: 3}
+  - ItemName: Owl Uniform
+    Item: {fileID: 3011710637427380133, guid: 3c8d2434c10f26c42baf079157919c47, type: 3}
     Stock: 1
-  - Item: {fileID: 7701271712345465664, guid: 6b1fe6ba2d6dfb44e86f0594af87dd36, type: 3}
+  - ItemName: Owl Mask
+    Item: {fileID: 1894475026819698963, guid: f4410af7add3943419c5c6b4b8efa05b, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 36659b70ab02933438ae211235aeb67e, type: 3}
+  - ItemName: Griffon Cloak
+    Item: {fileID: 8275399496006930914, guid: 22ff1da9317b8d14fbe3c8ef7cb4ea60, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 3c8d2434c10f26c42baf079157919c47, type: 3}
+  - ItemName: Griffon Uniform
+    Item: {fileID: 4091827544677105848, guid: d7a22b6fbc128a04e8e4b85d2e082fba, type: 3}
     Stock: 1
-  - Item: {fileID: 1894475026819698963, guid: f4410af7add3943419c5c6b4b8efa05b, type: 3}
+  - ItemName: Griffon Boots
+    Item: {fileID: 7106618204054676533, guid: f0acd3a6a2fe3d745aecb5aa632db635, type: 3}
     Stock: 1
-  - Item: {fileID: 8275399496006930914, guid: 22ff1da9317b8d14fbe3c8ef7cb4ea60, type: 3}
+  - ItemName: Griffon Head
+    Item: {fileID: 7636118406116123594, guid: 0a3cbe890b4a2df49aceab1e00c792dd, type: 3}
     Stock: 1
-  - Item: {fileID: 4091827544677105848, guid: d7a22b6fbc128a04e8e4b85d2e082fba, type: 3}
+  - ItemName: Apron
+    Item: {fileID: 3921521694364753778, guid: 34840ba56d91a4e4bb5c615fe3c2b1f3, type: 3}
     Stock: 1
-  - Item: {fileID: 7106618204054676533, guid: f0acd3a6a2fe3d745aecb5aa632db635, type: 3}
+  - ItemName: Waiters Outfit
+    Item: {fileID: 5480900738568975519, guid: 9bb52425bd84e21469e37eb87c90e8eb, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 0a3cbe890b4a2df49aceab1e00c792dd, type: 3}
+  - ItemName: Military Jacket
+    Item: {fileID: 1942180931913338160, guid: 1125504802c358c4f92101904d921ba5, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 34840ba56d91a4e4bb5c615fe3c2b1f3, type: 3}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 5480900738568975519, guid: 9bb52425bd84e21469e37eb87c90e8eb, type: 3}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 1942180931913338160, guid: 1125504802c358c4f92101904d921ba5, type: 3}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: Cyborg Visor
+    Item: {fileID: 6632660008125443998, guid: b1658a111386bd941a0c892cecc1721d, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: Holiday Priests Robes
+    Item: {fileID: 4396341318306884477, guid: 952fcc0a66cc10f4dabc47ee13d626ef, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: White Robe
+    Item: {fileID: 3921521694364753778, guid: 6168a00e66ca21f45b31140fb85e3527, type: 3}
     Stock: 1
-  - Item: {fileID: 6632660008125443998, guid: b1658a111386bd941a0c892cecc1721d, type: 3}
+  - ItemName: Fake Witch Hat
+    Item: {fileID: 3123762211482604667, guid: 220264ebdd6cb324aa31c41def444ced, type: 3}
     Stock: 1
-  - Item: {fileID: 4396341318306884477, guid: 952fcc0a66cc10f4dabc47ee13d626ef, type: 3}
+  - ItemName: Fake Witch Robe
+    Item: {fileID: 1301179775764226454, guid: dffc3f118fe6c9045b8823e560e6879a, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 6168a00e66ca21f45b31140fb85e3527, type: 3}
+  - ItemName: Sundress
+    Item: {fileID: 3011710637427380133, guid: 4319a1b0d53702e458b176248bc470bb, type: 3}
     Stock: 1
-  - Item: {fileID: 3123762211482604667, guid: 220264ebdd6cb324aa31c41def444ced, type: 3}
+  - ItemName: Witch Costume Wig
+    Item: {fileID: 7636118406116123594, guid: 0b41adbfc6852cd4ead543d008d5ced6, type: 3}
     Stock: 1
-  - Item: {fileID: 1301179775764226454, guid: dffc3f118fe6c9045b8823e560e6879a, type: 3}
+  - ItemName: Broom
+    Item: {fileID: 7881540825094338729, guid: 8e2977953ed34c84c82792c99d2549b5, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 4319a1b0d53702e458b176248bc470bb, type: 3}
+  - ItemName: Fake Wizard Hat
+    Item: {fileID: 3437465412837995611, guid: 76db9576a63116843a098fe7aadd38d0, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 0b41adbfc6852cd4ead543d008d5ced6, type: 3}
+  - ItemName: Fake Wizard Robe
+    Item: {fileID: 5606995281160065308, guid: 3c8ea2f4d578dc04e9b17d73f6dbb5d4, type: 3}
     Stock: 1
-  - Item: {fileID: 7881540825094338729, guid: 8e2977953ed34c84c82792c99d2549b5, type: 3}
-    Stock: 1
-  - Item: {fileID: 3437465412837995611, guid: 76db9576a63116843a098fe7aadd38d0, type: 3}
-    Stock: 1
-  - Item: {fileID: 5606995281160065308, guid: 3c8ea2f4d578dc04e9b17d73f6dbb5d4, type: 3}
-    Stock: 1
-  - Item: {fileID: 7781396554342910705, guid: c0bdfc0522dc2ef43add0458efd1c87c, type: 3}
+  - ItemName: Wizard Staff
+    Item: {fileID: 7781396554342910705, guid: c0bdfc0522dc2ef43add0458efd1c87c, type: 3}
     Stock: 3
-  - Item: {fileID: 6404652678407139925, guid: abed35e9cfa734a00815cf8cda62687a, type: 3}
+  - ItemName: Clown Mask
+    Item: {fileID: 6404652678407139925, guid: abed35e9cfa734a00815cf8cda62687a, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: a08b3d5119d894fcb917204c9c820035, type: 3}
+  - ItemName: Clown Suit
+    Item: {fileID: 3011710637427380133, guid: a08b3d5119d894fcb917204c9c820035, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 6e0f2c36f6463c041ae9aee579487c6c, type: 3}
+  - ItemName: Sexy Clown Mask
+    Item: {fileID: 6404652678407139925, guid: 6e0f2c36f6463c041ae9aee579487c6c, type: 3}
     Stock: 1
-  - Item: {fileID: 1492798854262677143, guid: edb26444a4c140d4d834a7e3744c6987, type: 3}
+  - ItemName: Sexy Clown Suit
+    Item: {fileID: 1492798854262677143, guid: edb26444a4c140d4d834a7e3744c6987, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 82493ba3850304e50a7d25606a4f59f1, type: 3}
+  - ItemName: Mime Mask
+    Item: {fileID: 6404652678407139925, guid: 82493ba3850304e50a7d25606a4f59f1, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 57b4739d8947544f387d028cd2dd59b9, type: 3}
+  - ItemName: Mimes Outfit
+    Item: {fileID: 3011710637427380133, guid: 57b4739d8947544f387d028cd2dd59b9, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 2a7be38bec4c1de4d9848443b6691ffb, type: 3}
+  - ItemName: Sexy Mime Mask
+    Item: {fileID: 6404652678407139925, guid: 2a7be38bec4c1de4d9848443b6691ffb, type: 3}
     Stock: 1
-  - Item: {fileID: 5885306984695151954, guid: 3d55f979c8704f140978abc825d2b2fd, type: 3}
+  - ItemName: 'Sexy Mime Outfit '
+    Item: {fileID: 5885306984695151954, guid: 3d55f979c8704f140978abc825d2b2fd, type: 3}
     Stock: 1
-  - Item: {fileID: 473568899097301326, guid: f43feffec45b57c488d5f1a6a997e44e, type: 3}
+  - ItemName: Mimes Skirt
+    Item: {fileID: 473568899097301326, guid: f43feffec45b57c488d5f1a6a997e44e, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: db75a4358d367fe4fb19674599ff151b, type: 3}
+  - ItemName: Bat Mask
+    Item: {fileID: 8250509897985616090, guid: db75a4358d367fe4fb19674599ff151b, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: 3764de3d3f666b54e920367717e19cef, type: 3}
+  - ItemName: Bee Mask
+    Item: {fileID: 8250509897985616090, guid: 3764de3d3f666b54e920367717e19cef, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: a50acc58f03d4b446a2b1cd811412062, type: 3}
+  - ItemName: Bear Mask
+    Item: {fileID: 8250509897985616090, guid: a50acc58f03d4b446a2b1cd811412062, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: 3be55be10627a1c4287742ea1f152ce4, type: 3}
+  - ItemName: Raven Mask
+    Item: {fileID: 8250509897985616090, guid: 3be55be10627a1c4287742ea1f152ce4, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: b219bc180622ef54bb9cb933eb75b579, type: 3}
+  - ItemName: Jackal Mask
+    Item: {fileID: 8250509897985616090, guid: b219bc180622ef54bb9cb933eb75b579, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: 9f644e05e98184b49986be56dfe02118, type: 3}
+  - ItemName: Fox Mask
+    Item: {fileID: 8250509897985616090, guid: 9f644e05e98184b49986be56dfe02118, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 5fb5e0de959fad947a5e99d5732f0cea, type: 3}
+  - ItemName: Pig Mask
+    Item: {fileID: 6404652678407139925, guid: 5fb5e0de959fad947a5e99d5732f0cea, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: a192eab07682ae043a36c5a861253483, type: 3}
+  - ItemName: Frog Mask
+    Item: {fileID: 6404652678407139925, guid: a192eab07682ae043a36c5a861253483, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 0a7acbc202f68734e9b20a6d20325ae1, type: 3}
+  - ItemName: Cow Mask
+    Item: {fileID: 6404652678407139925, guid: 0a7acbc202f68734e9b20a6d20325ae1, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 60070f120c9e05d488a904831b34e0f1, type: 3}
+  - ItemName: Horse Head Mask
+    Item: {fileID: 6404652678407139925, guid: 60070f120c9e05d488a904831b34e0f1, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: 0128ae9dfe8c4864195fecd6ea30069d, type: 3}
+  - ItemName: Tribal Mask
+    Item: {fileID: 8250509897985616090, guid: 0128ae9dfe8c4864195fecd6ea30069d, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 7620c1f80fbe6f14d9fd21f5db20cb7b, type: 3}
+  - ItemName: Rat Mask
+    Item: {fileID: 6404652678407139925, guid: 7620c1f80fbe6f14d9fd21f5db20cb7b, type: 3}
     Stock: 1
-  - Item: {fileID: 6632660008125443998, guid: 42dd5abdb29322b4488e621e804f183e, type: 3}
+  - ItemName: Carp Mask
+    Item: {fileID: 6632660008125443998, guid: 42dd5abdb29322b4488e621e804f183e, type: 3}
     Stock: 1
-  - Item: {fileID: 2376803533225964856, guid: 62d22c2cb38aaac43a7aa56d55e3d14f, type: 3}
+  - ItemName: Coveralls
+    Item: {fileID: 2376803533225964856, guid: 62d22c2cb38aaac43a7aa56d55e3d14f, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: bddc8fa44a800174c99860d180042f90, type: 3}
+  - ItemName: Sombrero
+    Item: {fileID: 7636118406116123594, guid: bddc8fa44a800174c99860d180042f90, type: 3}
     Stock: 1
-  - Item: {fileID: 8738207183834668076, guid: af90d446b899ee6468c242bfbcd268ef, type: 3}
+  - ItemName: Green Sombrero
+    Item: {fileID: 8738207183834668076, guid: af90d446b899ee6468c242bfbcd268ef, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: d0a8e4c118a58f64a9266c1823b2fcad, type: 3}
+  - ItemName: Poncho
+    Item: {fileID: 3921521694364753778, guid: d0a8e4c118a58f64a9266c1823b2fcad, type: 3}
     Stock: 1
-  - Item: {fileID: 415463255368557816, guid: d644e2f949146914792c03f61e0e0159, type: 3}
+  - ItemName: Green Poncho
+    Item: {fileID: 415463255368557816, guid: d644e2f949146914792c03f61e0e0159, type: 3}
     Stock: 1
-  - Item: {fileID: 415463255368557816, guid: 12dcc52a5637d56458e76418f34a311f, type: 3}
+  - ItemName: Red Poncho
+    Item: {fileID: 415463255368557816, guid: 12dcc52a5637d56458e76418f34a311f, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: ab23fc0ba00b309459f2a039f0098d57, type: 3}
+  - ItemName: Maid Costume
+    Item: {fileID: 3011710637427380133, guid: ab23fc0ba00b309459f2a039f0098d57, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: de49a39e89fc6194aa45f7ffa599e023, type: 3}
+  - ItemName: Maid Apron
+    Item: {fileID: 3921521694364753778, guid: de49a39e89fc6194aa45f7ffa599e023, type: 3}
     Stock: 1
-  - Item: {fileID: 2502055301998392637, guid: d77ca13e6df71a4468e5a524d3c698bc, type: 3}
+  - ItemName: Maid Uniform
+    Item: {fileID: 2502055301998392637, guid: d77ca13e6df71a4468e5a524d3c698bc, type: 3}
     Stock: 1
-  - Item: {fileID: 3431291279286482953, guid: 93bbf35c21b5ce2409f3629563e6b472, type: 3}
+  - ItemName: Cold Goggles
+    Item: {fileID: 3431291279286482953, guid: 93bbf35c21b5ce2409f3629563e6b472, type: 3}
     Stock: 1
-  - Item: {fileID: 3431291279286482953, guid: 43dd73f81bdd78d48b1c5dbb5282c018, type: 3}
+  - ItemName: Heat Goggles
+    Item: {fileID: 3431291279286482953, guid: 43dd73f81bdd78d48b1c5dbb5282c018, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 2742720268778434146, guid: c8da485465c6fb940bbbddcf4f5f35ea, type: 3}
+  - ItemName: Jester Suit
+    Item: {fileID: 2742720268778434146, guid: c8da485465c6fb940bbbddcf4f5f35ea, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: df75062744e5124438b26c708fc3c4bf, type: 3}
+  - ItemName: Jester Hat
+    Item: {fileID: 7636118406116123594, guid: df75062744e5124438b26c708fc3c4bf, type: 3}
     Stock: 1
-  - Item: {fileID: 8268190986286055793, guid: 6d3f856edbd845b44ad9f4030930fbf0, type: 3}
+  - ItemName: Jester Shoes
+    Item: {fileID: 8268190986286055793, guid: 6d3f856edbd845b44ad9f4030930fbf0, type: 3}
     Stock: 1
-  - Item: {fileID: 252125311143380003, guid: d803155f0b3c037468a104eb481c6028, type: 3}
+  - ItemName: Jester Suit Alt
+    Item: {fileID: 252125311143380003, guid: d803155f0b3c037468a104eb481c6028, type: 3}
     Stock: 1
-  - Item: {fileID: 4007281676653997199, guid: 5fd32a3f872dc974b9c639d885f43c2d, type: 3}
+  - ItemName: Jester Hat Alt
+    Item: {fileID: 4007281676653997199, guid: 5fd32a3f872dc974b9c639d885f43c2d, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 7106618204054676533, guid: 30c04342a3030604cb06307edec1be3e, type: 3}
+  - ItemName: Yellow Performers Boots
+    Item: {fileID: 7106618204054676533, guid: 30c04342a3030604cb06307edec1be3e, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: c5201f4ee96407a46b44a9152af08746, type: 3}
+  - ItemName: Yellow Performers Outfit
+    Item: {fileID: 3011710637427380133, guid: c5201f4ee96407a46b44a9152af08746, type: 3}
     Stock: 1
-  - Item: {fileID: 7106618204054676533, guid: dc9ca4db6af99c54894263534d3b8fe7, type: 3}
+  - ItemName: Blue Performers Boots
+    Item: {fileID: 7106618204054676533, guid: dc9ca4db6af99c54894263534d3b8fe7, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: a9879dc61a0ed294a85cfe1e31df1f98, type: 3}
+  - ItemName: Blue Performers Outfit
+    Item: {fileID: 3011710637427380133, guid: a9879dc61a0ed294a85cfe1e31df1f98, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 464bcf92c0e446e4d982940c67ab4e12, type: 3}
+  - ItemName: Carp Costume
+    Item: {fileID: 3921521694364753778, guid: 464bcf92c0e446e4d982940c67ab4e12, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: b6ce806e76da3dd4096437c5611d39b2, type: 3}
+  - ItemName: Carp Hood
+    Item: {fileID: 7636118406116123594, guid: b6ce806e76da3dd4096437c5611d39b2, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 76d3668ace33a504db5e9b1c973c3c47, type: 3}
+  - ItemName: Corgi Costume
+    Item: {fileID: 3921521694364753778, guid: 76d3668ace33a504db5e9b1c973c3c47, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: b57fb41270e12e0498ffe5a3f369d2c7, type: 3}
+  - ItemName: Corgi Hood
+    Item: {fileID: 7636118406116123594, guid: b57fb41270e12e0498ffe5a3f369d2c7, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: bc71229dac2972e4e87732e2501a3dd9, type: 3}
+  - ItemName: Bee Costume
+    Item: {fileID: 3921521694364753778, guid: bc71229dac2972e4e87732e2501a3dd9, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 4d867daacf105a044ba911410ff538ec, type: 3}
+  - ItemName: Bee Hood
+    Item: {fileID: 7636118406116123594, guid: 4d867daacf105a044ba911410ff538ec, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 196e831acf107a548885b12a5afd7686, type: 3}
+  - ItemName: Joy Mask
+    Item: {fileID: 6404652678407139925, guid: 196e831acf107a548885b12a5afd7686, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 2dd1f7a0ba7e44540b1efff013ca6032, type: 3}
+  - ItemName: Shrine Maidens Wig
+    Item: {fileID: 7636118406116123594, guid: 2dd1f7a0ba7e44540b1efff013ca6032, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 0423dc5963da4b54fbf12fd43bfe260e, type: 3}
+  - ItemName: Shrine Maidens Outfit
+    Item: {fileID: 3921521694364753778, guid: 0423dc5963da4b54fbf12fd43bfe260e, type: 3}
     Stock: 1
-  - Item: {fileID: 7781396554342910705, guid: 81995251e2a2eca4f90a7feadcc62b49, type: 3}
+  - ItemName: Gohei
+    Item: {fileID: 7781396554342910705, guid: 81995251e2a2eca4f90a7feadcc62b49, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 5545929812217067487, guid: ae4a690ad52c79c4fab73ca540cde5ac, type: 3}
+  - ItemName: Black Gar Glasses
+    Item: {fileID: 5545929812217067487, guid: ae4a690ad52c79c4fab73ca540cde5ac, type: 3}
     Stock: 2
-  - Item: {fileID: 3431291279286482953, guid: 55f84d3d2305ff64184bb7a99ef1c103, type: 3}
+  - ItemName: Blindfold
+    Item: {fileID: 3431291279286482953, guid: 55f84d3d2305ff64184bb7a99ef1c103, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 1656165686329110666, guid: b25e9a05d86428341bc29213996a893d, type: 3}
+  - ItemName: Rainbow Clown Suit
+    Item: {fileID: 1656165686329110666, guid: b25e9a05d86428341bc29213996a893d, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 2a4b15314ed79284390ffd3d350bde37, type: 3}
+  - ItemName: Robes Of The Honk Mother
+    Item: {fileID: 3921521694364753778, guid: 2a4b15314ed79284390ffd3d350bde37, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 84d03d866a1ee8d48a83c8ccef547e21, type: 3}
+  - ItemName: Hat Of The Honk Mother
+    Item: {fileID: 7636118406116123594, guid: 84d03d866a1ee8d48a83c8ccef547e21, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -439,341 +598,509 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 3921521694364753778, guid: a13fbe8edd77fac409d1ce7543dee807, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: a13fbe8edd77fac409d1ce7543dee807, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 5a2c36e5029b04a45a559c20eea57600, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 5a2c36e5029b04a45a559c20eea57600, type: 3}
     Stock: 1
-  - Item: {fileID: 482378326749940947, guid: aa9224525bbbd5a59922f2fd2e4215bb, type: 3}
+  - ItemName: 
+    Item: {fileID: 482378326749940947, guid: aa9224525bbbd5a59922f2fd2e4215bb, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 65a378878b1d64f428bb7a05510b9092, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 65a378878b1d64f428bb7a05510b9092, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 185e8f1981e885b47a92b5e69ca88f1d, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 185e8f1981e885b47a92b5e69ca88f1d, type: 3}
     Stock: 1
-  - Item: {fileID: 6595718230816168079, guid: a9799cb5acad5a44fa29b2eb0f75c5c0, type: 3}
+  - ItemName: 
+    Item: {fileID: 6595718230816168079, guid: a9799cb5acad5a44fa29b2eb0f75c5c0, type: 3}
     Stock: 1
-  - Item: {fileID: 3955254198958978278, guid: faa0112f6ce89384e8aa4545fe64fb0a, type: 3}
+  - ItemName: 
+    Item: {fileID: 3955254198958978278, guid: faa0112f6ce89384e8aa4545fe64fb0a, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: a731bca6e7803034eaf73a1ff169485b, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: a731bca6e7803034eaf73a1ff169485b, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 3864fa9dd4aa14c4c83805082e402fc2, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 3864fa9dd4aa14c4c83805082e402fc2, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 90c2bcb8434d2c442a4c22a235bd6ff1, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 90c2bcb8434d2c442a4c22a235bd6ff1, type: 3}
     Stock: 1
-  - Item: {fileID: 6632660008125443998, guid: 2d19dbdc797a03a43b454ba27020415b, type: 3}
+  - ItemName: 
+    Item: {fileID: 6632660008125443998, guid: 2d19dbdc797a03a43b454ba27020415b, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: ba41c95ddca00aa4ca99feeed566e1d9, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: ba41c95ddca00aa4ca99feeed566e1d9, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: f7c0d4c0fca38674a8e3d778edfb1a7e, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: f7c0d4c0fca38674a8e3d778edfb1a7e, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: d26ae7b210f3fc840a5dc1647d95344a, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: d26ae7b210f3fc840a5dc1647d95344a, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 40c0513d984473e48a1393a33244bc46, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 40c0513d984473e48a1393a33244bc46, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: e021575b277d72e4bbcd1365adf65f5b, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: e021575b277d72e4bbcd1365adf65f5b, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 35a07bc0cd215c24888e3ed416359c43, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 35a07bc0cd215c24888e3ed416359c43, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 74ff45c24da2a354c926a07813318a1c, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 74ff45c24da2a354c926a07813318a1c, type: 3}
     Stock: 1
-  - Item: {fileID: 1656165686329110666, guid: 2a3ca69e5f8019e4388af8a531a8c4c8, type: 3}
+  - ItemName: 
+    Item: {fileID: 1656165686329110666, guid: 2a3ca69e5f8019e4388af8a531a8c4c8, type: 3}
     Stock: 1
-  - Item: {fileID: 1656165686329110666, guid: c6d7c947c93bd6a479c7197367cf6675, type: 3}
+  - ItemName: 
+    Item: {fileID: 1656165686329110666, guid: c6d7c947c93bd6a479c7197367cf6675, type: 3}
     Stock: 1
-  - Item: {fileID: 1656165686329110666, guid: 6626f7059fcde804aa7d3e5bc015f9e3, type: 3}
+  - ItemName: 
+    Item: {fileID: 1656165686329110666, guid: 6626f7059fcde804aa7d3e5bc015f9e3, type: 3}
     Stock: 1
-  - Item: {fileID: 1656165686329110666, guid: 8de7067b2153d394990fd2f38f51eb31, type: 3}
+  - ItemName: 
+    Item: {fileID: 1656165686329110666, guid: 8de7067b2153d394990fd2f38f51eb31, type: 3}
     Stock: 1
-  - Item: {fileID: 1656165686329110666, guid: 4bd6816b9935b6948a33c5fd9f1f562f, type: 3}
+  - ItemName: 
+    Item: {fileID: 1656165686329110666, guid: 4bd6816b9935b6948a33c5fd9f1f562f, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 362e418a402e61647802081d06826f88, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 362e418a402e61647802081d06826f88, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: a5c2833832604a146bb01b103de9174e, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: a5c2833832604a146bb01b103de9174e, type: 3}
     Stock: 1
-  - Item: {fileID: 6127118939752068930, guid: b9ea9931e8b07a140ab790d555cace98, type: 3}
+  - ItemName: 
+    Item: {fileID: 6127118939752068930, guid: b9ea9931e8b07a140ab790d555cace98, type: 3}
     Stock: 1
-  - Item: {fileID: 2834735550645104383, guid: 51fa4efb14c93714ea1ff2121835d6cc, type: 3}
+  - ItemName: 
+    Item: {fileID: 2834735550645104383, guid: 51fa4efb14c93714ea1ff2121835d6cc, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 63587900698efce47a648bd987aef283, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 63587900698efce47a648bd987aef283, type: 3}
     Stock: 1
-  - Item: {fileID: 2647627343863631382, guid: 786f07174bf918c48a2388cbfa400fde, type: 3}
+  - ItemName: 
+    Item: {fileID: 2647627343863631382, guid: 786f07174bf918c48a2388cbfa400fde, type: 3}
     Stock: 1
-  - Item: {fileID: 7106618204054676533, guid: eaeac5365190b4842bedb2b846ff15da, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: eaeac5365190b4842bedb2b846ff15da, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: d87ab69a913cab84592eef571ad4b258, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: d87ab69a913cab84592eef571ad4b258, type: 3}
     Stock: 1
-  - Item: {fileID: 1433422093498208896, guid: 5cda432cc1acd554188a8e36173c2e80, type: 3}
+  - ItemName: 
+    Item: {fileID: 1433422093498208896, guid: 5cda432cc1acd554188a8e36173c2e80, type: 3}
     Stock: 1
-  - Item: {fileID: 1433422093498208896, guid: 79e10a657cef67c4b97b317574b8d768, type: 3}
+  - ItemName: 
+    Item: {fileID: 1433422093498208896, guid: 79e10a657cef67c4b97b317574b8d768, type: 3}
     Stock: 1
-  - Item: {fileID: 1433422093498208896, guid: d00739bfeb2f2ac44b71c2a0d42f4ddd, type: 3}
+  - ItemName: 
+    Item: {fileID: 1433422093498208896, guid: d00739bfeb2f2ac44b71c2a0d42f4ddd, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 5a6e2e3a0a44146198136e4fa2798db5, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 5a6e2e3a0a44146198136e4fa2798db5, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: c61b0ba80af0439449f9a47dfcbdd8a4, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: c61b0ba80af0439449f9a47dfcbdd8a4, type: 3}
     Stock: 1
-  - Item: {fileID: 4795735908449438376, guid: 64a0d2d91b5c1d24596fcac46075e587, type: 3}
+  - ItemName: 
+    Item: {fileID: 4795735908449438376, guid: 64a0d2d91b5c1d24596fcac46075e587, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 9445628fd16314b7388c7086f5fd2f26, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 9445628fd16314b7388c7086f5fd2f26, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: dff9b7e8f22ff9b4cb9e2f035702e875, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: dff9b7e8f22ff9b4cb9e2f035702e875, type: 3}
     Stock: 1
-  - Item: {fileID: 1268281847278913779, guid: 73a102ba242379c4b92c25800ea7976a, type: 3}
+  - ItemName: 
+    Item: {fileID: 1268281847278913779, guid: 73a102ba242379c4b92c25800ea7976a, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 489b0e24de7b7dc4ea31a401aadb3779, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 489b0e24de7b7dc4ea31a401aadb3779, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 6aeac73f4196c0a92a6db19aa7d06391, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 6aeac73f4196c0a92a6db19aa7d06391, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 9445628fd16314b7388c7086f5fd2f26, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 9445628fd16314b7388c7086f5fd2f26, type: 3}
     Stock: 1
-  - Item: {fileID: 6980020022460415521, guid: 2e40dad0882daeb4bbd61afc69196ac1, type: 3}
+  - ItemName: 
+    Item: {fileID: 6980020022460415521, guid: 2e40dad0882daeb4bbd61afc69196ac1, type: 3}
     Stock: 1
-  - Item: {fileID: 6980020022460415521, guid: e00d12849f2494441989ee85ea7ed5c8, type: 3}
+  - ItemName: 
+    Item: {fileID: 6980020022460415521, guid: e00d12849f2494441989ee85ea7ed5c8, type: 3}
     Stock: 1
-  - Item: {fileID: 6980020022460415521, guid: 9c308081529a1fa43850db366eb71631, type: 3}
+  - ItemName: 
+    Item: {fileID: 6980020022460415521, guid: 9c308081529a1fa43850db366eb71631, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
     Stock: 1
-  - Item: {fileID: 3431291279286482953, guid: 5c940802546a18f46af0e10ee4ddc95b, type: 3}
+  - ItemName: 
+    Item: {fileID: 3431291279286482953, guid: 5c940802546a18f46af0e10ee4ddc95b, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 5480900738568975519, guid: 48285da19a755284693023b1c12c153e, type: 3}
+  - ItemName: 
+    Item: {fileID: 5480900738568975519, guid: 48285da19a755284693023b1c12c153e, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 404a54992896a5d4caacc205764bf058, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 404a54992896a5d4caacc205764bf058, type: 3}
     Stock: 1
-  - Item: {fileID: 4546394627455633865, guid: 706adbdc94f3ee04ea1d02ddbb027dae, type: 3}
+  - ItemName: 
+    Item: {fileID: 4546394627455633865, guid: 706adbdc94f3ee04ea1d02ddbb027dae, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 593845527b97851419727b6919afa92e, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 593845527b97851419727b6919afa92e, type: 3}
     Stock: 1
-  - Item: {fileID: 7701271712345465664, guid: 6b1fe6ba2d6dfb44e86f0594af87dd36, type: 3}
+  - ItemName: 
+    Item: {fileID: 7701271712345465664, guid: 6b1fe6ba2d6dfb44e86f0594af87dd36, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 36659b70ab02933438ae211235aeb67e, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 36659b70ab02933438ae211235aeb67e, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 3c8d2434c10f26c42baf079157919c47, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 3c8d2434c10f26c42baf079157919c47, type: 3}
     Stock: 1
-  - Item: {fileID: 1894475026819698963, guid: f4410af7add3943419c5c6b4b8efa05b, type: 3}
+  - ItemName: 
+    Item: {fileID: 1894475026819698963, guid: f4410af7add3943419c5c6b4b8efa05b, type: 3}
     Stock: 1
-  - Item: {fileID: 8275399496006930914, guid: 22ff1da9317b8d14fbe3c8ef7cb4ea60, type: 3}
+  - ItemName: 
+    Item: {fileID: 8275399496006930914, guid: 22ff1da9317b8d14fbe3c8ef7cb4ea60, type: 3}
     Stock: 1
-  - Item: {fileID: 4091827544677105848, guid: d7a22b6fbc128a04e8e4b85d2e082fba, type: 3}
+  - ItemName: 
+    Item: {fileID: 4091827544677105848, guid: d7a22b6fbc128a04e8e4b85d2e082fba, type: 3}
     Stock: 1
-  - Item: {fileID: 7106618204054676533, guid: f0acd3a6a2fe3d745aecb5aa632db635, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: f0acd3a6a2fe3d745aecb5aa632db635, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 0a3cbe890b4a2df49aceab1e00c792dd, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 0a3cbe890b4a2df49aceab1e00c792dd, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 34840ba56d91a4e4bb5c615fe3c2b1f3, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 34840ba56d91a4e4bb5c615fe3c2b1f3, type: 3}
     Stock: 1
-  - Item: {fileID: 5480900738568975519, guid: 9bb52425bd84e21469e37eb87c90e8eb, type: 3}
+  - ItemName: 
+    Item: {fileID: 5480900738568975519, guid: 9bb52425bd84e21469e37eb87c90e8eb, type: 3}
     Stock: 1
-  - Item: {fileID: 1942180931913338160, guid: 1125504802c358c4f92101904d921ba5, type: 3}
+  - ItemName: 
+    Item: {fileID: 1942180931913338160, guid: 1125504802c358c4f92101904d921ba5, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 6632660008125443998, guid: b1658a111386bd941a0c892cecc1721d, type: 3}
+  - ItemName: 
+    Item: {fileID: 6632660008125443998, guid: b1658a111386bd941a0c892cecc1721d, type: 3}
     Stock: 1
-  - Item: {fileID: 4396341318306884477, guid: 952fcc0a66cc10f4dabc47ee13d626ef, type: 3}
+  - ItemName: 
+    Item: {fileID: 4396341318306884477, guid: 952fcc0a66cc10f4dabc47ee13d626ef, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 6168a00e66ca21f45b31140fb85e3527, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 6168a00e66ca21f45b31140fb85e3527, type: 3}
     Stock: 1
-  - Item: {fileID: 3123762211482604667, guid: 220264ebdd6cb324aa31c41def444ced, type: 3}
+  - ItemName: 
+    Item: {fileID: 3123762211482604667, guid: 220264ebdd6cb324aa31c41def444ced, type: 3}
     Stock: 1
-  - Item: {fileID: 1301179775764226454, guid: dffc3f118fe6c9045b8823e560e6879a, type: 3}
+  - ItemName: 
+    Item: {fileID: 1301179775764226454, guid: dffc3f118fe6c9045b8823e560e6879a, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 4319a1b0d53702e458b176248bc470bb, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 4319a1b0d53702e458b176248bc470bb, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 0b41adbfc6852cd4ead543d008d5ced6, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 0b41adbfc6852cd4ead543d008d5ced6, type: 3}
     Stock: 1
-  - Item: {fileID: 7881540825094338729, guid: 8e2977953ed34c84c82792c99d2549b5, type: 3}
+  - ItemName: 
+    Item: {fileID: 7881540825094338729, guid: 8e2977953ed34c84c82792c99d2549b5, type: 3}
     Stock: 1
-  - Item: {fileID: 3437465412837995611, guid: 76db9576a63116843a098fe7aadd38d0, type: 3}
+  - ItemName: 
+    Item: {fileID: 3437465412837995611, guid: 76db9576a63116843a098fe7aadd38d0, type: 3}
     Stock: 1
-  - Item: {fileID: 5606995281160065308, guid: 3c8ea2f4d578dc04e9b17d73f6dbb5d4, type: 3}
+  - ItemName: 
+    Item: {fileID: 5606995281160065308, guid: 3c8ea2f4d578dc04e9b17d73f6dbb5d4, type: 3}
     Stock: 1
-  - Item: {fileID: 7781396554342910705, guid: c0bdfc0522dc2ef43add0458efd1c87c, type: 3}
+  - ItemName: 
+    Item: {fileID: 7781396554342910705, guid: c0bdfc0522dc2ef43add0458efd1c87c, type: 3}
     Stock: 3
-  - Item: {fileID: 6404652678407139925, guid: abed35e9cfa734a00815cf8cda62687a, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: abed35e9cfa734a00815cf8cda62687a, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: a08b3d5119d894fcb917204c9c820035, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: a08b3d5119d894fcb917204c9c820035, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 6e0f2c36f6463c041ae9aee579487c6c, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 6e0f2c36f6463c041ae9aee579487c6c, type: 3}
     Stock: 1
-  - Item: {fileID: 1492798854262677143, guid: edb26444a4c140d4d834a7e3744c6987, type: 3}
+  - ItemName: 
+    Item: {fileID: 1492798854262677143, guid: edb26444a4c140d4d834a7e3744c6987, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 82493ba3850304e50a7d25606a4f59f1, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 82493ba3850304e50a7d25606a4f59f1, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 57b4739d8947544f387d028cd2dd59b9, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 57b4739d8947544f387d028cd2dd59b9, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 2a7be38bec4c1de4d9848443b6691ffb, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 2a7be38bec4c1de4d9848443b6691ffb, type: 3}
     Stock: 1
-  - Item: {fileID: 5885306984695151954, guid: 3d55f979c8704f140978abc825d2b2fd, type: 3}
+  - ItemName: 
+    Item: {fileID: 5885306984695151954, guid: 3d55f979c8704f140978abc825d2b2fd, type: 3}
     Stock: 1
-  - Item: {fileID: 473568899097301326, guid: f43feffec45b57c488d5f1a6a997e44e, type: 3}
+  - ItemName: 
+    Item: {fileID: 473568899097301326, guid: f43feffec45b57c488d5f1a6a997e44e, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: db75a4358d367fe4fb19674599ff151b, type: 3}
+  - ItemName: 
+    Item: {fileID: 8250509897985616090, guid: db75a4358d367fe4fb19674599ff151b, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: 3764de3d3f666b54e920367717e19cef, type: 3}
+  - ItemName: 
+    Item: {fileID: 8250509897985616090, guid: 3764de3d3f666b54e920367717e19cef, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: a50acc58f03d4b446a2b1cd811412062, type: 3}
+  - ItemName: 
+    Item: {fileID: 8250509897985616090, guid: a50acc58f03d4b446a2b1cd811412062, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: 3be55be10627a1c4287742ea1f152ce4, type: 3}
+  - ItemName: 
+    Item: {fileID: 8250509897985616090, guid: 3be55be10627a1c4287742ea1f152ce4, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: b219bc180622ef54bb9cb933eb75b579, type: 3}
+  - ItemName: 
+    Item: {fileID: 8250509897985616090, guid: b219bc180622ef54bb9cb933eb75b579, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: 9f644e05e98184b49986be56dfe02118, type: 3}
+  - ItemName: 
+    Item: {fileID: 8250509897985616090, guid: 9f644e05e98184b49986be56dfe02118, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 5fb5e0de959fad947a5e99d5732f0cea, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 5fb5e0de959fad947a5e99d5732f0cea, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: a192eab07682ae043a36c5a861253483, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: a192eab07682ae043a36c5a861253483, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 0a7acbc202f68734e9b20a6d20325ae1, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 0a7acbc202f68734e9b20a6d20325ae1, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 60070f120c9e05d488a904831b34e0f1, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 60070f120c9e05d488a904831b34e0f1, type: 3}
     Stock: 1
-  - Item: {fileID: 8250509897985616090, guid: 0128ae9dfe8c4864195fecd6ea30069d, type: 3}
+  - ItemName: 
+    Item: {fileID: 8250509897985616090, guid: 0128ae9dfe8c4864195fecd6ea30069d, type: 3}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 7620c1f80fbe6f14d9fd21f5db20cb7b, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 7620c1f80fbe6f14d9fd21f5db20cb7b, type: 3}
     Stock: 1
-  - Item: {fileID: 6632660008125443998, guid: 42dd5abdb29322b4488e621e804f183e, type: 3}
+  - ItemName: 
+    Item: {fileID: 6632660008125443998, guid: 42dd5abdb29322b4488e621e804f183e, type: 3}
     Stock: 1
-  - Item: {fileID: 2376803533225964856, guid: 62d22c2cb38aaac43a7aa56d55e3d14f, type: 3}
+  - ItemName: 
+    Item: {fileID: 2376803533225964856, guid: 62d22c2cb38aaac43a7aa56d55e3d14f, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: bddc8fa44a800174c99860d180042f90, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: bddc8fa44a800174c99860d180042f90, type: 3}
     Stock: 1
-  - Item: {fileID: 8738207183834668076, guid: af90d446b899ee6468c242bfbcd268ef, type: 3}
+  - ItemName: 
+    Item: {fileID: 8738207183834668076, guid: af90d446b899ee6468c242bfbcd268ef, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: d0a8e4c118a58f64a9266c1823b2fcad, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: d0a8e4c118a58f64a9266c1823b2fcad, type: 3}
     Stock: 1
-  - Item: {fileID: 415463255368557816, guid: d644e2f949146914792c03f61e0e0159, type: 3}
+  - ItemName: 
+    Item: {fileID: 415463255368557816, guid: d644e2f949146914792c03f61e0e0159, type: 3}
     Stock: 1
-  - Item: {fileID: 415463255368557816, guid: 12dcc52a5637d56458e76418f34a311f, type: 3}
+  - ItemName: 
+    Item: {fileID: 415463255368557816, guid: 12dcc52a5637d56458e76418f34a311f, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: ab23fc0ba00b309459f2a039f0098d57, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: ab23fc0ba00b309459f2a039f0098d57, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: de49a39e89fc6194aa45f7ffa599e023, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: de49a39e89fc6194aa45f7ffa599e023, type: 3}
     Stock: 1
-  - Item: {fileID: 2502055301998392637, guid: d77ca13e6df71a4468e5a524d3c698bc, type: 3}
+  - ItemName: 
+    Item: {fileID: 2502055301998392637, guid: d77ca13e6df71a4468e5a524d3c698bc, type: 3}
     Stock: 1
-  - Item: {fileID: 3431291279286482953, guid: 93bbf35c21b5ce2409f3629563e6b472, type: 3}
+  - ItemName: 
+    Item: {fileID: 3431291279286482953, guid: 93bbf35c21b5ce2409f3629563e6b472, type: 3}
     Stock: 1
-  - Item: {fileID: 3431291279286482953, guid: 43dd73f81bdd78d48b1c5dbb5282c018, type: 3}
+  - ItemName: 
+    Item: {fileID: 3431291279286482953, guid: 43dd73f81bdd78d48b1c5dbb5282c018, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 2742720268778434146, guid: c8da485465c6fb940bbbddcf4f5f35ea, type: 3}
+  - ItemName: 
+    Item: {fileID: 2742720268778434146, guid: c8da485465c6fb940bbbddcf4f5f35ea, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: df75062744e5124438b26c708fc3c4bf, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: df75062744e5124438b26c708fc3c4bf, type: 3}
     Stock: 1
-  - Item: {fileID: 8268190986286055793, guid: 6d3f856edbd845b44ad9f4030930fbf0, type: 3}
+  - ItemName: 
+    Item: {fileID: 8268190986286055793, guid: 6d3f856edbd845b44ad9f4030930fbf0, type: 3}
     Stock: 1
-  - Item: {fileID: 252125311143380003, guid: d803155f0b3c037468a104eb481c6028, type: 3}
+  - ItemName: 
+    Item: {fileID: 252125311143380003, guid: d803155f0b3c037468a104eb481c6028, type: 3}
     Stock: 1
-  - Item: {fileID: 4007281676653997199, guid: 5fd32a3f872dc974b9c639d885f43c2d, type: 3}
+  - ItemName: 
+    Item: {fileID: 4007281676653997199, guid: 5fd32a3f872dc974b9c639d885f43c2d, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 7106618204054676533, guid: 30c04342a3030604cb06307edec1be3e, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 30c04342a3030604cb06307edec1be3e, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: c5201f4ee96407a46b44a9152af08746, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: c5201f4ee96407a46b44a9152af08746, type: 3}
     Stock: 1
-  - Item: {fileID: 7106618204054676533, guid: dc9ca4db6af99c54894263534d3b8fe7, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: dc9ca4db6af99c54894263534d3b8fe7, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: a9879dc61a0ed294a85cfe1e31df1f98, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: a9879dc61a0ed294a85cfe1e31df1f98, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 464bcf92c0e446e4d982940c67ab4e12, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 464bcf92c0e446e4d982940c67ab4e12, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: b6ce806e76da3dd4096437c5611d39b2, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: b6ce806e76da3dd4096437c5611d39b2, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 76d3668ace33a504db5e9b1c973c3c47, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 76d3668ace33a504db5e9b1c973c3c47, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: b57fb41270e12e0498ffe5a3f369d2c7, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: b57fb41270e12e0498ffe5a3f369d2c7, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: bc71229dac2972e4e87732e2501a3dd9, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: bc71229dac2972e4e87732e2501a3dd9, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 4d867daacf105a044ba911410ff538ec, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 4d867daacf105a044ba911410ff538ec, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 6404652678407139925, guid: 196e831acf107a548885b12a5afd7686, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 196e831acf107a548885b12a5afd7686, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 2dd1f7a0ba7e44540b1efff013ca6032, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 2dd1f7a0ba7e44540b1efff013ca6032, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 0423dc5963da4b54fbf12fd43bfe260e, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 0423dc5963da4b54fbf12fd43bfe260e, type: 3}
     Stock: 1
-  - Item: {fileID: 7781396554342910705, guid: 81995251e2a2eca4f90a7feadcc62b49, type: 3}
+  - ItemName: 
+    Item: {fileID: 7781396554342910705, guid: 81995251e2a2eca4f90a7feadcc62b49, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 5545929812217067487, guid: ae4a690ad52c79c4fab73ca540cde5ac, type: 3}
+  - ItemName: 
+    Item: {fileID: 5545929812217067487, guid: ae4a690ad52c79c4fab73ca540cde5ac, type: 3}
     Stock: 2
-  - Item: {fileID: 3431291279286482953, guid: 55f84d3d2305ff64184bb7a99ef1c103, type: 3}
+  - ItemName: 
+    Item: {fileID: 3431291279286482953, guid: 55f84d3d2305ff64184bb7a99ef1c103, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 1656165686329110666, guid: b25e9a05d86428341bc29213996a893d, type: 3}
+  - ItemName: 
+    Item: {fileID: 1656165686329110666, guid: b25e9a05d86428341bc29213996a893d, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 2a4b15314ed79284390ffd3d350bde37, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 2a4b15314ed79284390ffd3d350bde37, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 84d03d866a1ee8d48a83c8ccef547e21, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 84d03d866a1ee8d48a83c8ccef547e21, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/BODA.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/BODA.prefab
@@ -96,9 +96,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 6546673936360135170, guid: b7831b25f6bc923458647be942a2609f, type: 3}
+  - ItemName: Soda Water
+    Item: {fileID: 6546673936360135170, guid: b7831b25f6bc923458647be942a2609f, type: 3}
     Stock: 30
-  - Item: {fileID: 6546673936360135170, guid: 9df8b42a3b7c7554ab9c48ba64b45d2e, type: 3}
+  - ItemName: Space Cola
+    Item: {fileID: 6546673936360135170, guid: 9df8b42a3b7c7554ab9c48ba64b45d2e, type: 3}
     Stock: 20
   HullColor: {r: 0.64705884, g: 0.63529414, b: 0.16078432, a: 1}
   EjectObjects: 0
@@ -107,9 +109,11 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 6546673936360135170, guid: b7831b25f6bc923458647be942a2609f, type: 3}
+  - ItemName: 
+    Item: {fileID: 6546673936360135170, guid: b7831b25f6bc923458647be942a2609f, type: 3}
     Stock: 30
-  - Item: {fileID: 6546673936360135170, guid: 9df8b42a3b7c7554ab9c48ba64b45d2e, type: 3}
+  - ItemName: 
+    Item: {fileID: 6546673936360135170, guid: 9df8b42a3b7c7554ab9c48ba64b45d2e, type: 3}
     Stock: 20
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/BarDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/BarDrobe.prefab
@@ -97,49 +97,71 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 7636118406116123594, guid: 489b0e24de7b7dc4ea31a401aadb3779, type: 3}
+  - ItemName: Top Hat
+    Item: {fileID: 7636118406116123594, guid: 489b0e24de7b7dc4ea31a401aadb3779, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
+  - ItemName: Service Headset
+    Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
     Stock: 2
-  - Item: {fileID: 5480900738568975519, guid: 48285da19a755284693023b1c12c153e, type: 3}
+  - ItemName: Amish Suit
+    Item: {fileID: 5480900738568975519, guid: 48285da19a755284693023b1c12c153e, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: c842b429251c54792a95e292b838d034, type: 3}
+  - ItemName: Bartenders Uniform
+    Item: {fileID: 3011710637427380133, guid: c842b429251c54792a95e292b838d034, type: 3}
     Stock: 2
-  - Item: {fileID: 1263341537948385592, guid: 872a07241939db44a92aae9b275b6063, type: 3}
+  - ItemName: Bartenders Skirt
+    Item: {fileID: 1263341537948385592, guid: 872a07241939db44a92aae9b275b6063, type: 3}
     Stock: 2
-  - Item: {fileID: 6187303026489560953, guid: e91ce8b61d4df214a9ea32f3adc87154, type: 3}
+  - ItemName: Purple Bartenders Uniform
+    Item: {fileID: 6187303026489560953, guid: e91ce8b61d4df214a9ea32f3adc87154, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: ab23fc0ba00b309459f2a039f0098d57, type: 3}
+  - ItemName: Maid Costume
+    Item: {fileID: 3011710637427380133, guid: ab23fc0ba00b309459f2a039f0098d57, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
+  - ItemName: Waistcoat
+    Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
     Stock: 2
-  - Item: {fileID: 8307977129538392449, guid: a9fc0438d9e83ad4aa6ea3637ca7af3e, type: 3}
+  - ItemName: Purple Bartender Apron
+    Item: {fileID: 8307977129538392449, guid: a9fc0438d9e83ad4aa6ea3637ca7af3e, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: de49a39e89fc6194aa45f7ffa599e023, type: 3}
+  - ItemName: Maid Apron
+    Item: {fileID: 3921521694364753778, guid: de49a39e89fc6194aa45f7ffa599e023, type: 3}
     Stock: 2
-  - Item: {fileID: 3116170454584013683, guid: db265d83fcf1bbb46aedc59510228a5d, type: 3}
+  - ItemName: Black Cap
+    Item: {fileID: 3116170454584013683, guid: db265d83fcf1bbb46aedc59510228a5d, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
+  - ItemName: Laceup Shoes
+    Item: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 1909889960012756402, guid: 2dcc926f902b2e44a802f217063efa15, type: 3}
+  - ItemName: Box OF Beanbags
+    Item: {fileID: 1909889960012756402, guid: 2dcc926f902b2e44a802f217063efa15, type: 3}
     Stock: 1
-  - Item: {fileID: 8654279767492581603, guid: 98de935f80510c4468285ffd5a01d9e0, type: 3}
+  - ItemName: Armor Vest Slim
+    Item: {fileID: 8654279767492581603, guid: 98de935f80510c4468285ffd5a01d9e0, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 2679964424910470999, guid: a0035ec751052984f8f49ff76eadbb3d, type: 3}
+  - ItemName: Beer Goggles
+    Item: {fileID: 2679964424910470999, guid: a0035ec751052984f8f49ff76eadbb3d, type: 3}
     Stock: 1
-  - Item: {fileID: 3961673132676458627, guid: 61c2c1d3267084042bfdfd08fdd7c7a7, type: 3}
+  - ItemName: Pet Collar
+    Item: {fileID: 3961673132676458627, guid: 61c2c1d3267084042bfdfd08fdd7c7a7, type: 3}
     Stock: 1
-  - Item: {fileID: 6700281191928912403, guid: 1fc9adbf381f65c4b986900fe3a89148, type: 3}
+  - ItemName: Bandolier
+    Item: {fileID: 6700281191928912403, guid: 1fc9adbf381f65c4b986900fe3a89148, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -148,49 +170,71 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 7636118406116123594, guid: 489b0e24de7b7dc4ea31a401aadb3779, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 489b0e24de7b7dc4ea31a401aadb3779, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
     Stock: 2
-  - Item: {fileID: 5480900738568975519, guid: 48285da19a755284693023b1c12c153e, type: 3}
+  - ItemName: 
+    Item: {fileID: 5480900738568975519, guid: 48285da19a755284693023b1c12c153e, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: c842b429251c54792a95e292b838d034, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: c842b429251c54792a95e292b838d034, type: 3}
     Stock: 2
-  - Item: {fileID: 1263341537948385592, guid: 872a07241939db44a92aae9b275b6063, type: 3}
+  - ItemName: 
+    Item: {fileID: 1263341537948385592, guid: 872a07241939db44a92aae9b275b6063, type: 3}
     Stock: 2
-  - Item: {fileID: 6187303026489560953, guid: e91ce8b61d4df214a9ea32f3adc87154, type: 3}
+  - ItemName: 
+    Item: {fileID: 6187303026489560953, guid: e91ce8b61d4df214a9ea32f3adc87154, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: ab23fc0ba00b309459f2a039f0098d57, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: ab23fc0ba00b309459f2a039f0098d57, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
     Stock: 2
-  - Item: {fileID: 8307977129538392449, guid: a9fc0438d9e83ad4aa6ea3637ca7af3e, type: 3}
+  - ItemName: 
+    Item: {fileID: 8307977129538392449, guid: a9fc0438d9e83ad4aa6ea3637ca7af3e, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: de49a39e89fc6194aa45f7ffa599e023, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: de49a39e89fc6194aa45f7ffa599e023, type: 3}
     Stock: 2
-  - Item: {fileID: 3116170454584013683, guid: db265d83fcf1bbb46aedc59510228a5d, type: 3}
+  - ItemName: 
+    Item: {fileID: 3116170454584013683, guid: db265d83fcf1bbb46aedc59510228a5d, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 1909889960012756402, guid: 2dcc926f902b2e44a802f217063efa15, type: 3}
+  - ItemName: 
+    Item: {fileID: 1909889960012756402, guid: 2dcc926f902b2e44a802f217063efa15, type: 3}
     Stock: 1
-  - Item: {fileID: 8654279767492581603, guid: 98de935f80510c4468285ffd5a01d9e0, type: 3}
+  - ItemName: 
+    Item: {fileID: 8654279767492581603, guid: 98de935f80510c4468285ffd5a01d9e0, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 2679964424910470999, guid: a0035ec751052984f8f49ff76eadbb3d, type: 3}
+  - ItemName: 
+    Item: {fileID: 2679964424910470999, guid: a0035ec751052984f8f49ff76eadbb3d, type: 3}
     Stock: 1
-  - Item: {fileID: 3961673132676458627, guid: 61c2c1d3267084042bfdfd08fdd7c7a7, type: 3}
+  - ItemName: 
+    Item: {fileID: 3961673132676458627, guid: 61c2c1d3267084042bfdfd08fdd7c7a7, type: 3}
     Stock: 1
-  - Item: {fileID: 6700281191928912403, guid: 1fc9adbf381f65c4b986900fe3a89148, type: 3}
+  - ItemName: 
+    Item: {fileID: 6700281191928912403, guid: 1fc9adbf381f65c4b986900fe3a89148, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/Booze-O-Mat.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/Booze-O-Mat.prefab
@@ -96,81 +96,119 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 4148869193865041042, guid: b66f3404d1c91fe31a896dd10dde764f, type: 3}
+  - ItemName: Shaker
+    Item: {fileID: 4148869193865041042, guid: b66f3404d1c91fe31a896dd10dde764f, type: 3}
     Stock: 1
-  - Item: {fileID: 5426160498802093876, guid: 73832b33f58924a40b5c771587f9707e, type: 3}
+  - ItemName: Drinking Glass
+    Item: {fileID: 5426160498802093876, guid: 73832b33f58924a40b5c771587f9707e, type: 3}
     Stock: 30
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 12
-  - Item: {fileID: 5426160498802093876, guid: e5194eace4d5b754b8671dee0aa516b0, type: 3}
+  - ItemName: Flask
+    Item: {fileID: 5426160498802093876, guid: e5194eace4d5b754b8671dee0aa516b0, type: 3}
     Stock: 3
-  - Item: {fileID: 5426160498802093876, guid: b824900a57dbe644e851efc08d4017dd, type: 3}
+  - ItemName: Ice Cup
+    Item: {fileID: 5426160498802093876, guid: b824900a57dbe644e851efc08d4017dd, type: 3}
     Stock: 10
-  - Item: {fileID: 6248929123533218389, guid: 8ce1f633994ab084d8999c6c608105ec, type: 3}
+  - ItemName: Orange Juice
+    Item: {fileID: 6248929123533218389, guid: 8ce1f633994ab084d8999c6c608105ec, type: 3}
     Stock: 4
-  - Item: {fileID: 6248929123533218389, guid: 497cfce25a366144fb92014c3eadf431, type: 3}
+  - ItemName: Tomato Juice
+    Item: {fileID: 6248929123533218389, guid: 497cfce25a366144fb92014c3eadf431, type: 3}
     Stock: 4
-  - Item: {fileID: 6248929123533218389, guid: 57821c0cc44f3824bafe246a644ce82f, type: 3}
+  - ItemName: Lime Juice
+    Item: {fileID: 6248929123533218389, guid: 57821c0cc44f3824bafe246a644ce82f, type: 3}
     Stock: 4
-  - Item: {fileID: 6248929123533218389, guid: 191fd33a71ba4a5499077c7f913c8e0a, type: 3}
+  - ItemName: Milk Cream
+    Item: {fileID: 6248929123533218389, guid: 191fd33a71ba4a5499077c7f913c8e0a, type: 3}
     Stock: 4
-  - Item: {fileID: 6546673936360135170, guid: 9df8b42a3b7c7554ab9c48ba64b45d2e, type: 3}
+  - ItemName: Space Cola
+    Item: {fileID: 6546673936360135170, guid: 9df8b42a3b7c7554ab9c48ba64b45d2e, type: 3}
     Stock: 8
-  - Item: {fileID: 6546673936360135170, guid: 473d54ef6d2278d4fb21703ff8c73856, type: 3}
+  - ItemName: TBorgs Tonic Water
+    Item: {fileID: 6546673936360135170, guid: 473d54ef6d2278d4fb21703ff8c73856, type: 3}
     Stock: 8
-  - Item: {fileID: 6546673936360135170, guid: b7831b25f6bc923458647be942a2609f, type: 3}
+  - ItemName: Soda Water
+    Item: {fileID: 6546673936360135170, guid: b7831b25f6bc923458647be942a2609f, type: 3}
     Stock: 15
-  - Item: {fileID: 6546673936360135170, guid: e87239ad02449c9448d296098720eee1, type: 3}
+  - ItemName: SolDry
+    Item: {fileID: 6546673936360135170, guid: e87239ad02449c9448d296098720eee1, type: 3}
     Stock: 8
-  - Item: {fileID: 6248929123533218389, guid: 4f479d8510b6af74e897e5162e5f6c12, type: 3}
+  - ItemName: Jester Grenadine
+    Item: {fileID: 6248929123533218389, guid: 4f479d8510b6af74e897e5162e5f6c12, type: 3}
     Stock: 4
-  - Item: {fileID: 6248929123533218389, guid: 3ce5947353b01e24db3b979f8e3e55dc, type: 3}
+  - ItemName: Menthol
+    Item: {fileID: 6248929123533218389, guid: 3ce5947353b01e24db3b979f8e3e55dc, type: 3}
     Stock: 4
-  - Item: {fileID: 1150524617746403880, guid: eab2e016a76b9d844a1163cb42e86b6b, type: 3}
+  - ItemName: MagmAle
+    Item: {fileID: 1150524617746403880, guid: eab2e016a76b9d844a1163cb42e86b6b, type: 3}
     Stock: 6
-  - Item: {fileID: 1150524617746403880, guid: 8293bf9edcadf604f82121a421203d88, type: 3}
+  - ItemName: Space Beer
+    Item: {fileID: 1150524617746403880, guid: 8293bf9edcadf604f82121a421203d88, type: 3}
     Stock: 6
-  - Item: {fileID: 8304274547702105696, guid: cbf8a187a73d7d243ab6ccdc325f1742, type: 3}
+  - ItemName: Griffeater Gin
+    Item: {fileID: 8304274547702105696, guid: cbf8a187a73d7d243ab6ccdc325f1742, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 56d91ad002311c74ab3bdfbd34db3031, type: 3}
+  - ItemName: UncleGitsSpecialReserve
+    Item: {fileID: 6248929123533218389, guid: 56d91ad002311c74ab3bdfbd34db3031, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: a56cbed44f98a5e42b906bf9891a2c9b, type: 3}
+  - ItemName: Caccavo Guarenteed Quality Tequilla
+    Item: {fileID: 6248929123533218389, guid: a56cbed44f98a5e42b906bf9891a2c9b, type: 3}
     Stock: 5
-  - Item: {fileID: 1321544868721115095, guid: cef63d01a274d414ba46966ae5790027, type: 3}
+  - ItemName: Tunguska Tripple Distilled
+    Item: {fileID: 1321544868721115095, guid: cef63d01a274d414ba46966ae5790027, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: cff447661bd203b4d953de37364c8b5a, type: 3}
+  - ItemName: Goldeneye Vermouth
+    Item: {fileID: 6248929123533218389, guid: cff447661bd203b4d953de37364c8b5a, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: ccd24e5a9686bf74bb1f8920532a289f, type: 3}
+  - ItemName: Captain Petes Cuban Spiced Rum
+    Item: {fileID: 6248929123533218389, guid: ccd24e5a9686bf74bb1f8920532a289f, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 3a23de27c51cc1a458383295afdc9450, type: 3}
+  - ItemName: Doublebeards Bearded Special Wine
+    Item: {fileID: 6248929123533218389, guid: 3a23de27c51cc1a458383295afdc9450, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: b63168adfc4bc004197f31da7ac8a072, type: 3}
+  - ItemName: Chataeu De Baton Premium Congnac
+    Item: {fileID: 6248929123533218389, guid: b63168adfc4bc004197f31da7ac8a072, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: fd6f0f3e1a7166a4eb97ecd062844139, type: 3}
+  - ItemName: Robert Robusts Coffee Liquor
+    Item: {fileID: 6248929123533218389, guid: fd6f0f3e1a7166a4eb97ecd062844139, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 3fa6e890bb0a03b4893e76bb9cdd93be, type: 3}
+  - ItemName: Jian Hard Cider
+    Item: {fileID: 6248929123533218389, guid: 3fa6e890bb0a03b4893e76bb9cdd93be, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 573b3f3cbe9c31e48b588976ecf36370, type: 3}
+  - ItemName: Extra Strong Absinthe
+    Item: {fileID: 6248929123533218389, guid: 573b3f3cbe9c31e48b588976ecf36370, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 6348f03cf598e19458b740e222906630, type: 3}
+  - ItemName: Philipes Well Aged Grappa
+    Item: {fileID: 6248929123533218389, guid: 6348f03cf598e19458b740e222906630, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 8cfb6743ac489814cbd030062676851f, type: 3}
+  - ItemName: Ryos Traditional Sake
+    Item: {fileID: 6248929123533218389, guid: 8cfb6743ac489814cbd030062676851f, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 206d77c5787026342888b8de24229939, type: 3}
+  - ItemName: Buckin Broncos Apple Jack
+    Item: {fileID: 6248929123533218389, guid: 206d77c5787026342888b8de24229939, type: 3}
     Stock: 5
-  - Item: {fileID: 5426160498802093876, guid: f27a3b4aebb07064a9042faa05595c0a, type: 3}
+  - ItemName: Glass Bottle
+    Item: {fileID: 5426160498802093876, guid: f27a3b4aebb07064a9042faa05595c0a, type: 3}
     Stock: 15
-  - Item: {fileID: 5028644169083187354, guid: 422be4089fc3dfb4d937537bc583421a, type: 3}
+  - ItemName: Small Glass Bottle
+    Item: {fileID: 5028644169083187354, guid: 422be4089fc3dfb4d937537bc583421a, type: 3}
     Stock: 15
-  - Item: {fileID: 6618353530657536621, guid: 35f78c76766179044a32dbd9e20e5c46, type: 3}
+  - ItemName: Duke Purple Tea
+    Item: {fileID: 6618353530657536621, guid: 35f78c76766179044a32dbd9e20e5c46, type: 3}
     Stock: 12
-  - Item: {fileID: 6248929123533218389, guid: f8d3fe2b9e292774bb5dcb507290dfa8, type: 3}
+  - ItemName: Fernet Bronca
+    Item: {fileID: 6248929123533218389, guid: f8d3fe2b9e292774bb5dcb507290dfa8, type: 3}
     Stock: 5
-  - Item: {fileID: 2407726982561424373, guid: cc9f39d2dab50ac46a16018eeb5bd7b1, type: 3}
+  - ItemName: Ethanol Bottle
+    Item: {fileID: 2407726982561424373, guid: cc9f39d2dab50ac46a16018eeb5bd7b1, type: 3}
     Stock: 4
-  - Item: {fileID: 6248929123533218389, guid: 90c421bf39f2fa14c87a8164b227a76e, type: 3}
+  - ItemName: Eau D'dandy Brut Champagne
+    Item: {fileID: 6248929123533218389, guid: 90c421bf39f2fa14c87a8164b227a76e, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 424cde2de08853a49b97c3320e7ed50c, type: 3}
+  - ItemName: Mont DeRequin Trappistes Bleu
+    Item: {fileID: 6248929123533218389, guid: 424cde2de08853a49b97c3320e7ed50c, type: 3}
     Stock: 5
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -179,81 +217,119 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 4148869193865041042, guid: b66f3404d1c91fe31a896dd10dde764f, type: 3}
+  - ItemName: 
+    Item: {fileID: 4148869193865041042, guid: b66f3404d1c91fe31a896dd10dde764f, type: 3}
     Stock: 1
-  - Item: {fileID: 5426160498802093876, guid: 73832b33f58924a40b5c771587f9707e, type: 3}
+  - ItemName: 
+    Item: {fileID: 5426160498802093876, guid: 73832b33f58924a40b5c771587f9707e, type: 3}
     Stock: 30
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 12
-  - Item: {fileID: 5426160498802093876, guid: e5194eace4d5b754b8671dee0aa516b0, type: 3}
+  - ItemName: 
+    Item: {fileID: 5426160498802093876, guid: e5194eace4d5b754b8671dee0aa516b0, type: 3}
     Stock: 3
-  - Item: {fileID: 5426160498802093876, guid: b824900a57dbe644e851efc08d4017dd, type: 3}
+  - ItemName: 
+    Item: {fileID: 5426160498802093876, guid: b824900a57dbe644e851efc08d4017dd, type: 3}
     Stock: 10
-  - Item: {fileID: 6248929123533218389, guid: 8ce1f633994ab084d8999c6c608105ec, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 8ce1f633994ab084d8999c6c608105ec, type: 3}
     Stock: 4
-  - Item: {fileID: 6248929123533218389, guid: 497cfce25a366144fb92014c3eadf431, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 497cfce25a366144fb92014c3eadf431, type: 3}
     Stock: 4
-  - Item: {fileID: 6248929123533218389, guid: 57821c0cc44f3824bafe246a644ce82f, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 57821c0cc44f3824bafe246a644ce82f, type: 3}
     Stock: 4
-  - Item: {fileID: 6248929123533218389, guid: 191fd33a71ba4a5499077c7f913c8e0a, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 191fd33a71ba4a5499077c7f913c8e0a, type: 3}
     Stock: 4
-  - Item: {fileID: 6546673936360135170, guid: 9df8b42a3b7c7554ab9c48ba64b45d2e, type: 3}
+  - ItemName: 
+    Item: {fileID: 6546673936360135170, guid: 9df8b42a3b7c7554ab9c48ba64b45d2e, type: 3}
     Stock: 8
-  - Item: {fileID: 6546673936360135170, guid: 473d54ef6d2278d4fb21703ff8c73856, type: 3}
+  - ItemName: 
+    Item: {fileID: 6546673936360135170, guid: 473d54ef6d2278d4fb21703ff8c73856, type: 3}
     Stock: 8
-  - Item: {fileID: 6546673936360135170, guid: b7831b25f6bc923458647be942a2609f, type: 3}
+  - ItemName: 
+    Item: {fileID: 6546673936360135170, guid: b7831b25f6bc923458647be942a2609f, type: 3}
     Stock: 15
-  - Item: {fileID: 6546673936360135170, guid: e87239ad02449c9448d296098720eee1, type: 3}
+  - ItemName: 
+    Item: {fileID: 6546673936360135170, guid: e87239ad02449c9448d296098720eee1, type: 3}
     Stock: 8
-  - Item: {fileID: 6248929123533218389, guid: 4f479d8510b6af74e897e5162e5f6c12, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 4f479d8510b6af74e897e5162e5f6c12, type: 3}
     Stock: 4
-  - Item: {fileID: 6248929123533218389, guid: 3ce5947353b01e24db3b979f8e3e55dc, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 3ce5947353b01e24db3b979f8e3e55dc, type: 3}
     Stock: 4
-  - Item: {fileID: 1150524617746403880, guid: eab2e016a76b9d844a1163cb42e86b6b, type: 3}
+  - ItemName: 
+    Item: {fileID: 1150524617746403880, guid: eab2e016a76b9d844a1163cb42e86b6b, type: 3}
     Stock: 6
-  - Item: {fileID: 1150524617746403880, guid: 8293bf9edcadf604f82121a421203d88, type: 3}
+  - ItemName: 
+    Item: {fileID: 1150524617746403880, guid: 8293bf9edcadf604f82121a421203d88, type: 3}
     Stock: 6
-  - Item: {fileID: 8304274547702105696, guid: cbf8a187a73d7d243ab6ccdc325f1742, type: 3}
+  - ItemName: 
+    Item: {fileID: 8304274547702105696, guid: cbf8a187a73d7d243ab6ccdc325f1742, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 56d91ad002311c74ab3bdfbd34db3031, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 56d91ad002311c74ab3bdfbd34db3031, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: a56cbed44f98a5e42b906bf9891a2c9b, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: a56cbed44f98a5e42b906bf9891a2c9b, type: 3}
     Stock: 5
-  - Item: {fileID: 1321544868721115095, guid: cef63d01a274d414ba46966ae5790027, type: 3}
+  - ItemName: 
+    Item: {fileID: 1321544868721115095, guid: cef63d01a274d414ba46966ae5790027, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: cff447661bd203b4d953de37364c8b5a, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: cff447661bd203b4d953de37364c8b5a, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: ccd24e5a9686bf74bb1f8920532a289f, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: ccd24e5a9686bf74bb1f8920532a289f, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 3a23de27c51cc1a458383295afdc9450, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 3a23de27c51cc1a458383295afdc9450, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: b63168adfc4bc004197f31da7ac8a072, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: b63168adfc4bc004197f31da7ac8a072, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: fd6f0f3e1a7166a4eb97ecd062844139, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: fd6f0f3e1a7166a4eb97ecd062844139, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 3fa6e890bb0a03b4893e76bb9cdd93be, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 3fa6e890bb0a03b4893e76bb9cdd93be, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 573b3f3cbe9c31e48b588976ecf36370, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 573b3f3cbe9c31e48b588976ecf36370, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 6348f03cf598e19458b740e222906630, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 6348f03cf598e19458b740e222906630, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 8cfb6743ac489814cbd030062676851f, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 8cfb6743ac489814cbd030062676851f, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 206d77c5787026342888b8de24229939, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 206d77c5787026342888b8de24229939, type: 3}
     Stock: 5
-  - Item: {fileID: 5426160498802093876, guid: f27a3b4aebb07064a9042faa05595c0a, type: 3}
+  - ItemName: 
+    Item: {fileID: 5426160498802093876, guid: f27a3b4aebb07064a9042faa05595c0a, type: 3}
     Stock: 15
-  - Item: {fileID: 5028644169083187354, guid: 422be4089fc3dfb4d937537bc583421a, type: 3}
+  - ItemName: 
+    Item: {fileID: 5028644169083187354, guid: 422be4089fc3dfb4d937537bc583421a, type: 3}
     Stock: 15
-  - Item: {fileID: 6618353530657536621, guid: 35f78c76766179044a32dbd9e20e5c46, type: 3}
+  - ItemName: 
+    Item: {fileID: 6618353530657536621, guid: 35f78c76766179044a32dbd9e20e5c46, type: 3}
     Stock: 12
-  - Item: {fileID: 6248929123533218389, guid: f8d3fe2b9e292774bb5dcb507290dfa8, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: f8d3fe2b9e292774bb5dcb507290dfa8, type: 3}
     Stock: 5
-  - Item: {fileID: 2407726982561424373, guid: cc9f39d2dab50ac46a16018eeb5bd7b1, type: 3}
+  - ItemName: 
+    Item: {fileID: 2407726982561424373, guid: cc9f39d2dab50ac46a16018eeb5bd7b1, type: 3}
     Stock: 4
-  - Item: {fileID: 6248929123533218389, guid: 90c421bf39f2fa14c87a8164b227a76e, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 90c421bf39f2fa14c87a8164b227a76e, type: 3}
     Stock: 5
-  - Item: {fileID: 6248929123533218389, guid: 424cde2de08853a49b97c3320e7ed50c, type: 3}
+  - ItemName: 
+    Item: {fileID: 6248929123533218389, guid: 424cde2de08853a49b97c3320e7ed50c, type: 3}
     Stock: 5
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/CargoDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/CargoDrobe.prefab
@@ -97,21 +97,29 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 9204123767053120434, guid: f12be30eb7f2ac9488b987831b29a6e9, type: 3}
+  - ItemName: Cargo Winter Coat
+    Item: {fileID: 9204123767053120434, guid: f12be30eb7f2ac9488b987831b29a6e9, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: efbc8c2ff833d4924a01c0a134819dd7, type: 3}
+  - ItemName: Cargo Technicians Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: efbc8c2ff833d4924a01c0a134819dd7, type: 3}
     Stock: 3
-  - Item: {fileID: 1966734932007505171, guid: d0f1a9b75fd9b4c4498f65e576a9d815, type: 3}
+  - ItemName: Cargo Technicians Jumskirt
+    Item: {fileID: 1966734932007505171, guid: d0f1a9b75fd9b4c4498f65e576a9d815, type: 3}
     Stock: 3
-  - Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
+  - ItemName: Black Shoes
+    Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
     Stock: 3
-  - Item: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26, type: 3}
+  - ItemName: Fingerless Gloves
+    Item: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26, type: 3}
     Stock: 3
-  - Item: {fileID: 7636118406116123594, guid: 788649a7f84574c48a54361479106732, type: 3}
+  - ItemName: Cargo Cap
+    Item: {fileID: 7636118406116123594, guid: 788649a7f84574c48a54361479106732, type: 3}
     Stock: 3
-  - Item: {fileID: 835768756810601639, guid: 455167e17d2dd4f24b32aaafea5e7fb2, type: 3}
+  - ItemName: Cargo Headset
+    Item: {fileID: 835768756810601639, guid: 455167e17d2dd4f24b32aaafea5e7fb2, type: 3}
     Stock: 3
-  - Item: {fileID: 3240567849674671610, guid: 5e60c8d094f22e34288e8e180e8632e9, type: 3}
+  - ItemName: Shaft Miners Jumpsuit
+    Item: {fileID: 3240567849674671610, guid: 5e60c8d094f22e34288e8e180e8632e9, type: 3}
     Stock: 3
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -120,21 +128,29 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 9204123767053120434, guid: f12be30eb7f2ac9488b987831b29a6e9, type: 3}
+  - ItemName: 
+    Item: {fileID: 9204123767053120434, guid: f12be30eb7f2ac9488b987831b29a6e9, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: efbc8c2ff833d4924a01c0a134819dd7, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: efbc8c2ff833d4924a01c0a134819dd7, type: 3}
     Stock: 3
-  - Item: {fileID: 1966734932007505171, guid: d0f1a9b75fd9b4c4498f65e576a9d815, type: 3}
+  - ItemName: 
+    Item: {fileID: 1966734932007505171, guid: d0f1a9b75fd9b4c4498f65e576a9d815, type: 3}
     Stock: 3
-  - Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
     Stock: 3
-  - Item: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26, type: 3}
+  - ItemName: 
+    Item: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26, type: 3}
     Stock: 3
-  - Item: {fileID: 7636118406116123594, guid: 788649a7f84574c48a54361479106732, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 788649a7f84574c48a54361479106732, type: 3}
     Stock: 3
-  - Item: {fileID: 835768756810601639, guid: 455167e17d2dd4f24b32aaafea5e7fb2, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: 455167e17d2dd4f24b32aaafea5e7fb2, type: 3}
     Stock: 3
-  - Item: {fileID: 3240567849674671610, guid: 5e60c8d094f22e34288e8e180e8632e9, type: 3}
+  - ItemName: 
+    Item: {fileID: 3240567849674671610, guid: 5e60c8d094f22e34288e8e180e8632e9, type: 3}
     Stock: 3
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/ChapDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/ChapDrobe.prefab
@@ -97,57 +97,83 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 2631301970094974667, guid: 4a7edcb6b0aa41f4f812fc2b11ac6ba0, type: 3}
+  - ItemName: Trophy Rack
+    Item: {fileID: 2631301970094974667, guid: 4a7edcb6b0aa41f4f812fc2b11ac6ba0, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 46e9a65fa189a4ae98dc1686675a6fab, type: 3}
+  - ItemName: Chaplains Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 46e9a65fa189a4ae98dc1686675a6fab, type: 3}
     Stock: 1
-  - Item: {fileID: 3694014063137355943, guid: eef5ab2615dd4924184c5c1f2ebddd96, type: 3}
+  - ItemName: Chaplains Jumpskirt
+    Item: {fileID: 3694014063137355943, guid: eef5ab2615dd4924184c5c1f2ebddd96, type: 3}
     Stock: 1
-  - Item: {fileID: 7106618204054676533, guid: faf3ae6d19eb7d6179472f49c1c5e7b3, type: 3}
+  - ItemName: Magic Sandals
+    Item: {fileID: 7106618204054676533, guid: faf3ae6d19eb7d6179472f49c1c5e7b3, type: 3}
     Stock: 1
-  - Item: {fileID: 4396341318306884477, guid: e244af83de9c4b34e81a92b8fc49d697, type: 3}
+  - ItemName: Nub Robe
+    Item: {fileID: 4396341318306884477, guid: e244af83de9c4b34e81a92b8fc49d697, type: 3}
     Stock: 1
-  - Item: {fileID: 5928712846358127699, guid: 57dc1686331ca564e808b94f84fe8fb0, type: 3}
+  - ItemName: Nun Hood
+    Item: {fileID: 5928712846358127699, guid: 57dc1686331ca564e808b94f84fe8fb0, type: 3}
     Stock: 1
-  - Item: {fileID: 4396341318306884477, guid: 952fcc0a66cc10f4dabc47ee13d626ef, type: 3}
+  - ItemName: Holiday Priests Robes
+    Item: {fileID: 4396341318306884477, guid: 952fcc0a66cc10f4dabc47ee13d626ef, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 3a12db5b378157d44850130a940fcccc, type: 3}
+  - ItemName: Monks Habit
+    Item: {fileID: 3921521694364753778, guid: 3a12db5b378157d44850130a940fcccc, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: 2676698809287454ca982a60b8310752, type: 3}
+  - ItemName: Kippah
+    Item: {fileID: 7636118406116123594, guid: 2676698809287454ca982a60b8310752, type: 3}
     Stock: 3
-  - Item: {fileID: 3921521694364753778, guid: 6168a00e66ca21f45b31140fb85e3527, type: 3}
+  - ItemName: White Robe
+    Item: {fileID: 3921521694364753778, guid: 6168a00e66ca21f45b31140fb85e3527, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: d3a4af0eb408c32499a7fdbd285001f2, type: 3}
+  - ItemName: White Taqiyah
+    Item: {fileID: 7636118406116123594, guid: d3a4af0eb408c32499a7fdbd285001f2, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 99972b6fb78d35245885d5917704db00, type: 3}
+  - ItemName: Red Taqiyah
+    Item: {fileID: 7636118406116123594, guid: 99972b6fb78d35245885d5917704db00, type: 3}
     Stock: 3
-  - Item: {fileID: 3921521694364753778, guid: b3e9e115e52513c4eb88129b029216ef, type: 3}
+  - ItemName: Eastern Monks Robes
+    Item: {fileID: 3921521694364753778, guid: b3e9e115e52513c4eb88129b029216ef, type: 3}
     Stock: 1
-  - Item: {fileID: 616735813865956089, guid: 48f01c8a7b7848048a0ba8fa85a07a7d, type: 3}
+  - ItemName: Rasta Cap
+    Item: {fileID: 616735813865956089, guid: 48f01c8a7b7848048a0ba8fa85a07a7d, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 7727aa2611c63c343bc1366c82ac77b6, type: 3}
+  - ItemName: Medieval Jew Hat
+    Item: {fileID: 7636118406116123594, guid: 7727aa2611c63c343bc1366c82ac77b6, type: 3}
     Stock: 3
-  - Item: {fileID: 3921521694364753778, guid: 2a4b15314ed79284390ffd3d350bde37, type: 3}
+  - ItemName: Robes Of The Honk Mother
+    Item: {fileID: 3921521694364753778, guid: 2a4b15314ed79284390ffd3d350bde37, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 84d03d866a1ee8d48a83c8ccef547e21, type: 3}
+  - ItemName: Hat Of The Honk Mother
+    Item: {fileID: 7636118406116123594, guid: 84d03d866a1ee8d48a83c8ccef547e21, type: 3}
     Stock: 1
-  - Item: {fileID: 4396341318306884477, guid: e707afa4977956141a62cc6890d088ca, type: 3}
+  - ItemName: Bishops Robes
+    Item: {fileID: 4396341318306884477, guid: e707afa4977956141a62cc6890d088ca, type: 3}
     Stock: 1
-  - Item: {fileID: 5928712846358127699, guid: 0c2a702923a3e6346933f0c6d52fed5d, type: 3}
+  - ItemName: Bishop Mitre
+    Item: {fileID: 5928712846358127699, guid: 0c2a702923a3e6346933f0c6d52fed5d, type: 3}
     Stock: 1
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -156,57 +182,83 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 2631301970094974667, guid: 4a7edcb6b0aa41f4f812fc2b11ac6ba0, type: 3}
+  - ItemName: 
+    Item: {fileID: 2631301970094974667, guid: 4a7edcb6b0aa41f4f812fc2b11ac6ba0, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 46e9a65fa189a4ae98dc1686675a6fab, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 46e9a65fa189a4ae98dc1686675a6fab, type: 3}
     Stock: 1
-  - Item: {fileID: 3694014063137355943, guid: eef5ab2615dd4924184c5c1f2ebddd96, type: 3}
+  - ItemName: 
+    Item: {fileID: 3694014063137355943, guid: eef5ab2615dd4924184c5c1f2ebddd96, type: 3}
     Stock: 1
-  - Item: {fileID: 7106618204054676533, guid: faf3ae6d19eb7d6179472f49c1c5e7b3, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: faf3ae6d19eb7d6179472f49c1c5e7b3, type: 3}
     Stock: 1
-  - Item: {fileID: 4396341318306884477, guid: e244af83de9c4b34e81a92b8fc49d697, type: 3}
+  - ItemName: 
+    Item: {fileID: 4396341318306884477, guid: e244af83de9c4b34e81a92b8fc49d697, type: 3}
     Stock: 1
-  - Item: {fileID: 5928712846358127699, guid: 57dc1686331ca564e808b94f84fe8fb0, type: 3}
+  - ItemName: 
+    Item: {fileID: 5928712846358127699, guid: 57dc1686331ca564e808b94f84fe8fb0, type: 3}
     Stock: 1
-  - Item: {fileID: 4396341318306884477, guid: 952fcc0a66cc10f4dabc47ee13d626ef, type: 3}
+  - ItemName: 
+    Item: {fileID: 4396341318306884477, guid: 952fcc0a66cc10f4dabc47ee13d626ef, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 3a12db5b378157d44850130a940fcccc, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 3a12db5b378157d44850130a940fcccc, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: 2676698809287454ca982a60b8310752, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 2676698809287454ca982a60b8310752, type: 3}
     Stock: 3
-  - Item: {fileID: 3921521694364753778, guid: 6168a00e66ca21f45b31140fb85e3527, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 6168a00e66ca21f45b31140fb85e3527, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: d3a4af0eb408c32499a7fdbd285001f2, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: d3a4af0eb408c32499a7fdbd285001f2, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 99972b6fb78d35245885d5917704db00, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 99972b6fb78d35245885d5917704db00, type: 3}
     Stock: 3
-  - Item: {fileID: 3921521694364753778, guid: b3e9e115e52513c4eb88129b029216ef, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: b3e9e115e52513c4eb88129b029216ef, type: 3}
     Stock: 1
-  - Item: {fileID: 616735813865956089, guid: 48f01c8a7b7848048a0ba8fa85a07a7d, type: 3}
+  - ItemName: 
+    Item: {fileID: 616735813865956089, guid: 48f01c8a7b7848048a0ba8fa85a07a7d, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 7727aa2611c63c343bc1366c82ac77b6, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 7727aa2611c63c343bc1366c82ac77b6, type: 3}
     Stock: 3
-  - Item: {fileID: 3921521694364753778, guid: 2a4b15314ed79284390ffd3d350bde37, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 2a4b15314ed79284390ffd3d350bde37, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 84d03d866a1ee8d48a83c8ccef547e21, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 84d03d866a1ee8d48a83c8ccef547e21, type: 3}
     Stock: 1
-  - Item: {fileID: 4396341318306884477, guid: e707afa4977956141a62cc6890d088ca, type: 3}
+  - ItemName: 
+    Item: {fileID: 4396341318306884477, guid: e707afa4977956141a62cc6890d088ca, type: 3}
     Stock: 1
-  - Item: {fileID: 5928712846358127699, guid: 0c2a702923a3e6346933f0c6d52fed5d, type: 3}
+  - ItemName: 
+    Item: {fileID: 5928712846358127699, guid: 0c2a702923a3e6346933f0c6d52fed5d, type: 3}
     Stock: 1
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/ChefDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/ChefDrobe.prefab
@@ -97,39 +97,56 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 5480900738568975519, guid: 9bb52425bd84e21469e37eb87c90e8eb, type: 3}
+  - ItemName: Waiters Outfit
+    Item: {fileID: 5480900738568975519, guid: 9bb52425bd84e21469e37eb87c90e8eb, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: ab23fc0ba00b309459f2a039f0098d57, type: 3}
+  - ItemName: Maid Costume
+    Item: {fileID: 3011710637427380133, guid: ab23fc0ba00b309459f2a039f0098d57, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
+  - ItemName: Service Headset
+    Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
+  - ItemName: Waistcoat
+    Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: de49a39e89fc6194aa45f7ffa599e023, type: 3}
+  - ItemName: Maid Apron
+    Item: {fileID: 3921521694364753778, guid: de49a39e89fc6194aa45f7ffa599e023, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: 4dddb342829e74925b4e0ca0d8cc5150, type: 3}
+  - ItemName: Cooks Apron
+    Item: {fileID: 3921521694364753778, guid: 4dddb342829e74925b4e0ca0d8cc5150, type: 3}
     Stock: 3
-  - Item: {fileID: 2850241452416116279, guid: 3961caf40305bd741b8c919afd07fca2, type: 3}
+  - ItemName: White Cap
+    Item: {fileID: 2850241452416116279, guid: 3961caf40305bd741b8c919afd07fca2, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 3d7f780dd3e1311438048a6c387cc2e6, type: 3}
+  - ItemName: Chefs Apron
+    Item: {fileID: 3921521694364753778, guid: 3d7f780dd3e1311438048a6c387cc2e6, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: 82223aa9f2653409893db380f44262de, type: 3}
+  - ItemName: Cooks Suit
+    Item: {fileID: 3011710637427380133, guid: 82223aa9f2653409893db380f44262de, type: 3}
     Stock: 2
-  - Item: {fileID: 8595759586749855722, guid: 20b5c706c9fa6d6488022b9b64d732b8, type: 3}
+  - ItemName: Cooks Skirt
+    Item: {fileID: 8595759586749855722, guid: 20b5c706c9fa6d6488022b9b64d732b8, type: 3}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: c1986e2665f9a413694ce37f09e0f17e, type: 3}
+  - ItemName: Chef Hat
+    Item: {fileID: 7636118406116123594, guid: c1986e2665f9a413694ce37f09e0f17e, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: 02622c7083ed0ff489e3eee4e97e0d79, type: 3}
+  - ItemName: Grilling Shorts
+    Item: {fileID: 3011710637427380133, guid: 02622c7083ed0ff489e3eee4e97e0d79, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 3c6a831db5491964b8410e18ee7f8a1d, type: 3}
+  - ItemName: Grilling Sandals
+    Item: {fileID: 7106618204054676533, guid: 3c6a831db5491964b8410e18ee7f8a1d, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 6557358717024540051, guid: caa7ec1293d63a74aa063307403f0c7e, type: 3}
+  - ItemName: Winter Coat
+    Item: {fileID: 6557358717024540051, guid: caa7ec1293d63a74aa063307403f0c7e, type: 3}
     Stock: 2
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -138,39 +155,56 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 5480900738568975519, guid: 9bb52425bd84e21469e37eb87c90e8eb, type: 3}
+  - ItemName: 
+    Item: {fileID: 5480900738568975519, guid: 9bb52425bd84e21469e37eb87c90e8eb, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: ab23fc0ba00b309459f2a039f0098d57, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: ab23fc0ba00b309459f2a039f0098d57, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: de49a39e89fc6194aa45f7ffa599e023, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: de49a39e89fc6194aa45f7ffa599e023, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: 4dddb342829e74925b4e0ca0d8cc5150, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 4dddb342829e74925b4e0ca0d8cc5150, type: 3}
     Stock: 3
-  - Item: {fileID: 2850241452416116279, guid: 3961caf40305bd741b8c919afd07fca2, type: 3}
+  - ItemName: 
+    Item: {fileID: 2850241452416116279, guid: 3961caf40305bd741b8c919afd07fca2, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: 3d7f780dd3e1311438048a6c387cc2e6, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 3d7f780dd3e1311438048a6c387cc2e6, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: 82223aa9f2653409893db380f44262de, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 82223aa9f2653409893db380f44262de, type: 3}
     Stock: 2
-  - Item: {fileID: 8595759586749855722, guid: 20b5c706c9fa6d6488022b9b64d732b8, type: 3}
+  - ItemName: 
+    Item: {fileID: 8595759586749855722, guid: 20b5c706c9fa6d6488022b9b64d732b8, type: 3}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: c1986e2665f9a413694ce37f09e0f17e, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: c1986e2665f9a413694ce37f09e0f17e, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: 02622c7083ed0ff489e3eee4e97e0d79, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 02622c7083ed0ff489e3eee4e97e0d79, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 3c6a831db5491964b8410e18ee7f8a1d, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 3c6a831db5491964b8410e18ee7f8a1d, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 6557358717024540051, guid: caa7ec1293d63a74aa063307403f0c7e, type: 3}
+  - ItemName: 
+    Item: {fileID: 6557358717024540051, guid: caa7ec1293d63a74aa063307403f0c7e, type: 3}
     Stock: 2
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/ChemDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/ChemDrobe.prefab
@@ -97,25 +97,35 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 1129040505000015364, guid: 86141c7e9c63dd840a578746cb3c53c4, type: 3}
+  - ItemName: Chemistry Backpack
+    Item: {fileID: 1129040505000015364, guid: 86141c7e9c63dd840a578746cb3c53c4, type: 3}
     Stock: 2
-  - Item: {fileID: 4827279270293072794, guid: f3772ed991e136c44844cff068e0116d, type: 3}
+  - ItemName: Chemist Satchel
+    Item: {fileID: 4827279270293072794, guid: f3772ed991e136c44844cff068e0116d, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+  - ItemName: White Shoes
+    Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: 54c252491fc58478aac029a841777c90, type: 3}
+  - ItemName: Chemists Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 54c252491fc58478aac029a841777c90, type: 3}
     Stock: 2
-  - Item: {fileID: 6618757841128137006, guid: 0a840a47782653a47a8bcefb93b92131, type: 3}
+  - ItemName: Chemists Jumpskirt
+    Item: {fileID: 6618757841128137006, guid: 0a840a47782653a47a8bcefb93b92131, type: 3}
     Stock: 2
-  - Item: {fileID: 7374481989050852271, guid: 1fada2a01fe5e49208acb17e93095002, type: 3}
+  - ItemName: Chemists Labcoat
+    Item: {fileID: 7374481989050852271, guid: 1fada2a01fe5e49208acb17e93095002, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: cad7d826b673041f5b2b4d9b9d64aa09, type: 3}
+  - ItemName: Medical Headset
+    Item: {fileID: 835768756810601639, guid: cad7d826b673041f5b2b4d9b9d64aa09, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -124,25 +134,35 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 1129040505000015364, guid: 86141c7e9c63dd840a578746cb3c53c4, type: 3}
+  - ItemName: 
+    Item: {fileID: 1129040505000015364, guid: 86141c7e9c63dd840a578746cb3c53c4, type: 3}
     Stock: 2
-  - Item: {fileID: 4827279270293072794, guid: f3772ed991e136c44844cff068e0116d, type: 3}
+  - ItemName: 
+    Item: {fileID: 4827279270293072794, guid: f3772ed991e136c44844cff068e0116d, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: 54c252491fc58478aac029a841777c90, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 54c252491fc58478aac029a841777c90, type: 3}
     Stock: 2
-  - Item: {fileID: 6618757841128137006, guid: 0a840a47782653a47a8bcefb93b92131, type: 3}
+  - ItemName: 
+    Item: {fileID: 6618757841128137006, guid: 0a840a47782653a47a8bcefb93b92131, type: 3}
     Stock: 2
-  - Item: {fileID: 7374481989050852271, guid: 1fada2a01fe5e49208acb17e93095002, type: 3}
+  - ItemName: 
+    Item: {fileID: 7374481989050852271, guid: 1fada2a01fe5e49208acb17e93095002, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: cad7d826b673041f5b2b4d9b9d64aa09, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: cad7d826b673041f5b2b4d9b9d64aa09, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/CoffeeVending.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/CoffeeVending.prefab
@@ -96,9 +96,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 4979961816922530936, guid: d6be48f0b2535c34db63e050f6424259, type: 3}
+  - ItemName: Coffee Cup
+    Item: {fileID: 4979961816922530936, guid: d6be48f0b2535c34db63e050f6424259, type: 3}
     Stock: 5
-  - Item: {fileID: 6618353530657536621, guid: 35f78c76766179044a32dbd9e20e5c46, type: 3}
+  - ItemName: Duke Purple Tea
+    Item: {fileID: 6618353530657536621, guid: 35f78c76766179044a32dbd9e20e5c46, type: 3}
     Stock: 5
   HullColor: {r: 0.39607844, g: 0.52156866, b: 0.27450982, a: 1}
   EjectObjects: 0
@@ -107,9 +109,11 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 4979961816922530936, guid: d6be48f0b2535c34db63e050f6424259, type: 3}
+  - ItemName: 
+    Item: {fileID: 4979961816922530936, guid: d6be48f0b2535c34db63e050f6424259, type: 3}
     Stock: 5
-  - Item: {fileID: 6618353530657536621, guid: 35f78c76766179044a32dbd9e20e5c46, type: 3}
+  - ItemName: 
+    Item: {fileID: 6618353530657536621, guid: 35f78c76766179044a32dbd9e20e5c46, type: 3}
     Stock: 5
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/CuraDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/CuraDrobe.prefab
@@ -97,43 +97,62 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 8734328976324889014, guid: 83442ea1bc97ef04db1f9962a2f7021d, type: 3}
+  - ItemName: Pen1
+    Item: {fileID: 8734328976324889014, guid: 83442ea1bc97ef04db1f9962a2f7021d, type: 3}
     Stock: 4
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: aacc30d5087d94ec7a4764c686da7e57, type: 3}
+  - ItemName: Sensible Suit
+    Item: {fileID: 3011710637427380133, guid: aacc30d5087d94ec7a4764c686da7e57, type: 3}
     Stock: 2
-  - Item: {fileID: 8634698533066501967, guid: 47d960509ca10d34da540dc8029ffece, type: 3}
+  - ItemName: Sensible Suitskirt
+    Item: {fileID: 8634698533066501967, guid: 47d960509ca10d34da540dc8029ffece, type: 3}
     Stock: 2
-  - Item: {fileID: 6127118939752068930, guid: b9ea9931e8b07a140ab790d555cace98, type: 3}
+  - ItemName: Green Suit
+    Item: {fileID: 6127118939752068930, guid: b9ea9931e8b07a140ab790d555cace98, type: 3}
     Stock: 2
-  - Item: {fileID: 2834735550645104383, guid: 51fa4efb14c93714ea1ff2121835d6cc, type: 3}
+  - ItemName: Green Suitskirt
+    Item: {fileID: 2834735550645104383, guid: 51fa4efb14c93714ea1ff2121835d6cc, type: 3}
     Stock: 2
-  - Item: {fileID: 6532394448030161815, guid: 70e762212c1501d49bbcd7004162631a, type: 3}
+  - ItemName: Teal Suit
+    Item: {fileID: 6532394448030161815, guid: 70e762212c1501d49bbcd7004162631a, type: 3}
     Stock: 2
-  - Item: {fileID: 1231553946908593111, guid: 0c4edd45da8bda84b8ffa10e660ce6f4, type: 3}
+  - ItemName: Teal Suitskirt
+    Item: {fileID: 1231553946908593111, guid: 0c4edd45da8bda84b8ffa10e660ce6f4, type: 3}
     Stock: 2
-  - Item: {fileID: 9001442491608015058, guid: bed6dd4c42e234f4180cfa233fcf9027, type: 3}
+  - ItemName: Explorer Bag
+    Item: {fileID: 9001442491608015058, guid: bed6dd4c42e234f4180cfa233fcf9027, type: 3}
     Stock: 1
-  - Item: {fileID: 2054783994787064243, guid: 64532b0908b2c1c40a11a32ef95e5a5d, type: 3}
+  - ItemName: Explorer Stachel
+    Item: {fileID: 2054783994787064243, guid: 64532b0908b2c1c40a11a32ef95e5a5d, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 3431291279286482953, guid: e7c66dc6818ee2e4e8a12a7fbfa0a374, type: 3}
+  - ItemName: Prescription Glasses
+    Item: {fileID: 3431291279286482953, guid: e7c66dc6818ee2e4e8a12a7fbfa0a374, type: 3}
     Stock: 2
-  - Item: {fileID: 7025772132153801043, guid: b7680266b91b6d141a4f255aefb9cf2d, type: 3}
+  - ItemName: Jam Jar Glasses
+    Item: {fileID: 7025772132153801043, guid: b7680266b91b6d141a4f255aefb9cf2d, type: 3}
     Stock: 1
-  - Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
+  - ItemName: Service Headset
+    Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -142,43 +161,62 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 8734328976324889014, guid: 83442ea1bc97ef04db1f9962a2f7021d, type: 3}
+  - ItemName: 
+    Item: {fileID: 8734328976324889014, guid: 83442ea1bc97ef04db1f9962a2f7021d, type: 3}
     Stock: 4
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: aacc30d5087d94ec7a4764c686da7e57, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: aacc30d5087d94ec7a4764c686da7e57, type: 3}
     Stock: 2
-  - Item: {fileID: 8634698533066501967, guid: 47d960509ca10d34da540dc8029ffece, type: 3}
+  - ItemName: 
+    Item: {fileID: 8634698533066501967, guid: 47d960509ca10d34da540dc8029ffece, type: 3}
     Stock: 2
-  - Item: {fileID: 6127118939752068930, guid: b9ea9931e8b07a140ab790d555cace98, type: 3}
+  - ItemName: 
+    Item: {fileID: 6127118939752068930, guid: b9ea9931e8b07a140ab790d555cace98, type: 3}
     Stock: 2
-  - Item: {fileID: 2834735550645104383, guid: 51fa4efb14c93714ea1ff2121835d6cc, type: 3}
+  - ItemName: 
+    Item: {fileID: 2834735550645104383, guid: 51fa4efb14c93714ea1ff2121835d6cc, type: 3}
     Stock: 2
-  - Item: {fileID: 6532394448030161815, guid: 70e762212c1501d49bbcd7004162631a, type: 3}
+  - ItemName: 
+    Item: {fileID: 6532394448030161815, guid: 70e762212c1501d49bbcd7004162631a, type: 3}
     Stock: 2
-  - Item: {fileID: 1231553946908593111, guid: 0c4edd45da8bda84b8ffa10e660ce6f4, type: 3}
+  - ItemName: 
+    Item: {fileID: 1231553946908593111, guid: 0c4edd45da8bda84b8ffa10e660ce6f4, type: 3}
     Stock: 2
-  - Item: {fileID: 9001442491608015058, guid: bed6dd4c42e234f4180cfa233fcf9027, type: 3}
+  - ItemName: 
+    Item: {fileID: 9001442491608015058, guid: bed6dd4c42e234f4180cfa233fcf9027, type: 3}
     Stock: 1
-  - Item: {fileID: 2054783994787064243, guid: 64532b0908b2c1c40a11a32ef95e5a5d, type: 3}
+  - ItemName: 
+    Item: {fileID: 2054783994787064243, guid: 64532b0908b2c1c40a11a32ef95e5a5d, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 3431291279286482953, guid: e7c66dc6818ee2e4e8a12a7fbfa0a374, type: 3}
+  - ItemName: 
+    Item: {fileID: 3431291279286482953, guid: e7c66dc6818ee2e4e8a12a7fbfa0a374, type: 3}
     Stock: 2
-  - Item: {fileID: 7025772132153801043, guid: b7680266b91b6d141a4f255aefb9cf2d, type: 3}
+  - ItemName: 
+    Item: {fileID: 7025772132153801043, guid: b7680266b91b6d141a4f255aefb9cf2d, type: 3}
     Stock: 1
-  - Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/DetDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/DetDrobe.prefab
@@ -96,45 +96,65 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 3011710637427380133, guid: de7c66806376e49fd871dfce32fb6d26, type: 3}
+  - ItemName: Hard Worn Suit
+    Item: {fileID: 3011710637427380133, guid: de7c66806376e49fd871dfce32fb6d26, type: 3}
     Stock: 2
-  - Item: {fileID: 5302982331206035619, guid: bb7d1020ce10a7348b237ddd07a02fc2, type: 3}
+  - ItemName: Hard Worn Suit Skirt
+    Item: {fileID: 5302982331206035619, guid: bb7d1020ce10a7348b237ddd07a02fc2, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
+  - ItemName: Brown Shoes
+    Item: {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: 02d871d46281a42d1820f9b47a8124c6, type: 3}
+  - ItemName: Trenchcoat
+    Item: {fileID: 3921521694364753778, guid: 02d871d46281a42d1820f9b47a8124c6, type: 3}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: 5dd96f5e685214da19f65b06f2463aa2, type: 3}
+  - ItemName: Detectives Hat
+    Item: {fileID: 7636118406116123594, guid: 5dd96f5e685214da19f65b06f2463aa2, type: 3}
     Stock: 2
-  - Item: {fileID: 5977298191026215751, guid: 5c40f1e282a3589419bfcca5e7c95320, type: 3}
+  - ItemName: Nor Suit
+    Item: {fileID: 5977298191026215751, guid: 5c40f1e282a3589419bfcca5e7c95320, type: 3}
     Stock: 2
-  - Item: {fileID: 1171842931862335605, guid: 6c9c26df204b0f94f8be3ae03e8051ca, type: 3}
+  - ItemName: Noir Suit Skirt
+    Item: {fileID: 1171842931862335605, guid: 6c9c26df204b0f94f8be3ae03e8051ca, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
+  - ItemName: Waistcoat
+    Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
+  - ItemName: Laceup Shoes
+    Item: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
     Stock: 2
-  - Item: {fileID: 684762946367608382, guid: 5020827e4b280bd4384aa06dda5649bd, type: 3}
+  - ItemName: Noir Trenchcoat
+    Item: {fileID: 684762946367608382, guid: 5020827e4b280bd4384aa06dda5649bd, type: 3}
     Stock: 2
-  - Item: {fileID: 5347176894764292324, guid: 9901a08af652ad04dbbf4519ea57e575, type: 3}
+  - ItemName: Noir Suit Coat
+    Item: {fileID: 5347176894764292324, guid: 9901a08af652ad04dbbf4519ea57e575, type: 3}
     Stock: 2
-  - Item: {fileID: 6980020022460415521, guid: e00c6afc5648f951aac2a8d6dfcc4620, type: 3}
+  - ItemName: Noir Beret
+    Item: {fileID: 6980020022460415521, guid: e00c6afc5648f951aac2a8d6dfcc4620, type: 3}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: 59b6ec971c7da824b83117e8faa53db3, type: 3}
+  - ItemName: Fedora
+    Item: {fileID: 7636118406116123594, guid: 59b6ec971c7da824b83117e8faa53db3, type: 3}
     Stock: 2
-  - Item: {fileID: 6804612781048497285, guid: 7783baf2677b3a844aff37585692717e, type: 3}
+  - ItemName: Beige Fedora
+    Item: {fileID: 6804612781048497285, guid: 7783baf2677b3a844aff37585692717e, type: 3}
     Stock: 2
-  - Item: {fileID: 3862752096800770460, guid: 5719a72c573a068478eaf6400b4f4c22, type: 3}
+  - ItemName: White Fedora
+    Item: {fileID: 3862752096800770460, guid: 5719a72c573a068478eaf6400b4f4c22, type: 3}
     Stock: 2
-  - Item: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
+  - ItemName: Black Gloves
+    Item: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
     Stock: 2
-  - Item: {fileID: 6373161644663410599, guid: 47e758de6e8330e8ba5c0cf96801afa8, type: 3}
+  - ItemName: Latex Gloves
+    Item: {fileID: 6373161644663410599, guid: 47e758de6e8330e8ba5c0cf96801afa8, type: 3}
     Stock: 2
-  - Item: {fileID: 8684129920059976793, guid: 0010029d500bcc9469c05ec34573f8de, type: 3}
+  - ItemName: Detectives Flask
+    Item: {fileID: 8684129920059976793, guid: 0010029d500bcc9469c05ec34573f8de, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: 63587900698efce47a648bd987aef283, type: 3}
+  - ItemName: Flat Cap
+    Item: {fileID: 7636118406116123594, guid: 63587900698efce47a648bd987aef283, type: 3}
     Stock: 2
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -143,45 +163,65 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 3011710637427380133, guid: de7c66806376e49fd871dfce32fb6d26, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: de7c66806376e49fd871dfce32fb6d26, type: 3}
     Stock: 2
-  - Item: {fileID: 5302982331206035619, guid: bb7d1020ce10a7348b237ddd07a02fc2, type: 3}
+  - ItemName: 
+    Item: {fileID: 5302982331206035619, guid: bb7d1020ce10a7348b237ddd07a02fc2, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: 02d871d46281a42d1820f9b47a8124c6, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 02d871d46281a42d1820f9b47a8124c6, type: 3}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: 5dd96f5e685214da19f65b06f2463aa2, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 5dd96f5e685214da19f65b06f2463aa2, type: 3}
     Stock: 2
-  - Item: {fileID: 5977298191026215751, guid: 5c40f1e282a3589419bfcca5e7c95320, type: 3}
+  - ItemName: 
+    Item: {fileID: 5977298191026215751, guid: 5c40f1e282a3589419bfcca5e7c95320, type: 3}
     Stock: 2
-  - Item: {fileID: 1171842931862335605, guid: 6c9c26df204b0f94f8be3ae03e8051ca, type: 3}
+  - ItemName: 
+    Item: {fileID: 1171842931862335605, guid: 6c9c26df204b0f94f8be3ae03e8051ca, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: b046050b01e425d4b937899facb6aaf4, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
     Stock: 2
-  - Item: {fileID: 684762946367608382, guid: 5020827e4b280bd4384aa06dda5649bd, type: 3}
+  - ItemName: 
+    Item: {fileID: 684762946367608382, guid: 5020827e4b280bd4384aa06dda5649bd, type: 3}
     Stock: 2
-  - Item: {fileID: 5347176894764292324, guid: 9901a08af652ad04dbbf4519ea57e575, type: 3}
+  - ItemName: 
+    Item: {fileID: 5347176894764292324, guid: 9901a08af652ad04dbbf4519ea57e575, type: 3}
     Stock: 2
-  - Item: {fileID: 6980020022460415521, guid: e00c6afc5648f951aac2a8d6dfcc4620, type: 3}
+  - ItemName: 
+    Item: {fileID: 6980020022460415521, guid: e00c6afc5648f951aac2a8d6dfcc4620, type: 3}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: 59b6ec971c7da824b83117e8faa53db3, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 59b6ec971c7da824b83117e8faa53db3, type: 3}
     Stock: 2
-  - Item: {fileID: 6804612781048497285, guid: 7783baf2677b3a844aff37585692717e, type: 3}
+  - ItemName: 
+    Item: {fileID: 6804612781048497285, guid: 7783baf2677b3a844aff37585692717e, type: 3}
     Stock: 2
-  - Item: {fileID: 3862752096800770460, guid: 5719a72c573a068478eaf6400b4f4c22, type: 3}
+  - ItemName: 
+    Item: {fileID: 3862752096800770460, guid: 5719a72c573a068478eaf6400b4f4c22, type: 3}
     Stock: 2
-  - Item: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
+  - ItemName: 
+    Item: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
     Stock: 2
-  - Item: {fileID: 6373161644663410599, guid: 47e758de6e8330e8ba5c0cf96801afa8, type: 3}
+  - ItemName: 
+    Item: {fileID: 6373161644663410599, guid: 47e758de6e8330e8ba5c0cf96801afa8, type: 3}
     Stock: 2
-  - Item: {fileID: 8684129920059976793, guid: 0010029d500bcc9469c05ec34573f8de, type: 3}
+  - ItemName: 
+    Item: {fileID: 8684129920059976793, guid: 0010029d500bcc9469c05ec34573f8de, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: 63587900698efce47a648bd987aef283, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 63587900698efce47a648bd987aef283, type: 3}
     Stock: 2
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/EngiDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/EngiDrobe.prefab
@@ -97,31 +97,44 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 3
-  - Item: {fileID: 2814261017750131953, guid: 3d586d5738df167469974943cd4a69ff, type: 3}
+  - ItemName: Industrial Duffel Bag
+    Item: {fileID: 2814261017750131953, guid: 3d586d5738df167469974943cd4a69ff, type: 3}
     Stock: 3
-  - Item: {fileID: 6527078367214184808, guid: 9ece9b1c0b01fa46ab120b1b423b1739, type: 3}
+  - ItemName: Industrial Backpack
+    Item: {fileID: 6527078367214184808, guid: 9ece9b1c0b01fa46ab120b1b423b1739, type: 3}
     Stock: 3
-  - Item: {fileID: 6682071155640065413, guid: 99480f95d67c6cc4c852e3e388dc70df, type: 3}
+  - ItemName: Industrial Satchel
+    Item: {fileID: 6682071155640065413, guid: 99480f95d67c6cc4c852e3e388dc70df, type: 3}
     Stock: 3
-  - Item: {fileID: 261889401176459054, guid: c432d0b09f765e440a39dea62e9a423e, type: 3}
+  - ItemName: Engineering Winter Coat
+    Item: {fileID: 261889401176459054, guid: c432d0b09f765e440a39dea62e9a423e, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: 669c8831af14a4225968399b65b23461, type: 3}
+  - ItemName: Engineers Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 669c8831af14a4225968399b65b23461, type: 3}
     Stock: 3
-  - Item: {fileID: 5068148558929777541, guid: cab0ec567d4192b4fb04ae3e9bcd3cbf, type: 3}
+  - ItemName: Engineers Jumpskirt
+    Item: {fileID: 5068148558929777541, guid: cab0ec567d4192b4fb04ae3e9bcd3cbf, type: 3}
     Stock: 3
-  - Item: {fileID: 7600537285617727737, guid: 0fb5b023412da224eb30c4702c2c22c2, type: 3}
+  - ItemName: Engineers Hazard Jumpsuit
+    Item: {fileID: 7600537285617727737, guid: 0fb5b023412da224eb30c4702c2c22c2, type: 3}
     Stock: 3
-  - Item: {fileID: 3921521694364753778, guid: 35cd853acdce0094f9462e049e31ed8e, type: 3}
+  - ItemName: Hazard Vest
+    Item: {fileID: 3921521694364753778, guid: 35cd853acdce0094f9462e049e31ed8e, type: 3}
     Stock: 3
-  - Item: {fileID: 7106618204054676533, guid: 67eaf03d3dc08490c85f77c1aedf4a15, type: 3}
+  - ItemName: Work Boots
+    Item: {fileID: 7106618204054676533, guid: 67eaf03d3dc08490c85f77c1aedf4a15, type: 3}
     Stock: 3
-  - Item: {fileID: 7636118406116123594, guid: 64e430f828cfc465ea88b8d6e6fecda4, type: 3}
+  - ItemName: Hard Hat
+    Item: {fileID: 7636118406116123594, guid: 64e430f828cfc465ea88b8d6e6fecda4, type: 3}
     Stock: 3
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 3
-  - Item: {fileID: 835768756810601639, guid: ce8ad09737e5d47c0876505a3366d37d, type: 3}
+  - ItemName: Engineering Headset
+    Item: {fileID: 835768756810601639, guid: ce8ad09737e5d47c0876505a3366d37d, type: 3}
     Stock: 3
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -130,31 +143,44 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 3
-  - Item: {fileID: 2814261017750131953, guid: 3d586d5738df167469974943cd4a69ff, type: 3}
+  - ItemName: 
+    Item: {fileID: 2814261017750131953, guid: 3d586d5738df167469974943cd4a69ff, type: 3}
     Stock: 3
-  - Item: {fileID: 6527078367214184808, guid: 9ece9b1c0b01fa46ab120b1b423b1739, type: 3}
+  - ItemName: 
+    Item: {fileID: 6527078367214184808, guid: 9ece9b1c0b01fa46ab120b1b423b1739, type: 3}
     Stock: 3
-  - Item: {fileID: 6682071155640065413, guid: 99480f95d67c6cc4c852e3e388dc70df, type: 3}
+  - ItemName: 
+    Item: {fileID: 6682071155640065413, guid: 99480f95d67c6cc4c852e3e388dc70df, type: 3}
     Stock: 3
-  - Item: {fileID: 261889401176459054, guid: c432d0b09f765e440a39dea62e9a423e, type: 3}
+  - ItemName: 
+    Item: {fileID: 261889401176459054, guid: c432d0b09f765e440a39dea62e9a423e, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: 669c8831af14a4225968399b65b23461, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 669c8831af14a4225968399b65b23461, type: 3}
     Stock: 3
-  - Item: {fileID: 5068148558929777541, guid: cab0ec567d4192b4fb04ae3e9bcd3cbf, type: 3}
+  - ItemName: 
+    Item: {fileID: 5068148558929777541, guid: cab0ec567d4192b4fb04ae3e9bcd3cbf, type: 3}
     Stock: 3
-  - Item: {fileID: 7600537285617727737, guid: 0fb5b023412da224eb30c4702c2c22c2, type: 3}
+  - ItemName: 
+    Item: {fileID: 7600537285617727737, guid: 0fb5b023412da224eb30c4702c2c22c2, type: 3}
     Stock: 3
-  - Item: {fileID: 3921521694364753778, guid: 35cd853acdce0094f9462e049e31ed8e, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 35cd853acdce0094f9462e049e31ed8e, type: 3}
     Stock: 3
-  - Item: {fileID: 7106618204054676533, guid: 67eaf03d3dc08490c85f77c1aedf4a15, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 67eaf03d3dc08490c85f77c1aedf4a15, type: 3}
     Stock: 3
-  - Item: {fileID: 7636118406116123594, guid: 64e430f828cfc465ea88b8d6e6fecda4, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 64e430f828cfc465ea88b8d6e6fecda4, type: 3}
     Stock: 3
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 3
-  - Item: {fileID: 835768756810601639, guid: ce8ad09737e5d47c0876505a3366d37d, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: ce8ad09737e5d47c0876505a3366d37d, type: 3}
     Stock: 3
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/GeneDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/GeneDrobe.prefab
@@ -97,21 +97,29 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 3011710637427380133, guid: 05d3054c3617b467ea8e086e2969e172, type: 3}
+  - ItemName: Geneticists Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 05d3054c3617b467ea8e086e2969e172, type: 3}
     Stock: 2
-  - Item: {fileID: 2283914521931275349, guid: a925b6dda477c1148bfd2997307dec63, type: 3}
+  - ItemName: Geneticisits Jumpskirt
+    Item: {fileID: 2283914521931275349, guid: a925b6dda477c1148bfd2997307dec63, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+  - ItemName: White Shoes
+    Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
     Stock: 2
-  - Item: {fileID: 7374481989050852271, guid: 1eabf8d0cc67b4d04926dd8eb07bf946, type: 3}
+  - ItemName: Genetics Labcoat
+    Item: {fileID: 7374481989050852271, guid: 1eabf8d0cc67b4d04926dd8eb07bf946, type: 3}
     Stock: 2
-  - Item: {fileID: 8541207335635205697, guid: 3eb130e231b60914a8b231815835140b, type: 3}
+  - ItemName: Genetics Backpack
+    Item: {fileID: 8541207335635205697, guid: 3eb130e231b60914a8b231815835140b, type: 3}
     Stock: 2
-  - Item: {fileID: 4322743953814334108, guid: 1bc887b434113ae4781d4604fb619175, type: 3}
+  - ItemName: Geneticist Satchel
+    Item: {fileID: 4322743953814334108, guid: 1bc887b434113ae4781d4604fb619175, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: 34a45eaa0bb60420f8e508486a85c92f, type: 3}
+  - ItemName: Genetics Headset
+    Item: {fileID: 835768756810601639, guid: 34a45eaa0bb60420f8e508486a85c92f, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -120,21 +128,29 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 3011710637427380133, guid: 05d3054c3617b467ea8e086e2969e172, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 05d3054c3617b467ea8e086e2969e172, type: 3}
     Stock: 2
-  - Item: {fileID: 2283914521931275349, guid: a925b6dda477c1148bfd2997307dec63, type: 3}
+  - ItemName: 
+    Item: {fileID: 2283914521931275349, guid: a925b6dda477c1148bfd2997307dec63, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
     Stock: 2
-  - Item: {fileID: 7374481989050852271, guid: 1eabf8d0cc67b4d04926dd8eb07bf946, type: 3}
+  - ItemName: 
+    Item: {fileID: 7374481989050852271, guid: 1eabf8d0cc67b4d04926dd8eb07bf946, type: 3}
     Stock: 2
-  - Item: {fileID: 8541207335635205697, guid: 3eb130e231b60914a8b231815835140b, type: 3}
+  - ItemName: 
+    Item: {fileID: 8541207335635205697, guid: 3eb130e231b60914a8b231815835140b, type: 3}
     Stock: 2
-  - Item: {fileID: 4322743953814334108, guid: 1bc887b434113ae4781d4604fb619175, type: 3}
+  - ItemName: 
+    Item: {fileID: 4322743953814334108, guid: 1bc887b434113ae4781d4604fb619175, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: 34a45eaa0bb60420f8e508486a85c92f, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: 34a45eaa0bb60420f8e508486a85c92f, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/Hydrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/Hydrobe.prefab
@@ -96,31 +96,44 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 5002772168956495688, guid: d43607a44ab318a4b8d4c67c1d1be07b, type: 3}
+  - ItemName: Botany Backpack
+    Item: {fileID: 5002772168956495688, guid: d43607a44ab318a4b8d4c67c1d1be07b, type: 3}
     Stock: 2
-  - Item: {fileID: 4939012316700738046, guid: bf31902c0ee77334baa8871ced8aa3e5, type: 3}
+  - ItemName: Bonanist Satchel
+    Item: {fileID: 4939012316700738046, guid: bf31902c0ee77334baa8871ced8aa3e5, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 2152560991686967986, guid: 235c4b516e37ca441a0a0d9763f7f152, type: 3}
+  - ItemName: Hydroponics Winter Coat
+    Item: {fileID: 2152560991686967986, guid: 235c4b516e37ca441a0a0d9763f7f152, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: 34840ba56d91a4e4bb5c615fe3c2b1f3, type: 3}
+  - ItemName: Apron
+    Item: {fileID: 3921521694364753778, guid: 34840ba56d91a4e4bb5c615fe3c2b1f3, type: 3}
     Stock: 3
-  - Item: {fileID: 2376803533225964856, guid: 62d22c2cb38aaac43a7aa56d55e3d14f, type: 3}
+  - ItemName: Coveralls
+    Item: {fileID: 2376803533225964856, guid: 62d22c2cb38aaac43a7aa56d55e3d14f, type: 3}
     Stock: 3
-  - Item: {fileID: 3294504280138469786, guid: 64f782a949afec64f84132ffb98b2a58, type: 3}
+  - ItemName: Horticultural Waders
+    Item: {fileID: 3294504280138469786, guid: 64f782a949afec64f84132ffb98b2a58, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: 489cb478de43746cda8af4fd63be9282, type: 3}
+  - ItemName: Botanists Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 489cb478de43746cda8af4fd63be9282, type: 3}
     Stock: 3
-  - Item: {fileID: 1706925151317036771, guid: f10fbf4f4a9d423449ef84f1a38684b1, type: 3}
+  - ItemName: Botanists Jumpskirt
+    Item: {fileID: 1706925151317036771, guid: f10fbf4f4a9d423449ef84f1a38684b1, type: 3}
     Stock: 3
-  - Item: {fileID: 6404652678407139925, guid: ff09e60d118a31e478d827be7faa2f0b, type: 3}
+  - ItemName: Botany Bandana
+    Item: {fileID: 6404652678407139925, guid: ff09e60d118a31e478d827be7faa2f0b, type: 3}
     Stock: 3
-  - Item: {fileID: 6373161644663410599, guid: 676cb7a2be9be4f458d53d0a197a35cd, type: 3}
+  - ItemName: Botanists Leather Gloves
+    Item: {fileID: 6373161644663410599, guid: 676cb7a2be9be4f458d53d0a197a35cd, type: 3}
     Stock: 3
-  - Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
+  - ItemName: Service Headset
+    Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
     Stock: 3
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 3
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -129,31 +142,44 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 5002772168956495688, guid: d43607a44ab318a4b8d4c67c1d1be07b, type: 3}
+  - ItemName: 
+    Item: {fileID: 5002772168956495688, guid: d43607a44ab318a4b8d4c67c1d1be07b, type: 3}
     Stock: 2
-  - Item: {fileID: 4939012316700738046, guid: bf31902c0ee77334baa8871ced8aa3e5, type: 3}
+  - ItemName: 
+    Item: {fileID: 4939012316700738046, guid: bf31902c0ee77334baa8871ced8aa3e5, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 2152560991686967986, guid: 235c4b516e37ca441a0a0d9763f7f152, type: 3}
+  - ItemName: 
+    Item: {fileID: 2152560991686967986, guid: 235c4b516e37ca441a0a0d9763f7f152, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: 34840ba56d91a4e4bb5c615fe3c2b1f3, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 34840ba56d91a4e4bb5c615fe3c2b1f3, type: 3}
     Stock: 3
-  - Item: {fileID: 2376803533225964856, guid: 62d22c2cb38aaac43a7aa56d55e3d14f, type: 3}
+  - ItemName: 
+    Item: {fileID: 2376803533225964856, guid: 62d22c2cb38aaac43a7aa56d55e3d14f, type: 3}
     Stock: 3
-  - Item: {fileID: 3294504280138469786, guid: 64f782a949afec64f84132ffb98b2a58, type: 3}
+  - ItemName: 
+    Item: {fileID: 3294504280138469786, guid: 64f782a949afec64f84132ffb98b2a58, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: 489cb478de43746cda8af4fd63be9282, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 489cb478de43746cda8af4fd63be9282, type: 3}
     Stock: 3
-  - Item: {fileID: 1706925151317036771, guid: f10fbf4f4a9d423449ef84f1a38684b1, type: 3}
+  - ItemName: 
+    Item: {fileID: 1706925151317036771, guid: f10fbf4f4a9d423449ef84f1a38684b1, type: 3}
     Stock: 3
-  - Item: {fileID: 6404652678407139925, guid: ff09e60d118a31e478d827be7faa2f0b, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: ff09e60d118a31e478d827be7faa2f0b, type: 3}
     Stock: 3
-  - Item: {fileID: 6373161644663410599, guid: 676cb7a2be9be4f458d53d0a197a35cd, type: 3}
+  - ItemName: 
+    Item: {fileID: 6373161644663410599, guid: 676cb7a2be9be4f458d53d0a197a35cd, type: 3}
     Stock: 3
-  - Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
     Stock: 3
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 3
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/JaniDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/JaniDrobe.prefab
@@ -97,43 +97,62 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 3011710637427380133, guid: 8fd881065be8b411d84cfc10b38be725, type: 3}
+  - ItemName: Janitors Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 8fd881065be8b411d84cfc10b38be725, type: 3}
     Stock: 2
-  - Item: {fileID: 4011149429169960813, guid: cad85b5dad5b95d468fc34d2c6a01947, type: 3}
+  - ItemName: Janitos Jumpskirt
+    Item: {fileID: 4011149429169960813, guid: cad85b5dad5b95d468fc34d2c6a01947, type: 3}
     Stock: 2
-  - Item: {fileID: 2502055301998392637, guid: d77ca13e6df71a4468e5a524d3c698bc, type: 3}
+  - ItemName: Maid Uniform
+    Item: {fileID: 2502055301998392637, guid: d77ca13e6df71a4468e5a524d3c698bc, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
+  - ItemName: Black Gloves
+    Item: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
     Stock: 2
-  - Item: {fileID: 1454153603153415932, guid: bcf175e4b2e739a47a94808c336aaa33, type: 3}
+  - ItemName: Purple Cap
+    Item: {fileID: 1454153603153415932, guid: bcf175e4b2e739a47a94808c336aaa33, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 7781396554342910705, guid: bffa4f7b47979d445854af572064d36b, type: 3}
+  - ItemName: Fly Swatter
+    Item: {fileID: 7781396554342910705, guid: bffa4f7b47979d445854af572064d36b, type: 3}
     Stock: 2
-  - Item: {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb, type: 3}
+  - ItemName: Flash Light
+    Item: {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb, type: 3}
     Stock: 2
-  - Item: {fileID: 2419386692754613975, guid: 6603caafe8df84b4da1c797343cdf8c6, type: 3}
+  - ItemName: Wet Floor Sign
+    Item: {fileID: 2419386692754613975, guid: 6603caafe8df84b4da1c797343cdf8c6, type: 3}
     Stock: 6
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 6694482156107280369, guid: f9e1c882fbe2384428dd2e8cca1f375c, type: 3}
+  - ItemName: Soap Nanotrasen
+    Item: {fileID: 6694482156107280369, guid: f9e1c882fbe2384428dd2e8cca1f375c, type: 3}
     Stock: 2
-  - Item: {fileID: 359432221073519209, guid: 4dddcb74ff9a3ee4ca69bc6d757dca03, type: 3}
+  - ItemName: Trash Bag
+    Item: {fileID: 359432221073519209, guid: 4dddcb74ff9a3ee4ca69bc6d757dca03, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 7a2370ed5124e4897ba86392a2d9052b, type: 3}
+  - ItemName: Golashes
+    Item: {fileID: 7106618204054676533, guid: 7a2370ed5124e4897ba86392a2d9052b, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 1069655924402247308, guid: 43a2f25b1176348c68d5d896d48d2fc6, type: 3}
+  - ItemName: Janitor Belt Full
+    Item: {fileID: 1069655924402247308, guid: 43a2f25b1176348c68d5d896d48d2fc6, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
+  - ItemName: Service Headset
+    Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
     Stock: 2
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -142,43 +161,62 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 3011710637427380133, guid: 8fd881065be8b411d84cfc10b38be725, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 8fd881065be8b411d84cfc10b38be725, type: 3}
     Stock: 2
-  - Item: {fileID: 4011149429169960813, guid: cad85b5dad5b95d468fc34d2c6a01947, type: 3}
+  - ItemName: 
+    Item: {fileID: 4011149429169960813, guid: cad85b5dad5b95d468fc34d2c6a01947, type: 3}
     Stock: 2
-  - Item: {fileID: 2502055301998392637, guid: d77ca13e6df71a4468e5a524d3c698bc, type: 3}
+  - ItemName: 
+    Item: {fileID: 2502055301998392637, guid: d77ca13e6df71a4468e5a524d3c698bc, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
+  - ItemName: 
+    Item: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
     Stock: 2
-  - Item: {fileID: 1454153603153415932, guid: bcf175e4b2e739a47a94808c336aaa33, type: 3}
+  - ItemName: 
+    Item: {fileID: 1454153603153415932, guid: bcf175e4b2e739a47a94808c336aaa33, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 7781396554342910705, guid: bffa4f7b47979d445854af572064d36b, type: 3}
+  - ItemName: 
+    Item: {fileID: 7781396554342910705, guid: bffa4f7b47979d445854af572064d36b, type: 3}
     Stock: 2
-  - Item: {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb, type: 3}
+  - ItemName: 
+    Item: {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb, type: 3}
     Stock: 2
-  - Item: {fileID: 2419386692754613975, guid: 6603caafe8df84b4da1c797343cdf8c6, type: 3}
+  - ItemName: 
+    Item: {fileID: 2419386692754613975, guid: 6603caafe8df84b4da1c797343cdf8c6, type: 3}
     Stock: 6
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 6694482156107280369, guid: f9e1c882fbe2384428dd2e8cca1f375c, type: 3}
+  - ItemName: 
+    Item: {fileID: 6694482156107280369, guid: f9e1c882fbe2384428dd2e8cca1f375c, type: 3}
     Stock: 2
-  - Item: {fileID: 359432221073519209, guid: 4dddcb74ff9a3ee4ca69bc6d757dca03, type: 3}
+  - ItemName: 
+    Item: {fileID: 359432221073519209, guid: 4dddcb74ff9a3ee4ca69bc6d757dca03, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 7a2370ed5124e4897ba86392a2d9052b, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 7a2370ed5124e4897ba86392a2d9052b, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 1069655924402247308, guid: 43a2f25b1176348c68d5d896d48d2fc6, type: 3}
+  - ItemName: 
+    Item: {fileID: 1069655924402247308, guid: 43a2f25b1176348c68d5d896d48d2fc6, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: 357fbde8e937c49c6b4e0b33e089eb89, type: 3}
     Stock: 2
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/LawDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/LawDrobe.prefab
@@ -97,55 +97,80 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 5044818797694645434, guid: 65eab09d2aab23342a31649bae60bc93, type: 3}
+  - ItemName: Leather Satchel
+    Item: {fileID: 5044818797694645434, guid: 65eab09d2aab23342a31649bae60bc93, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 1992656631147830107, guid: 6861c2a7b893541488ad7e9e51c4d119, type: 3}
+  - ItemName: Blue Suit
+    Item: {fileID: 1992656631147830107, guid: 6861c2a7b893541488ad7e9e51c4d119, type: 3}
     Stock: 1
-  - Item: {fileID: 4427291013977649474, guid: 4b9b555f5b302244fb1235845e92dc3f, type: 3}
+  - ItemName: Blue Suit Skirt
+    Item: {fileID: 4427291013977649474, guid: 4b9b555f5b302244fb1235845e92dc3f, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: c6a7074451cf5634783832221e9b8e75, type: 3}
+  - ItemName: Blue Suit Jacket
+    Item: {fileID: 3921521694364753778, guid: c6a7074451cf5634783832221e9b8e75, type: 3}
     Stock: 1
-  - Item: {fileID: 2262651372276479178, guid: e585654aca660b04298c0256d0f33b3c, type: 3}
+  - ItemName: Purple Suit
+    Item: {fileID: 2262651372276479178, guid: e585654aca660b04298c0256d0f33b3c, type: 3}
     Stock: 1
-  - Item: {fileID: 8701009116104039739, guid: 0a933270d4c4d6545b3e7043f324a84a, type: 3}
+  - ItemName: Purple Suit Skirt
+    Item: {fileID: 8701009116104039739, guid: 0a933270d4c4d6545b3e7043f324a84a, type: 3}
     Stock: 1
-  - Item: {fileID: 5465670587632719396, guid: ee492cd2d07eb1848a6b1bb6325f5602, type: 3}
+  - ItemName: Purple Suit Jacket
+    Item: {fileID: 5465670587632719396, guid: ee492cd2d07eb1848a6b1bb6325f5602, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: dff9b7e8f22ff9b4cb9e2f035702e875, type: 3}
+  - ItemName: Black Suit
+    Item: {fileID: 3011710637427380133, guid: dff9b7e8f22ff9b4cb9e2f035702e875, type: 3}
     Stock: 1
-  - Item: {fileID: 1268281847278913779, guid: 73a102ba242379c4b92c25800ea7976a, type: 3}
+  - ItemName: Black Suit Skirt
+    Item: {fileID: 1268281847278913779, guid: 73a102ba242379c4b92c25800ea7976a, type: 3}
     Stock: 1
-  - Item: {fileID: 8147068681370657815, guid: 2c0b855ad3ee093408a42685b3407613, type: 3}
+  - ItemName: Black Suit Jacket
+    Item: {fileID: 8147068681370657815, guid: 2c0b855ad3ee093408a42685b3407613, type: 3}
     Stock: 1
-  - Item: {fileID: 2424092949808625863, guid: cc8ff9ea40dc642448c2ff8860ac2c9b, type: 3}
+  - ItemName: Female Black Suit
+    Item: {fileID: 2424092949808625863, guid: cc8ff9ea40dc642448c2ff8860ac2c9b, type: 3}
     Stock: 1
-  - Item: {fileID: 8616276870168769456, guid: eac3e67aff750324182932333b7a3624, type: 3}
+  - ItemName: Female Black Suit Skirt
+    Item: {fileID: 8616276870168769456, guid: eac3e67aff750324182932333b7a3624, type: 3}
     Stock: 1
-  - Item: {fileID: 6179510555677923175, guid: 119a19b7af9f24a4eae413817fdef76d, type: 3}
+  - ItemName: Executive Suit
+    Item: {fileID: 6179510555677923175, guid: 119a19b7af9f24a4eae413817fdef76d, type: 3}
     Stock: 1
-  - Item: {fileID: 2560471778974185141, guid: 48c00b66f5992a24286217287c104f4b, type: 3}
+  - ItemName: Executive Suit Skirt
+    Item: {fileID: 2560471778974185141, guid: 48c00b66f5992a24286217287c104f4b, type: 3}
     Stock: 1
-  - Item: {fileID: 4262665523380157268, guid: 9e1795c845a20134abc7b0eed8f2f750, type: 3}
+  - ItemName: Lawyer Blue Suit
+    Item: {fileID: 4262665523380157268, guid: 9e1795c845a20134abc7b0eed8f2f750, type: 3}
     Stock: 1
-  - Item: {fileID: 6140895010394082659, guid: 02bec04043bbbea48b517d42f7df674f, type: 3}
+  - ItemName: Lawyer Blue Suit Skirt
+    Item: {fileID: 6140895010394082659, guid: 02bec04043bbbea48b517d42f7df674f, type: 3}
     Stock: 1
-  - Item: {fileID: 4947012438125509461, guid: 06e70572528debe4cadc549115f1443c, type: 3}
+  - ItemName: Lawyer Red Suit
+    Item: {fileID: 4947012438125509461, guid: 06e70572528debe4cadc549115f1443c, type: 3}
     Stock: 1
-  - Item: {fileID: 3164486558502274994, guid: 13d2153fed29afa47936895ab1fe27fe, type: 3}
+  - ItemName: Lawyer Red Suit Skirt
+    Item: {fileID: 3164486558502274994, guid: 13d2153fed29afa47936895ab1fe27fe, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 6e6c876b4d53442588042c04884308f2, type: 3}
+  - ItemName: Lawyer Black Suit
+    Item: {fileID: 3011710637427380133, guid: 6e6c876b4d53442588042c04884308f2, type: 3}
     Stock: 1
-  - Item: {fileID: 5502800332140862390, guid: 45c3cbada4660604e8fb72afd758c4e2, type: 3}
+  - ItemName: Lawyer Black Suit Skirt
+    Item: {fileID: 5502800332140862390, guid: 45c3cbada4660604e8fb72afd758c4e2, type: 3}
     Stock: 1
-  - Item: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
+  - ItemName: Laceup Shoes
+    Item: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
     Stock: 2
-  - Item: {fileID: 3708231617607487601, guid: dcb36ae56960eb34a8988e485be4515e, type: 3}
+  - ItemName: Lawyer Headset
+    Item: {fileID: 3708231617607487601, guid: dcb36ae56960eb34a8988e485be4515e, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -154,55 +179,80 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 5044818797694645434, guid: 65eab09d2aab23342a31649bae60bc93, type: 3}
+  - ItemName: 
+    Item: {fileID: 5044818797694645434, guid: 65eab09d2aab23342a31649bae60bc93, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 1
-  - Item: {fileID: 1992656631147830107, guid: 6861c2a7b893541488ad7e9e51c4d119, type: 3}
+  - ItemName: 
+    Item: {fileID: 1992656631147830107, guid: 6861c2a7b893541488ad7e9e51c4d119, type: 3}
     Stock: 1
-  - Item: {fileID: 4427291013977649474, guid: 4b9b555f5b302244fb1235845e92dc3f, type: 3}
+  - ItemName: 
+    Item: {fileID: 4427291013977649474, guid: 4b9b555f5b302244fb1235845e92dc3f, type: 3}
     Stock: 1
-  - Item: {fileID: 3921521694364753778, guid: c6a7074451cf5634783832221e9b8e75, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: c6a7074451cf5634783832221e9b8e75, type: 3}
     Stock: 1
-  - Item: {fileID: 2262651372276479178, guid: e585654aca660b04298c0256d0f33b3c, type: 3}
+  - ItemName: 
+    Item: {fileID: 2262651372276479178, guid: e585654aca660b04298c0256d0f33b3c, type: 3}
     Stock: 1
-  - Item: {fileID: 8701009116104039739, guid: 0a933270d4c4d6545b3e7043f324a84a, type: 3}
+  - ItemName: 
+    Item: {fileID: 8701009116104039739, guid: 0a933270d4c4d6545b3e7043f324a84a, type: 3}
     Stock: 1
-  - Item: {fileID: 5465670587632719396, guid: ee492cd2d07eb1848a6b1bb6325f5602, type: 3}
+  - ItemName: 
+    Item: {fileID: 5465670587632719396, guid: ee492cd2d07eb1848a6b1bb6325f5602, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: dff9b7e8f22ff9b4cb9e2f035702e875, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: dff9b7e8f22ff9b4cb9e2f035702e875, type: 3}
     Stock: 1
-  - Item: {fileID: 1268281847278913779, guid: 73a102ba242379c4b92c25800ea7976a, type: 3}
+  - ItemName: 
+    Item: {fileID: 1268281847278913779, guid: 73a102ba242379c4b92c25800ea7976a, type: 3}
     Stock: 1
-  - Item: {fileID: 8147068681370657815, guid: 2c0b855ad3ee093408a42685b3407613, type: 3}
+  - ItemName: 
+    Item: {fileID: 8147068681370657815, guid: 2c0b855ad3ee093408a42685b3407613, type: 3}
     Stock: 1
-  - Item: {fileID: 2424092949808625863, guid: cc8ff9ea40dc642448c2ff8860ac2c9b, type: 3}
+  - ItemName: 
+    Item: {fileID: 2424092949808625863, guid: cc8ff9ea40dc642448c2ff8860ac2c9b, type: 3}
     Stock: 1
-  - Item: {fileID: 8616276870168769456, guid: eac3e67aff750324182932333b7a3624, type: 3}
+  - ItemName: 
+    Item: {fileID: 8616276870168769456, guid: eac3e67aff750324182932333b7a3624, type: 3}
     Stock: 1
-  - Item: {fileID: 6179510555677923175, guid: 119a19b7af9f24a4eae413817fdef76d, type: 3}
+  - ItemName: 
+    Item: {fileID: 6179510555677923175, guid: 119a19b7af9f24a4eae413817fdef76d, type: 3}
     Stock: 1
-  - Item: {fileID: 2560471778974185141, guid: 48c00b66f5992a24286217287c104f4b, type: 3}
+  - ItemName: 
+    Item: {fileID: 2560471778974185141, guid: 48c00b66f5992a24286217287c104f4b, type: 3}
     Stock: 1
-  - Item: {fileID: 4262665523380157268, guid: 9e1795c845a20134abc7b0eed8f2f750, type: 3}
+  - ItemName: 
+    Item: {fileID: 4262665523380157268, guid: 9e1795c845a20134abc7b0eed8f2f750, type: 3}
     Stock: 1
-  - Item: {fileID: 6140895010394082659, guid: 02bec04043bbbea48b517d42f7df674f, type: 3}
+  - ItemName: 
+    Item: {fileID: 6140895010394082659, guid: 02bec04043bbbea48b517d42f7df674f, type: 3}
     Stock: 1
-  - Item: {fileID: 4947012438125509461, guid: 06e70572528debe4cadc549115f1443c, type: 3}
+  - ItemName: 
+    Item: {fileID: 4947012438125509461, guid: 06e70572528debe4cadc549115f1443c, type: 3}
     Stock: 1
-  - Item: {fileID: 3164486558502274994, guid: 13d2153fed29afa47936895ab1fe27fe, type: 3}
+  - ItemName: 
+    Item: {fileID: 3164486558502274994, guid: 13d2153fed29afa47936895ab1fe27fe, type: 3}
     Stock: 1
-  - Item: {fileID: 3011710637427380133, guid: 6e6c876b4d53442588042c04884308f2, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 6e6c876b4d53442588042c04884308f2, type: 3}
     Stock: 1
-  - Item: {fileID: 5502800332140862390, guid: 45c3cbada4660604e8fb72afd758c4e2, type: 3}
+  - ItemName: 
+    Item: {fileID: 5502800332140862390, guid: 45c3cbada4660604e8fb72afd758c4e2, type: 3}
     Stock: 1
-  - Item: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 3e5e43af50c3e4b2d9b5e5ccbbde3ea2, type: 3}
     Stock: 2
-  - Item: {fileID: 3708231617607487601, guid: dcb36ae56960eb34a8988e485be4515e, type: 3}
+  - ItemName: 
+    Item: {fileID: 3708231617607487601, guid: dcb36ae56960eb34a8988e485be4515e, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/MediDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/MediDrobe.prefab
@@ -97,51 +97,74 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 6700281191928912403, guid: 0ad6b406825f747548ae2f66be19e5bd, type: 3}
+  - ItemName: Medical Belt
+    Item: {fileID: 6700281191928912403, guid: 0ad6b406825f747548ae2f66be19e5bd, type: 3}
     Stock: 4
-  - Item: {fileID: 3961673132676458627, guid: c57257234670e0e44a8b4f2b83801b45, type: 3}
+  - ItemName: Stehoscope
+    Item: {fileID: 3961673132676458627, guid: c57257234670e0e44a8b4f2b83801b45, type: 3}
     Stock: 4
-  - Item: {fileID: 7425210154282081895, guid: c271fd63aa2bed245926cf071649e942, type: 3}
+  - ItemName: Medical Duffel Bag
+    Item: {fileID: 7425210154282081895, guid: c271fd63aa2bed245926cf071649e942, type: 3}
     Stock: 4
-  - Item: {fileID: 6247235260549825398, guid: d3d13a092fe1468f39f64019ed6cda47, type: 3}
+  - ItemName: Medical Backpack
+    Item: {fileID: 6247235260549825398, guid: d3d13a092fe1468f39f64019ed6cda47, type: 3}
     Stock: 4
-  - Item: {fileID: 6220654682088235423, guid: 14f12e8e60a402947a0ce63c3cb12501, type: 3}
+  - ItemName: Medical Satchel
+    Item: {fileID: 6220654682088235423, guid: 14f12e8e60a402947a0ce63c3cb12501, type: 3}
     Stock: 4
-  - Item: {fileID: 6132127289375276769, guid: f27991fd74b5f6941a1ad2f9e161a022, type: 3}
+  - ItemName: Medical Winter Coat
+    Item: {fileID: 6132127289375276769, guid: f27991fd74b5f6941a1ad2f9e161a022, type: 3}
     Stock: 4
-  - Item: {fileID: 3011710637427380133, guid: 604161a1d792749539a5f1b0eb6e4749, type: 3}
+  - ItemName: Medical Doctors Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 604161a1d792749539a5f1b0eb6e4749, type: 3}
     Stock: 4
-  - Item: {fileID: 5920421737069179531, guid: 4d0474175ab0fcc49acc7daf8c3dc271, type: 3}
+  - ItemName: Medical Doctors Jumpskirt
+    Item: {fileID: 5920421737069179531, guid: 4d0474175ab0fcc49acc7daf8c3dc271, type: 3}
     Stock: 4
-  - Item: {fileID: 3011710637427380133, guid: 091e9109cd71d5c4f9760883e85fe866, type: 3}
+  - ItemName: Paramedics Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 091e9109cd71d5c4f9760883e85fe866, type: 3}
     Stock: 4
-  - Item: {fileID: 8711982915321370836, guid: d3017b0e77acb7a4698a95281de92f44, type: 3}
+  - ItemName: Paramedics Jumpskirt
+    Item: {fileID: 8711982915321370836, guid: d3017b0e77acb7a4698a95281de92f44, type: 3}
     Stock: 4
-  - Item: {fileID: 5628543767998948467, guid: c36814fb35b346c4bb4c655939943986, type: 3}
+  - ItemName: Nurse Dress
+    Item: {fileID: 5628543767998948467, guid: c36814fb35b346c4bb4c655939943986, type: 3}
     Stock: 4
-  - Item: {fileID: 7636118406116123594, guid: bb118b34602036247a9e597743e4e0a4, type: 3}
+  - ItemName: Nurse Hat
+    Item: {fileID: 7636118406116123594, guid: bb118b34602036247a9e597743e4e0a4, type: 3}
     Stock: 4
-  - Item: {fileID: 1853682798720230140, guid: 42b8312937564f84ca906c22a8aa23b7, type: 3}
+  - ItemName: Medical Scrubs Blue
+    Item: {fileID: 1853682798720230140, guid: 42b8312937564f84ca906c22a8aa23b7, type: 3}
     Stock: 4
-  - Item: {fileID: 1853682798720230140, guid: b7293f2ee1e4b5b408a9c76ca1f03f0a, type: 3}
+  - ItemName: Medical Scrubs Green
+    Item: {fileID: 1853682798720230140, guid: b7293f2ee1e4b5b408a9c76ca1f03f0a, type: 3}
     Stock: 4
-  - Item: {fileID: 1853682798720230140, guid: 1c4a4e2e7d6a9ce4e9135ceb57d872b8, type: 3}
+  - ItemName: Medical Scrubs Purple
+    Item: {fileID: 1853682798720230140, guid: 1c4a4e2e7d6a9ce4e9135ceb57d872b8, type: 3}
     Stock: 4
-  - Item: {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226, type: 3}
+  - ItemName: Labcoat
+    Item: {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226, type: 3}
     Stock: 4
-  - Item: {fileID: 7950450905082407941, guid: ae6a4b707a3e192449843e8b3196b67c, type: 3}
+  - ItemName: Paramedic Jacket
+    Item: {fileID: 7950450905082407941, guid: ae6a4b707a3e192449843e8b3196b67c, type: 3}
     Stock: 4
-  - Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+  - ItemName: White Shoes
+    Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
     Stock: 4
-  - Item: {fileID: 7106618204054676533, guid: 7ca9937224493ae47be250db23caef24, type: 3}
+  - ItemName: Blue Shoes
+    Item: {fileID: 7106618204054676533, guid: 7ca9937224493ae47be250db23caef24, type: 3}
     Stock: 4
-  - Item: {fileID: 2877682655692791251, guid: 9818845d510044c45878180a25f836b7, type: 3}
+  - ItemName: Paramedic Cap
+    Item: {fileID: 2877682655692791251, guid: 9818845d510044c45878180a25f836b7, type: 3}
     Stock: 4
-  - Item: {fileID: 4017285472711692952, guid: 1d20e3f3f09719d46870ba3554189ec1, type: 3}
+  - ItemName: Surgical Apron
+    Item: {fileID: 4017285472711692952, guid: 1d20e3f3f09719d46870ba3554189ec1, type: 3}
     Stock: 4
-  - Item: {fileID: 6404652678407139925, guid: e9076ebebbcd65e56b189cd1a837d018, type: 3}
+  - ItemName: Sterile Mask
+    Item: {fileID: 6404652678407139925, guid: e9076ebebbcd65e56b189cd1a837d018, type: 3}
     Stock: 4
-  - Item: {fileID: 835768756810601639, guid: cad7d826b673041f5b2b4d9b9d64aa09, type: 3}
+  - ItemName: Medical Headset
+    Item: {fileID: 835768756810601639, guid: cad7d826b673041f5b2b4d9b9d64aa09, type: 3}
     Stock: 4
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -150,51 +173,74 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 6700281191928912403, guid: 0ad6b406825f747548ae2f66be19e5bd, type: 3}
+  - ItemName: 
+    Item: {fileID: 6700281191928912403, guid: 0ad6b406825f747548ae2f66be19e5bd, type: 3}
     Stock: 4
-  - Item: {fileID: 3961673132676458627, guid: c57257234670e0e44a8b4f2b83801b45, type: 3}
+  - ItemName: 
+    Item: {fileID: 3961673132676458627, guid: c57257234670e0e44a8b4f2b83801b45, type: 3}
     Stock: 4
-  - Item: {fileID: 7425210154282081895, guid: c271fd63aa2bed245926cf071649e942, type: 3}
+  - ItemName: 
+    Item: {fileID: 7425210154282081895, guid: c271fd63aa2bed245926cf071649e942, type: 3}
     Stock: 4
-  - Item: {fileID: 6247235260549825398, guid: d3d13a092fe1468f39f64019ed6cda47, type: 3}
+  - ItemName: 
+    Item: {fileID: 6247235260549825398, guid: d3d13a092fe1468f39f64019ed6cda47, type: 3}
     Stock: 4
-  - Item: {fileID: 6220654682088235423, guid: 14f12e8e60a402947a0ce63c3cb12501, type: 3}
+  - ItemName: 
+    Item: {fileID: 6220654682088235423, guid: 14f12e8e60a402947a0ce63c3cb12501, type: 3}
     Stock: 4
-  - Item: {fileID: 6132127289375276769, guid: f27991fd74b5f6941a1ad2f9e161a022, type: 3}
+  - ItemName: 
+    Item: {fileID: 6132127289375276769, guid: f27991fd74b5f6941a1ad2f9e161a022, type: 3}
     Stock: 4
-  - Item: {fileID: 3011710637427380133, guid: 604161a1d792749539a5f1b0eb6e4749, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 604161a1d792749539a5f1b0eb6e4749, type: 3}
     Stock: 4
-  - Item: {fileID: 5920421737069179531, guid: 4d0474175ab0fcc49acc7daf8c3dc271, type: 3}
+  - ItemName: 
+    Item: {fileID: 5920421737069179531, guid: 4d0474175ab0fcc49acc7daf8c3dc271, type: 3}
     Stock: 4
-  - Item: {fileID: 3011710637427380133, guid: 091e9109cd71d5c4f9760883e85fe866, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 091e9109cd71d5c4f9760883e85fe866, type: 3}
     Stock: 4
-  - Item: {fileID: 8711982915321370836, guid: d3017b0e77acb7a4698a95281de92f44, type: 3}
+  - ItemName: 
+    Item: {fileID: 8711982915321370836, guid: d3017b0e77acb7a4698a95281de92f44, type: 3}
     Stock: 4
-  - Item: {fileID: 5628543767998948467, guid: c36814fb35b346c4bb4c655939943986, type: 3}
+  - ItemName: 
+    Item: {fileID: 5628543767998948467, guid: c36814fb35b346c4bb4c655939943986, type: 3}
     Stock: 4
-  - Item: {fileID: 7636118406116123594, guid: bb118b34602036247a9e597743e4e0a4, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: bb118b34602036247a9e597743e4e0a4, type: 3}
     Stock: 4
-  - Item: {fileID: 1853682798720230140, guid: 42b8312937564f84ca906c22a8aa23b7, type: 3}
+  - ItemName: 
+    Item: {fileID: 1853682798720230140, guid: 42b8312937564f84ca906c22a8aa23b7, type: 3}
     Stock: 4
-  - Item: {fileID: 1853682798720230140, guid: b7293f2ee1e4b5b408a9c76ca1f03f0a, type: 3}
+  - ItemName: 
+    Item: {fileID: 1853682798720230140, guid: b7293f2ee1e4b5b408a9c76ca1f03f0a, type: 3}
     Stock: 4
-  - Item: {fileID: 1853682798720230140, guid: 1c4a4e2e7d6a9ce4e9135ceb57d872b8, type: 3}
+  - ItemName: 
+    Item: {fileID: 1853682798720230140, guid: 1c4a4e2e7d6a9ce4e9135ceb57d872b8, type: 3}
     Stock: 4
-  - Item: {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226, type: 3}
     Stock: 4
-  - Item: {fileID: 7950450905082407941, guid: ae6a4b707a3e192449843e8b3196b67c, type: 3}
+  - ItemName: 
+    Item: {fileID: 7950450905082407941, guid: ae6a4b707a3e192449843e8b3196b67c, type: 3}
     Stock: 4
-  - Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
     Stock: 4
-  - Item: {fileID: 7106618204054676533, guid: 7ca9937224493ae47be250db23caef24, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 7ca9937224493ae47be250db23caef24, type: 3}
     Stock: 4
-  - Item: {fileID: 2877682655692791251, guid: 9818845d510044c45878180a25f836b7, type: 3}
+  - ItemName: 
+    Item: {fileID: 2877682655692791251, guid: 9818845d510044c45878180a25f836b7, type: 3}
     Stock: 4
-  - Item: {fileID: 4017285472711692952, guid: 1d20e3f3f09719d46870ba3554189ec1, type: 3}
+  - ItemName: 
+    Item: {fileID: 4017285472711692952, guid: 1d20e3f3f09719d46870ba3554189ec1, type: 3}
     Stock: 4
-  - Item: {fileID: 6404652678407139925, guid: e9076ebebbcd65e56b189cd1a837d018, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: e9076ebebbcd65e56b189cd1a837d018, type: 3}
     Stock: 4
-  - Item: {fileID: 835768756810601639, guid: cad7d826b673041f5b2b4d9b9d64aa09, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: cad7d826b673041f5b2b4d9b9d64aa09, type: 3}
     Stock: 4
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/RoboDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/RoboDrobe.prefab
@@ -97,31 +97,44 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: 2a2d871db32f24302b1aeb03f3652c48, type: 3}
+  - ItemName: Roboticists Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 2a2d871db32f24302b1aeb03f3652c48, type: 3}
     Stock: 2
-  - Item: {fileID: 6710415053653577436, guid: 676e9af4e37de5645a97d7ad338cfcef, type: 3}
+  - ItemName: Roboticists Jumpskirt
+    Item: {fileID: 6710415053653577436, guid: 676e9af4e37de5645a97d7ad338cfcef, type: 3}
     Stock: 2
-  - Item: {fileID: 4890432691518747385, guid: 430362c2798d81c43aca26b9da3f19b4, type: 3}
+  - ItemName: Roboticists Overalls
+    Item: {fileID: 4890432691518747385, guid: 430362c2798d81c43aca26b9da3f19b4, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226, type: 3}
+  - ItemName: Labcoat
+    Item: {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
+  - ItemName: Black Shoes
+    Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
     Stock: 2
-  - Item: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26, type: 3}
+  - ItemName: Fingerless Gloves
+    Item: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26, type: 3}
     Stock: 2
-  - Item: {fileID: 3116170454584013683, guid: db265d83fcf1bbb46aedc59510228a5d, type: 3}
+  - ItemName: Black Cap
+    Item: {fileID: 3116170454584013683, guid: db265d83fcf1bbb46aedc59510228a5d, type: 3}
     Stock: 2
-  - Item: {fileID: 1924955219277933708, guid: ebb0ac9609fb25343a446115d914a444, type: 3}
+  - ItemName: Skull Bandana
+    Item: {fileID: 1924955219277933708, guid: ebb0ac9609fb25343a446115d914a444, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: 9acc02a92f57c48a6ab94a5f9cd68b57, type: 3}
+  - ItemName: Robotics Headset
+    Item: {fileID: 835768756810601639, guid: 9acc02a92f57c48a6ab94a5f9cd68b57, type: 3}
     Stock: 2
-  - Item: {fileID: 4396341318306884477, guid: 1d54376f0c6f4474b8839a8847d19a9f, type: 3}
+  - ItemName: Techpriest Robes
+    Item: {fileID: 4396341318306884477, guid: 1d54376f0c6f4474b8839a8847d19a9f, type: 3}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: 93c3b540119b16945b32d1d69bc3a786, type: 3}
+  - ItemName: Techpriest Hood
+    Item: {fileID: 7636118406116123594, guid: 93c3b540119b16945b32d1d69bc3a786, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -130,29 +143,41 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: 2a2d871db32f24302b1aeb03f3652c48, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 2a2d871db32f24302b1aeb03f3652c48, type: 3}
     Stock: 2
-  - Item: {fileID: 6710415053653577436, guid: 676e9af4e37de5645a97d7ad338cfcef, type: 3}
+  - ItemName: 
+    Item: {fileID: 6710415053653577436, guid: 676e9af4e37de5645a97d7ad338cfcef, type: 3}
     Stock: 2
-  - Item: {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: ed1b2998d2c424811881ca9c2cad1226, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
     Stock: 2
-  - Item: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26, type: 3}
+  - ItemName: 
+    Item: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26, type: 3}
     Stock: 2
-  - Item: {fileID: 3116170454584013683, guid: db265d83fcf1bbb46aedc59510228a5d, type: 3}
+  - ItemName: 
+    Item: {fileID: 3116170454584013683, guid: db265d83fcf1bbb46aedc59510228a5d, type: 3}
     Stock: 2
-  - Item: {fileID: 1924955219277933708, guid: ebb0ac9609fb25343a446115d914a444, type: 3}
+  - ItemName: 
+    Item: {fileID: 1924955219277933708, guid: ebb0ac9609fb25343a446115d914a444, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: 9acc02a92f57c48a6ab94a5f9cd68b57, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: 9acc02a92f57c48a6ab94a5f9cd68b57, type: 3}
     Stock: 2
-  - Item: {fileID: 4396341318306884477, guid: 1d54376f0c6f4474b8839a8847d19a9f, type: 3}
+  - ItemName: 
+    Item: {fileID: 4396341318306884477, guid: 1d54376f0c6f4474b8839a8847d19a9f, type: 3}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: 93c3b540119b16945b32d1d69bc3a786, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 93c3b540119b16945b32d1d69bc3a786, type: 3}
     Stock: 2
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/SciDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/SciDrobe.prefab
@@ -97,27 +97,38 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 3
-  - Item: {fileID: 5064226321362517998, guid: 08cfe1b88b57ef54480353de29933380, type: 3}
+  - ItemName: Science Backpack
+    Item: {fileID: 5064226321362517998, guid: 08cfe1b88b57ef54480353de29933380, type: 3}
     Stock: 3
-  - Item: {fileID: 5273891547540461841, guid: cd434f09e5742b6489500c1dae094e28, type: 3}
+  - ItemName: Scientist Satchel
+    Item: {fileID: 5273891547540461841, guid: cd434f09e5742b6489500c1dae094e28, type: 3}
     Stock: 3
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 3
-  - Item: {fileID: 7902944202316490397, guid: 06088292fadbbdd40a0d7dce08102a37, type: 3}
+  - ItemName: Science Winter Coat
+    Item: {fileID: 7902944202316490397, guid: 06088292fadbbdd40a0d7dce08102a37, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: d39638a7abcdf4a25b189fa975eab5e7, type: 3}
+  - ItemName: Scientists Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: d39638a7abcdf4a25b189fa975eab5e7, type: 3}
     Stock: 3
-  - Item: {fileID: 5032308470899878357, guid: 52c38364bd286a7498241ec0af93ed9e, type: 3}
+  - ItemName: Scientists Jumpskirt
+    Item: {fileID: 5032308470899878357, guid: 52c38364bd286a7498241ec0af93ed9e, type: 3}
     Stock: 3
-  - Item: {fileID: 7374481989050852271, guid: d45ca61e9864044ebb02cf9d0d01f986, type: 3}
+  - ItemName: Scientist Labcoat
+    Item: {fileID: 7374481989050852271, guid: d45ca61e9864044ebb02cf9d0d01f986, type: 3}
     Stock: 3
-  - Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+  - ItemName: White Shoes
+    Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
     Stock: 3
-  - Item: {fileID: 835768756810601639, guid: 1fbcb2849c5f146458ba2aa13634279c, type: 3}
+  - ItemName: Science Headset
+    Item: {fileID: 835768756810601639, guid: 1fbcb2849c5f146458ba2aa13634279c, type: 3}
     Stock: 3
-  - Item: {fileID: 6404652678407139925, guid: 996d62bfe3bf26c4e95c2a77cadabbd2, type: 3}
+  - ItemName: Gas Mask
+    Item: {fileID: 6404652678407139925, guid: 996d62bfe3bf26c4e95c2a77cadabbd2, type: 3}
     Stock: 3
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -126,27 +137,38 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 3
-  - Item: {fileID: 5064226321362517998, guid: 08cfe1b88b57ef54480353de29933380, type: 3}
+  - ItemName: 
+    Item: {fileID: 5064226321362517998, guid: 08cfe1b88b57ef54480353de29933380, type: 3}
     Stock: 3
-  - Item: {fileID: 5273891547540461841, guid: cd434f09e5742b6489500c1dae094e28, type: 3}
+  - ItemName: 
+    Item: {fileID: 5273891547540461841, guid: cd434f09e5742b6489500c1dae094e28, type: 3}
     Stock: 3
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 3
-  - Item: {fileID: 7902944202316490397, guid: 06088292fadbbdd40a0d7dce08102a37, type: 3}
+  - ItemName: 
+    Item: {fileID: 7902944202316490397, guid: 06088292fadbbdd40a0d7dce08102a37, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: d39638a7abcdf4a25b189fa975eab5e7, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: d39638a7abcdf4a25b189fa975eab5e7, type: 3}
     Stock: 3
-  - Item: {fileID: 5032308470899878357, guid: 52c38364bd286a7498241ec0af93ed9e, type: 3}
+  - ItemName: 
+    Item: {fileID: 5032308470899878357, guid: 52c38364bd286a7498241ec0af93ed9e, type: 3}
     Stock: 3
-  - Item: {fileID: 7374481989050852271, guid: d45ca61e9864044ebb02cf9d0d01f986, type: 3}
+  - ItemName: 
+    Item: {fileID: 7374481989050852271, guid: d45ca61e9864044ebb02cf9d0d01f986, type: 3}
     Stock: 3
-  - Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
     Stock: 3
-  - Item: {fileID: 835768756810601639, guid: 1fbcb2849c5f146458ba2aa13634279c, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: 1fbcb2849c5f146458ba2aa13634279c, type: 3}
     Stock: 3
-  - Item: {fileID: 6404652678407139925, guid: 996d62bfe3bf26c4e95c2a77cadabbd2, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 996d62bfe3bf26c4e95c2a77cadabbd2, type: 3}
     Stock: 3
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/SecDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/SecDrobe.prefab
@@ -97,39 +97,56 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 4947898699112671526, guid: 6920da5d154527242970c7c2f00fcd16, type: 3}
+  - ItemName: Security Winter Coat
+    Item: {fileID: 4947898699112671526, guid: 6920da5d154527242970c7c2f00fcd16, type: 3}
     Stock: 3
-  - Item: {fileID: 6150311403527200410, guid: 1a291489c8aa9da8598c8026ac53f935, type: 3}
+  - ItemName: Security Backpack
+    Item: {fileID: 6150311403527200410, guid: 1a291489c8aa9da8598c8026ac53f935, type: 3}
     Stock: 3
-  - Item: {fileID: 4491607388275499144, guid: 1ed809e1bad45b44ea65b44c81764ca9, type: 3}
+  - ItemName: Security Satchel
+    Item: {fileID: 4491607388275499144, guid: 1ed809e1bad45b44ea65b44c81764ca9, type: 3}
     Stock: 3
-  - Item: {fileID: 5246620180480384242, guid: ed03c800dbd4d674d8f01df08a62ce57, type: 3}
+  - ItemName: Security Duffel Bag
+    Item: {fileID: 5246620180480384242, guid: ed03c800dbd4d674d8f01df08a62ce57, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: 56b3a5e4aaeeac7409c2ce3816b0c339, type: 3}
+  - ItemName: Security Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 56b3a5e4aaeeac7409c2ce3816b0c339, type: 3}
     Stock: 3
-  - Item: {fileID: 7778659549401236757, guid: 8087f011fc841754da147d221e5c2fe8, type: 3}
+  - ItemName: Security Jumpskirt
+    Item: {fileID: 7778659549401236757, guid: 8087f011fc841754da147d221e5c2fe8, type: 3}
     Stock: 3
-  - Item: {fileID: 7641241167666149781, guid: 917bee919ce4fb54593ed1120ba407af, type: 3}
+  - ItemName: Grey Security Jumpsuit
+    Item: {fileID: 7641241167666149781, guid: 917bee919ce4fb54593ed1120ba407af, type: 3}
     Stock: 3
-  - Item: {fileID: 2737947386721379442, guid: 6642e0b20df9dc743b1885dcd01e3024, type: 3}
+  - ItemName: Blue Shirt And Tie
+    Item: {fileID: 2737947386721379442, guid: 6642e0b20df9dc743b1885dcd01e3024, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: db6925c2066e4fb49a396bacd6dc7552, type: 3}
+  - ItemName: Khaki Pants
+    Item: {fileID: 3011710637427380133, guid: db6925c2066e4fb49a396bacd6dc7552, type: 3}
     Stock: 3
-  - Item: {fileID: 7106618204054676533, guid: eaeac5365190b4842bedb2b846ff15da, type: 3}
+  - ItemName: Jack Boots
+    Item: {fileID: 7106618204054676533, guid: eaeac5365190b4842bedb2b846ff15da, type: 3}
     Stock: 3
-  - Item: {fileID: 3164270768286331101, guid: a4d736b34e26278479563c6bf5f121ce, type: 3}
+  - ItemName: Security Beret
+    Item: {fileID: 3164270768286331101, guid: a4d736b34e26278479563c6bf5f121ce, type: 3}
     Stock: 3
-  - Item: {fileID: 6275557669645425591, guid: 97f84dca143c7fb4fbd86610313472a0, type: 3}
+  - ItemName: Security Cap
+    Item: {fileID: 6275557669645425591, guid: 97f84dca143c7fb4fbd86610313472a0, type: 3}
     Stock: 3
-  - Item: {fileID: 5346501866518943165, guid: ab2acbff0b11d6d4aa18a2211082f330, type: 3}
+  - ItemName: Red Bandana
+    Item: {fileID: 5346501866518943165, guid: ab2acbff0b11d6d4aa18a2211082f330, type: 3}
     Stock: 3
-  - Item: {fileID: 5437448505016987486, guid: 3f0da6473d897f11f88cf172ed0c5f30, type: 3}
+  - ItemName: Security Headset
+    Item: {fileID: 5437448505016987486, guid: 3f0da6473d897f11f88cf172ed0c5f30, type: 3}
     Stock: 3
-  - Item: {fileID: 1070110363393237790, guid: 591574bb7d99d2245b5f15166ea5be76, type: 3}
+  - ItemName: Security Officers Formal Uniform
+    Item: {fileID: 1070110363393237790, guid: 591574bb7d99d2245b5f15166ea5be76, type: 3}
     Stock: 3
-  - Item: {fileID: 3921521694364753778, guid: 453dfbebf99d34049a240acec7a49706, type: 3}
+  - ItemName: Security Officers Formal Jacket
+    Item: {fileID: 3921521694364753778, guid: 453dfbebf99d34049a240acec7a49706, type: 3}
     Stock: 3
-  - Item: {fileID: 8054706762914598631, guid: 14669856ddf44564fac40935a5a8e2b4, type: 3}
+  - ItemName: Security Navy Beret
+    Item: {fileID: 8054706762914598631, guid: 14669856ddf44564fac40935a5a8e2b4, type: 3}
     Stock: 3
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -138,39 +155,56 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 4947898699112671526, guid: 6920da5d154527242970c7c2f00fcd16, type: 3}
+  - ItemName: 
+    Item: {fileID: 4947898699112671526, guid: 6920da5d154527242970c7c2f00fcd16, type: 3}
     Stock: 3
-  - Item: {fileID: 6150311403527200410, guid: 1a291489c8aa9da8598c8026ac53f935, type: 3}
+  - ItemName: 
+    Item: {fileID: 6150311403527200410, guid: 1a291489c8aa9da8598c8026ac53f935, type: 3}
     Stock: 3
-  - Item: {fileID: 4491607388275499144, guid: 1ed809e1bad45b44ea65b44c81764ca9, type: 3}
+  - ItemName: 
+    Item: {fileID: 4491607388275499144, guid: 1ed809e1bad45b44ea65b44c81764ca9, type: 3}
     Stock: 3
-  - Item: {fileID: 5246620180480384242, guid: ed03c800dbd4d674d8f01df08a62ce57, type: 3}
+  - ItemName: 
+    Item: {fileID: 5246620180480384242, guid: ed03c800dbd4d674d8f01df08a62ce57, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: 56b3a5e4aaeeac7409c2ce3816b0c339, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 56b3a5e4aaeeac7409c2ce3816b0c339, type: 3}
     Stock: 3
-  - Item: {fileID: 7778659549401236757, guid: 8087f011fc841754da147d221e5c2fe8, type: 3}
+  - ItemName: 
+    Item: {fileID: 7778659549401236757, guid: 8087f011fc841754da147d221e5c2fe8, type: 3}
     Stock: 3
-  - Item: {fileID: 7641241167666149781, guid: 917bee919ce4fb54593ed1120ba407af, type: 3}
+  - ItemName: 
+    Item: {fileID: 7641241167666149781, guid: 917bee919ce4fb54593ed1120ba407af, type: 3}
     Stock: 3
-  - Item: {fileID: 2737947386721379442, guid: 6642e0b20df9dc743b1885dcd01e3024, type: 3}
+  - ItemName: 
+    Item: {fileID: 2737947386721379442, guid: 6642e0b20df9dc743b1885dcd01e3024, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: db6925c2066e4fb49a396bacd6dc7552, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: db6925c2066e4fb49a396bacd6dc7552, type: 3}
     Stock: 3
-  - Item: {fileID: 7106618204054676533, guid: eaeac5365190b4842bedb2b846ff15da, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: eaeac5365190b4842bedb2b846ff15da, type: 3}
     Stock: 3
-  - Item: {fileID: 3164270768286331101, guid: a4d736b34e26278479563c6bf5f121ce, type: 3}
+  - ItemName: 
+    Item: {fileID: 3164270768286331101, guid: a4d736b34e26278479563c6bf5f121ce, type: 3}
     Stock: 3
-  - Item: {fileID: 6275557669645425591, guid: 97f84dca143c7fb4fbd86610313472a0, type: 3}
+  - ItemName: 
+    Item: {fileID: 6275557669645425591, guid: 97f84dca143c7fb4fbd86610313472a0, type: 3}
     Stock: 3
-  - Item: {fileID: 5346501866518943165, guid: ab2acbff0b11d6d4aa18a2211082f330, type: 3}
+  - ItemName: 
+    Item: {fileID: 5346501866518943165, guid: ab2acbff0b11d6d4aa18a2211082f330, type: 3}
     Stock: 3
-  - Item: {fileID: 5437448505016987486, guid: 3f0da6473d897f11f88cf172ed0c5f30, type: 3}
+  - ItemName: 
+    Item: {fileID: 5437448505016987486, guid: 3f0da6473d897f11f88cf172ed0c5f30, type: 3}
     Stock: 3
-  - Item: {fileID: 1070110363393237790, guid: 591574bb7d99d2245b5f15166ea5be76, type: 3}
+  - ItemName: 
+    Item: {fileID: 1070110363393237790, guid: 591574bb7d99d2245b5f15166ea5be76, type: 3}
     Stock: 3
-  - Item: {fileID: 3921521694364753778, guid: 453dfbebf99d34049a240acec7a49706, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 453dfbebf99d34049a240acec7a49706, type: 3}
     Stock: 3
-  - Item: {fileID: 8054706762914598631, guid: 14669856ddf44564fac40935a5a8e2b4, type: 3}
+  - ItemName: 
+    Item: {fileID: 8054706762914598631, guid: 14669856ddf44564fac40935a5a8e2b4, type: 3}
     Stock: 3
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/ViroDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/ViroDrobe.prefab
@@ -97,23 +97,32 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 9131202711572530880, guid: 0c198ac94169aed40ab72b2afc2d4cc5, type: 3}
+  - ItemName: Virology Backpack
+    Item: {fileID: 9131202711572530880, guid: 0c198ac94169aed40ab72b2afc2d4cc5, type: 3}
     Stock: 2
-  - Item: {fileID: 516347036442809227, guid: e128aa90b7c4cd741bc16b385d99f54a, type: 3}
+  - ItemName: Virologist Satchel
+    Item: {fileID: 516347036442809227, guid: e128aa90b7c4cd741bc16b385d99f54a, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+  - ItemName: White Shoes
+    Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: aab6051d13dac4be8a3ca172d9b74051, type: 3}
+  - ItemName: Virologists Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: aab6051d13dac4be8a3ca172d9b74051, type: 3}
     Stock: 2
-  - Item: {fileID: 4172758320385125961, guid: 7294d72d86040fa45a54a16e2c0a36bf, type: 3}
+  - ItemName: Virologists Jumpskirt
+    Item: {fileID: 4172758320385125961, guid: 7294d72d86040fa45a54a16e2c0a36bf, type: 3}
     Stock: 2
-  - Item: {fileID: 7374481989050852271, guid: 22ce62e388fa84ff098d72a7856ea506, type: 3}
+  - ItemName: Virology Labcoat
+    Item: {fileID: 7374481989050852271, guid: 22ce62e388fa84ff098d72a7856ea506, type: 3}
     Stock: 2
-  - Item: {fileID: 6404652678407139925, guid: e9076ebebbcd65e56b189cd1a837d018, type: 3}
+  - ItemName: Sterile Mask
+    Item: {fileID: 6404652678407139925, guid: e9076ebebbcd65e56b189cd1a837d018, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: cad7d826b673041f5b2b4d9b9d64aa09, type: 3}
+  - ItemName: Medical Headset
+    Item: {fileID: 835768756810601639, guid: cad7d826b673041f5b2b4d9b9d64aa09, type: 3}
     Stock: 2
   HullColor: {r: 1, g: 1, b: 1, a: 1}
   EjectObjects: 0
@@ -122,23 +131,32 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 9131202711572530880, guid: 0c198ac94169aed40ab72b2afc2d4cc5, type: 3}
+  - ItemName: 
+    Item: {fileID: 9131202711572530880, guid: 0c198ac94169aed40ab72b2afc2d4cc5, type: 3}
     Stock: 2
-  - Item: {fileID: 516347036442809227, guid: e128aa90b7c4cd741bc16b385d99f54a, type: 3}
+  - ItemName: 
+    Item: {fileID: 516347036442809227, guid: e128aa90b7c4cd741bc16b385d99f54a, type: 3}
     Stock: 2
-  - Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
     Stock: 2
-  - Item: {fileID: 3011710637427380133, guid: aab6051d13dac4be8a3ca172d9b74051, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: aab6051d13dac4be8a3ca172d9b74051, type: 3}
     Stock: 2
-  - Item: {fileID: 4172758320385125961, guid: 7294d72d86040fa45a54a16e2c0a36bf, type: 3}
+  - ItemName: 
+    Item: {fileID: 4172758320385125961, guid: 7294d72d86040fa45a54a16e2c0a36bf, type: 3}
     Stock: 2
-  - Item: {fileID: 7374481989050852271, guid: 22ce62e388fa84ff098d72a7856ea506, type: 3}
+  - ItemName: 
+    Item: {fileID: 7374481989050852271, guid: 22ce62e388fa84ff098d72a7856ea506, type: 3}
     Stock: 2
-  - Item: {fileID: 6404652678407139925, guid: e9076ebebbcd65e56b189cd1a837d018, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: e9076ebebbcd65e56b189cd1a837d018, type: 3}
     Stock: 2
-  - Item: {fileID: 835768756810601639, guid: cad7d826b673041f5b2b4d9b9d64aa09, type: 3}
+  - ItemName: 
+    Item: {fileID: 835768756810601639, guid: cad7d826b673041f5b2b4d9b9d64aa09, type: 3}
     Stock: 2
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/YouTool.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/YouTool.prefab
@@ -203,41 +203,59 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 5680136605834777345, guid: c3e6805b264a935428b0de415ea57943, type: 3}
+  - ItemName: Medium Cable Coil
+    Item: {fileID: 5680136605834777345, guid: c3e6805b264a935428b0de415ea57943, type: 3}
     Stock: 10
-  - Item: {fileID: 6918947953705996213, guid: f709eab732189d6429ae3fa5beaf3fd3, type: 3}
+  - ItemName: Pocket Crowbar
+    Item: {fileID: 6918947953705996213, guid: f709eab732189d6429ae3fa5beaf3fd3, type: 3}
     Stock: 5
-  - Item: {fileID: 6989221924687263735, guid: b735ab74dab174a4f90c79558cd51e43, type: 3}
+  - ItemName: Welding Tool
+    Item: {fileID: 6989221924687263735, guid: b735ab74dab174a4f90c79558cd51e43, type: 3}
     Stock: 3
-  - Item: {fileID: 1844587092189195201, guid: 3266ceefb65da2f4cb4bbfd297415ad5, type: 3}
+  - ItemName: Wirecutter
+    Item: {fileID: 1844587092189195201, guid: 3266ceefb65da2f4cb4bbfd297415ad5, type: 3}
     Stock: 5
-  - Item: {fileID: 4930866777566109869, guid: 7976a84ef9209f14697cdd941b913e2a, type: 3}
+  - ItemName: Wrench
+    Item: {fileID: 4930866777566109869, guid: 7976a84ef9209f14697cdd941b913e2a, type: 3}
     Stock: 5
-  - Item: {fileID: 8238071069653876758, guid: bf74e8243028ec14ebeb6578ebd2fcf4, type: 3}
+  - ItemName: Atmospheric Analyzer
+    Item: {fileID: 8238071069653876758, guid: bf74e8243028ec14ebeb6578ebd2fcf4, type: 3}
     Stock: 5
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 5
-  - Item: {fileID: 8868920090029130384, guid: 366fb594c17e76346bbb29ad4ce021ad, type: 3}
+  - ItemName: Screwdriver
+    Item: {fileID: 8868920090029130384, guid: 366fb594c17e76346bbb29ad4ce021ad, type: 3}
     Stock: 5
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 5
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 5
-  - Item: {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb, type: 3}
+  - ItemName: Flashlight
+    Item: {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb, type: 3}
     Stock: 5
-  - Item: {fileID: 6200957232458716886, guid: 29d7ceeefbf3c484e82d37353cea673e, type: 3}
+  - ItemName: Earmuffs
+    Item: {fileID: 6200957232458716886, guid: 29d7ceeefbf3c484e82d37353cea673e, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: EMPTY SLOT
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 6700281191928912403, guid: 45d5212210f77468d9d791c1f922bdc6, type: 3}
+  - ItemName: Toolbelt
+    Item: {fileID: 6700281191928912403, guid: 45d5212210f77468d9d791c1f922bdc6, type: 3}
     Stock: 2
-  - Item: {fileID: 970193913688544828, guid: 32fcd56a575fd884ebae6deb79a43656, type: 3}
+  - ItemName: Multitool
+    Item: {fileID: 970193913688544828, guid: 32fcd56a575fd884ebae6deb79a43656, type: 3}
     Stock: 2
-  - Item: {fileID: 8139484074677452963, guid: d0c4b52b477e35e44a7e0c0a6876892c, type: 3}
+  - ItemName: Upgraded Industrial Welding Tool
+    Item: {fileID: 8139484074677452963, guid: d0c4b52b477e35e44a7e0c0a6876892c, type: 3}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: df90174791c3adda585b7cb6c9f01473, type: 3}
+  - ItemName: Welding Helmet
+    Item: {fileID: 7636118406116123594, guid: df90174791c3adda585b7cb6c9f01473, type: 3}
     Stock: 2
-  - Item: {fileID: 6373161644663410599, guid: 3ee7b87ce4e35534f9c3a2ccf747811e, type: 3}
+  - ItemName: Budget Insulated Gloves
+    Item: {fileID: 6373161644663410599, guid: 3ee7b87ce4e35534f9c3a2ccf747811e, type: 3}
     Stock: 1
   HullColor: {r: 0.79607844, g: 0.6509804, b: 0.20392157, a: 1}
   EjectObjects: 0
@@ -246,41 +264,59 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 5680136605834777345, guid: c3e6805b264a935428b0de415ea57943, type: 3}
+  - ItemName: 
+    Item: {fileID: 5680136605834777345, guid: c3e6805b264a935428b0de415ea57943, type: 3}
     Stock: 10
-  - Item: {fileID: 6918947953705996213, guid: f709eab732189d6429ae3fa5beaf3fd3, type: 3}
+  - ItemName: 
+    Item: {fileID: 6918947953705996213, guid: f709eab732189d6429ae3fa5beaf3fd3, type: 3}
     Stock: 5
-  - Item: {fileID: 6989221924687263735, guid: b735ab74dab174a4f90c79558cd51e43, type: 3}
+  - ItemName: 
+    Item: {fileID: 6989221924687263735, guid: b735ab74dab174a4f90c79558cd51e43, type: 3}
     Stock: 3
-  - Item: {fileID: 1844587092189195201, guid: 3266ceefb65da2f4cb4bbfd297415ad5, type: 3}
+  - ItemName: 
+    Item: {fileID: 1844587092189195201, guid: 3266ceefb65da2f4cb4bbfd297415ad5, type: 3}
     Stock: 5
-  - Item: {fileID: 4930866777566109869, guid: 7976a84ef9209f14697cdd941b913e2a, type: 3}
+  - ItemName: 
+    Item: {fileID: 4930866777566109869, guid: 7976a84ef9209f14697cdd941b913e2a, type: 3}
     Stock: 5
-  - Item: {fileID: 8238071069653876758, guid: bf74e8243028ec14ebeb6578ebd2fcf4, type: 3}
+  - ItemName: 
+    Item: {fileID: 8238071069653876758, guid: bf74e8243028ec14ebeb6578ebd2fcf4, type: 3}
     Stock: 5
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 5
-  - Item: {fileID: 8868920090029130384, guid: 366fb594c17e76346bbb29ad4ce021ad, type: 3}
+  - ItemName: 
+    Item: {fileID: 8868920090029130384, guid: 366fb594c17e76346bbb29ad4ce021ad, type: 3}
     Stock: 5
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 5
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 5
-  - Item: {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb, type: 3}
+  - ItemName: 
+    Item: {fileID: 5734849685452875998, guid: 6f371050bff8b32438f91c7c680900bb, type: 3}
     Stock: 5
-  - Item: {fileID: 6200957232458716886, guid: 29d7ceeefbf3c484e82d37353cea673e, type: 3}
+  - ItemName: 
+    Item: {fileID: 6200957232458716886, guid: 29d7ceeefbf3c484e82d37353cea673e, type: 3}
     Stock: 1
-  - Item: {fileID: 0}
+  - ItemName: 
+    Item: {fileID: 0}
     Stock: 2
-  - Item: {fileID: 6700281191928912403, guid: 45d5212210f77468d9d791c1f922bdc6, type: 3}
+  - ItemName: 
+    Item: {fileID: 6700281191928912403, guid: 45d5212210f77468d9d791c1f922bdc6, type: 3}
     Stock: 2
-  - Item: {fileID: 970193913688544828, guid: 32fcd56a575fd884ebae6deb79a43656, type: 3}
+  - ItemName: 
+    Item: {fileID: 970193913688544828, guid: 32fcd56a575fd884ebae6deb79a43656, type: 3}
     Stock: 2
-  - Item: {fileID: 8139484074677452963, guid: d0c4b52b477e35e44a7e0c0a6876892c, type: 3}
+  - ItemName: 
+    Item: {fileID: 8139484074677452963, guid: d0c4b52b477e35e44a7e0c0a6876892c, type: 3}
     Stock: 2
-  - Item: {fileID: 7636118406116123594, guid: df90174791c3adda585b7cb6c9f01473, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: df90174791c3adda585b7cb6c9f01473, type: 3}
     Stock: 2
-  - Item: {fileID: 6373161644663410599, guid: 3ee7b87ce4e35534f9c3a2ccf747811e, type: 3}
+  - ItemName: 
+    Item: {fileID: 6373161644663410599, guid: 3ee7b87ce4e35534f9c3a2ccf747811e, type: 3}
     Stock: 1
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/seed vendor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/seed vendor.prefab
@@ -355,6 +355,56 @@ PrefabInstance:
       propertyPath: InitialVendorContent.Array.data[11].Stock
       value: 3
       objectReference: {fileID: 0}
+    - target: {fileID: 114810295364911794, guid: 9e0f5bd15f2cf8d418b36169f24c58ae,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[2].ItemName
+      value: Wheat Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 114810295364911794, guid: 9e0f5bd15f2cf8d418b36169f24c58ae,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[3].ItemName
+      value: Onion Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 114810295364911794, guid: 9e0f5bd15f2cf8d418b36169f24c58ae,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[4].ItemName
+      value: Tomato Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 114810295364911794, guid: 9e0f5bd15f2cf8d418b36169f24c58ae,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[5].ItemName
+      value: Lemon Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 114810295364911794, guid: 9e0f5bd15f2cf8d418b36169f24c58ae,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[6].ItemName
+      value: Sucarcane Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 114810295364911794, guid: 9e0f5bd15f2cf8d418b36169f24c58ae,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[7].ItemName
+      value: Potato Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 114810295364911794, guid: 9e0f5bd15f2cf8d418b36169f24c58ae,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[8].ItemName
+      value: Rice Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 114810295364911794, guid: 9e0f5bd15f2cf8d418b36169f24c58ae,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[9].ItemName
+      value: Tower Cap Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 114810295364911794, guid: 9e0f5bd15f2cf8d418b36169f24c58ae,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[10].ItemName
+      value: Nutriment Bottle
+      objectReference: {fileID: 0}
+    - target: {fileID: 114810295364911794, guid: 9e0f5bd15f2cf8d418b36169f24c58ae,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[11].ItemName
+      value: Bucket
+      objectReference: {fileID: 0}
     - target: {fileID: 212917313431182876, guid: 9e0f5bd15f2cf8d418b36169f24c58ae,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_16.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_16.prefab
@@ -96,13 +96,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
+  - ItemName: Beef Jerky
+    Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
+  - ItemName: Cookie
+    Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
+  - ItemName: 4no Raisins
+    Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: 6366d9ab2983aa44aa585fd0f7557e17, type: 3}
+  - ItemName: Donut
+    Item: {fileID: 6532193109441330816, guid: 6366d9ab2983aa44aa585fd0f7557e17, type: 3}
     Stock: 5
   HullColor: {r: 0.7294118, g: 0.06666667, b: 0.23529413, a: 1}
   EjectObjects: 0
@@ -111,13 +115,17 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
+  - ItemName: 
+    Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
+  - ItemName: 
+    Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
+  - ItemName: 
+    Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: 6366d9ab2983aa44aa585fd0f7557e17, type: 3}
+  - ItemName: 
+    Item: {fileID: 6532193109441330816, guid: 6366d9ab2983aa44aa585fd0f7557e17, type: 3}
     Stock: 5
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_17.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_17.prefab
@@ -96,13 +96,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
+  - ItemName: Beef Jerky
+    Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
+  - ItemName: Cookie
+    Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
+  - ItemName: 4no Raisins
+    Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: 6366d9ab2983aa44aa585fd0f7557e17, type: 3}
+  - ItemName: Donut
+    Item: {fileID: 6532193109441330816, guid: 6366d9ab2983aa44aa585fd0f7557e17, type: 3}
     Stock: 5
   HullColor: {r: 0.7294118, g: 0.06666667, b: 0.23529413, a: 1}
   EjectObjects: 0
@@ -111,13 +115,17 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
+  - ItemName: 
+    Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
+  - ItemName: 
+    Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
+  - ItemName: 
+    Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: 6366d9ab2983aa44aa585fd0f7557e17, type: 3}
+  - ItemName: 
+    Item: {fileID: 6532193109441330816, guid: 6366d9ab2983aa44aa585fd0f7557e17, type: 3}
     Stock: 5
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_185.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_185.prefab
@@ -96,12 +96,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
+  - ItemName: 4no Raisins
+    Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
+  - ItemName: Beef Jerky
+    Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
     Stock: 2
-  - Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
+  - ItemName: Cookie
+    Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
     Stock: 2
+  - ItemName: Donut
+    Item: {fileID: 6532193109441330816, guid: 6366d9ab2983aa44aa585fd0f7557e17, type: 3}
+    Stock: 5
   HullColor: {r: 0.25882354, g: 0.25882354, b: 0.25882354, a: 1}
   EjectObjects: 1
   EjectDirection: 2
@@ -109,11 +115,14 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
+  - ItemName: 
+    Item: {fileID: 6532193109441330816, guid: cd60162658a8c12479da578b14efa79e, type: 3}
     Stock: 5
-  - Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
+  - ItemName: 
+    Item: {fileID: 6532193109441330816, guid: db7cd7b4544fd9b44b751a043a6b2e53, type: 3}
     Stock: 2
-  - Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
+  - ItemName: 
+    Item: {fileID: 6532193109441330816, guid: bd8e044768eca1d409b74dd7b4915e37, type: 3}
     Stock: 2
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_188.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_188.prefab
@@ -96,11 +96,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
+  - ItemName: Grey Backpack
+    Item: {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
     Stock: 5
-  - Item: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523, type: 3}
+  - ItemName: Grey Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523, type: 3}
     Stock: 5
-  - Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
+  - ItemName: Black Shoes
+    Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
     Stock: 5
   HullColor: {r: 0.39215687, g: 0.39215687, b: 0.39215687, a: 1}
   EjectObjects: 0
@@ -109,11 +112,14 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
+  - ItemName: 
+    Item: {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
     Stock: 5
-  - Item: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523, type: 3}
     Stock: 5
-  - Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
     Stock: 5
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_190.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_190.prefab
@@ -177,17 +177,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523, type: 3}
+  - ItemName: Grey Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523, type: 3}
     Stock: 5
-  - Item: {fileID: 3921521694364753778, guid: 02d871d46281a42d1820f9b47a8124c6, type: 3}
+  - ItemName: Trenchcoat
+    Item: {fileID: 3921521694364753778, guid: 02d871d46281a42d1820f9b47a8124c6, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523, type: 3}
+  - ItemName: Grey Jumpsuit
+    Item: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523, type: 3}
     Stock: 5
-  - Item: {fileID: 8977591776819106885, guid: cae650b8120e1f04a840374168f5169e, type: 3}
+  - ItemName: Grey Duffel Bag
+    Item: {fileID: 8977591776819106885, guid: cae650b8120e1f04a840374168f5169e, type: 3}
     Stock: 5
-  - Item: {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
+  - ItemName: Grey Backpack
+    Item: {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
     Stock: 5
-  - Item: {fileID: 7440297224124026255, guid: a168a3bbdfd796d48bf524dd9bef1803, type: 3}
+  - ItemName: Grey Satchel
+    Item: {fileID: 7440297224124026255, guid: a168a3bbdfd796d48bf524dd9bef1803, type: 3}
     Stock: 5
   HullColor: {r: 0.39215687, g: 0.39215687, b: 0.39215687, a: 1}
   EjectObjects: 0
@@ -196,17 +202,23 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523, type: 3}
     Stock: 5
-  - Item: {fileID: 3921521694364753778, guid: 02d871d46281a42d1820f9b47a8124c6, type: 3}
+  - ItemName: 
+    Item: {fileID: 3921521694364753778, guid: 02d871d46281a42d1820f9b47a8124c6, type: 3}
     Stock: 3
-  - Item: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523, type: 3}
+  - ItemName: 
+    Item: {fileID: 3011710637427380133, guid: 5a4f48d58142749de92013eb1e1d0523, type: 3}
     Stock: 5
-  - Item: {fileID: 8977591776819106885, guid: cae650b8120e1f04a840374168f5169e, type: 3}
+  - ItemName: 
+    Item: {fileID: 8977591776819106885, guid: cae650b8120e1f04a840374168f5169e, type: 3}
     Stock: 5
-  - Item: {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
+  - ItemName: 
+    Item: {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49, type: 3}
     Stock: 5
-  - Item: {fileID: 7440297224124026255, guid: a168a3bbdfd796d48bf524dd9bef1803, type: 3}
+  - ItemName: 
+    Item: {fileID: 7440297224124026255, guid: a168a3bbdfd796d48bf524dd9bef1803, type: 3}
     Stock: 5
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_192.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_192.prefab
@@ -96,15 +96,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
+  - ItemName: Black Shoes
+    Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
     Stock: 5
-  - Item: {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
+  - ItemName: Brown Shoes
+    Item: {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
     Stock: 5
-  - Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+  - ItemName: White Shoes
+    Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
     Stock: 5
-  - Item: {fileID: 7636118406116123594, guid: 5a6e2e3a0a44146198136e4fa2798db5, type: 3}
+  - ItemName: Kitty Ears
+    Item: {fileID: 7636118406116123594, guid: 5a6e2e3a0a44146198136e4fa2798db5, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 489b0e24de7b7dc4ea31a401aadb3779, type: 3}
+  - ItemName: Top Hat
+    Item: {fileID: 7636118406116123594, guid: 489b0e24de7b7dc4ea31a401aadb3779, type: 3}
     Stock: 2
   HullColor: {r: 0.39215687, g: 0.39215687, b: 0.39215687, a: 1}
   EjectObjects: 0
@@ -113,15 +118,20 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa, type: 3}
     Stock: 5
-  - Item: {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: f61a15e56150d45e78d9458034719cbb, type: 3}
     Stock: 5
-  - Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
+  - ItemName: 
+    Item: {fileID: 7106618204054676533, guid: 33d5403cf4de64f558d4b1735fdf85b4, type: 3}
     Stock: 5
-  - Item: {fileID: 7636118406116123594, guid: 5a6e2e3a0a44146198136e4fa2798db5, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 5a6e2e3a0a44146198136e4fa2798db5, type: 3}
     Stock: 1
-  - Item: {fileID: 7636118406116123594, guid: 489b0e24de7b7dc4ea31a401aadb3779, type: 3}
+  - ItemName: 
+    Item: {fileID: 7636118406116123594, guid: 489b0e24de7b7dc4ea31a401aadb3779, type: 3}
     Stock: 2
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_194.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_194.prefab
@@ -177,17 +177,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 6404652678407139925, guid: dce8e376d2eca40eabe3f055b41a021c, type: 3}
+  - ItemName: Breath Mask
+    Item: {fileID: 6404652678407139925, guid: dce8e376d2eca40eabe3f055b41a021c, type: 3}
     Stock: 5
-  - Item: {fileID: 3431291279286482953, guid: 0c3e7a0b25eff4d33a4f511cfc36b5d9, type: 3}
+  - ItemName: Sunglasses
+    Item: {fileID: 3431291279286482953, guid: 0c3e7a0b25eff4d33a4f511cfc36b5d9, type: 3}
     Stock: 5
-  - Item: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
+  - ItemName: Black Gloves
+    Item: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
     Stock: 5
-  - Item: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26, type: 3}
+  - ItemName: Fingerless Gloves
+    Item: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26, type: 3}
     Stock: 5
-  - Item: {fileID: 6404652678407139925, guid: abed35e9cfa734a00815cf8cda62687a, type: 3}
+  - ItemName: Clown Mask
+    Item: {fileID: 6404652678407139925, guid: abed35e9cfa734a00815cf8cda62687a, type: 3}
     Stock: 5
-  - Item: {fileID: 6404652678407139925, guid: 82493ba3850304e50a7d25606a4f59f1, type: 3}
+  - ItemName: Mime Mask
+    Item: {fileID: 6404652678407139925, guid: 82493ba3850304e50a7d25606a4f59f1, type: 3}
     Stock: 5
   HullColor: {r: 0.36862746, g: 0.36862746, b: 0.36862746, a: 1}
   EjectObjects: 0
@@ -196,17 +202,23 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 6404652678407139925, guid: dce8e376d2eca40eabe3f055b41a021c, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: dce8e376d2eca40eabe3f055b41a021c, type: 3}
     Stock: 5
-  - Item: {fileID: 3431291279286482953, guid: 0c3e7a0b25eff4d33a4f511cfc36b5d9, type: 3}
+  - ItemName: 
+    Item: {fileID: 3431291279286482953, guid: 0c3e7a0b25eff4d33a4f511cfc36b5d9, type: 3}
     Stock: 5
-  - Item: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
+  - ItemName: 
+    Item: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73, type: 3}
     Stock: 5
-  - Item: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26, type: 3}
+  - ItemName: 
+    Item: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26, type: 3}
     Stock: 5
-  - Item: {fileID: 6404652678407139925, guid: abed35e9cfa734a00815cf8cda62687a, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: abed35e9cfa734a00815cf8cda62687a, type: 3}
     Stock: 5
-  - Item: {fileID: 6404652678407139925, guid: 82493ba3850304e50a7d25606a4f59f1, type: 3}
+  - ItemName: 
+    Item: {fileID: 6404652678407139925, guid: 82493ba3850304e50a7d25606a4f59f1, type: 3}
     Stock: 5
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_24.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_24.prefab
@@ -95,13 +95,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 8594439505056330043, guid: 838a4732b2dece64497d074b7a700be6, type: 3}
+  - ItemName: Grenade
+    Item: {fileID: 8594439505056330043, guid: 838a4732b2dece64497d074b7a700be6, type: 3}
     Stock: 20
-  - Item: {fileID: 8582594776399167655, guid: f23b37dbf83885c4aabb3240de1c5b19, type: 3}
+  - ItemName: L6SAW_Ballistic
+    Item: {fileID: 8582594776399167655, guid: f23b37dbf83885c4aabb3240de1c5b19, type: 3}
     Stock: 1
-  - Item: {fileID: 742292832060491855, guid: 7bfcc39ce2266f54581ac24597ce0434, type: 3}
+  - ItemName: Magazine_a762
+    Item: {fileID: 742292832060491855, guid: 7bfcc39ce2266f54581ac24597ce0434, type: 3}
     Stock: 2
-  - Item: {fileID: 5260985750374485318, guid: 36e3533550bd8a943ad05db76b83fdd3, type: 3}
+  - ItemName: Emag
+    Item: {fileID: 5260985750374485318, guid: 36e3533550bd8a943ad05db76b83fdd3, type: 3}
     Stock: 1
   HullColor: {r: 0.40784314, g: 0.41568628, b: 0.36862746, a: 1}
   EjectObjects: 0
@@ -110,13 +114,17 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 8594439505056330043, guid: 838a4732b2dece64497d074b7a700be6, type: 3}
+  - ItemName: 
+    Item: {fileID: 8594439505056330043, guid: 838a4732b2dece64497d074b7a700be6, type: 3}
     Stock: 20
-  - Item: {fileID: 8582594776399167655, guid: f23b37dbf83885c4aabb3240de1c5b19, type: 3}
+  - ItemName: 
+    Item: {fileID: 8582594776399167655, guid: f23b37dbf83885c4aabb3240de1c5b19, type: 3}
     Stock: 1
-  - Item: {fileID: 742292832060491855, guid: 7bfcc39ce2266f54581ac24597ce0434, type: 3}
+  - ItemName: 
+    Item: {fileID: 742292832060491855, guid: 7bfcc39ce2266f54581ac24597ce0434, type: 3}
     Stock: 2
-  - Item: {fileID: 5260985750374485318, guid: 36e3533550bd8a943ad05db76b83fdd3, type: 3}
+  - ItemName: 
+    Item: {fileID: 5260985750374485318, guid: 36e3533550bd8a943ad05db76b83fdd3, type: 3}
     Stock: 1
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_51.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Vending/vending_51.prefab
@@ -204,11 +204,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   InitialVendorContent:
-  - Item: {fileID: 8127442588295923452, guid: 706cc1f035332384c96f001de4760563, type: 3}
+  - ItemName: Handcuffs
+    Item: {fileID: 8127442588295923452, guid: 706cc1f035332384c96f001de4760563, type: 3}
     Stock: 5
-  - Item: {fileID: 6507000735928756314, guid: c8db81d5fc87fc5409a6f7c00e5ebc96, type: 3}
+  - ItemName: Laser Gun
+    Item: {fileID: 6507000735928756314, guid: c8db81d5fc87fc5409a6f7c00e5ebc96, type: 3}
     Stock: 1
-  - Item: {fileID: 6507000735928756314, guid: 66e26e048c0ee0448878c27b37dc685f, type: 3}
+  - ItemName: Energy Gun
+    Item: {fileID: 6507000735928756314, guid: 66e26e048c0ee0448878c27b37dc685f, type: 3}
     Stock: 2
   HullColor: {r: 0.7490196, g: 0.7490196, b: 0.7490196, a: 1}
   EjectObjects: 0
@@ -217,11 +220,14 @@ MonoBehaviour:
   restockMessage: Items restocked.
   noAccessMessage: Access denied!
   VendorContent:
-  - Item: {fileID: 8127442588295923452, guid: 706cc1f035332384c96f001de4760563, type: 3}
+  - ItemName: 
+    Item: {fileID: 8127442588295923452, guid: 706cc1f035332384c96f001de4760563, type: 3}
     Stock: 5
-  - Item: {fileID: 6507000735928756314, guid: c8db81d5fc87fc5409a6f7c00e5ebc96, type: 3}
+  - ItemName: 
+    Item: {fileID: 6507000735928756314, guid: c8db81d5fc87fc5409a6f7c00e5ebc96, type: 3}
     Stock: 1
-  - Item: {fileID: 6507000735928756314, guid: 66e26e048c0ee0448878c27b37dc685f, type: 3}
+  - ItemName: 
+    Item: {fileID: 6507000735928756314, guid: 66e26e048c0ee0448878c27b37dc685f, type: 3}
     Stock: 2
   ActualCurrentPowerState: 2
   DoesntRequirePower: 0

--- a/UnityProject/Assets/Scripts/Objects/Vendor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Vendor.cs
@@ -245,6 +245,7 @@ public class VendorItemUpdateEvent : UnityEvent<VendorItem> { }
 [System.Serializable]
 public class VendorItem
 {
+	public string ItemName;
 	public GameObject Item;
 	public int Stock = 5;
 
@@ -252,5 +253,6 @@ public class VendorItem
 	{
 		this.Item = item.Item;
 		this.Stock = item.Stock;
+		this.ItemName = Item.name;
 	}
 }


### PR DESCRIPTION
_PROTIP: Check out our [Development Gotchas](https://unitystation.github.io/unitystation/development/Development-Gotchas-and-Common-Mistakes/) page to help ensure your PR is accepted and help you prevent common mistakes._

### Purpose
Adds name field into the VendorItem List to enable clear view of items within the inspector.
Adds rolling pin, mixing bowl, and drinking glasses to dinnerware vendor
Adds dinnerware vendor to maps which were missing them. 

### Notes:
_Please enter any other relevant information here_
