### PR TITLE
More action dialogues

### DIFF
--- a/UnityProject/Assets/Scripts/Hacking/HackingProcesses/HackingProcessDoorSimple.cs
+++ b/UnityProject/Assets/Scripts/Hacking/HackingProcesses/HackingProcessDoorSimple.cs
@@ -98,8 +98,8 @@ public class HackingProcessDoorSimple : HackingProcessBase
 		{
 			if (Controller != null)
 			{
-				Chat.AddExamineMsgFromServer(interaction.Performer,
-					"You " + (WiresExposed ? "close" : "open") + " the " + doorName + "'s maintenance panel");
+				Chat.AddActionMsgToChat(interaction.Performer, "You " + (WiresExposed ? "close" : "open") + " the " + doorName + "'s maintenance panel.",
+					$"{interaction.Performer.ExpensiveName()} " + (WiresExposed ? "closes" : "opens") + " the " + doorName + "'s maintenance panel.");
 				ServerTryTogglePanel();
 			}
 

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/TileInteraction/TableInteractionClimb.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/TileInteraction/TableInteractionClimb.cs
@@ -74,5 +74,9 @@ public class TableInteractionClimb : TileInteraction
 				}
 			}
 		}).ServerStartProgress(interaction.UsedObject.RegisterTile(), 3.0f, interaction.Performer);
+		
+		Chat.AddActionMsgToChat(interaction.Performer,
+			"You begin cimbing onto the table...",
+			$"{interaction.Performer.ExpensiveName()} begins climbing onto the table...");
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Others/Restraint.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Restraint.cs
@@ -59,7 +59,8 @@ public class Restraint : MonoBehaviour, ICheckedInteractable<HandApply>
 			if(performer.GetComponent<PlayerScript>()?.IsInReach(target, true) ?? false)
 			{
 				target.GetComponent<PlayerMove>().Cuff(interaction);
-				Chat.AddExamineMsgFromServer(performer, $"You successfully restrain {target.ExpensiveName()}.");
+				Chat.AddActionMsgToChat(performer, $"You successfully restrain {target.ExpensiveName()}.",
+					$"{performer.ExpensiveName()} successfully restrains {target.ExpensiveName()}.");
 			}
 		}
 
@@ -68,7 +69,9 @@ public class Restraint : MonoBehaviour, ICheckedInteractable<HandApply>
 		if (bar != null)
 		{
 			SoundManager.PlayNetworkedAtPos(sound, target.transform.position, sourceObj: target.gameObject);
-			Chat.AddExamineMsgFromServer(performer, $"You begin restraining {target.ExpensiveName()} with your {target.gameObject.ExpensiveName()}...");
+			Chat.AddActionMsgToChat(performer,
+				$"You begin restraining {target.ExpensiveName()}...",
+				$"{performer.ExpensiveName()} begins restraining {target.ExpensiveName()}...");
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Others/Restraint.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Restraint.cs
@@ -59,6 +59,7 @@ public class Restraint : MonoBehaviour, ICheckedInteractable<HandApply>
 			if(performer.GetComponent<PlayerScript>()?.IsInReach(target, true) ?? false)
 			{
 				target.GetComponent<PlayerMove>().Cuff(interaction);
+				Chat.AddExamineMsgFromServer(performer, $"You successfully restrain {target.ExpensiveName()}.");
 			}
 		}
 
@@ -67,6 +68,7 @@ public class Restraint : MonoBehaviour, ICheckedInteractable<HandApply>
 		if (bar != null)
 		{
 			SoundManager.PlayNetworkedAtPos(sound, target.transform.position, sourceObj: target.gameObject);
+			Chat.AddExamineMsgFromServer(performer, $"You begin restraining {target.ExpensiveName()} with your {target.gameObject.ExpensiveName()}...");
 		}
 	}
 }


### PR DESCRIPTION
## Purpose
This PR adds a few dialogue messages described under issue #4565 that were missing. It adds dialogue to the following actions:
*Climbing on tables
*Restaining other players (with handcuffs or otherwise)
*Opening maintenance panels on doors (used to only display for the player doing the action, now displays the dialogue for anyone witnessing it)

Fixes #4565