### PR TITLE
Add damage deflection to objects and tiles

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -60,8 +60,15 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 
 	public Action OnServerDespawnEvent;
 
+	[Tooltip("This object's initial \"HP\"")]
+	public float initialIntegrity = 100f;
+
 	[Tooltip("Sound to play when damage applied.")]
 	public string soundOnHit;
+
+	[Tooltip("A damage threshold the attack needs to pass in order to apply damage to this item.")]
+	public float damageDeflection = 0;
+
 	/// <summary>
 	/// Armor for this object.
 	/// </summary>
@@ -80,7 +87,6 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	[Tooltip("Below this temperature (in Kelvin) the object will be unaffected by fire exposure.")]
 	public float HeatResistance = 100;
 
-	public float initialIntegrity = 100f;
 
 	[SyncVar(hook = nameof(SyncOnFire))]
 	private bool onFire = false;
@@ -196,12 +202,11 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	public void ApplyDamage(float damage, AttackType attackType, DamageType damageType)
 	{
 		//already destroyed, don't apply damage
-		if (destroyed || Resistances.Indestructable) return;
+		if (destroyed || Resistances.Indestructable || damage < damageDeflection) return;
 
 		if (Resistances.FireProof && attackType == AttackType.Fire) return;
 
 		var damageInfo = new DamageInfo(damage, attackType, damageType);
-
 
 		damage = Armor.GetDamage(damage, attackType);
 		if (damage > 0)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/TilemapDamage.cs
@@ -117,7 +117,7 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 	private float AddDamage(float damage, AttackType attackType, MetaDataNode data,
 		BasicTile basicTile, Vector3 worldPosition)
 	{
-		data.AddTileDamage(Layer.LayerType, basicTile.Armor.GetDamage(damage, attackType));
+		data.AddTileDamage(Layer.LayerType, basicTile.Armor.GetDamage(damage < basicTile.damageDeflection? 0: damage, attackType));
 		SoundManager.PlayNetworkedAtPos(basicTile.SoundOnHit, worldPosition);
 		if (data.GetTileDamage(Layer.LayerType) >= basicTile.MaxHealth)
 		{
@@ -132,6 +132,7 @@ public class TilemapDamage : MonoBehaviour, IFireExposable
 	private float CalculateAbsorbDamaged(AttackType attackType, MetaDataNode data, BasicTile basicTile)
 	{
 		var damage = basicTile.MaxHealth - data.GetTileDamage(Layer.LayerType);
+
 		if (basicTile.MaxHealth < damage)
 		{
 			data.ResetDamage(Layer.LayerType);

--- a/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Tiles/BasicTile.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Container;
+using NaughtyAttributes;
 using Tilemaps.Behaviours;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -7,7 +8,7 @@ using UnityEngine.Tilemaps;
 
 public abstract class BasicTile : LayerTile
 {
-	[Tooltip("What it sounds like when walked over")]
+	[Tooltip("What it sounds like when walked over")][ShowIf(nameof(passable))]
 	public FloorTileType floorTileType = FloorTileType.floor;
 
 	[Tooltip("Allow gases to pass through the cell this tile occupies?")]
@@ -47,6 +48,9 @@ public abstract class BasicTile : LayerTile
 	[SerializeField]
 	private float maxHealth = 0f;
 	public float MaxHealth => maxHealth;
+
+	[Tooltip("A damage threshold the attack needs to pass in order to apply damage to this item.")]
+	public float damageDeflection = 0;
 
 	[Tooltip("Armor of this tile")]
 	[FormerlySerializedAs("Armor")]


### PR DESCRIPTION
### Purpose
This PR will add a new property, damage deflection, to objects and tiles. All incoming damage to objects and tiles will need to pass the damage deflection threshold in order to perform any further damage calculations. This will prevent people from destroying doors with their bare hands or hitting with something stupid like a pencil if they are persistent enough.

fixes #4408
fixes #4387

### Notes
No damage deflection values were given to any object or tile and should be added once this PR is approved by whoever enjoys doing prefab diving (@PetMudstone :eyes:).