### PR TITLE
Decreases Editor play start times

### DIFF
--- a/UnityProject/ProjectSettings/EditorSettings.asset
+++ b/UnityProject/ProjectSettings/EditorSettings.asset
@@ -10,7 +10,7 @@ EditorSettings:
   m_DefaultBehaviorMode: 1
   m_PrefabRegularEnvironment: {fileID: 0}
   m_PrefabUIEnvironment: {fileID: 0}
-  m_SpritePackerMode: 4
+  m_SpritePackerMode: 3
   m_SpritePackerPaddingPower: 1
   m_EtcTextureCompressorBehavior: 1
   m_EtcTextureFastCompressor: 1


### PR DESCRIPTION
for some reason, unity re-packs atlases every single time you start the game if they're set to build, I know it's dumb but this turns it off so it only is active in builds, this should decrease the in play mode FPS That doesn't seem too bad for a Quicker loading time