### PR TITLE
Fixing some small doc issues

### DIFF
--- a/docs/development/SyncVar-Best-Practices-for-Easy-Networking.md
+++ b/docs/development/SyncVar-Best-Practices-for-Easy-Networking.md
@@ -55,6 +55,7 @@ These are things you should almost ALWAYS do if using syncvar. If you see places
 
     * You generally will need a hook unless the client doesn't need to invoke any special logic when the value changes.
     * Note that Mirror actually does set the field automatically on the clientside when the hook is triggered by a server update, but if you called the hook directly on server side (instead of actually changing the field's value) it would not automatically change the value. This has created a lot of needless confusion and mistakes in the past because it is so situational, so sticking to the conventions documented on this page will avoid that confusion.
+
 3. (Only if you have a hook method) Override OnStartClient (make sure to use the "override" keyword!) and invoke the hook, passing it the current value of the field. If you are extending a component, make sure to call base.OnStartClient(). This ensures the SyncVar hook is called based on the initial value of the field that the server sends. Also call EnsureInit at the top to ensure any necessary init logic is called (Mirror may call OnStartClient before Awake/Start)
 
         :::csharp
@@ -66,7 +67,7 @@ These are things you should almost ALWAYS do if using syncvar. If you see places
             base.OnStartClient();
         }
         
-5. (Only if you have a hook method) Implement the IServerSpawn interface and set the syncvar field to the initial value in the method. This is a method which is invoked when an object is being spawned, regardless of if it's coming from the pool or not. This ensures that the object is properly re-initialized when it is being spawned from the object pool.
+4. (Only if you have a hook method) Implement the IServerSpawn interface and set the syncvar field to the initial value in the method. This is a method which is invoked when an object is being spawned, regardless of if it's coming from the pool or not. This ensures that the object is properly re-initialized when it is being spawned from the object pool.
 
         :::csharp
         public void OnSpawnServer()

--- a/docs/development/SyncVar-Best-Practices-for-Easy-Networking.md
+++ b/docs/development/SyncVar-Best-Practices-for-Easy-Networking.md
@@ -96,17 +96,28 @@ These are things you should almost ALWAYS do if using syncvar. If you see places
 
 # Various Issues Caused by Improper SyncVar Usage
 Here's some symptoms of improper syncvar usage:
+
 1. Clients who join after the syncvar field has been updated during gameplay (sometimes called "late joining clients") will not display the correct game state. Usually caused by not calling the hook in OnStartClient, sometimes caused by failing to properly override OnStartClient (using override keyword and using the correct method name).
+
 2. Server player sees a different game state than the client. Usually caused by setting the syncvar field directly without going through the hook method.
+
 3. SyncVar hooks throwing NREs - usually caused by failing to define an EnsureInit() method and call it at the top of the SyncVar hooks. Unity is calling the SyncVar hook before Awake/Start.
-3. Client intermittently sees the incorrect game state related to a sync var. Usually caused by having SyncVar logic which has a race condition - the client is relying on the syncvar updates / server messages arriving in a particular order.
-4. A newly-spawned object behaves differently than other objects of its type. This is due to failing to have a separate editor-assignable initial value for the field or failing to reset the field in OnSpawnServer. Your SyncVar field value was set to something other than the default, then was destroyed and returned to pool, then spawned from the pool with that same field value. This is solved by implementing IServerSpawn and initializing the syncvar value to its proper initial value (either the editor-assignable value or a hardcoded default).
+
+4. Client intermittently sees the incorrect game state related to a sync var. Usually caused by having SyncVar logic which has a race condition - the client is relying on the syncvar updates / server messages arriving in a particular order.
+
+5. A newly-spawned object behaves differently than other objects of its type. This is due to failing to have a separate editor-assignable initial value for the field or failing to reset the field in OnSpawnServer. Your SyncVar field value was set to something other than the default, then was destroyed and returned to pool, then spawned from the pool with that same field value. This is solved by implementing IServerSpawn and initializing the syncvar value to its proper initial value (either the editor-assignable value or a hardcoded default).
 
 # Surprising SyncVar Facts
 Here are some of the things you might not know about how they work which explains the reasoning for the above practices. Not 100% certain on all of these but they might as well be true.
+
 1. SyncVar hooks don't fire on the server when the server changes the field. They only fire on the client when the client receives the new value. Thus the server player will not have the hook called. This is the reason to always change the syncvar by way of the hook method on the server.
+
 2. SyncVar hooks don't fire when client connects and receives the initial value of the field. This is why you should call the syncvar hook manually in OnStartClient.
+
 3. SyncVar only works properly on specific types of fields ([see the docs](https://docs.unity3d.com/Manual/UNetStateSync.html)), but Unity does not seem to complain very noisily if you use it on an invalid type - the game still builds. If your syncvar doesn't appear to be working, chances are you are using it on an invalid type.
-3. SyncVar hooks, OnStartServer and OnStartClient may be called before Unity's Awake/Start hooks.
-4. If you don't update the field's value in the syncvar hook using the new value passed to the hook method, the client-side value won't be updated. This is why you should always update the field in the first line of the hook method.
-5. It takes a varying amount of time for the server to send the updated SyncVar field to the client, so make sure the code doesn't depend on the syncvar change arriving at a particular time or in a particular order in relation to other network messages or syncvar updates. If you change 2 syncvars on the server and also send a net message, they could arrive on the client in any order.
+
+4. SyncVar hooks, OnStartServer and OnStartClient may be called before Unity's Awake/Start hooks.
+
+5. If you don't update the field's value in the syncvar hook using the new value passed to the hook method, the client-side value won't be updated. This is why you should always update the field in the first line of the hook method.
+
+6. It takes a varying amount of time for the server to send the updated SyncVar field to the client, so make sure the code doesn't depend on the syncvar change arriving at a particular time or in a particular order in relation to other network messages or syncvar updates. If you change 2 syncvars on the server and also send a net message, they could arrive on the client in any order.


### PR DESCRIPTION
### Purpose

Fixed small issues on the SyncVar-Best-Practices-for-Easy-Networking.md documentation page, as it isn't being properly formatted at https://unitystation.github.io/unitystation/development/SyncVar-Best-Practices-for-Easy-Networking/.
