### PR TITLE
Bug fixes

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/Shovel.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/Shovel.prefab
@@ -64,8 +64,13 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 6f84a6a37a3027a42b64a593a2669838,
+      objectReference: {fileID: 21300000, guid: 87e93125755a53742926fbcad3109246,
         type: 3}
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: itemSprites.InventoryIcon.Sprites.Array.size
@@ -224,7 +229,7 @@ PrefabInstance:
         type: 3}
       propertyPath: PresentSpriteSet
       value: 
-      objectReference: {fileID: 11400000, guid: 080fbedacf4fcb942848780bab70bba9,
+      objectReference: {fileID: 11400000, guid: dfe82174f045a024fad255f39e2b81e3,
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/office_chair.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/office_chair.prefab
@@ -284,7 +284,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  initialName: office char
+  initialName: office chair
   initialDescription: For sitting down or getting strapped onto.
   willHighlight: 1
   exportCost: 0

--- a/UnityProject/Assets/Scripts/Objects/WallmountSpriteBehavior.cs
+++ b/UnityProject/Assets/Scripts/Objects/WallmountSpriteBehavior.cs
@@ -20,6 +20,20 @@ public class WallmountSpriteBehavior : MonoBehaviour {
 	//parent wallmount behavior
 	private WallmountBehavior wallmountBehavior;
 
+	private LightingSystem lightingSystem;
+	private LightingSystem LightingSystem
+	{
+		get
+		{
+			if (this.lightingSystem == null && Camera.main.TryGetComponent(out LightingSystem lightingSystem))
+			{
+				this.lightingSystem = lightingSystem;
+			}
+
+			return this.lightingSystem;
+		}
+	}
+
 	private void Start()
 	{
 		spriteRenderer = GetComponent<SpriteRenderer>();
@@ -29,14 +43,23 @@ public class WallmountSpriteBehavior : MonoBehaviour {
 	// Handles rendering logic, only runs when this sprite is on camera
 	private void OnWillRenderObject()
 	{
-		//don't run check until player is created
+		// don't run check until player is created
 		if (PlayerManager.LocalPlayer == null || wallmountBehavior == null)
 		{
 			return;
 		}
 
-		//recalculate if it is facing the player
-		bool visible = wallmountBehavior.IsFacingPosition(Camera2DFollow.followControl.target.position);
+		bool visible;
+		// If the lighting system is disabled, we're probably a ghost or have the dev spawner open.
+		if (!LightingSystem.enabled)
+		{
+			visible = true;
+		}
+		else
+		{
+			// recalculate if it is facing the player
+			visible = wallmountBehavior.IsFacingPosition(Camera2DFollow.followControl.target.position);
+		}
 		spriteRenderer.color = new Color(spriteRenderer.color.r, spriteRenderer.color.g, spriteRenderer.color.b, visible ? 1 : 0);
 	}
 }

--- a/UnityProject/Assets/Scripts/Player/Huggable.cs
+++ b/UnityProject/Assets/Scripts/Player/Huggable.cs
@@ -33,18 +33,14 @@ public class Huggable : MonoBehaviour, ICheckedInteractable<HandApply>
 		performerName = interaction.Performer.ExpensiveName();
 		targetName = interaction.TargetObject.ExpensiveName();
 
-		if (interaction.TargetObject.TryGetComponent(out RegisterPlayer targetRegisterPlayer))
+		if (interaction.TargetObject.TryGetComponent(out RegisterPlayer targetRegisterPlayer) && targetRegisterPlayer.IsLayingDown)
 		{
-			if (targetRegisterPlayer.IsLayingDown)
-			{
-				HelpUp();
-				return;
-			}
+			HelpUp();
 		}
-
-		if (TryFieryHug()) return;
-
-		Hug();
+		else if (!TryFieryHug())
+		{
+			Hug();
+		}
 
 		SoundManager.PlayNetworkedAtPos(
 				"ThudSwoosh", interaction.TargetObject.WorldPosServer(), Random.Range(0.8f, 1.2f), sourceObj: interaction.TargetObject);

--- a/UnityProject/Assets/Scripts/Player/Huggable.cs
+++ b/UnityProject/Assets/Scripts/Player/Huggable.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 /// </summary>
 public class Huggable : MonoBehaviour, ICheckedInteractable<HandApply>
 {
+	private HandApply interaction;
 	private string performerName;
 	private string targetName;
 
@@ -28,9 +29,41 @@ public class Huggable : MonoBehaviour, ICheckedInteractable<HandApply>
 
 	public void ServerPerformInteraction(HandApply interaction)
 	{
+		this.interaction = interaction;
 		performerName = interaction.Performer.ExpensiveName();
 		targetName = interaction.TargetObject.ExpensiveName();
 
+		if (interaction.TargetObject.TryGetComponent(out RegisterPlayer targetRegisterPlayer))
+		{
+			if (targetRegisterPlayer.IsLayingDown)
+			{
+				HelpUp();
+				return;
+			}
+		}
+
+		if (TryFieryHug()) return;
+
+		Hug();
+
+		SoundManager.PlayNetworkedAtPos(
+				"ThudSwoosh", interaction.TargetObject.WorldPosServer(), Random.Range(0.8f, 1.2f), sourceObj: interaction.TargetObject);
+	}
+
+	// TODO Consider moving this into its own component, or merging Huggable, this and CPRable into
+	// one "Helpable" component.
+	private void HelpUp()
+	{
+		var targetRegisterPlayer = interaction.TargetObject.GetComponent<RegisterPlayer>();
+		targetRegisterPlayer.ServerHelpUp();
+
+		Chat.AddActionMsgToChat(interaction.Performer,
+				$"You try to help {targetName} up.", $"{performerName} tries to help {targetName} up.");
+		Chat.AddExamineMsgFromServer(interaction.TargetObject, $"{performerName} tries help you up!");
+	}
+
+	private bool TryFieryHug()
+	{
 		var performerLHB = interaction.Performer.GetComponent<LivingHealthBehaviour>();
 		var targetLHB = interaction.TargetObject.GetComponent<LivingHealthBehaviour>();
 
@@ -42,12 +75,16 @@ public class Huggable : MonoBehaviour, ICheckedInteractable<HandApply>
 			Chat.AddCombatMsgToChat(
 					interaction.Performer, $"You hug {targetName} with fire!", $"{performerName} hugs {targetName} with fire!");
 			Chat.AddExamineMsgFromServer(interaction.TargetObject, $"{performerName} hugs you with fire!");
+
+			return true;
 		}
-		else
-		{
-			Chat.AddActionMsgToChat(
-					interaction.Performer, $"You hug {targetName}.", $"{performerName} hugs {targetName}.");
-			Chat.AddExamineMsgFromServer(interaction.TargetObject, $"{performerName} hugs you.");
-		}
+
+		return false;
+	}
+
+	private void Hug()
+	{
+		Chat.AddActionMsgToChat(interaction.Performer, $"You hug {targetName}.", $"{performerName} hugs {targetName}.");
+		Chat.AddExamineMsgFromServer(interaction.TargetObject, $"{performerName} hugs you.");
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -10,6 +10,7 @@ using Random = UnityEngine.Random;
 [ExecuteInEditMode]
 public class RegisterPlayer : RegisterTile, IServerSpawn
 {
+	const int HELP_CHANCE = 33; // Percent.
 
 	// tracks whether player is down or upright.
 	[SyncVar(hook = nameof(SyncIsLayingDown))]
@@ -148,6 +149,20 @@ public class RegisterPlayer : RegisterTile, IServerSpawn
 	}
 
 	/// <summary>
+	/// Try to help the player stand back up.
+	/// </summary>
+	[Server]
+	public void ServerHelpUp()
+	{
+		if (!IsLayingDown) return;
+
+		// Check if lying down because of stun. If stunned, there is a chance helping can fail.
+		if (IsSlippingServer && Random.Range(0, 100) > HELP_CHANCE) return;
+
+		ServerRemoveStun();
+	}
+
+	/// <summary>
 	/// Slips and stuns the player.
 	/// </summary>
 	/// <param name="slipWhileWalking">Enables slipping while walking.</param>
@@ -202,7 +217,13 @@ public class RegisterPlayer : RegisterTile, IServerSpawn
 	private IEnumerator StunTimer(float stunTime)
 	{
 		yield return WaitFor.Seconds(stunTime);
-		ServerRemoveStun();
+
+		// Check if player is still stunned when timer ends
+		// (may have been helped up by another player, for example)
+		if (IsSlippingServer)
+		{
+			ServerRemoveStun();
+		}
 	}
 
 	private void ServerRemoveStun()

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class Hands : MonoBehaviour
 {
@@ -28,6 +29,25 @@ public class Hands : MonoBehaviour
 	{
 		IsRight = true;
 		hasSwitchedHands = false;
+	}
+
+	private void OnEnable()
+	{
+		SceneManager.activeSceneChanged += OnLevelFinishedLoading;
+	}
+
+	private void OnDisable()
+	{
+		SceneManager.activeSceneChanged -= OnLevelFinishedLoading;
+	}
+
+	private void OnLevelFinishedLoading(Scene oldScene, Scene newScene)
+	{
+		if (PlayerManager.LocalPlayerScript != null && PlayerManager.LocalPlayerScript.playerNetworkActions != null)
+		{
+			// Reset active hand on game restart - there may be a better event to subscribe to than OnLevelFinishLoading
+			SetHand(true);
+		}
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/UI/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/UIManager.cs
@@ -361,24 +361,13 @@ public class UIManager : MonoBehaviour
 	/// <param name="player">player performing the action</param>
 	/// <returns>progress bar associated with this action (can use this to interrupt progress). Null if
 	/// progress was not started for some reason (such as already in progress for this action on the specified tile).</returns>
-	public static ProgressBar _ServerStartProgress(IProgressAction progressAction, ActionTarget actionTarget,
-		float timeForCompletion,
-		GameObject player)
+	public static ProgressBar _ServerStartProgress(
+			IProgressAction progressAction, ActionTarget actionTarget, float timeForCompletion, GameObject player)
 	{
-		//convert to an offset so local position ends up being correct even on moving matrix
-		var offsetFromPlayer = actionTarget.TargetWorldPosition.To2Int() - player.TileWorldPosition();
-		//convert to local position so it appears correct on moving matrix
-		//do not use tileworldposition for actual spawn position - bar will appear shifted on moving matrix
-		var targetWorldPosition = player.transform.position + offsetFromPlayer.To3Int();
-		var targetTilePosition = player.TileWorldPosition() + offsetFromPlayer;
-		var targetMatrixInfo = MatrixManager.AtPoint(targetTilePosition.To3Int(), true);
+		var targetMatrixInfo = MatrixManager.AtPoint(actionTarget.TargetWorldPosition.CutToInt(), true);
 		var targetParent = targetMatrixInfo.Objects;
-		//snap to local position
-		var targetLocalPosition = targetParent.transform.InverseTransformPoint(targetWorldPosition).RoundToInt();
 
-		//back to world so we can call PoolClientInstantiate
-		targetWorldPosition = targetParent.transform.TransformPoint(targetLocalPosition);
-		var barObject = Spawn.ClientPrefab("ProgressBar", targetWorldPosition, targetParent).GameObject;
+		var barObject = Spawn.ClientPrefab("ProgressBar", actionTarget.TargetWorldPosition, targetParent).GameObject;
 		var progressBar = barObject.GetComponent<ProgressBar>();
 
 		//make sure it should start and call start hooks


### PR DESCRIPTION
### Purpose
- Ghosts are now able to see wallmounts from any direction. Fixes #2822 and fixes #4700.
- Prone players can no longer be hugged; instead if they are in good health they will be helped to their feet.
- Fixes the progress bar sometimes spawning on the wrong tile when on a moving matrix.
- Fixes player hand not set to right hand on restart. Fixes #3067.
- Fixes the Shovel prefab; it is no longer a spacecarp.

### Note
> Unable to test changes with round restarts as I have repeatedly been unable to keep a client connected without crashing during the restart. This is of particular importance to the fourth bullet point and so should probably be tested.