### PR TITLE
Fix hair and socks not removing when selecting or scrolling to "None" for character customization

### DIFF
--- a/UnityProject/Assets/Scripts/UI/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Lobby/CharacterCustomization.cs
@@ -55,6 +55,11 @@ namespace Lobby
 
 		public Action onCloseAction;
 
+		/// <summary>
+		/// Empty, blank sprite texture used for selecting null customizations
+		/// (e.g. selecting or scrolling to "None" for hair, facial hair, underwear,
+		/// or socks).
+		/// </summary>
 		public SpriteDataSO BobTheEmptySprite;
 
 		void OnEnable()

--- a/UnityProject/Assets/Scripts/UI/Lobby/CharacterCustomization.cs
+++ b/UnityProject/Assets/Scripts/UI/Lobby/CharacterCustomization.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using DatabaseAPI;
@@ -451,7 +451,7 @@ namespace Lobby
 			);
 			if (pcd == null)
 			{
-				hairSpriteController.sprites.SetSpriteSO(pcd.SpriteEquipped);
+				hairSpriteController.sprites.SetSpriteSO(BobTheEmptySprite);
 			}
 			else
 			{
@@ -604,7 +604,7 @@ namespace Lobby
 			);
 			if (pcd == null)
 			{
-				socksSpriteController.sprites.SetSpriteSO(pcd.SpriteEquipped);
+				socksSpriteController.sprites.SetSpriteSO(BobTheEmptySprite);
 			}
 			else
 			{


### PR DESCRIPTION
### Purpose

Fixes #4800 of encountering a `NullReferenceException` and hair/socks not removed when selecting or scrolling to "None" for socks and hair.

### Notes:

Added small amount of XML documentation for the `BobTheEmptySprite` field.
