### PR TITLE
NRE correction

### DIFF
--- a/UnityProject/Assets/Scripts/Electricity/FunctionsAndClasses/PowerSupplyFunction.cs
+++ b/UnityProject/Assets/Scripts/Electricity/FunctionsAndClasses/PowerSupplyFunction.cs
@@ -15,31 +15,7 @@ public static class PowerSupplyFunction  {
 	public static void TurnOffSupply(ModuleSupplyingDevice Supply)
 	{
 		Supply.ControllingNode.Node.InData.Data.ChangeToOff = true;
-
-		try
-		{
-			ElectricalManager.Instance.electricalSync.NUCurrentChange.Add(Supply.ControllingNode);
-		}
-		catch(NullReferenceException ex)
-		{
-			// Temporary stuff to help debug a NullReferenceException, That code will be removed when the exception is fixed
-			StringBuilder sbError = new StringBuilder();
-
-			sbError.AppendLine($"\n\nRound Time: {GameManager.Instance.stationTime.ToString("O")}");
-			sbError.AppendLine($"Scene: {GameManager.Instance.gameObject.scene.name}");
-			sbError.AppendLine($"Supply : {Supply.name}");
-
-			if (ElectricalManager.Instance == null)
-				sbError.AppendLine("Instance was null");
-			else if (ElectricalManager.Instance.electricalSync == null)
-				sbError.AppendLine("electricalSync was null");
-			else if (ElectricalManager.Instance.electricalSync.NUCurrentChange == null)
-				sbError.AppendLine("NUCurrentChange was null");
-
-			sbError.AppendLine($"Original Exception : {ex.Message}\n\n{ex.StackTrace}");
-
-			throw new Exception(sbError.ToString(), ex);
-		}
+		ElectricalManager.Instance.electricalSync.NUCurrentChange.Add(Supply.ControllingNode);
 	}
 	public static void TurnOnSupply(ModuleSupplyingDevice Supply)
 	{

--- a/UnityProject/Assets/Scripts/Electricity/NodeModules/ModuleSupplyingDevice.cs
+++ b/UnityProject/Assets/Scripts/Electricity/NodeModules/ModuleSupplyingDevice.cs
@@ -110,12 +110,14 @@ public class ModuleSupplyingDevice : ElectricalModuleInheritance
 			}
 		}
 
+
+		// On some transitional scenes like the DontDestroyOnLoad scene, we don't have an ElectricalManager.
+		// We should not try to update it in those cases.
 		if (ElectricalManager.Instance?.electricalSync?.NUResistanceChange != null)
 		{
 			ElectricalManager.Instance.electricalSync.NUResistanceChange.Add(ControllingNode);
+			PowerSupplyFunction.TurnOffSupply(this);
 		}
-
-		PowerSupplyFunction.TurnOffSupply(this);
 	}
 	public override void PowerNetworkUpdate()
 	{


### PR DESCRIPTION
Caused by the inexistance of ElectricalManager Instance in special scenes like the DontDestroyOnLoad scene.

To reproduce, just end the current round, again and again the error is bound to happen once in a while.

Object reference not set to an instance of an object
PowerSupplyFunction.TurnOffSupply (ModuleSupplyingDevice Supply) (at Assets/Scripts/Electricity/FunctionsAndClasses/PowerSupplyFunction.cs:21)
PowerSupplyFunction.TurnOffSupply (ModuleSupplyingDevice Supply) (at Assets/Scripts/Electricity/FunctionsAndClasses/PowerSupplyFunction.cs:41)
ModuleSupplyingDevice.TurnOffSupply () (at Assets/Scripts/Electricity/NodeModules/ModuleSupplyingDevice.cs:118)
ReactorTurbine.OnDisable () (at Assets/Scripts/Electricity/Engine/ReactorTurbine.cs:33)
