### PR TITLE
Expand gameConfig.json to allow server configuration

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Disposals/Pipes/DisposalPipeSplitterA.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Disposals/Pipes/DisposalPipeSplitterA.prefab
@@ -6,7 +6,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1706338798251575173}
+  m_GameObject: {fileID: 7176090347676296583}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
@@ -30,7 +30,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1706338798251575173}
+  m_GameObject: {fileID: 7176090347676296583}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
@@ -50,14 +50,12 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1706338798251575173}
+  m_GameObject: {fileID: 7176090347676296583}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7d430438099380c429fa99b5886ff5e3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
   wrenchTime: 0
   weldTime: 3
   disposalPipeTileUp: {fileID: 11400000, guid: 3210372876be9a447a4c96cef0cc93b5, type: 2}
@@ -73,7 +71,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1706338798251575173}
+  m_GameObject: {fileID: 7176090347676296583}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5657f3ab371d77f449cbbb38e86b7d4c, type: 3}
@@ -85,7 +83,7 @@ MonoBehaviour:
   Down: {fileID: 21300002, guid: ea83ff53d18ddc2449127136f3a2cab5, type: 3}
   Left: {fileID: 21300004, guid: ea83ff53d18ddc2449127136f3a2cab5, type: 3}
   Up: {fileID: 21300000, guid: ea83ff53d18ddc2449127136f3a2cab5, type: 3}
-  spriteRenderer: {fileID: 1499169744200704914}
+  spriteRenderer: {fileID: 7176090347676250686}
 --- !u!1001 &7176090347676343903
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -272,13 +270,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7af28adb717b4c44b8b2002b27670bd, type: 3}
---- !u!1 &1706338798251575173 stripped
+--- !u!1 &7176090347676296583 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8374648283101600218, guid: a7af28adb717b4c44b8b2002b27670bd,
     type: 3}
   m_PrefabInstance: {fileID: 7176090347676343903}
   m_PrefabAsset: {fileID: 0}
---- !u!212 &1499169744200704914 stripped
+--- !u!212 &7176090347676250686 stripped
 SpriteRenderer:
   m_CorrespondingSourceObject: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
     type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Disposals/Pipes/DisposalPipeSplitterA.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Disposals/Pipes/DisposalPipeSplitterA.prefab
@@ -6,7 +6,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7176090347676296583}
+  m_GameObject: {fileID: 1706338798251575173}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
@@ -30,7 +30,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7176090347676296583}
+  m_GameObject: {fileID: 1706338798251575173}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 819809cff2481914d883a6e1fefb4edd, type: 3}
@@ -50,12 +50,14 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7176090347676296583}
+  m_GameObject: {fileID: 1706338798251575173}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7d430438099380c429fa99b5886ff5e3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
   wrenchTime: 0
   weldTime: 3
   disposalPipeTileUp: {fileID: 11400000, guid: 3210372876be9a447a4c96cef0cc93b5, type: 2}
@@ -71,7 +73,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7176090347676296583}
+  m_GameObject: {fileID: 1706338798251575173}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5657f3ab371d77f449cbbb38e86b7d4c, type: 3}
@@ -83,7 +85,7 @@ MonoBehaviour:
   Down: {fileID: 21300002, guid: ea83ff53d18ddc2449127136f3a2cab5, type: 3}
   Left: {fileID: 21300004, guid: ea83ff53d18ddc2449127136f3a2cab5, type: 3}
   Up: {fileID: 21300000, guid: ea83ff53d18ddc2449127136f3a2cab5, type: 3}
-  spriteRenderer: {fileID: 7176090347676250686}
+  spriteRenderer: {fileID: 1499169744200704914}
 --- !u!1001 &7176090347676343903
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -270,13 +272,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7af28adb717b4c44b8b2002b27670bd, type: 3}
---- !u!1 &7176090347676296583 stripped
+--- !u!1 &1706338798251575173 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8374648283101600218, guid: a7af28adb717b4c44b8b2002b27670bd,
     type: 3}
   m_PrefabInstance: {fileID: 7176090347676343903}
   m_PrefabAsset: {fileID: 0}
---- !u!212 &7176090347676250686 stripped
+--- !u!212 &1499169744200704914 stripped
 SpriteRenderer:
   m_CorrespondingSourceObject: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
     type: 3}

--- a/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
@@ -60,7 +60,7 @@ namespace GameConfig
 		public float PreRoundTime;
 		public float RoundEndTime;
 		public int RoundsPerMap;
-		public string DefaultGameMode;
+		public string InitialGameMode;
 		public bool RespawnAllowed;
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
@@ -56,5 +56,11 @@ namespace GameConfig
 	{
 		public bool RandomEventsAllowed;
 		public bool SpawnLavaLand;
+		public int MinPlayersForCountdown;
+		public float PreRoundTime;
+		public float RoundEndTime;
+		public int RoundsPerMap;
+		public string DefaultGameMode;
+		public bool RespawnAllowed;
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -107,8 +107,11 @@ public partial class GameManager : MonoBehaviour
 		{
 			Destroy(this);
 		}
+	}
 
-		// Set up server defaults
+	private void Start()
+	{
+		// Set up server defaults, needs to be loaded here to ensure gameConfigManager is load.
 		LoadConfig();
 		RespawnCurrentlyAllowed = RespawnAllowed;
 		NextGameMode = InitialGameMode;

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -54,8 +54,7 @@ public partial class GameManager : MonoBehaviour
 	/// <summary>
 	/// The game mode that the server will switch to at round end if no mode or an invalid mode is selected.
 	/// <summary>
-	// TODO: Add validation to ensure gamemode exists, currently unimplemented
-	public string DefaultGameMode { get; set; } = "Random";
+	public string InitialGameMode { get; set; } = "Random";
 
 	public Text roundTimer;
 
@@ -112,7 +111,7 @@ public partial class GameManager : MonoBehaviour
 		// Set up server defaults
 		LoadConfig();
 		RespawnCurrentlyAllowed = RespawnAllowed;
-		//NextGameMode = DefaultGameMode;
+		NextGameMode = InitialGameMode;
 	}
 
 	///<summary>
@@ -134,8 +133,8 @@ public partial class GameManager : MonoBehaviour
 		if(GameConfigManager.GameConfig.RoundsPerMap != null)
 			RoundsPerMap = GameConfigManager.GameConfig.RoundsPerMap;
 
-		if(GameConfigManager.GameConfig.DefaultGameMode != null)
-			DefaultGameMode = GameConfigManager.GameConfig.DefaultGameMode;
+		if(GameConfigManager.GameConfig.InitialGameMode != null)
+			InitialGameMode = GameConfigManager.GameConfig.InitialGameMode;
 
 		if(GameConfigManager.GameConfig.RespawnAllowed != null)
 			RespawnAllowed = GameConfigManager.GameConfig.RespawnAllowed;
@@ -375,17 +374,16 @@ public partial class GameManager : MonoBehaviour
 		// Only do this stuff on the server
 		if (CustomNetworkManager.Instance._isServer)
 		{
-			if (string.IsNullOrEmpty(NextGameMode)
-			    || NextGameMode == "Random")
+			if (string.IsNullOrEmpty(NextGameMode) || NextGameMode == "Random")
 			{
 				SetRandomGameMode();
 			}
 			else
 			{
+				//Set game mode to the selected game mode
 				SetGameMode(NextGameMode);
-				//set it back to random when it has been loaded
-				//TODO set default game modes
-				NextGameMode = "Random";
+				//Then reset it to the default game mode set in the config for next round.
+				NextGameMode = InitialGameMode;
 			}
 
 			// Game mode specific setup

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -116,8 +116,8 @@ public partial class GameManager : MonoBehaviour
 	}
 
 	///<summary>
-	/// Loads what we need from the GameConfigManager.
-	/// If the JSON is configured incorrectly, uses default values.
+	/// Loads end user config settings for server defaults.
+	/// If the JSON is configured incorrectly (null entry), uses default values.
 	///</summary>
 	// TODO: Currently, there is no data validation to ensure the config has reasonable values, need to configure setters.
 	private void LoadConfig() 

--- a/UnityProject/Assets/StreamingAssets/config/gameConfig.json
+++ b/UnityProject/Assets/StreamingAssets/config/gameConfig.json
@@ -11,7 +11,7 @@
 
 	"RoundsPerMap": 10,
 
-	"DefaultGameMode": "Random",
+	"InitialGameMode": "Random",
 
 	"RespawnAllowed": false
 }

--- a/UnityProject/Assets/StreamingAssets/config/gameConfig.json
+++ b/UnityProject/Assets/StreamingAssets/config/gameConfig.json
@@ -1,5 +1,17 @@
 {
 	"RandomEventsAllowed": true,
 
-	"SpawnLavaLand": false
+	"SpawnLavaLand": false,
+
+	"MinPlayersForCountdown": 1,
+
+	"PreRoundTime": 120,
+
+	"RoundEndTime": 60,
+
+	"RoundsPerMap": 10,
+
+	"DefaultGameMode": "Random",
+
+	"RespawnAllowed": false
 }


### PR DESCRIPTION
### Purpose
Expands gameConfig.json to include many server side variables that are not covered by the game mode in order to allow the end user to customize their server settings.  Adds functionality to change the default game mode (currently only in config).

### Notes:
Variables added to the config are: MinPlayersForCountdown, PreRoundTime, RoundEndTime, RoundsPerMap (no use yet), InitialGameMode (new), and RespawnAllowed.  These are set at start so Game Mode can override (eg in the case of RespawnAllowed).

GameManager.cs updated to use get/set convention for these variables to allow data validation to be later implemented.  Currently neither GameManagerConfig nor GameManager possess any data validation methods other than to prevent the use of null values.  This means that the end user may put unintended values into their config.  This largely will not impact performance other than the user feeling dumb that he has to wait a million seconds for the round to start, but we may want to limit what the user can enter.  Validation for InitialGameMode is already being handled by GameManager.GameMode.
