### PR TITLE
Fixes some disposals bugs

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MineralDoors.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Doors/MineralDoors.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0c788dafab80d6b44bdaa272bc467deb
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/SoundManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/SoundManager.prefab
@@ -5179,6 +5179,170 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
+--- !u!1 &1288841114939779441
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 28893058180260526}
+  - component: {fileID: 6033250783300300408}
+  m_Layer: 0
+  m_Name: Clang
+  m_TagString: SoundFX
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &28893058180260526
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1288841114939779441}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2961261946748269813}
+  m_RootOrder: 76
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!82 &6033250783300300408
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1288841114939779441}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 24300001, guid: 94208a0928046438d9b8a00796e7a5a7,
+    type: 2}
+  m_audioClip: {fileID: 8300000, guid: ed1a9e093f9234be3a6b596e9e57d3a5, type: 3}
+  m_PlayOnAwake: 0
+  m_Volume: 0.4
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 30
+  Pan2D: 0
+  rolloffMode: 2
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0.033333335
+      value: 1
+      inSlope: -30.011993
+      outSlope: -30.011993
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.06666667
+      value: 0.5
+      inSlope: -7.5029984
+      outSlope: -7.5029984
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.13333334
+      value: 0.25
+      inSlope: -1.8757496
+      outSlope: -1.8757496
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.26666668
+      value: 0.125
+      inSlope: -0.4689374
+      outSlope: -0.4689374
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.53333336
+      value: 0.0625
+      inSlope: -0.11723435
+      outSlope: -0.11723435
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: -0.033346657
+      outSlope: -0.033346657
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
 --- !u!1 &1290191276088659983
 GameObject:
   m_ObjectHideFlags: 0
@@ -34411,6 +34575,7 @@ Transform:
   - {fileID: 2399264215065784550}
   - {fileID: 8491084614241142674}
   - {fileID: 7479164034653056641}
+  - {fileID: 28893058180260526}
   m_Father: {fileID: 5630492256413423177}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/TabPipeDispenser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/TabPipeDispenser.prefab
@@ -2076,15 +2076,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Hidden: 0
   isPopOut: 1
-  Provider: {fileID: 0}
-  ProviderRegisterTile: {fileID: 0}
-  Type: 24
-  OnTabOpened:
-    m_PersistentCalls:
-      m_Calls: []
   OnTabClosed:
     m_PersistentCalls:
       m_Calls: []
+  OnTabOpened:
+    m_PersistentCalls:
+      m_Calls: []
+  Provider: {fileID: 0}
+  ProviderRegisterTile: {fileID: 0}
+  Type: 24
   categorySwitcher: {fileID: 5224746791700680373}
   dispensePageSwitcher: {fileID: 7035438463351932546}
   layerToggles:
@@ -9192,6 +9192,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: TransitTubesText
+      objectReference: {fileID: 0}
+    - target: {fileID: 4735958661600894371, guid: 1d0d4cec35fffac458087b5a6f61520f,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 4879831074043828582, guid: 1d0d4cec35fffac458087b5a6f61520f,
         type: 3}

--- a/UnityProject/Assets/Scripts/Disposals/DisposalBin.cs
+++ b/UnityProject/Assets/Scripts/Disposals/DisposalBin.cs
@@ -22,7 +22,10 @@ namespace Disposals
 		const int AUTO_FLUSH_DELAY = 2;
 		const float ANIMATION_TIME = 1.3f; // As per sprite sheet JSON file.
 
+// Ignore never-assigned-to warning as it is assigned via inspector
+#pragma warning disable CS0649
 		[SerializeField] AudioSource rechargeSFX;
+#pragma warning restore CS0649
 
 		HasNetworkTab netTab;
 		SpriteHandler overlaysSpriteHandler;

--- a/UnityProject/Assets/Scripts/Disposals/DisposalBin.cs
+++ b/UnityProject/Assets/Scripts/Disposals/DisposalBin.cs
@@ -22,10 +22,7 @@ namespace Disposals
 		const int AUTO_FLUSH_DELAY = 2;
 		const float ANIMATION_TIME = 1.3f; // As per sprite sheet JSON file.
 
-// Ignore never-assigned-to warning as it is assigned via inspector
-#pragma warning disable CS0649
-		[SerializeField] AudioSource rechargeSFX;
-#pragma warning restore CS0649
+		[SerializeField] AudioSource rechargeSFX = null;
 
 		HasNetworkTab netTab;
 		SpriteHandler overlaysSpriteHandler;

--- a/UnityProject/Assets/Scripts/Disposals/DisposalMachine.cs
+++ b/UnityProject/Assets/Scripts/Disposals/DisposalMachine.cs
@@ -141,6 +141,7 @@ namespace Disposals
 		protected DisposalVirtualContainer SpawnNewContainer()
 		{
 			GameObject containerObject = DisposalsManager.SpawnVirtualContainer(registerObject.WorldPositionServer);
+			containerObject.GetComponent<ObjectBehaviour>().parentContainer = objectBehaviour;
 			return containerObject.GetComponent<DisposalVirtualContainer>();
 		}
 

--- a/UnityProject/Assets/Scripts/Disposals/DisposalOutlet.cs
+++ b/UnityProject/Assets/Scripts/Disposals/DisposalOutlet.cs
@@ -131,6 +131,7 @@ namespace Disposals
 		public void ServerReceiveAndEjectContainer(DisposalVirtualContainer virtualContainer)
 		{
 			receivedContainers.Add(virtualContainer);
+			virtualContainer.GetComponent<ObjectBehaviour>().parentContainer = objectBehaviour;
 			if (!OutletOperating) StartCoroutine(RunEjectionSequence());
 		}
 

--- a/UnityProject/Assets/Scripts/Disposals/DisposalPipe.cs
+++ b/UnityProject/Assets/Scripts/Disposals/DisposalPipe.cs
@@ -7,6 +7,8 @@ namespace Disposals
 	[CreateAssetMenu(fileName = "DisposalPipe", menuName = "Tiles/Disposal Pipe", order = 1)]
 	public class DisposalPipe : BasicTile, IExaminable
 	{
+// Ignore never-assigned-to warning as it is assigned via inspector
+#pragma warning disable CS0649
 		[Tooltip("Set the type of disposal pipe this is.")]
 		public DisposalPipeType PipeType;
 
@@ -20,6 +22,7 @@ namespace Disposals
 		[SerializeField]
 		[Tooltip("Set the sides available for connecting to other disposal pipes.")]
 		List<ConnectablePoint> _ConnectablePoints;
+#pragma warning restore CS0649
 
 		Dictionary<OrientationEnum, DisposalPipeConnType> connectablePoints;
 		public Dictionary<OrientationEnum, DisposalPipeConnType> ConnectablePoints {

--- a/UnityProject/Assets/Scripts/Disposals/DisposalPipe.cs
+++ b/UnityProject/Assets/Scripts/Disposals/DisposalPipe.cs
@@ -7,8 +7,6 @@ namespace Disposals
 	[CreateAssetMenu(fileName = "DisposalPipe", menuName = "Tiles/Disposal Pipe", order = 1)]
 	public class DisposalPipe : BasicTile, IExaminable
 	{
-// Ignore never-assigned-to warning as it is assigned via inspector
-#pragma warning disable CS0649
 		[Tooltip("Set the type of disposal pipe this is.")]
 		public DisposalPipeType PipeType;
 
@@ -21,8 +19,7 @@ namespace Disposals
 
 		[SerializeField]
 		[Tooltip("Set the sides available for connecting to other disposal pipes.")]
-		List<ConnectablePoint> _ConnectablePoints;
-#pragma warning restore CS0649
+		List<ConnectablePoint> _ConnectablePoints = new List<ConnectablePoint>();
 
 		Dictionary<OrientationEnum, DisposalPipeConnType> connectablePoints;
 		public Dictionary<OrientationEnum, DisposalPipeConnType> ConnectablePoints {

--- a/UnityProject/Assets/Scripts/Disposals/DisposalPipeObject.cs
+++ b/UnityProject/Assets/Scripts/Disposals/DisposalPipeObject.cs
@@ -13,6 +13,8 @@ namespace Disposals
 		TileChangeManager tileChangeManager;
 		ObjectBehaviour behaviour;
 
+// Ignore never-assigned-to warning as it is assigned via inspector
+#pragma warning disable CS0649
 		[SerializeField]
 		[Tooltip("Tile to spawn when pipe is welded in the Up orientation.")]
 		DisposalPipe disposalPipeTileUp;
@@ -28,6 +30,7 @@ namespace Disposals
 		[SerializeField]
 		[Tooltip("Tile to spawn when pipe is welded in the Right orientation.")]
 		DisposalPipe disposalPipeTileRight;
+#pragma warning disable CS0649
 
 		string objectName;
 		HandApply currentInteraction;

--- a/UnityProject/Assets/Scripts/Disposals/DisposalPipeObject.cs
+++ b/UnityProject/Assets/Scripts/Disposals/DisposalPipeObject.cs
@@ -13,24 +13,21 @@ namespace Disposals
 		TileChangeManager tileChangeManager;
 		ObjectBehaviour behaviour;
 
-// Ignore never-assigned-to warning as it is assigned via inspector
-#pragma warning disable CS0649
 		[SerializeField]
 		[Tooltip("Tile to spawn when pipe is welded in the Up orientation.")]
-		DisposalPipe disposalPipeTileUp;
+		DisposalPipe disposalPipeTileUp = null;
 
 		[SerializeField]
 		[Tooltip("Tile to spawn when pipe is welded in the Down orientation.")]
-		DisposalPipe disposalPipeTileDown;
+		DisposalPipe disposalPipeTileDown = null;
 
 		[SerializeField]
 		[Tooltip("Tile to spawn when pipe is welded in the Left orientation.")]
-		DisposalPipe disposalPipeTileLeft;
+		DisposalPipe disposalPipeTileLeft = null;
 
 		[SerializeField]
 		[Tooltip("Tile to spawn when pipe is welded in the Right orientation.")]
-		DisposalPipe disposalPipeTileRight;
-#pragma warning disable CS0649
+		DisposalPipe disposalPipeTileRight = null;
 
 		string objectName;
 		HandApply currentInteraction;

--- a/UnityProject/Assets/Scripts/Disposals/DisposalVirtualContainer.cs
+++ b/UnityProject/Assets/Scripts/Disposals/DisposalVirtualContainer.cs
@@ -82,6 +82,34 @@ namespace Disposals
 
 		#endregion AddContents
 
+		#region RemoveContents
+
+		public void RemoveItem(ObjectBehaviour item)
+		{
+			if (containedItems.Remove(item))
+			{
+				EjectItemOrObject(item);
+			}
+		}
+
+		public void RemoveObject(ObjectBehaviour entity)
+		{
+			if (containedObjects.Remove(entity))
+			{
+				EjectItemOrObject(entity);
+			}
+		}
+
+		public void RemovePlayer(ObjectBehaviour player)
+		{
+			if (containedPlayers.Remove(player))
+			{
+				EjectPlayer(player);
+			}
+		}
+
+		#endregion RemoveContents
+
 		#region EjectContents
 
 		void EjectContainedItems()
@@ -214,6 +242,24 @@ namespace Disposals
 		}
 
 		#endregion EjectContents
+
+		public void PlayerTryEscaping(GameObject player)
+		{
+			if (!player.TryGetComponent(out ObjectBehaviour playerBehaviour)) return;
+			if (!containedPlayers.Contains(playerBehaviour)) return;
+
+			GameObject disposalMachine = ContainerBehaviour.parentContainer?.gameObject;
+			if (disposalMachine == null)
+			{
+				// Must be in the disposal pipes
+				SoundManager.PlayNetworkedAtPos("Clang", ContainerWorldPosition);
+			}
+			else if (disposalMachine.TryGetComponent(out DisposalBin disposalBin))
+			{
+				// In a disposal bin
+				disposalBin.PlayerTryClimbingOut(player);
+			}
+		}
 
 		public void OnDespawnServer(DespawnInfo info)
 		{

--- a/UnityProject/Assets/Scripts/UI/Net/Page/NetPageSwitcher.cs
+++ b/UnityProject/Assets/Scripts/UI/Net/Page/NetPageSwitcher.cs
@@ -109,6 +109,8 @@ public class NetPageSwitcher : NetUIStringElement
 	/// <param name="pageIndex">The index of the page to be activated (from Pages field)</param>
 	public void SetActivePage(int pageIndex)
 	{
+		if (Pages.ElementAtOrDefault(pageIndex) == null) return;
+
 		SetActivePage(Pages[pageIndex]);
 	}
 


### PR DESCRIPTION
### Purpose
- Players can now exit disposal bins by attempting to move, alleviating issue #4646. Fixes part 12. of issue #4654.
- Clicking the transit tubes toggle in the pipe dispenser no longer causes a server error. Partially fixes part 10. of #4654.
- Attempting to move while in a disposals pipe will now produce a clang sound. Fixes part D. of #4654.
- Fixes a few compiler warnings. Fixes part 1. of #4654.

### Notes
> Issue #2398 can probably be closed.