### PR TITLE
Cargo shuttle now doesn't sell people

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -66,9 +66,9 @@ public class CargoManager : MonoBehaviour
 	bool CheckLifeforms()
 	{
 		Transform ObjectHolder = CargoShuttle.Instance.SearchForObjectsOnShuttle();
-		for (int i = 0; i < ObjectHolder.childCount; i++)
+		foreach (Transform child in ObjectHolder)
 		{
-			if (ObjectHolder.GetChild(i).transform.gameObject.layer == 12 || ObjectHolder.GetChild(i).transform.gameObject.layer == 8)
+			if (child.transform.gameObject.layer == 12 || child.transform.gameObject.layer == 8)
 			{
 				return true;
 			}

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -65,13 +65,15 @@ public class CargoManager : MonoBehaviour
 	/// <returns>true if a lifeform is found, false if none is found</returns>
 	bool CheckLifeforms()
 	{
+		LayerMask layersToCheck = LayerMask.GetMask("Player", "NPC");
 		Transform ObjectHolder = CargoShuttle.Instance.SearchForObjectsOnShuttle();
 		foreach (Transform child in ObjectHolder)
 		{
-			if (child.transform.gameObject.layer == 12 || child.transform.gameObject.layer == 8)
+			if(((1<<child.gameObject.layer) & layersToCheck) == 0)
 			{
-				return true;
+				continue;
 			}
+			return true;
 		}
 		return false;
 	}

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -63,12 +63,12 @@ public class CargoManager : MonoBehaviour
 	/// Checks for any Lifeforms (dead or alive) that might be aboard the shuttle
 	/// </summary>
 	/// <returns>true if a lifeform is found, false if none is found</returns>
-	bool LifeformChecker()
+	bool CheckLifeforms()
 	{
 		Transform ObjectHolder = CargoShuttle.Instance.SearchForObjectsOnShuttle();
 		for (int i = 0; i < ObjectHolder.childCount; i++)
 		{
-			if (ObjectHolder.GetChild(i).GetComponent<LivingHealthBehaviour>() != null)
+			if (ObjectHolder.GetChild(i).transform.gameObject.layer == 12 || ObjectHolder.GetChild(i).transform.gameObject.layer == 8)
 			{
 				return true;
 			}
@@ -124,7 +124,7 @@ public class CargoManager : MonoBehaviour
 			//and will call OnShuttleArrival()
 			else if (ShuttleStatus == ShuttleStatus.DockedStation)
 			{
-				if (LifeformChecker())
+				if (CheckLifeforms())
 				{
 					CurrentFlyTime = 0;
 					CentcomMessage += "Due to safety and security reasons, the automatic cargo shuttle is unable to depart with any human, alien or animal organisms aboard." + "\n";

--- a/UnityProject/Assets/Scripts/Shuttles/CargoShuttle.cs
+++ b/UnityProject/Assets/Scripts/Shuttles/CargoShuttle.cs
@@ -112,16 +112,25 @@ public class CargoShuttle : MonoBehaviour
 	}
 
 	/// <summary>
+	/// Scans and finds all objects that are aboard the shuttle.
+	/// <returns>All objects found as children of a Transform variable.</returns>
+	/// </summary>
+	public Transform SearchForObjectsOnShuttle()
+	{
+		//note: This scan also seems to find objects contained inside closets only if the object was placed
+		//into the crate after the crate was already on the cargo shuttle. Hence we are using alreadySold
+		//to avoid duplicate selling in lieu of a more thorough fix to closet held items logic.
+		Transform ObjectHolder = mm.MatrixInfo.Objects;
+		return ObjectHolder;
+	}
+
+	/// <summary>
 	/// Calls CargoManager.DestroyItem() for all items on the shuttle.
 	/// Server only.
 	/// </summary>
 	void UnloadCargo()
 	{
-		//Destroy all items on the shuttle
-		//note: This scan also seems to find objects contained inside closets only if the object was placed
-		//into the crate after the crate was already on the cargo shuttle. Hence we are using alreadySold
-		//to avoid duplicate selling in lieu of a more thorough fix to closet held items logic.
-		Transform objectHolder = mm.MatrixInfo.Objects;
+		Transform objectHolder = SearchForObjectsOnShuttle();
 		//track what we've already sold so it's not sold twice.
 		HashSet<GameObject> alreadySold = new HashSet<GameObject>();
 		for (int i = 0; i < objectHolder.childCount; i++)


### PR DESCRIPTION
'Edited the CargoShuttle script and separated its item scanner from the "UnloadCargo" function before attaching it to a public "SearchForObjectsOnShuttle" function that returns a Transform Object
-Added a "LifeformChecker" function in CargoManager that looks for any players or animals on the shuttle.
-Modified the "CallShuttle" function on CargoManager so that, using "LifeformChecker", it avoids flying off from the station with a player or animal.

### Purpose
Fixes the issue that allowed the cargo shuttle to fly off from the station with characters on board and erase them afterwards by preventing the shuttle from flying as long as any object that could be alive is aboard.
### Notes:
None
