### PR TITLE
Wires don't place correctly tiles. #4462

### DIFF
--- a/UnityProject/Assets/Scripts/Input System/CablePlacementVisualisation.cs
+++ b/UnityProject/Assets/Scripts/Input System/CablePlacementVisualisation.cs
@@ -54,14 +54,6 @@ public class CablePlacementVisualisation : MonoBehaviour
 	/// </summary>
 	private Vector3Int lastMouseWordlPositionInt;
 	/// <summary>
-	/// Vector used to check distance between connections
-	/// </summary>
-	private Vector2Int startPointVector;
-	/// <summary>
-	/// Vector used to check distance between connections
-	/// </summary>
-	private Vector2Int endPointVector;
-	/// <summary>
 	/// The target tile the cable will be placed on.
 	/// </summary>
 	private GameObject target;
@@ -107,8 +99,6 @@ public class CablePlacementVisualisation : MonoBehaviour
 		if (CommonInput.GetMouseButtonDown(0))
 		{
 			startPoint = currentConnection;
-			startPointVector = point;
-
 			target = MouseUtils.GetOrderedObjectsUnderMouse().FirstOrDefault();
 
 			SetConnectionPointColor(startPoint, startPointColor);
@@ -117,9 +107,9 @@ public class CablePlacementVisualisation : MonoBehaviour
 		else if (CommonInput.GetMouseButtonUp(0))
 		{
 			endPoint = currentConnection;
-			endPointVector = point;
 			Build();
 			ResetValues();
+			return;
 		}
 
 		// check if position has changed
@@ -149,9 +139,10 @@ public class CablePlacementVisualisation : MonoBehaviour
 	/// </summary>
 	private void Build()
 	{
-		if (startPoint == endPoint || Mathf.Abs(startPointVector.x - endPointVector.x) > 2.5 || Mathf.Abs(startPointVector.y - endPointVector.y) > 2.5 || target == null) return;
+		if (startPoint == endPoint || target == null) return;
 
-		ConnectionApply cableApply = ConnectionApply.ByLocalPlayer(target, startPoint, endPoint, null);
+		Vector2 targetVector = (connectionPointRenderers[endPoint].transform.position - transform.position);
+		ConnectionApply cableApply = ConnectionApply.ByLocalPlayer(target, startPoint, endPoint, targetVector);
 
 		//if HandObject is null, then its an empty hand apply so we only need to check the receiving object
 		if (cableApply.HandObject != null)
@@ -187,10 +178,7 @@ public class CablePlacementVisualisation : MonoBehaviour
 
 		// reset points
 		startPoint = Connection.NA;
-		startPointVector = -Vector2Int.one;
-
 		endPoint = Connection.NA;
-		endPointVector = -Vector2Int.one;
 
 		lastMouseWordlPositionInt = Vector3Int.zero;
 		lastConnection = Connection.NA;


### PR DESCRIPTION
### Purpose
#4462 

### Notes:
(CablePlacementVisualisation.cs)
- add targetVector to ConnectionApply
- remove startPointVector and endPointVector variables because they are no longer used

![giff](https://user-images.githubusercontent.com/42096831/86453585-5327b080-bd1e-11ea-9400-aa89020e367f.gif)

