### PR TITLE
Change clothing render order, make tools not disappear anymore.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/AtmosphericAnalyzer.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/AtmosphericAnalyzer.prefab
@@ -1,23 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &1685268818508430524
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8238071069653876758}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e15827970984ba78808f03bc3f01586, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clothData: {fileID: 11400000, guid: dd04f1c9e3f2115429eccb933007791d, type: 2}
-  variantIndex: -1
-  variantType: 0
-  hideClothingFlags: 0
 --- !u!114 &7539747127651399313
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/HandDrill.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/HandDrill.prefab
@@ -1,23 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-8852648715883522900
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4930866777566109869}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e15827970984ba78808f03bc3f01586, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clothData: {fileID: 11400000, guid: cd1897e9e67346946942af65d71b5949, type: 2}
-  variantIndex: -1
-  variantType: 0
-  hideClothingFlags: 0
 --- !u!114 &6165183157056971393
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Jaws of Life.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Jaws of Life.prefab
@@ -15,24 +15,6 @@ MonoBehaviour:
   toolTraits:
   - {fileID: 11400000, guid: 5524008e9372c468aacfb95c83179a91, type: 2}
   - {fileID: 11400000, guid: a78723f619e4a41f3ae170507ca20644, type: 2}
---- !u!114 &6996102117196664092
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6918947953705996213}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e15827970984ba78808f03bc3f01586, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clothData: {fileID: 11400000, guid: d9be76e7e2467544da6a73f705044079, type: 2}
-  variantIndex: -1
-  variantType: 0
-  hideClothingFlags: 0
 --- !u!1001 &1691278609676860386
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/PocketCrowbar.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/PocketCrowbar.prefab
@@ -1,23 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &8756140990652241181
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6918947953705996213}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e15827970984ba78808f03bc3f01586, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clothData: {fileID: 11400000, guid: fd6d56940f905ec489839b3572e942f2, type: 2}
-  variantIndex: -1
-  variantType: 0
-  hideClothingFlags: 0
 --- !u!1001 &1691278609676860386
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -249,9 +231,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c9c58a9243d494537abcb4ee470efab0, type: 3}
---- !u!1 &6918947953705996213 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8610225452865205335, guid: c9c58a9243d494537abcb4ee470efab0,
-    type: 3}
-  m_PrefabInstance: {fileID: 1691278609676860386}
-  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Screwdriver.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Screwdriver.prefab
@@ -100,24 +100,6 @@ MonoBehaviour:
   spriteIndex: 0
   variantIndex: 0
   SetSpriteOnStartUp: 0
---- !u!114 &3235139753472268816
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8868920090029130384}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e15827970984ba78808f03bc3f01586, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clothData: {fileID: 11400000, guid: d389b60f80f3e7a4ba45641e99f2ee1e, type: 2}
-  variantIndex: -1
-  variantType: 0
-  hideClothingFlags: 0
 --- !u!1001 &894265496429246151
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -308,12 +290,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c9c58a9243d494537abcb4ee470efab0, type: 3}
---- !u!1 &8868920090029130384 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8610225452865205335, guid: c9c58a9243d494537abcb4ee470efab0,
-    type: 3}
-  m_PrefabInstance: {fileID: 894265496429246151}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &8865118116160962532 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8605860254165158179, guid: c9c58a9243d494537abcb4ee470efab0,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/WeldingTools/WeldingTool.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/WeldingTools/WeldingTool.prefab
@@ -1,23 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-7122471403829571703
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6989221924687263735}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e15827970984ba78808f03bc3f01586, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clothData: {fileID: 11400000, guid: 3e1b90ec549986c4589cb48e44443f94, type: 2}
-  variantIndex: -1
-  variantType: 0
-  hideClothingFlags: 0
 --- !u!114 &4591132913751966026
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wirecutter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wirecutter.prefab
@@ -1,23 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-3936921038804244693
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1844587092189195201}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e15827970984ba78808f03bc3f01586, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clothData: {fileID: 11400000, guid: 0a91f4e009a521f41866c49e6b788bf2, type: 2}
-  variantIndex: -1
-  variantType: 0
-  hideClothingFlags: 0
 --- !u!1001 &7990758211881508758
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -218,9 +200,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c9c58a9243d494537abcb4ee470efab0, type: 3}
---- !u!1 &1844587092189195201 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8610225452865205335, guid: c9c58a9243d494537abcb4ee470efab0,
-    type: 3}
-  m_PrefabInstance: {fileID: 7990758211881508758}
-  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wrench.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Wrench.prefab
@@ -1,23 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-445795656939454608
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4930866777566109869}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e15827970984ba78808f03bc3f01586, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  clothData: {fileID: 11400000, guid: f3a350f4e41be9947a4c507cfb4da270, type: 2}
-  variantIndex: -1
-  variantType: 0
-  hideClothingFlags: 0
 --- !u!1001 &3679545742786352378
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -253,9 +235,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c9c58a9243d494537abcb4ee470efab0, type: 3}
---- !u!1 &4930866777566109869 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8610225452865205335, guid: c9c58a9243d494537abcb4ee470efab0,
-    type: 3}
-  m_PrefabInstance: {fileID: 3679545742786352378}
-  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Player/Resources/Player_V3(uNet).prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Player/Resources/Player_V3(uNet).prefab
@@ -144,7 +144,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -902452607
   m_SortingLayer: 16
-  m_SortingOrder: 13
+  m_SortingOrder: 16
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -1940,7 +1940,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -902452607
   m_SortingLayer: 16
-  m_SortingOrder: 19
+  m_SortingOrder: 23
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0


### PR DESCRIPTION
### Purpose
- Player clothing rendering order slightly changed.
  - Masks render under hats.
  - Hair renders over belts.
- Remove ClothingV2 script from tools since it caused them to disappear.