### PR TITLE
Fancy item storage

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/Snacks/TinyChocolate.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/Snacks/TinyChocolate.prefab
@@ -123,6 +123,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1447570747421811365, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447570747421811365, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
       propertyPath: initialDescription
       value: A tiny and sweet chocolate.
       objectReference: {fileID: 0}
@@ -131,6 +136,12 @@ PrefabInstance:
       propertyPath: initialName
       value: tiny chocolate
       objectReference: {fileID: 0}
+    - target: {fileID: 1447570747421811365, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
+        type: 3}
+      propertyPath: initialTraits.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 736042e9dbc505449a2f3247c610d458,
+        type: 2}
     - target: {fileID: 5169367590891271744, guid: eaf8c1f2a0f9374488e16061fd5b4dcd,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Storage/DonutBox.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Storage/DonutBox.prefab
@@ -13,6 +13,53 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 7607c9da35b2b014ba9e59a4117d1b3f,
         type: 2}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.size
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[0]
+      value: 
+      objectReference: {fileID: 21300000, guid: 289f1d456d4a4c043b96cda8189caf61,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[1]
+      value: 
+      objectReference: {fileID: 21300000, guid: 0716dd09dd7de8748b4ca3ae87db7dda,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[2]
+      value: 
+      objectReference: {fileID: 21300000, guid: 2de309c0800491b468f57e3da54f66cf,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[3]
+      value: 
+      objectReference: {fileID: 21300000, guid: 84bac67834b86ef428a5a8835ec68249,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[4]
+      value: 
+      objectReference: {fileID: 21300000, guid: f24761ef8a979e64fbdb883dca6cee7d,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[5]
+      value: 
+      objectReference: {fileID: 21300000, guid: 60a44726cd214f3478578895319da0c6,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[6]
+      value: 
+      objectReference: {fileID: 21300000, guid: 448c21b6e8ad297448d445356c99b5af,
+        type: 3}
     - target: {fileID: 8170131852768406190, guid: 351fa36521ade244b9d7d66b21f7f333,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Resources/Prefabs/Items/Storage/EggCarton.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Storage/EggCarton.prefab
@@ -13,6 +13,89 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: ceb2edadb6e9c194fb0dd94fad04f0f2,
         type: 2}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.size
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[0]
+      value: 
+      objectReference: {fileID: 21300000, guid: 4d63b976e0d0fc046aac0d043abb9a81,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[1]
+      value: 
+      objectReference: {fileID: 21300000, guid: 3f2d296198a0766419e4c801ac7216f7,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[2]
+      value: 
+      objectReference: {fileID: 21300000, guid: 6546aa645911ccc4aa30ba7ea35483f8,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[3]
+      value: 
+      objectReference: {fileID: 21300000, guid: 55cbc4e267f10234f9edc041bd7aae24,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[4]
+      value: 
+      objectReference: {fileID: 21300000, guid: 2cf3a8be20133004b87f838b18115bbc,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[5]
+      value: 
+      objectReference: {fileID: 21300000, guid: 85e42b48914043f418427c815f8fa4d8,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[6]
+      value: 
+      objectReference: {fileID: 21300000, guid: 6c17e8910aa326246a348e04ecb24e72,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[7]
+      value: 
+      objectReference: {fileID: 21300000, guid: 1f709507ea0b02346b8813db81fd2806,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[8]
+      value: 
+      objectReference: {fileID: 21300000, guid: 48c67324edc139e49a7d096f727a7d58,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[9]
+      value: 
+      objectReference: {fileID: 21300000, guid: 5459a5f2b043fe8419f564cd4c33b708,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[10]
+      value: 
+      objectReference: {fileID: 21300000, guid: 41adb67b1eaf81843ae8d2b4c792bd2e,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[11]
+      value: 
+      objectReference: {fileID: 21300000, guid: 647b0ab92c7a10b4fa77d9337c4e7f3c,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[12]
+      value: 
+      objectReference: {fileID: 21300000, guid: 111d194bb9d7e4847832e54bff00ed10,
+        type: 3}
     - target: {fileID: 8170131852768406190, guid: 351fa36521ade244b9d7d66b21f7f333,
         type: 3}
       propertyPath: initialDescription
@@ -91,6 +174,18 @@ PrefabInstance:
       propertyPath: initialName
       value: egg carton
       objectReference: {fileID: 0}
+    - target: {fileID: 8170131852768406190, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: a674b2a3e407f6e4f87a9f49850934bc,
+        type: 2}
+    - target: {fileID: 8170131852768406190, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: ed0edd038937a6041b828f8560ff792f,
+        type: 2}
     - target: {fileID: 8466288508669376144, guid: 351fa36521ade244b9d7d66b21f7f333,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Storage/FancyStorageBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Storage/FancyStorageBase.prefab
@@ -1,5 +1,21 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &3044181827350616606
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8615308116400047564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: adb32492e5772fa4d9e222f1a90d8359, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteHandler: {fileID: 2506717331081805387}
+  spritesByCount: []
 --- !u!1001 &4980904903103666879
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -101,3 +117,21 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e46ba34aab52d654787ef10d896b0874, type: 3}
+--- !u!1 &8615308116400047564 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3643415983708594035, guid: e46ba34aab52d654787ef10d896b0874,
+    type: 3}
+  m_PrefabInstance: {fileID: 4980904903103666879}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2506717331081805387 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7482199438493803764, guid: e46ba34aab52d654787ef10d896b0874,
+    type: 3}
+  m_PrefabInstance: {fileID: 4980904903103666879}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Storage/HeartShapedBox.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Storage/HeartShapedBox.prefab
@@ -13,6 +13,65 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: dd6f5765a41f81c4088a698b85e4c445,
         type: 2}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.size
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[0]
+      value: 
+      objectReference: {fileID: 21300000, guid: 2f488163437d6be4f8e83c2a58a4144f,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[1]
+      value: 
+      objectReference: {fileID: 21300000, guid: d2fc115decf9ff4499a21b78b6c06e9a,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[2]
+      value: 
+      objectReference: {fileID: 21300000, guid: e22c2ae77e18522459bc194c87d19a20,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[3]
+      value: 
+      objectReference: {fileID: 21300000, guid: 2b9ef2b263f0db74db10cfdf12ef0246,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[4]
+      value: 
+      objectReference: {fileID: 21300000, guid: b386975e07a3f5540b837adcba2b0213,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[5]
+      value: 
+      objectReference: {fileID: 21300000, guid: d421842929c5a4e43806ca30f9a7af9b,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[6]
+      value: 
+      objectReference: {fileID: 21300000, guid: bb00f2d5975bbd84a921d0a5de2b21da,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[7]
+      value: 
+      objectReference: {fileID: 21300000, guid: e19188a4087903449a4fff2c15fe506b,
+        type: 3}
+    - target: {fileID: 3044181827350616606, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: spritesByCount.Array.data[8]
+      value: 
+      objectReference: {fileID: 21300000, guid: 9adaf25ea2d23734cb609a316c6f86cd,
+        type: 3}
     - target: {fileID: 8170131852768406190, guid: 351fa36521ade244b9d7d66b21f7f333,
         type: 3}
       propertyPath: itemSprites.RightHand.Sprites.Array.size
@@ -96,6 +155,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300006, guid: e51227076b9453147b1b647f4a5fc162,
         type: 3}
+    - target: {fileID: 8170131852768406190, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 287d89133ee73c449a871c8252c6996a,
+        type: 2}
+    - target: {fileID: 8170131852768406190, guid: 351fa36521ade244b9d7d66b21f7f333,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 24365362b77e81744b47d64a895035ec,
+        type: 2}
     - target: {fileID: 8466288508669376144, guid: 351fa36521ade244b9d7d66b21f7f333,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/HeartShapedBoxCapacity.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/HeartShapedBoxCapacity.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: HeartShapedBoxCapacity
   m_EditorClassIdentifier: 
   MaxItemSize: 5
-  Whitelist: []
-  Required:
+  Whitelist:
   - {fileID: 11400000, guid: 736042e9dbc505449a2f3247c610d458, type: 2}
+  Required: []
   Blacklist: []

--- a/UnityProject/Assets/Scripts/Inventory/FancyItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Inventory/FancyItemStorage.cs
@@ -19,9 +19,15 @@ public class FancyItemStorage : NetworkBehaviour
 	public Sprite[] spritesByCount;
 
 	private ItemStorage storage;
+	private Pickupable pickupable;
 
 	[SyncVar(hook = "OnObjectsCountChanged")]
 	private int objectsInsideCount;
+
+	private void Awake()
+	{
+		pickupable = GetComponent<Pickupable>();
+	}
 
 	[ServerCallback]
 	private void Start()
@@ -64,8 +70,13 @@ public class FancyItemStorage : NetworkBehaviour
 			newSprite = spritesByCount.Last();
 		}
 
-		// apply it to sprite handler
-		spriteHandler.SetSprite(newSprite);
+		if (newSprite)
+		{
+			// apply it to sprite handler
+			spriteHandler.SetSprite(newSprite);
+			// try to update in-hand sprite
+			pickupable?.RefreshUISlotImage();
+		}
 	}
 
 	[Server]

--- a/UnityProject/Assets/Scripts/Inventory/FancyItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Inventory/FancyItemStorage.cs
@@ -1,0 +1,78 @@
+﻿using Mirror;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+/// <summary>
+/// The 'fancy' component defines objects like donut boxes, egg boxes or cigs packets
+/// that show how many items are in the ItemStorage on the sprite itself
+/// 
+/// Need to have ItemStorage component on a same gameobject
+/// </summary>
+[RequireComponent(typeof(ItemStorage))]
+public class FancyItemStorage : NetworkBehaviour
+{
+	public SpriteHandler spriteHandler;
+	[Tooltip("Sprite for each objects count inside container")]
+	public Sprite[] spritesByCount;
+
+	private ItemStorage storage;
+
+	[SyncVar(hook = "OnObjectsCountChanged")]
+	private int objectsInsideCount;
+
+	[ServerCallback]
+	private void Start()
+	{
+		// get ItemStorage on a same object
+		storage = GetComponent<ItemStorage>();
+		if (!storage)
+		{
+			Logger.LogError($"FancyItemStorage on {gameObject.name} can't find ItemStorage component!", Category.Containers);
+			return;
+		}
+
+		// get all slots and subscribe if any slot changed
+		var allSlots = storage.GetItemSlots();
+		foreach (var slot in allSlots)
+		{
+			slot.OnSlotContentsChangeServer.AddListener(OnStorageChanged);
+		}
+
+		// calculate occupied slots count
+		objectsInsideCount = allSlots.Count((s) => s.IsOccupied);
+	}
+
+	private void OnObjectsCountChanged(int oldVal, int objectsCount)
+	{
+		if (!spriteHandler || spritesByCount == null
+			|| spritesByCount.Length == 0)
+		{
+			return;
+		}
+
+		// select new sprite for container
+		Sprite newSprite;
+		if (objectsCount < spritesByCount.Length)
+		{
+			newSprite = spritesByCount[objectsCount];
+		}
+		else
+		{
+			newSprite = spritesByCount.Last();
+		}
+
+		// apply it to sprite handler
+		spriteHandler.SetSprite(newSprite);
+	}
+
+	[Server]
+	private void OnStorageChanged()
+	{
+		// recalculate occupied slots count and send to client
+		var allSlots = storage.GetItemSlots();
+		objectsInsideCount = allSlots.Count((s) => s.IsOccupied);
+	}
+}

--- a/UnityProject/Assets/Scripts/Inventory/FancyItemStorage.cs.meta
+++ b/UnityProject/Assets/Scripts/Inventory/FancyItemStorage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: adb32492e5772fa4d9e222f1a90d8359
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Added new component FancyItemStorage. The 'fancy' component defines objects like donuts boxes, egg boxes or cigs packets that show how many items are in the ItemStorage on the sprite itself. [Check original DM code](https://github.com/tgstation/tgstation/blob/1aa293ea337283a0191140a878eeba319221e5df/code/game/objects/items/storage/fancy.dm) for more details.

### Notes:
Not implemented open/close sprite change yet. Storages are always "open" by default.
Cigarettes and cigars use much more advanced mechanic and not yet implemented (several slots for different type of items inside).
