### PR TITLE
Make computer frames start working again.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/ComputerFrame.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/ComputerFrame.prefab
@@ -152,6 +152,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: b0485d0b10d5c4a7e8c31a997e28cc2b,
         type: 2}
+    - target: {fileID: 6153340046991516868, guid: aa11b93feb043fe4e84e2f313cc41f6b,
+        type: 3}
+      propertyPath: initialState
+      value: 
+      objectReference: {fileID: 11400000, guid: 0d5b51914201743839c146199035f0f6,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: aa11b93feb043fe4e84e2f313cc41f6b, type: 3}
 --- !u!1 &7744868707174103517 stripped


### PR DESCRIPTION
### Purpose
Fixes #4627 by making computer frames actually have a initial state as they are supposed to, making them securable. Now you can actually make computers again. 
