### PR TITLE
Fixes gateway teleport.

### DIFF
--- a/UnityProject/Assets/Scripts/Gateway/StationGateway.cs
+++ b/UnityProject/Assets/Scripts/Gateway/StationGateway.cs
@@ -229,7 +229,7 @@ public class StationGateway : NetworkBehaviour, IAPCPowered
 	[Server]
 	public virtual void TransportPlayers(ObjectBehaviour player)
 	{
-		var newPosition = selectedWorld.Position;
+		var newPosition = selectedWorld.registerTile.WorldPosition;
 		if (selectedWorld.OverrideCoord != Vector3Int.zero)
 		{
 			newPosition = selectedWorld.OverrideCoord;
@@ -242,7 +242,7 @@ public class StationGateway : NetworkBehaviour, IAPCPowered
 	[Server]
 	public virtual void TransportObjectsItems(ObjectBehaviour objectsitems)
 	{
-		var newPosition = selectedWorld.Position;
+		var newPosition = selectedWorld.registerTile.WorldPosition;
 		if (selectedWorld.OverrideCoord != Vector3Int.zero)
 		{
 			newPosition = selectedWorld.OverrideCoord;

--- a/UnityProject/Assets/Scripts/Gateway/WorldGateway.cs
+++ b/UnityProject/Assets/Scripts/Gateway/WorldGateway.cs
@@ -33,7 +33,8 @@ public class WorldGateway : StationGateway
 	{
 		SetOffline();
 		registerTile = GetComponent<RegisterTile>();
-		Position = registerTile.WorldPosition;
+
+		Position = gameObject.transform.position.RoundToInt();
 
 		ServerChangeState(false);
 

--- a/UnityProject/Assets/Scripts/Gateway/WorldGateway.cs
+++ b/UnityProject/Assets/Scripts/Gateway/WorldGateway.cs
@@ -34,8 +34,6 @@ public class WorldGateway : StationGateway
 		SetOffline();
 		registerTile = GetComponent<RegisterTile>();
 
-		Position = gameObject.transform.position.RoundToInt();
-
 		ServerChangeState(false);
 
 		if (ifWorldGateToWorldGate && StationGateway != null)


### PR DESCRIPTION
For some reason RegisterTile WorldPositionServer was returning the wrong coord, even though the matrix was correct.

So I had to switch over to transform.position
