### PR TITLE
add GibbingAllowed to gameconfig file

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Atmospherics;
+using GameConfig;
 using Light2D;
 using UnityEngine;
 using UnityEngine.Events;
@@ -367,7 +368,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	public virtual void ApplyDamageToBodypart(GameObject damagedBy, float damage,
 		AttackType attackType, DamageType damageType, BodyPartType bodyPartAim)
 	{
-		if (IsDead)
+		if (IsDead && GameManager.Instance.AllowGibbing)
 		{
 			afterDeathDamage += damage;
 			if (afterDeathDamage >= GIB_THRESHOLD)

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -368,7 +368,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	public virtual void ApplyDamageToBodypart(GameObject damagedBy, float damage,
 		AttackType attackType, DamageType damageType, BodyPartType bodyPartAim)
 	{
-		if (IsDead && GameManager.Instance.AllowGibbing)
+		if (IsDead && GameManager.Instance.GibbingAllowed)
 		{
 			afterDeathDamage += damage;
 			if (afterDeathDamage >= GIB_THRESHOLD)

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -368,14 +368,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	public virtual void ApplyDamageToBodypart(GameObject damagedBy, float damage,
 		AttackType attackType, DamageType damageType, BodyPartType bodyPartAim)
 	{
-		if (IsDead && GameManager.Instance.GibbingAllowed)
-		{
-			afterDeathDamage += damage;
-			if (afterDeathDamage >= GIB_THRESHOLD)
-			{
-				Harvest(); //Gib() instead when fancy gibs are in
-			}
-		}
+		TryGibbing(damage);
 
 		BodyPartBehaviour bodyPartBehaviour = GetBodyPart(damage, damageType, bodyPartAim);
 		if (bodyPartBehaviour == null)
@@ -419,6 +412,33 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 
 		Logger.LogTraceFormat("{3} received {0} {4} damage from {6} aimed for {5}. Health: {1}->{2}", Category.Health,
 			damage, prevHealth, OverallHealth, gameObject.name, damageType, bodyPartAim, damagedBy);
+	}
+
+	private void TryGibbing(float damage)
+	{
+		if (!IsDead)
+		{
+			return;
+		}
+
+		afterDeathDamage += damage;
+
+		// if damage IS OVER NINE THOUSAND!!!11!!!1 it means it is coming from a shuttle collision.
+		if (damage > 9000f && GameManager.Instance.ShuttleGibbingAllowed)
+		{
+			Harvest();
+			return;
+		}
+
+		if (!GameManager.Instance.GibbingAllowed)
+		{
+			return;
+		}
+
+		if (afterDeathDamage >= GIB_THRESHOLD)
+		{
+			Harvest();
+		}
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
@@ -63,5 +63,6 @@ namespace GameConfig
 		public string InitialGameMode;
 		public bool RespawnAllowed;
 		public int ShuttleDepartTime;
+		public bool AllowGibbing;
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
@@ -64,5 +64,6 @@ namespace GameConfig
 		public bool RespawnAllowed;
 		public int ShuttleDepartTime;
 		public bool GibbingAllowed;
+		public bool ShuttleGibbingAllowed;
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameConfigManager.cs
@@ -63,6 +63,6 @@ namespace GameConfig
 		public string InitialGameMode;
 		public bool RespawnAllowed;
 		public int ShuttleDepartTime;
-		public bool AllowGibbing;
+		public bool GibbingAllowed;
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -62,6 +62,11 @@ public partial class GameManager : MonoBehaviour
 	public bool GibbingAllowed { get; set; }
 
 	/// <summary>
+	/// If true, it will allow shuttles from dealing 9001 damage and instantly gibbing people when crashed
+	/// </summary>
+	public bool ShuttleGibbingAllowed { get; set; }
+
+	/// <summary>
 	/// The game mode that the server will switch to at round end if no mode or an invalid mode is selected.
 	/// <summary>
 	public string InitialGameMode { get; set; } = "Random";
@@ -157,6 +162,9 @@ public partial class GameManager : MonoBehaviour
 
 		if (GameConfigManager.GameConfig.GibbingAllowed != null)
 			GibbingAllowed = GameConfigManager.GameConfig.GibbingAllowed;
+
+		if (GameConfigManager.GameConfig.ShuttleGibbingAllowed != null)
+			ShuttleGibbingAllowed = GameConfigManager.GameConfig.ShuttleGibbingAllowed;
 	}
 
 	private void OnEnable()

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -59,7 +59,7 @@ public partial class GameManager : MonoBehaviour
 	/// <summary>
 	/// True if the server allows gibbing people when they receive enough post-mortem damage.
 	/// </summary>
-	public bool AllowGibbing { get; set; }
+	public bool GibbingAllowed { get; set; }
 
 	/// <summary>
 	/// The game mode that the server will switch to at round end if no mode or an invalid mode is selected.
@@ -155,8 +155,8 @@ public partial class GameManager : MonoBehaviour
 		if(GameConfigManager.GameConfig.ShuttleDepartTime != null)
 			ShuttleDepartTime = GameConfigManager.GameConfig.ShuttleDepartTime;
 
-		if (GameConfigManager.GameConfig.AllowGibbing != null)
-			AllowGibbing = GameConfigManager.GameConfig.AllowGibbing;
+		if (GameConfigManager.GameConfig.GibbingAllowed != null)
+			GibbingAllowed = GameConfigManager.GameConfig.GibbingAllowed;
 	}
 
 	private void OnEnable()

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -57,6 +57,11 @@ public partial class GameManager : MonoBehaviour
 	public bool RespawnAllowed { get; set; }
 
 	/// <summary>
+	/// True if the server allows gibbing people when they receive enough post-mortem damage.
+	/// </summary>
+	public bool AllowGibbing { get; set; }
+
+	/// <summary>
 	/// The game mode that the server will switch to at round end if no mode or an invalid mode is selected.
 	/// <summary>
 	public string InitialGameMode { get; set; } = "Random";
@@ -149,6 +154,9 @@ public partial class GameManager : MonoBehaviour
 
 		if(GameConfigManager.GameConfig.ShuttleDepartTime != null)
 			ShuttleDepartTime = GameConfigManager.GameConfig.ShuttleDepartTime;
+
+		if (GameConfigManager.GameConfig.AllowGibbing != null)
+			AllowGibbing = GameConfigManager.GameConfig.AllowGibbing;
 	}
 
 	private void OnEnable()

--- a/UnityProject/Assets/StreamingAssets/config/gameConfig.json
+++ b/UnityProject/Assets/StreamingAssets/config/gameConfig.json
@@ -17,5 +17,7 @@
 
 	"ShuttleDepartTime": 180,
 	
-	"GibbingAllowed": false
+	"GibbingAllowed": false,
+	
+	"ShuttleGibbingAllowed": true
 }

--- a/UnityProject/Assets/StreamingAssets/config/gameConfig.json
+++ b/UnityProject/Assets/StreamingAssets/config/gameConfig.json
@@ -17,5 +17,5 @@
 
 	"ShuttleDepartTime": 180,
 	
-	"AllowGibbing": false
+	"GibbingAllowed": false
 }

--- a/UnityProject/Assets/StreamingAssets/config/gameConfig.json
+++ b/UnityProject/Assets/StreamingAssets/config/gameConfig.json
@@ -15,5 +15,7 @@
 
 	"RespawnAllowed": false,
 
-	"ShuttleDepartTime": 180
+	"ShuttleDepartTime": 180,
+	
+	"AllowGibbing": false
 }


### PR DESCRIPTION
### Purpose
Adds a new option to game config file so servers can allow or disallow gibbing people when they receive enough post-death damage.

This is a temporal fix for #4454 as many players have voiced their concern with how easy it is to gib people. Gibbin would get more complex with health rework #4100 

### Notes:
It is disabled by default so servers who are ok with current gibbin situation will have to manually change it.
