### PR TITLE
NRE Correction Issue #4690

### DIFF
--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -63,7 +63,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply> ,
 	/// <summary>
 	/// Currently held items, only valid server side
 	/// </summary>
-	public IEnumerable<ObjectBehaviour> ServerHeldItems => serverHeldItems;
+	public List<ObjectBehaviour> ServerHeldItems => serverHeldItems;
 
 	/// <summary>
 	/// Currently held players, only valid server side
@@ -103,7 +103,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply> ,
 	private bool isLocked;
 
 	//Inventory
-	private IEnumerable<ObjectBehaviour> serverHeldItems = new List<ObjectBehaviour>();
+	private List<ObjectBehaviour> serverHeldItems = new List<ObjectBehaviour>();
 	private List<ObjectBehaviour> serverHeldPlayers = new List<ObjectBehaviour>();
 
 	private RegisterCloset registerTile;
@@ -208,7 +208,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply> ,
 		{
 			Despawn.ServerSingle(heldItem.gameObject);
 		}
-		serverHeldItems = Enumerable.Empty<ObjectBehaviour>();
+		serverHeldItems.Clear();
 	}
 
 	/// <summary>
@@ -232,7 +232,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply> ,
 	private void ServerAddInternalItemInternal(ObjectBehaviour toAdd, bool force = false)
 	{
 		if (toAdd == null || serverHeldItems.Contains(toAdd) || (!IsClosed && !force)) return;
-		serverHeldItems = serverHeldItems.Concat(new [] {toAdd});
+		serverHeldItems.Add(toAdd);
 		toAdd.parentContainer = pushPull;
 		toAdd.VisibleState = false;
 	}
@@ -479,7 +479,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply> ,
 			item.parentContainer = null;
 		}
 
-		serverHeldItems = Enumerable.Empty<ObjectBehaviour>();
+		serverHeldItems.Clear();
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Weapons/Grenade.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Grenade.cs
@@ -139,6 +139,14 @@ public class Grenade : NetworkBehaviour, IPredictedInteractable<HandActivate>, I
 			var explosionMatrix = registerItem.Matrix;
 			var worldPos = objectBehaviour.AssumedWorldPositionServer();
 
+			// If the grenade was in a closet before despawning it,
+			// it would be useful to remove it from the closet item list to avoid NullReferenceExceptions
+			ClosetControl closetControl = null;
+			if ((objectBehaviour.parentContainer != null) && (objectBehaviour.parentContainer.TryGetComponent(out closetControl)))
+			{
+				closetControl.ServerHeldItems.Remove(objectBehaviour);
+			}
+
 			// Despawn grenade
 			Despawn.ServerSingle(gameObject);
 


### PR DESCRIPTION
NRE Correction Issue #4690

Correction of a server side NRE when a grenade explodes in a locker.
The grenade was despawned but still in the locker list of item.

Suggestion for a more intelligent software : the locker should not handle it's own list of item.  We should one day create a component for lockers, boxes, crates, and other containers.