### PR TITLE
Unbreak GitKraken by adding non-commented text to main.yml.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,4 @@
+Some text so that GitKraken doesn't break. Comment out this line if the rest of the file isn't commented out. - Pet Mudstone.
 #name: Build Project
 
 #on:


### PR DESCRIPTION
### Purpose
#4792 broke GitKraken by making all the text in main.yml commented out. For some reason, .yml files that have all their text commented out breaks GitKraken. This PR makes the Unitystation repository no longer break GitKraken by adding non-commented text that does nothing to the top of main.yml. This text should be removed or commented out itself once the rest of main.yml is no longer commented out, or if GitKraken no longer breaks in response to .yml consisting solely of commented out text.
