### PR TITLE
PDA-Update minor fixes

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/PDA/PDAs/PDA.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/PDA/PDAs/PDA.prefab
@@ -71,12 +71,12 @@ SpriteRenderer:
   m_SortingLayerID: -1463207863
   m_SortingLayer: 11
   m_SortingOrder: 40
-  m_Sprite: {fileID: 21300000, guid: ca8d48aef5864fe44a9e3788a4e41086, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 82b3130ba6eb4588bb385d6caa76b70e, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 0.32, y: 0.32}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -269,6 +269,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isMeleeable: 1
   butcherTime: 2
   butcherSound: BladeSlice
 --- !u!114 &151170123639225118
@@ -512,7 +513,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a69951b025439433aaae48b3e8c4017b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  NetTabType: 24
+  NetTabType: 26
 --- !u!114 &2827089245972962627
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/TabPDA.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/TabPDA.prefab
@@ -3651,7 +3651,7 @@ MonoBehaviour:
         m_CallState: 2
   Provider: {fileID: 0}
   ProviderRegisterTile: {fileID: 0}
-  Type: 24
+  Type: 26
   mainSwitcher: {fileID: 7450241213286060534}
   menuPage: {fileID: 3138901832233827802}
   settingPage: {fileID: 7839253988664011157}

--- a/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
+++ b/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
@@ -36,6 +36,7 @@ namespace Items.PDA
 		[NonSerialized]
 		public IDCard IdCard;
 
+
 		[NonSerialized]
 		public bool IdEject;
 
@@ -260,6 +261,7 @@ namespace Items.PDA
 		{
 			//Checks the slots again and will update the variables
 			var slot = storage.GetIndexedItemSlot(0);
+			IdCard = null;
 			if (slot.IsEmpty != true && isServer)
 			{
 				IdCard = slot.Item.GetComponent<IDCard>();

--- a/UnityProject/Assets/Scripts/UI/Net/NetTab.cs
+++ b/UnityProject/Assets/Scripts/UI/Net/NetTab.cs
@@ -33,7 +33,8 @@ public enum NetTabType
 	ReactorController = 22,
 	BoilerTurbineController = 23,
 	PipeDispenser = 24,
-	DisposalBin = 25
+	DisposalBin = 25,
+	PDA = 26,
 	//add your tabs here
 }
 

--- a/UnityProject/Assets/Textures/items/pda/pda_pda.png.meta
+++ b/UnityProject/Assets/Textures/items/pda/pda_pda.png.meta
@@ -1,9 +1,9 @@
 fileFormatVersion: 2
-guid: ca8d48aef5864fe44a9e3788a4e41086
+guid: 82b3130ba6eb4588bb385d6caa76b70e
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 10
+  serializedVersion: 11
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -20,7 +20,7 @@ TextureImporter:
     externalNormalMap: 0
     heightScale: 0.25
     normalMapFilter: 0
-  isReadable: 1
+  isReadable: 0
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   grayScaleToAlpha: 0
@@ -57,6 +57,7 @@ TextureImporter:
   maxTextureSizeSet: 0
   compressionQualitySet: 0
   textureFormatSet: 0
+  applyGammaDecoding: 0
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
@@ -69,7 +70,7 @@ TextureImporter:
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
-    forceMaximumCompressionQuality_BC6H_BC7: 1
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
     buildTarget: Standalone
     maxTextureSize: 2048
@@ -81,14 +82,14 @@ TextureImporter:
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
-    forceMaximumCompressionQuality_BC6H_BC7: 1
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []
     outline: []
     physicsShape: []
     bones: []
-    spriteID: c6ca1fe9de45a2945a18997595334da7
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 


### PR DESCRIPTION
### Purpose
This fix is like two lines, all it does is add the PDA tab to NetTab(Somehow it went missing) and makes the IDcard variable go null when the PDA's ID slot changes, meaning that it will properly update when someone takes the ID out via the slot and not through the UI.
