### PR TITLE
BugHunt - ShuttleFuelSystem NREs

### DIFF
--- a/UnityProject/Assets/Scripts/Shuttles/ShuttleFuelSystem.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/ShuttleFuelSystem.cs
@@ -32,7 +32,7 @@ public class ShuttleFuelSystem : ManagedNetworkBehaviour
 	public override void UpdateMe()
 	{
 
-		if (Connector.canister != null)
+		if (this.Connector.canister != null)
 		{
 			FuelConsumption =  MatrixMove.ServerState.Speed / 25f;
 			if (MatrixMove.IsMovingServer && MatrixMove.RequiresFuel)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Connector.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Connector.cs
@@ -5,7 +5,7 @@ using Atmospherics;
 
 public class Connector : AdvancedPipe
 {
-	private Canister canister;
+	public Canister canister;
 
 	public void ConnectCanister(Canister newCanister)
 	{


### PR DESCRIPTION
### Purpose
Fixes an issue where ShuttleFuelSystem was sending a large number of NRES because it lacked an object reference.
