### PR TITLE
Simplify disposal machines and drawers to use new sprite system

### DIFF
--- a/UnityProject/Assets/Scripts/Disposals/DisposalOutlet.cs
+++ b/UnityProject/Assets/Scripts/Disposals/DisposalOutlet.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using Mirror;
 
 namespace Disposals
 {
@@ -11,14 +10,10 @@ namespace Disposals
 		const float ANIMATION_TIME = 4.2f; // As per sprite sheet JSON file.
 		const float EJECTION_DELAY = 3;
 
-		[SyncVar(hook = nameof(OnSyncOutletState))]
-		bool outletOperating = false;
-		[SyncVar(hook = nameof(OnSyncOrientation))]
-		Orientation orientation;
-
+		Directional directional;
 		List<DisposalVirtualContainer> receivedContainers = new List<DisposalVirtualContainer>();
 
-		public bool OutletOperating => outletOperating;
+		public bool OutletOperating { get; private set; }
 		public bool ServerHasContainers => receivedContainers.Count > 0;
 
 		#region Initialisation
@@ -27,17 +22,13 @@ namespace Disposals
 		{
 			base.Awake();
 
-			if (TryGetComponent(out Directional directional))
-			{
-				orientation = directional.InitialOrientation;
-				directional.OnDirectionChange.AddListener(OnDirectionChanged);
-			}
+			directional = GetComponent<Directional>();
 		}
 
-		public override void OnStartClient()
+		void Start()
 		{
-			base.OnStartClient();
-			UpdateSpriteOutletState();
+			directional.OnDirectionChange.AddListener(OnDirectionChanged);
+			UpdateSpriteState();
 			UpdateSpriteOrientation();
 		}
 
@@ -53,28 +44,22 @@ namespace Disposals
 
 		void OnDirectionChanged(Orientation newDir)
 		{
-			orientation = newDir;
+			UpdateSpriteOrientation();
 		}
 
 		#region Sync
 
-		void OnSyncOutletState(bool oldState, bool newState)
+		void SetOutletOperating(bool isOperating)
 		{
-			outletOperating = newState;
-			UpdateSpriteOutletState();
-		}
-
-		void OnSyncOrientation(Orientation oldState, Orientation newState)
-		{
-			orientation = newState;
-			UpdateSpriteOrientation();
+			OutletOperating = isOperating;
+			UpdateSpriteState();
 		}
 
 		#endregion Sync
 
 		#region Sprites
 
-		void UpdateSpriteOutletState()
+		void UpdateSpriteState()
 		{
 			if (OutletOperating) baseSpriteHandler.ChangeSprite(1);
 			else baseSpriteHandler.ChangeSprite(0);
@@ -82,7 +67,7 @@ namespace Disposals
 
 		void UpdateSpriteOrientation()
 		{
-			switch (orientation.AsEnum())
+			switch (directional.CurrentDirection.AsEnum())
 			{
 				case OrientationEnum.Up:
 					baseSpriteHandler.ChangeSpriteVariant(1);
@@ -141,21 +126,21 @@ namespace Disposals
 			while (ServerHasContainers)
 			{
 				// Outlet orifice opens...
-				outletOperating = true;
+				SetOutletOperating(true);
 				SoundManager.PlayNetworkedAtPos("DisposalMachineBuzzer", registerObject.WorldPositionServer, sourceObj: gameObject);
 				yield return WaitFor.Seconds(EJECTION_DELAY);
 
 				// Outlet orifice open. Release the charge.
 				foreach (DisposalVirtualContainer container in receivedContainers)
 				{
-					container.EjectContentsAndThrow(orientation.Vector);
+					container.EjectContentsAndThrow(directional.CurrentDirection.Vector);
 					Despawn.ServerSingle(container.gameObject);
 				}
 				receivedContainers.Clear();
 
 				// Close orifice, restore charge (containers may be received during this period).
 				yield return WaitFor.Seconds(ANIMATION_TIME - EJECTION_DELAY);
-				outletOperating = false;
+				SetOutletOperating(false);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Drawers/Cremator.cs
+++ b/UnityProject/Assets/Scripts/Drawers/Cremator.cs
@@ -74,7 +74,7 @@ public class Cremator : Drawer, IRightClickable, ICheckedInteractable<ContextMen
 
 	#region Server Only
 
-	protected override void CloseDrawer()
+	public override void CloseDrawer()
 	{
 		base.CloseDrawer();
 		// Note: the sprite setting done in base.CloseDrawer() would be overridden (an unnecessary sprite call).
@@ -87,9 +87,9 @@ public class Cremator : Drawer, IRightClickable, ICheckedInteractable<ContextMen
 	{
 		if (serverHeldItems.Count > 0 || serverHeldPlayers.Count > 0)
 		{
-			OnSyncDrawerState((DrawerState)CrematorState.ShutWithContents);
+			SetDrawerState((DrawerState)CrematorState.ShutWithContents);
 		}
-		else OnSyncDrawerState(DrawerState.Shut);
+		else SetDrawerState(DrawerState.Shut);
 	}
 
 	private void Cremate()
@@ -145,7 +145,7 @@ public class Cremator : Drawer, IRightClickable, ICheckedInteractable<ContextMen
 
 	private IEnumerator PlayIncineratingAnim()
 	{
-		OnSyncDrawerState((DrawerState)CrematorState.ShutAndActive);
+		SetDrawerState((DrawerState)CrematorState.ShutAndActive);
 		yield return WaitFor.Seconds(BURNING_DURATION);
 		OnFinishPlayerCremation();
 		UpdateCloseState();

--- a/UnityProject/Assets/Scripts/Drawers/Drawer.cs
+++ b/UnityProject/Assets/Scripts/Drawers/Drawer.cs
@@ -6,9 +6,9 @@ using Mirror;
 /// <summary>
 /// A generic drawer component designed for multi-tile drawer objects.
 /// </summary>
-[RequireComponent(typeof(PushPull))] // For setting held items' containers to the drawer.
+[RequireComponent(typeof(ObjectBehaviour))] // For setting held items' containers to the drawer.
 [ExecuteInEditMode]
-public class Drawer : NetworkBehaviour, IMatrixRotation, ICheckedInteractable<HandApply>, IServerDespawn//, System.IEquatable<>
+public class Drawer : NetworkBehaviour, IServerDespawn, ICheckedInteractable<HandApply>
 {
 	protected enum DrawerState
 	{
@@ -35,7 +35,6 @@ public class Drawer : NetworkBehaviour, IMatrixRotation, ICheckedInteractable<Ha
 	protected Vector3Int TrayWorldPosition => GetTrayPosition(DrawerWorldPosition); // Spawn requires world position
 	protected Vector3Int TrayLocalPosition => ((Vector3)TrayWorldPosition).ToLocalInt(Matrix);
 
-	[SyncVar]
 	protected GameObject tray;
 	protected CustomNetTransform trayTransform;
 	protected ObjectBehaviour trayBehaviour;
@@ -43,15 +42,15 @@ public class Drawer : NetworkBehaviour, IMatrixRotation, ICheckedInteractable<Ha
 
 	[SerializeField]
 	[Tooltip("The corresponding tray that the drawer will spawn.")]
-	protected GameObject trayPrefab;
+	protected GameObject trayPrefab = default;
 	[SerializeField]
 	[Tooltip("Whether the drawer can store players.")]
 	protected bool storePlayers = true;
 
-	protected DrawerState drawerState;
-	protected Orientation drawerOrientation;
+	protected DrawerState drawerState = DrawerState.Shut;
 
 	// Inventory
+	// Using a dictionary for held items so we can have a messy drawer by keeping their original vectors.
 	protected Dictionary<ObjectBehaviour, Vector3> serverHeldItems = new Dictionary<ObjectBehaviour, Vector3>();
 	protected List<ObjectBehaviour> serverHeldPlayers = new List<ObjectBehaviour>();
 
@@ -70,6 +69,7 @@ public class Drawer : NetworkBehaviour, IMatrixRotation, ICheckedInteractable<Ha
 		base.OnStartServer();
 		registerObject = GetComponent<RegisterObject>();
 		registerObject.WaitForMatrixInit(ServerInit);
+		directional.OnDirectionChange.AddListener(OnDirectionChanged);
 	}
 
 	void ServerInit(MatrixInfo matrixInfo)
@@ -81,32 +81,15 @@ public class Drawer : NetworkBehaviour, IMatrixRotation, ICheckedInteractable<Ha
 		}
 		tray = traySpawn.GameObject;
 
+		tray.GetComponent<InteractableDrawerTray>().parentDrawer = this;
 		traySpriteHandler = tray.GetComponentInChildren<SpriteHandler>();
 		trayTransform = tray.GetComponent<CustomNetTransform>();
 		trayBehaviour = tray.GetComponent<ObjectBehaviour>();
 		trayBehaviour.parentContainer = drawerPushPull;
 		trayBehaviour.VisibleState = false;
 
-		// These two will sync drawer state/orientation and render appropriate sprite
-		OnSyncDrawerState(DrawerState.Shut);
-		OnSyncOrientation(  directional.CurrentDirection);
-	}
-
-	public override void OnStartClient()
-	{
-		StartCoroutine(WaitForTray());
-		base.OnStartClient();
-	}
-
-	IEnumerator WaitForTray()
-	{
-		while (tray == null)
-		{
-			yield return WaitFor.EndOfFrame;
-		}
-
-		traySpriteHandler = tray.GetComponentInChildren<SpriteHandler>();
-		UpdateSpriteDirection();
+		UpdateSpriteState();
+		UpdateSpriteOrientation();
 	}
 
 	#endregion Init Methods
@@ -125,61 +108,54 @@ public class Drawer : NetworkBehaviour, IMatrixRotation, ICheckedInteractable<Ha
 		Despawn.ServerSingle(tray);
 	}
 
-	/// <summary>
-	/// As per IMatrixRotate interface - called when matrix is rotated, updates drawer orientation.
-	/// </summary>
-	public void OnMatrixRotate(MatrixRotationInfo rotationInfo)
-	{
-		if (rotationInfo.IsClientside) return;
-		if (!rotationInfo.IsEnding) return;
-
-		OnSyncOrientation(  directional.CurrentDirection);
-	}
-
 	#region Sprite
 
-	protected virtual void OnSyncDrawerState(DrawerState newState)
+	private void OnDirectionChanged(Orientation newDirection)
 	{
-		drawerState =  newState;
-		drawerSpriteHandler.ChangeSprite((int)drawerState);
-	}
-
-	/// <summary>
-	/// Called when drawerOrientation [SyncVar] variable is altered or the client has just joined.
-	/// </summary>
-	/// <param name="oldState"></param>
-	/// <param name="newState"></param>
-	protected void OnSyncOrientation( Orientation newState)
-	{
-		// True when late client joins - [SyncVar] occured, but only
-		// usable after OnStartClient(). Hence manual call in OnStartClient().
-		if (traySpriteHandler == null) return;
-
-		drawerOrientation =  newState;
-		UpdateSpriteDirection();
+		UpdateSpriteOrientation();
 	}
 
 	public void OnEditorDirectionChange()
 	{
-		OnSyncOrientation(  directional.InitialOrientation);
-		int spriteVariant = GetSpriteDirectionVariant();
-		drawerSpriteHandler.ChangeSprite((int)DrawerState.Shut);
-		drawerSpriteHandler.ChangeSpriteVariant(spriteVariant);
+		UpdateSpriteOrientation();
 	}
 
-	private int GetSpriteDirectionVariant()
+	/// <summary>
+	/// Updates the drawer to the given state and sets the sprites accordingly.
+	/// </summary>
+	/// <param name="newState">The new state the drawer should be set to</param>
+	protected void SetDrawerState(DrawerState newState)
 	{
-		if (drawerOrientation == Orientation.Up) return (int)SpriteOrientation.North;
-		else if (drawerOrientation == Orientation.Down) return (int)SpriteOrientation.South;
-		else if (drawerOrientation == Orientation.Left) return (int)SpriteOrientation.West;
-		else return (int)SpriteOrientation.East;
+		drawerState = newState;
+		UpdateSpriteState();
 	}
 
-	private void UpdateSpriteDirection()
+	private void UpdateSpriteState()
 	{
-		int spriteVariant = GetSpriteDirectionVariant();
+		drawerSpriteHandler.ChangeSprite((int)drawerState);
+	}
+
+	private void UpdateSpriteOrientation()
+	{
+		int spriteVariant = (int)GetSpriteDirection();
 		drawerSpriteHandler.ChangeSpriteVariant(spriteVariant);
-		traySpriteHandler.ChangeSpriteVariant(spriteVariant);
+
+		if (traySpriteHandler != null)
+		{
+			traySpriteHandler.ChangeSpriteVariant(spriteVariant);
+		}
+	}
+
+	private SpriteOrientation GetSpriteDirection()
+	{
+		switch (directional.CurrentDirection.AsEnum())
+		{
+			case OrientationEnum.Up: return SpriteOrientation.North;
+			case OrientationEnum.Down: return SpriteOrientation.South;
+			case OrientationEnum.Left: return SpriteOrientation.West;
+			case OrientationEnum.Right: return SpriteOrientation.East;
+			default: return SpriteOrientation.South;
+		}
 	}
 
 	#endregion Sprite
@@ -203,23 +179,18 @@ public class Drawer : NetworkBehaviour, IMatrixRotation, ICheckedInteractable<Ha
 	#endregion Interactions
 
 	/// <summary>
-	/// Returns the tray position from the given drawer position.
+	/// Returns the tray position from the current orientation and the given drawer position.
 	/// </summary>
-	/// <param name="vector">The drawer position</param>
+	/// <param name="drawerPosition">The drawer position</param>
 	/// <returns>The tray position</returns>
-	protected Vector3Int GetTrayPosition(Vector3Int vector)
+	protected Vector3Int GetTrayPosition(Vector3Int drawerPosition)
 	{
-		if (drawerOrientation ==  Orientation.Up) vector += Vector3Int.up;
-		else if (drawerOrientation == Orientation.Down) vector += Vector3Int.down;
-		else if (drawerOrientation == Orientation.Left) vector += Vector3Int.left;
-		else if (drawerOrientation == Orientation.Right) vector += Vector3Int.right;
-
-		return vector;
+		return (drawerPosition + directional.CurrentDirection.Vector).CutToInt();
 	}
 
 	#region Server Only
 
-	protected virtual void OpenDrawer()
+	public virtual void OpenDrawer()
 	{
 		trayBehaviour.parentContainer = null;
 		trayTransform.SetPosition(TrayWorldPosition);
@@ -228,10 +199,10 @@ public class Drawer : NetworkBehaviour, IMatrixRotation, ICheckedInteractable<Ha
 		EjectPlayers();
 
 		SoundManager.PlayNetworkedAtPos("BinOpen", DrawerWorldPosition, Random.Range(0.8f, 1.2f), sourceObj: gameObject);
-		OnSyncDrawerState(DrawerState.Open);
+		SetDrawerState(DrawerState.Open);
 	}
 
-	protected virtual void CloseDrawer()
+	public virtual void CloseDrawer()
 	{
 		trayBehaviour.parentContainer = drawerPushPull;
 		trayBehaviour.VisibleState = false;
@@ -240,7 +211,7 @@ public class Drawer : NetworkBehaviour, IMatrixRotation, ICheckedInteractable<Ha
 		if (storePlayers) GatherPlayers();
 
 		SoundManager.PlayNetworkedAtPos("BinClose", DrawerWorldPosition, Random.Range(0.8f, 1.2f), sourceObj: gameObject);
-		OnSyncDrawerState(DrawerState.Shut);
+		SetDrawerState(DrawerState.Shut);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Drawers/InteractableDrawerTray.cs
+++ b/UnityProject/Assets/Scripts/Drawers/InteractableDrawerTray.cs
@@ -1,23 +1,32 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 /// <summary>
-/// Interaction logic for drawer trays. Enables placing items on the tray.
+/// Interaction logic for drawer trays.
+/// Enables placing items on the tray and closing the drawer by clicking on the tray.
 /// </summary>
 public class InteractableDrawerTray : MonoBehaviour, ICheckedInteractable<PositionalHandApply>
 {
+	[NonSerialized]
+	public Drawer parentDrawer;
+
 	#region PositionalHandApply
 
 	public bool WillInteract(PositionalHandApply interaction, NetworkSide side)
 	{
-		if (!DefaultWillInteract.Default(interaction, side)) return false;
-		if (interaction.HandObject != null) return true;
-
-		return false;
+		return DefaultWillInteract.Default(interaction, side);
 	}
 
 	public void ServerPerformInteraction(PositionalHandApply interaction)
 	{
-		Inventory.ServerDrop(interaction.HandSlot, interaction.TargetVector);
+		if (interaction.UsedObject == null)
+		{
+			parentDrawer.CloseDrawer();
+		}
+		else
+		{
+			Inventory.ServerDrop(interaction.HandSlot, interaction.TargetVector);
+		}
 	}
 
 	#endregion PositionalHandApply

--- a/UnityProject/Assets/Scripts/Drawers/Morgue.cs
+++ b/UnityProject/Assets/Scripts/Drawers/Morgue.cs
@@ -57,7 +57,7 @@ public class Morgue : Drawer
 
 	#region Server Only
 
-	protected override void CloseDrawer()
+	public override void CloseDrawer()
 	{
 		base.CloseDrawer();
 		// Note: the sprite setting done in base.CloseDrawer() would be overridden (an unnecessary sprite call).
@@ -140,12 +140,12 @@ public class Morgue : Drawer
 
 		if (consciousnessPresent && !alarmBroken)
 		{
-			OnSyncDrawerState((DrawerState)MorgueState.ShutWithPlayer);
+			SetDrawerState((DrawerState) MorgueState.ShutWithPlayer);
 			StartCoroutine(PlayAlarm());
 		}
-		else if (serverHeldPlayers.Count > 0) OnSyncDrawerState( (DrawerState)MorgueState.ShutWithBraindead);
-		else if (serverHeldItems.Count > 0) OnSyncDrawerState( (DrawerState)MorgueState.ShutWithItems);
-		else  OnSyncDrawerState( DrawerState.Shut);
+		else if (serverHeldPlayers.Count > 0) SetDrawerState((DrawerState) MorgueState.ShutWithBraindead);
+		else if (serverHeldItems.Count > 0) SetDrawerState((DrawerState) MorgueState.ShutWithItems);
+		else SetDrawerState(DrawerState.Shut);
 	}
 
 	private IEnumerator PlayAlarm()
@@ -167,19 +167,19 @@ public class Morgue : Drawer
 	{
 		var oldState = drawerState;
 
-		OnSyncDrawerState((DrawerState)MorgueState.ShutWithItems);
+		SetDrawerState((DrawerState)MorgueState.ShutWithItems);
 		yield return WaitFor.Seconds(stateDelay);
-		OnSyncDrawerState((DrawerState)MorgueState.ShutWithPlayer);
+		SetDrawerState((DrawerState)MorgueState.ShutWithPlayer);
 		yield return WaitFor.Seconds(stateDelay);
-		OnSyncDrawerState((DrawerState)MorgueState.ShutWithItems);
+		SetDrawerState((DrawerState)MorgueState.ShutWithItems);
 		yield return WaitFor.Seconds(stateDelay);
-		OnSyncDrawerState((DrawerState)MorgueState.ShutWithPlayer);
+		SetDrawerState((DrawerState)MorgueState.ShutWithPlayer);
 		yield return WaitFor.Seconds(stateDelay);
-		OnSyncDrawerState((DrawerState)MorgueState.ShutWithBraindead);
+		SetDrawerState((DrawerState)MorgueState.ShutWithBraindead);
 		yield return WaitFor.Seconds(stateDelay * 6);
 
 		if (oldState != DrawerState.Open) UpdateCloseState();
-		else OnSyncDrawerState(DrawerState.Open);
+		else SetDrawerState(DrawerState.Open);
 	}
 
 	#endregion Server Only


### PR DESCRIPTION
- Simplifies disposal machines and drawers thanks to the new sprite system.
- Drawers (morgues, cremators) can now be closed by clicking on the tray with an empty hand.

> Doesn't re-introduce or fix issue #4160