### PR TITLE
Client is now notified why job selection fails, fix job request bug

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/Windows/Nanotrasen_JobSelect.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/Windows/Nanotrasen_JobSelect.prefab
@@ -112,6 +112,304 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Waiting for server confirmation...
+--- !u!1 &5062895357969556444
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5707824328331994596}
+  - component: {fileID: 5019919708374848078}
+  m_Layer: 5
+  m_Name: ErrorInfoWindow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5707824328331994596
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5062895357969556444}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 930297934159701236}
+  m_Father: {fileID: 6312343524722458272}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0.000030518}
+  m_SizeDelta: {x: 798.1, y: 323.1}
+  m_Pivot: {x: 0.5, y: 0.49999994}
+--- !u!114 &5019919708374848078
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5062895357969556444}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da97c6e985ce4debb1893fce40a4db98, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Colour: {fileID: 9104218134426116150}
+  banColor: {r: 0.6313726, g: 0, b: 0.19215688, a: 1}
+  infoColor: {r: 0, g: 0.6117647, b: 0.6117647, a: 1}
+  infoText: {fileID: 6164975309348339368}
+  title: {fileID: 1097561857238669938}
+--- !u!1 &5233300334094282474
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8121166936080224739}
+  - component: {fileID: 8056746257363704167}
+  - component: {fileID: 6651429917706787557}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8121166936080224739
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5233300334094282474}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5364222183153933865}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8056746257363704167
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5233300334094282474}
+  m_CullTransparentMesh: 0
+--- !u!114 &6651429917706787557
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5233300334094282474}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: dbe0045f727f34e40a9ddacbb0a5b3ec, type: 3}
+    m_FontSize: 44
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 55
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Dismiss
+--- !u!1 &5472652797263976269
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2224470400916725528}
+  - component: {fileID: 3985660927914729318}
+  - component: {fileID: 338857388366330604}
+  - component: {fileID: 2413185564570127379}
+  m_Layer: 5
+  m_Name: Header
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2224470400916725528
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5472652797263976269}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2776242728458692345}
+  m_Father: {fileID: 930297934159701236}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.32998657, y: 134.7}
+  m_SizeDelta: {x: -3.2, y: -269.4}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3985660927914729318
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5472652797263976269}
+  m_CullTransparentMesh: 0
+--- !u!114 &338857388366330604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5472652797263976269}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.14509805, g: 0.14901961, b: 0.16078432, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2413185564570127379
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5472652797263976269}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 0}
+  m_EffectDistance: {x: 0, y: -3}
+  m_UseGraphicAlpha: 1
+--- !u!1 &5960496101412250854
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7103422964388611809}
+  - component: {fileID: 2061105322705711935}
+  - component: {fileID: 3293146379746761526}
+  m_Layer: 5
+  m_Name: reasonText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7103422964388611809
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5960496101412250854}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 930297934159701236}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 2.09, y: -28}
+  m_SizeDelta: {x: 775.8, y: 70.8}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2061105322705711935
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5960496101412250854}
+  m_CullTransparentMesh: 0
+--- !u!114 &3293146379746761526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5960496101412250854}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.6313726, g: 0.058823533, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Unspecified error.
 --- !u!1 &6088874792490013080
 GameObject:
   m_ObjectHideFlags: 0
@@ -379,6 +677,7 @@ RectTransform:
   - {fileID: 6312338573119879666}
   - {fileID: 4084346847651530988}
   - {fileID: 1039284645197192262}
+  - {fileID: 5707824328331994596}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -497,6 +796,8 @@ MonoBehaviour:
   screen_Jobs: {fileID: 6088874885299057258}
   jobInfo: {fileID: 3196655623783654281}
   footer: {fileID: 2381354533637366457}
+  errorInfoWindow: {fileID: 5062895357969556444}
+  errorReasonText: {fileID: 3293146379746761526}
   waitMessage: {fileID: 4708227290949375273}
   waitForSpawnTimerMax: 6
 --- !u!1 &6089957433471938358
@@ -576,6 +877,441 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Choose Profession
+--- !u!1 &6169204605937738068
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2776242728458692345}
+  - component: {fileID: 15790220554719183}
+  - component: {fileID: 9104218134426116150}
+  m_Layer: 5
+  m_Name: main
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2776242728458692345
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6169204605937738068}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2224470400916725528}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 4.1}
+  m_SizeDelta: {x: 0, y: -8.3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &15790220554719183
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6169204605937738068}
+  m_CullTransparentMesh: 0
+--- !u!114 &9104218134426116150
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6169204605937738068}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3254902, g: 0.4156863, b: 0.49803925, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6878013072563038398
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7058201417675821588}
+  - component: {fileID: 588959515808314734}
+  - component: {fileID: 1097561857238669938}
+  m_Layer: 5
+  m_Name: title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7058201417675821588
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6878013072563038398}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 930297934159701236}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 2.09, y: 141.02}
+  m_SizeDelta: {x: 793.9, y: 41.045}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &588959515808314734
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6878013072563038398}
+  m_CullTransparentMesh: 0
+--- !u!114 &1097561857238669938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6878013072563038398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 28
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 53
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Job application rejected
+--- !u!1 &7069015799439446551
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5364222183153933865}
+  - component: {fileID: 9098922800436940643}
+  - component: {fileID: 4509158700629599261}
+  - component: {fileID: 2035722110288594119}
+  m_Layer: 5
+  m_Name: Ok button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5364222183153933865
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7069015799439446551}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.46893883, y: 0.46893883, z: 0.46893883}
+  m_Children:
+  - {fileID: 8121166936080224739}
+  m_Father: {fileID: 930297934159701236}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 9, y: 35}
+  m_SizeDelta: {x: 559.6, y: 91.3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9098922800436940643
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7069015799439446551}
+  m_CullTransparentMesh: 0
+--- !u!114 &4509158700629599261
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7069015799439446551}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3278302, g: 0.41883424, b: 0.5, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: cc3b2d94fa0a81a42899ff1375633780, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2035722110288594119
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7069015799439446551}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4509158700629599261}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5019919708374848078}
+        m_MethodName: BtnOk
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 1
+--- !u!1 &7351073362258410807
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3877508748370840911}
+  - component: {fileID: 4217997267814191115}
+  - component: {fileID: 6164975309348339368}
+  m_Layer: 5
+  m_Name: infoText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3877508748370840911
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7351073362258410807}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 930297934159701236}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 52}
+  m_SizeDelta: {x: 775.8, y: 70.8}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4217997267814191115
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7351073362258410807}
+  m_CullTransparentMesh: 0
+--- !u!114 &6164975309348339368
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7351073362258410807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 3
+    m_AlignByGeometry: 1
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'NanoTrasen Central Command regrets to inform you that your application
+    to live and work on Unitystation has been rejected. Reason:'
+--- !u!1 &8969172640276581171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 930297934159701236}
+  - component: {fileID: 2444345007932183690}
+  - component: {fileID: 1157190765864196013}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &930297934159701236
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8969172640276581171}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2224470400916725528}
+  - {fileID: 7058201417675821588}
+  - {fileID: 3877508748370840911}
+  - {fileID: 7103422964388611809}
+  - {fileID: 5364222183153933865}
+  m_Father: {fileID: 5707824328331994596}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2444345007932183690
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8969172640276581171}
+  m_CullTransparentMesh: 0
+--- !u!114 &1157190765864196013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8969172640276581171}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.105882354, g: 0.105882354, b: 0.18431373, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1001 &149570948672575722
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/UI/InfoWindow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/UI/InfoWindow.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 804792789876894655}
   - component: {fileID: 3379306402566806848}
   m_Layer: 5
-  m_Name: Panel (1)
+  m_Name: Header
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -31,13 +31,14 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2963329204209694634}
+  - {fileID: 7956500392207369031}
   m_Father: {fileID: 248255648219887015}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.32998657, y: 145.52}
-  m_SizeDelta: {x: -3.17, y: -291.05}
+  m_AnchoredPosition: {x: 0, y: -20.552}
+  m_SizeDelta: {x: 0, y: 41.105}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4095750390509588021
 CanvasRenderer:
@@ -246,17 +247,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5830879805517855213}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 248255648219887015}
+  m_Father: {fileID: 1244689166038208075}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 2.09, y: 145.52}
-  m_SizeDelta: {x: 793.92, y: 32.05}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -16}
+  m_SizeDelta: {x: -10, y: 32}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &555220076226683965
 CanvasRenderer:
@@ -291,7 +292,7 @@ MonoBehaviour:
     m_BestFit: 0
     m_MinSize: 10
     m_MaxSize: 53
-    m_Alignment: 3
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
@@ -332,8 +333,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 8.47}
-  m_SizeDelta: {x: 0, y: -16.93}
+  m_AnchoredPosition: {x: 0, y: 4}
+  m_SizeDelta: {x: 0, y: -8}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1126171656510365340
 CanvasRenderer:
@@ -401,7 +402,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 248255648219887015}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -441,7 +442,7 @@ MonoBehaviour:
     m_BestFit: 0
     m_MinSize: 2
     m_MaxSize: 40
-    m_Alignment: 4
+    m_Alignment: 3
     m_AlignByGeometry: 1
     m_RichText: 1
     m_HorizontalOverflow: 0
@@ -480,7 +481,7 @@ RectTransform:
   m_Children:
   - {fileID: 9163910947915071664}
   m_Father: {fileID: 248255648219887015}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
@@ -607,7 +608,6 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1244689166038208075}
-  - {fileID: 7956500392207369031}
   - {fileID: 4203903068185697308}
   - {fileID: 5037669391938228090}
   m_Father: {fileID: 4660853724584916151}

--- a/UnityProject/Assets/Scripts/Construction/WrenchSecurable.cs
+++ b/UnityProject/Assets/Scripts/Construction/WrenchSecurable.cs
@@ -66,9 +66,6 @@ public class WrenchSecurable : NetworkBehaviour, ICheckedInteractable<HandApply>
 
 	public void ServerPerformInteraction(HandApply interaction)
 	{
-		if (interaction.TargetObject != gameObject) return;
-		if (!Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench)) return;
-
 		currentInteraction = interaction;
 		TryWrench();
 	}

--- a/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
+++ b/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using Mirror;
 
 /// <summary>
@@ -40,6 +40,8 @@ public class ConnectedPlayer
 			gameObject = value;
 			if (gameObject != null)
 			{
+				// If player is in lobby, their controlled GameObject is JoinedViewer (which has JoinedViewer component).
+				// Else they're in the game and so have a GameObject that has PlayerScript attached.
 				Script = value.GetComponent<PlayerScript>();
 				ViewerScript = value.GetComponent<JoinedViewer>();
 			}

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -674,6 +674,7 @@ public partial class GameManager : MonoBehaviour
 	IEnumerator ServerRoundRestart()
 	{
 		Logger.Log("Server restarting round now.", Category.Round);
+		Chat.AddGameWideSystemMsgToChat("The round is now restarting...");
 
 		//Notify all clients that the round has ended
 		ServerToClientEventsMsg.SendToAll(EVENT.RoundEnded);

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -192,7 +192,7 @@ public class CustomNetworkManager : NetworkManager
 	public override void OnServerDisconnect(NetworkConnection conn)
 	{
 		//register them as removed from our own player list
-		PlayerList.Instance.Remove(conn);
+		PlayerList.Instance.RemoveByConnection(conn);
 
 		//NOTE: We don't call the base.OnServerDisconnect method because it destroys the player object -
 		//we want to keep the object around so player can rejoin and reenter their body.

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -1,9 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using Mirror;
-using Newtonsoft.Json;
 
 /// Comfy place to get players and their info (preferably via their connection)
 /// Has limited scope for clients (ClientConnectedPlayers only), sweet things are mostly for server
@@ -18,6 +17,7 @@ public partial class PlayerList : NetworkBehaviour
 
 	public static PlayerList Instance;
 	public int ConnectionCount => loggedIn.Count;
+	public int OfflineConnCount => loggedOff.Count;
 	public List<ConnectedPlayer> InGamePlayers => loggedIn.FindAll(player => player.Script != null);
 
 	public List<ConnectedPlayer> NonAntagPlayers =>
@@ -183,10 +183,10 @@ public partial class PlayerList : NetworkBehaviour
 			return player;
 		}
 
-		Logger.Log($"Player: {player.Username} client id is: {player.ClientId}");
-		var loggedOffClient = GetLoggedOffClient(player.ClientId);
+		Logger.Log($"Player {player.Username}'s client ID is: {player.ClientId}.");
 
-		if (loggedOffClient  != null)
+		var loggedOffClient = GetLoggedOffClient(player.ClientId);
+		if (loggedOffClient != null)
 		{
 			Logger.Log(
 				$"ConnectedPlayer Username({player.Username}) already exists in this server's PlayerList as Character({loggedOffClient.Name}) " +
@@ -200,10 +200,7 @@ public partial class PlayerList : NetworkBehaviour
 				return player;
 			}
 
-			player.GameObject = loggedOffClient.GameObject;
-			player.Name = loggedOffClient.Name; //Note that name won't be changed to empties/nulls
-			player.Job = loggedOffClient.Job;
-			player.ClientId = loggedOffClient.ClientId;
+			// Switching over to the old player's character is handled by JoinedViewer.
 		}
 
 		loggedIn.Add(player);
@@ -218,13 +215,13 @@ public partial class PlayerList : NetworkBehaviour
 	{
 		if (!loggedIn.Contains(player))
 		{
-			Logger.Log($"Player with name {player.Name} was not found in online players list. " +
-			           $"Verifying playerlists for integrity", Category.Connections);
+			Logger.Log($"Player with name {player.Name} was not found in online player list. " +
+					$"Verifying player lists for integrity...", Category.Connections);
 			ValidatePlayerListRecords();
 			return;
 		}
 
-		Logger.Log($"Added {player.Name} to offline player list", Category.Connections);
+		Logger.Log($"Added {player.Name} to offline player list.", Category.Connections);
 		loggedOff.Add(player);
 		loggedIn.Remove(player);
 		UpdateConnectedPlayersMessage.Send();
@@ -293,7 +290,6 @@ public partial class PlayerList : NetworkBehaviour
 		return getInternal(player => player.UserId == byUserID);
 	}
 
-
 	[Server]
 	public ConnectedPlayer GetByConnection(NetworkConnection connection)
 	{
@@ -320,54 +316,26 @@ public partial class PlayerList : NetworkBehaviour
 	}
 
 	[Server]
-	public void Remove(NetworkConnection connection)
+	public void RemoveByConnection(NetworkConnection connection)
 	{
 		if (connection == null)
 		{
-			Logger.Log($"Unknown Player Disconnected verifying playerlists for integrity - connection was null", Category.Connections);
+			Logger.Log($"Unknown player disconnected: verifying playerlists for integrity - connection was null.", Category.Connections);
 			ValidatePlayerListRecords();
 			return;
 		}
 
-		if (connection.identity == null)
+		var player = Get(connection);
+		if (player.Equals(ConnectedPlayer.Invalid))
 		{
-			Logger.Log($"Unknown Player Disconnected verifying playerlists for integrity - player controller was null IP:{connection.address}", Category.Connections);
+			Logger.Log($"Unknown player disconnected: verifying playerlists for integrity - connected player was invalid. " +
+					$"IP: {connection.address}. Name: {connection.identity.name}.", Category.Connections);
 			ValidatePlayerListRecords();
 			return;
 		}
 
-		var connectedPlayer = ConnectedPlayer.Invalid;
-
-		var playerScript = connection.identity.GetComponent<PlayerScript>();
-		if (playerScript != null)
-		{
-			var index = loggedIn.FindIndex(x => x.Script == playerScript);
-			if (index != -1)
-			{
-				connectedPlayer = loggedIn[index];
-			}
-		}
-
-		var joinedViewer = connection.identity.GetComponent<JoinedViewer>();
-		if (joinedViewer != null)
-		{
-			var index = loggedIn.FindIndex(x => x.ViewerScript == joinedViewer);
-			if (index != -1)
-			{
-				connectedPlayer = loggedIn[index];
-			}
-		}
-
-		if (connectedPlayer.Equals(ConnectedPlayer.Invalid))
-		{
-			Logger.Log($"Unknown Player Disconnected verifying playerlists for integrity - connected player was invalid IP:{connection.address} Name:{connection.identity.name}", Category.Connections);
-			ValidatePlayerListRecords();
-		}
-		else
-		{
-			CheckForLoggedOffAdmin(connectedPlayer.UserId, connectedPlayer.Username);
-			TryMoveClientToOfflineList(connectedPlayer);
-		}
+		CheckForLoggedOffAdmin(player.UserId, player.Username);
+		TryMoveClientToOfflineList(player);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
+++ b/UnityProject/Assets/Scripts/Player/JoinedViewer.cs
@@ -60,9 +60,11 @@ public class JoinedViewer : NetworkBehaviour
 			unverifiedUserid, unverifiedClientVersion, unverifiedConnPlayer, unverifiedToken);
 		if (!isValidPlayer) return; //this validates Userid and Token
 
-		// Check if they have a player to rejoin. If not, assign them a new client ID
+		// Check if they have a player to rejoin. If not, assign them a new client ID.
 		var loggedOffPlayer = PlayerList.Instance.TakeLoggedOffPlayerbyClientId(unverifiedClientId);
 
+		// If the player does not yet have an in-game object to control, they'll probably have a
+		// JoinedViewer assigned as they were only in the lobby. If so, destroy it and use the new one.
 		if (loggedOffPlayer != null)
 		{
 			var checkForViewer = loggedOffPlayer.GetComponent<JoinedViewer>();
@@ -75,7 +77,7 @@ public class JoinedViewer : NetworkBehaviour
 
 		UpdateConnectedPlayersMessage.Send();
 
-		// Only sync the pre-round countdown if it's already started
+		// Only sync the pre-round countdown if it's already started.
 		if (GameManager.Instance.CurrentRoundState == RoundState.PreRound)
 		{
 			if (GameManager.Instance.waitForStart)
@@ -88,16 +90,15 @@ public class JoinedViewer : NetworkBehaviour
 			}
 		}
 
-		//if there's a logged off player, we will force them to rejoin. Previous logic allowed client to reenter
-		//their body or not, which should not be up to the client!
+		// If there's a logged off player, we will force them to rejoin. Previous logic allowed client to re-enter
+		// their body or not, which should not be up to the client!
 		if (loggedOffPlayer != null)
 		{
 			StartCoroutine(WaitForLoggedOffObserver(loggedOffPlayer));
 		}
 		else
 		{
-			TargetLocalPlayerSetupNewPlayer(connectionToClient,
-				GameManager.Instance.CurrentRoundState);
+			TargetLocalPlayerSetupNewPlayer(connectionToClient, GameManager.Instance.CurrentRoundState);
 		}
 
 		PlayerList.Instance.CheckAdminState(unverifiedConnPlayer, unverifiedUserid);

--- a/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
+++ b/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
@@ -83,7 +83,7 @@ public class GUI_PlayerJobs : MonoBehaviour
 		waitMessage.SetActive(false);
 	}
 
-	public void ShowFailMessage(JoinedViewer.ClientRequestJobMessage.JobRequestError failReason)
+	public void ShowFailMessage(JoinedViewer.JobRequestError failReason)
 	{
 		waitForSpawnTimer = 0;
 		ShowJobSelection();
@@ -92,22 +92,20 @@ public class GUI_PlayerJobs : MonoBehaviour
 		errorInfoWindow.SetActive(true);
 	}
 
-	private string GetFailMessage(JoinedViewer.ClientRequestJobMessage.JobRequestError failReason)
+	private string GetFailMessage(JoinedViewer.JobRequestError failReason)
 	{
 		switch (failReason)
 		{
-			case JoinedViewer.ClientRequestJobMessage.JobRequestError.InvalidUserID:
+			case JoinedViewer.JobRequestError.InvalidUserID:
 				return "Invalid User ID.";
-			case JoinedViewer.ClientRequestJobMessage.JobRequestError.InvalidPlayerID:
+			case JoinedViewer.JobRequestError.InvalidPlayerID:
 				return "Invalid Player ID.";
-			case JoinedViewer.ClientRequestJobMessage.JobRequestError.RoundNotReady:
+			case JoinedViewer.JobRequestError.RoundNotReady:
 				return "New shift hasn't started yet.";
-			case JoinedViewer.ClientRequestJobMessage.JobRequestError.JobBanned:
+			case JoinedViewer.JobRequestError.JobBanned:
 				return "You were previously fired from this position. [Job-banned]";
-			case JoinedViewer.ClientRequestJobMessage.JobRequestError.PositionsFilled:
+			case JoinedViewer.JobRequestError.PositionsFilled:
 				return "All positions for this profession have been filled.";
-			case JoinedViewer.ClientRequestJobMessage.JobRequestError.JoinedViewerNull:
-				return "Processing error: spawnRequest.JoinedViewer was empty.";
 			default: return "Unspecified error.";
 		}
 	}

--- a/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
+++ b/UnityProject/Assets/Scripts/UI/Jobs/GUI_PlayerJobs.cs
@@ -28,6 +28,12 @@ public class GUI_PlayerJobs : MonoBehaviour
 	/// </summary>
 	public GameObject footer = null;
 
+	[SerializeField]
+	private GameObject errorInfoWindow = null;
+
+	[SerializeField]
+	private Text errorReasonText = null;
+
 	/// <summary>
 	/// A gameobject that is shown after job selection when the player is waiting to spawn.
 	/// </summary>
@@ -69,12 +75,48 @@ public class GUI_PlayerJobs : MonoBehaviour
 		waitForSpawnTimer = waitForSpawnTimerMax;
 	}
 
+	private void ShowJobSelection()
+	{
+		SoundManager.Play("Click01");
+		screen_Jobs.SetActive(true);
+		footer.SetActive(true);
+		waitMessage.SetActive(false);
+	}
+
+	public void ShowFailMessage(JoinedViewer.ClientRequestJobMessage.JobRequestError failReason)
+	{
+		waitForSpawnTimer = 0;
+		ShowJobSelection();
+
+		errorReasonText.text = GetFailMessage(failReason);
+		errorInfoWindow.SetActive(true);
+	}
+
+	private string GetFailMessage(JoinedViewer.ClientRequestJobMessage.JobRequestError failReason)
+	{
+		switch (failReason)
+		{
+			case JoinedViewer.ClientRequestJobMessage.JobRequestError.InvalidUserID:
+				return "Invalid User ID.";
+			case JoinedViewer.ClientRequestJobMessage.JobRequestError.InvalidPlayerID:
+				return "Invalid Player ID.";
+			case JoinedViewer.ClientRequestJobMessage.JobRequestError.RoundNotReady:
+				return "New shift hasn't started yet.";
+			case JoinedViewer.ClientRequestJobMessage.JobRequestError.JobBanned:
+				return "You were previously fired from this position. [Job-banned]";
+			case JoinedViewer.ClientRequestJobMessage.JobRequestError.PositionsFilled:
+				return "All positions for this profession have been filled.";
+			case JoinedViewer.ClientRequestJobMessage.JobRequestError.JoinedViewerNull:
+				return "Processing error: spawnRequest.JoinedViewer was empty.";
+			default: return "Unspecified error.";
+		}
+	}
+
 	void OnEnable()
 	{
 		screen_Jobs.SetActive(true);
 		SetFooter();
 		footer.SetActive(true);
-
 	}
 
 	/// <summary>
@@ -99,10 +141,7 @@ public class GUI_PlayerJobs : MonoBehaviour
 			if (waitForSpawnTimer <= 0)
 			{
 				// Job selection failed, re-open it.
-				SoundManager.Play("Click01");
-				screen_Jobs.SetActive(true);
-				footer.SetActive(true);
-				waitMessage.SetActive(false);
+				ShowJobSelection();
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/Hands.cs
@@ -31,25 +31,6 @@ public class Hands : MonoBehaviour
 		hasSwitchedHands = false;
 	}
 
-	private void OnEnable()
-	{
-		SceneManager.activeSceneChanged += OnLevelFinishedLoading;
-	}
-
-	private void OnDisable()
-	{
-		SceneManager.activeSceneChanged -= OnLevelFinishedLoading;
-	}
-
-	private void OnLevelFinishedLoading(Scene oldScene, Scene newScene)
-	{
-		if (PlayerManager.LocalPlayerScript != null && PlayerManager.LocalPlayerScript.playerNetworkActions != null)
-		{
-			// Reset active hand on game restart - there may be a better event to subscribe to than OnLevelFinishLoading
-			SetHand(true);
-		}
-	}
-
 	/// <summary>
 	/// Action to swap hands
 	/// </summary>
@@ -183,17 +164,16 @@ public class Hands : MonoBehaviour
 	/// <returns>True if they can, false if they cannot</returns>
 	private bool isValidPlayer()
 	{
-		if (PlayerManager.LocalPlayerScript != null)
-		{
-			// TODO tidy up this if statement once it's working correctly
-			if (!PlayerManager.LocalPlayerScript.playerMove.allowInput ||
+		if (PlayerManager.LocalPlayerScript == null) return false;
+
+		// TODO tidy up this if statement once it's working correctly
+		if (!PlayerManager.LocalPlayerScript.playerMove.allowInput ||
 				PlayerManager.LocalPlayerScript.IsGhost)
-			{
-				Logger.Log("Invalid player, cannot perform action!", Category.UI);
-				return false;
-			}
+		{
+			Logger.Log("Invalid player, cannot perform action!", Category.UI);
+			return false;
 		}
+
 		return true;
 	}
-
 }

--- a/UnityProject/Assets/Scripts/UI/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/UIManager.cs
@@ -279,6 +279,7 @@ public class UIManager : MonoBehaviour
 		}
 
 		StorageHandler.CloseStorageUI();
+		Hands.SetHand(true);
 		Camera2DFollow.followControl.ZeroStars();
 		IsOxygen = false;
 		GamePad.gameObject.SetActive(UseGamePad);


### PR DESCRIPTION
### Purpose
- Client is now notified why a job selection fails. 
![unitystation_loPd1b4ZXk](https://user-images.githubusercontent.com/6926225/89122810-909a7c00-d51e-11ea-93b5-d09ab3cd53a3.png)
- Players who disconnect while in the lobby can now properly select a profession after rejoining. Fixes #4743.
- Better reset to default hand solution than the one found in #4730.