### PR TITLE
Adjust Meleeable.cs defaults, make player characters not butcherable with knives.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Item.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Item.prefab
@@ -83,6 +83,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  snapToGridOnStart: 1
   IsFixedMatrix: 0
 --- !u!114 &499351249353511896
 MonoBehaviour:
@@ -159,6 +160,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isMeleeable: 0
   butcherTime: 2
   butcherSound: BladeSlice
 --- !u!114 &114734890905785284
@@ -308,9 +310,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  forceHidden: 0
 --- !u!1 &1344926539164060
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Player/Resources/Player_V3(uNet).prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Player/Resources/Player_V3(uNet).prefab
@@ -962,7 +962,7 @@ MonoBehaviour:
   - {fileID: 114859648697239420}
   - {fileID: 114645575864574208}
   - {fileID: 114626459693876662}
-  allowKnifeHarvest: 1
+  allowKnifeHarvest: 0
   butcherResults:
   - {fileID: 6532193109441330816, guid: 08f2ed80656ab8548b303e79671a18e8, type: 3}
   - {fileID: 6532193109441330816, guid: 08f2ed80656ab8548b303e79671a18e8, type: 3}
@@ -1107,6 +1107,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isMeleeable: 1
   butcherTime: 2
   butcherSound: BladeSlice
 --- !u!114 &6017414943583453005

--- a/UnityProject/Assets/Scripts/Weapons/Meleeable.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Meleeable.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 public class Meleeable : MonoBehaviour, IPredictedCheckedInteractable<PositionalHandApply>
 {
 	[SerializeField]
-	private bool isMeleeable = false;
+	private bool isMeleeable = true;
 
 	[SerializeField]
 	private static readonly StandardProgressActionConfig ProgressConfig


### PR DESCRIPTION
### Purpose
- Everything is now meleeable by default.
  - Items are still not meleeable by default now.
- You are now unable to butcher player characters using knives. **However, you can still gib them by dealing enough damage.**
