### PR TITLE
Some Server NRE Fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.cs
@@ -67,12 +67,6 @@ public partial class Chat : MonoBehaviour
 		if (!isOOC)
 		{
 			processedMessage = ProcessMessage(sentByPlayer, message);
-
-			if (!player.IsDeadOrGhost && player.mind.IsMiming && !processedMessage.chatModifiers.HasFlag(ChatModifier.Emote))
-			{
-				AddWarningMsgFromServer(sentByPlayer.GameObject, "You can't talk because you made a vow of silence.");
-				return;
-			}
 		}
 
 		var chatEvent = new ChatEvent
@@ -115,6 +109,12 @@ public partial class Chat : MonoBehaviour
 		// Check if the player is allowed to talk:
 		if (player != null && player.playerHealth != null)
 		{
+			if (!player.IsDeadOrGhost && player.mind.IsMiming && !processedMessage.chatModifiers.HasFlag(ChatModifier.Emote))
+			{
+				AddWarningMsgFromServer(sentByPlayer.GameObject, "You can't talk because you made a vow of silence.");
+				return;
+			}
+
 			if (player.playerHealth.IsCrit || player.playerHealth.IsCardiacArrest)
 			{
 				if (!player.playerHealth.IsDead)

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
@@ -61,7 +61,7 @@ namespace Chemistry.Components
 		/// Server side only. Current reagent mix inside container.
 		/// Invoke OnReagentMixChanged if you change anything in reagent mix
 		/// </summary>
-		private ReagentMix CurrentReagentMix
+		public ReagentMix CurrentReagentMix
 		{
 			get
 			{
@@ -72,14 +72,6 @@ namespace Chemistry.Components
 					currentReagentMix = initialReagentMix.Clone();
 				}
 				return currentReagentMix;
-			}
-		}
-
-		public ReagentMix CurrentReagentMixGet
-		{
-			get
-			{
-				return CurrentReagentMix;
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Food/DrinkableContainer.cs
+++ b/UnityProject/Assets/Scripts/Food/DrinkableContainer.cs
@@ -89,7 +89,7 @@ public class DrinkableContainer : Consumable
 
 		if ((int) drinkAmount == 0) return;
 
-		foreach (var reagent in container.CurrentReagentMixGet)
+		foreach (var reagent in container.CurrentReagentMix)
 		{
 			//if its not alcoholic skip
 			if (!AlcoholicDrinksSOScript.Instance.AlcoholicReagents.Contains(reagent.Key)) continue;

--- a/UnityProject/Assets/Scripts/Objects/FireAlarm.cs
+++ b/UnityProject/Assets/Scripts/Objects/FireAlarm.cs
@@ -179,9 +179,12 @@ public class FireAlarm : SubscriptionController, IServerLifecycle, ICheckedInter
 				StartCoroutine(SwitchCoolDown());
 				foreach (var firelock in FireLockList)
 				{
-					if (firelock.Controller.IsClosed)
+					var controller = firelock.Controller;
+					if (controller == null) continue;
+
+					if (controller.IsClosed)
 					{
-						firelock.Controller.ServerOpen();
+						controller.ServerOpen();
 					}
 				}
 			}

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -341,6 +341,7 @@ public class PushPull : NetworkBehaviour, IRightClickable, IServerSpawn {
 	/// Client asks to toggle pulling of given object
 	[Command]
 	public void CmdPullObject(GameObject pullableObject) {
+		if(pullableObject == null) return;
 		PushPull pullable = pullableObject.GetComponent<PushPull>();
 		if ( !pullable ) {
 			return;


### PR DESCRIPTION
<details>
<summary>Chat NRE Fix</summary>
NullReferenceException: Object reference not set to an instance of an object
Chat.AddChatMsgToChat (ConnectedPlayer sentByPlayer, System.String message, ChatChannel channels) (at /github/workspace/UnityProject/Assets/Scripts/Chat/Chat.cs:71)
PostToChatMessage.Process () (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/PostToChatMessage.cs:17)
GameMessageBase.Process (Mirror.NetworkConnection sentBy) (at /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:25)
ClientMessage.Process (Mirror.NetworkConnection sentBy) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs:14)
GameMessageBase.PreProcess (Mirror.NetworkConnection sentBy, GameMessageBase b) (at /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:18)
Mirror.MessagePacker+<>c__DisplayClass6_0`2[T,C].<MessageHandler>b__0 (Mirror.NetworkConnection conn, Mirror.NetworkReader reader, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/MessagePacker.cs:146)
Mirror.NetworkConnection.InvokeHandler (System.Int32 msgType, Mirror.NetworkReader reader, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:219)
Mirror.NetworkConnection.TransportReceive (System.ArraySegment`1[T] buffer, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:272)
Mirror.NetworkServer.OnDataReceived (System.Int32 connectionId, System.ArraySegment`1[T] data, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs:511)
UnityEngine.Events.InvokableCall`3[T1,T2,T3].Invoke (T1 args0, T2 args1, T3 args2) (at /home/builduser/buildslave/unity/build/Runtime/Export/UnityEvent/UnityEvent.cs:284)
UnityEngine.Events.UnityEvent`3[T0,T1,T2].Invoke (T0 arg0, T1 arg1, T2 arg2) (at /home/builduser/buildslave/unity/build/Runtime/Export/UnityEvent/UnityEvent/Un
</details>

<details>
<summary>Fire Alarm Fix</summary>
NullReferenceException
UnityEngine.Component.GetComponent[T] () (at /home/builduser/buildslave/unity/build/Runtime/Export/Scripting/Component.bindings.cs:42)
InteractableDoor.get_Controller () (at /github/workspace/UnityProject/Assets/Scripts/Doors/InteractableDoor.cs:23)
FireAlarm.ServerPerformInteraction (HandApply interaction) (at /github/workspace/UnityProject/Assets/Scripts/Objects/FireAlarm.cs:182)
RequestInteractMessage.ServerCheckAndTrigger[T] (T interaction, System.Collections.Generic.IEnumerable`1[T] interactables) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:334)
RequestInteractMessage.ProcessInteraction[T] (T interaction, UnityEngine.GameObject processorObj) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:316)
RequestInteractMessage.Process () (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestInteractMessage.cs:140)
GameMessageBase.Process (Mirror.NetworkConnection sentBy) (at /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:25)
ClientMessage.Process (Mirror.NetworkConnection sentBy) (at /github/workspace/UnityProject/Assets/Scripts/Messages/Client/ClientMessage.cs:14)
GameMessageBase.PreProcess (Mirror.NetworkConnection sentBy, GameMessageBase b) (at /github/workspace/UnityProject/Assets/Scripts/Messages/GameMessageBase.cs:18)
Mirror.MessagePacker+<>c__DisplayClass6_0`2[T,C].<MessageHandler>b__0 (Mirror.NetworkConnection conn, Mirror.NetworkReader reader, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/MessagePacker.cs:146)
Mirror.NetworkConnection.InvokeHandler (System.Int32 msgType, Mirror.NetworkReader reader, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:219)
Mirror.NetworkConnection.TransportReceive (System.ArraySegment`1[T] buffer, System.
</details>

<details>
<summary>PushPull NRE Fix</summary>
NullReferenceException: Object reference not set to an instance of an object
PushPull.CallCmdPullObject (UnityEngine.GameObject pullableObject) (at /github/workspace/UnityProject/Assets/Scripts/Objects/PushPull.cs:344)
PushPull.InvokeCmdCmdPullObject (Mirror.NetworkBehaviour obj, Mirror.NetworkReader reader) (at <a10f781bb79048c5b5d011d6314ad4e8>:0)
Mirror.NetworkBehaviour.InvokeHandlerDelegate (System.Int32 cmdHash, Mirror.MirrorInvokeType invokeType, Mirror.NetworkReader reader) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkBehaviour.cs:449)
Mirror.NetworkIdentity.HandleRemoteCall (System.Int32 componentIndex, System.Int32 functionHash, Mirror.MirrorInvokeType invokeType, Mirror.NetworkReader reader) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkIdentity.cs:928)
Mirror.NetworkIdentity.HandleCommand (System.Int32 componentIndex, System.Int32 cmdHash, Mirror.NetworkReader reader) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkIdentity.cs:948)
Mirror.NetworkServer.OnCommandMessage (Mirror.NetworkConnection conn, Mirror.CommandMessage msg) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs:901)
Mirror.MessagePacker+<>c__DisplayClass6_0`2[T,C].<MessageHandler>b__0 (Mirror.NetworkConnection conn, Mirror.NetworkReader reader, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/MessagePacker.cs:146)
Mirror.NetworkConnection.InvokeHandler (System.Int32 msgType, Mirror.NetworkReader reader, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:219)
Mirror.NetworkConnection.TransportReceive (System.ArraySegment`1[T] buffer, System.Int32 channelId) (at /github/workspace/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:272)
Mirror.NetworkServer.OnDataReceived (System.Int32 connectionId, System.ArraySegment`1[T] data, System.Int32 channelId) (at /github/workspace/UnityPro
</details>