### PR TITLE
Event fixes

### DIFF
--- a/UnityProject/Assets/Scripts/InGameEvents/EventScriptBase.cs
+++ b/UnityProject/Assets/Scripts/InGameEvents/EventScriptBase.cs
@@ -56,13 +56,13 @@ namespace InGameEvents
 
 		private void Start()
 		{
-			if (InGameEventsManager.Instance.ListOfFunEventScripts.Contains(this)) return;
 			InGameEventsManager.Instance.AddEventToList(this, EventType);
 		}
 
 		private void OnDestroy()
 		{
-			InGameEventsManager.Instance.ListOfFunEventScripts.Remove(this);
+			InGameEventsManager.Instance.RemoveEventFromList(this, EventType);
+			CancelInvoke();
 		}
 
 		public virtual void OnEventStart()

--- a/UnityProject/Assets/Scripts/InGameEvents/InGameEventsManager.cs
+++ b/UnityProject/Assets/Scripts/InGameEvents/InGameEventsManager.cs
@@ -102,9 +102,12 @@ namespace InGameEvents
 			if (list == null)
 			{
 				Debug.LogError("An event has been set to random type, random is a dummy type and cant be accessed.");
+				return;
 			}
 
-			list?.Add(eventToAdd);
+			if (list.Contains(eventToAdd)) return;
+
+			list.Add(eventToAdd);
 		}
 
 		public void TriggerSpecificEvent(int eventIndex, InGameEventType eventType, bool isFake = false, string adminName = null, bool announceEvent = true)
@@ -213,6 +216,25 @@ namespace InGameEvents
 				case InGameEventType.Debug:
 					return ListOfDebugEventScripts;
 				default: return null;
+			}
+		}
+
+		public void RemoveEventFromList(EventScriptBase eventToRemove, InGameEventType enumValue)
+		{
+			switch (enumValue)
+			{
+				case InGameEventType.Fun:
+					ListOfFunEventScripts.Remove(eventToRemove);
+					return;
+				case InGameEventType.Special:
+					ListOfSpecialEventScripts.Remove(eventToRemove);
+					return;
+				case InGameEventType.Antagonist:
+					ListOfAntagonistEventScripts.Remove(eventToRemove);
+					return;
+				case InGameEventType.Debug:
+					ListOfDebugEventScripts.Remove(eventToRemove);
+					return;
 			}
 		}
 


### PR DESCRIPTION
Might fix this error:

`NullReferenceException
UnityEngine.MonoBehaviour.Invoke (System.String methodName, System.Single time) (at /home/builduser/buildslave/unity/build/Runtime/Export/Scripting/MonoBehaviour.bindings.cs:39)
InGameEvents.EventScriptBase.OnEventStart () (at /github/workspace/UnityProject/Assets/Scripts/InGameEvents/EventScriptBase.cs:70)
InGameEvents.EventGiveItems.OnEventStart () (at /github/workspace/UnityProject/Assets/Scripts/InGameEvents/InGameEventScripts/EventGiveItems.cs:21)
InGameEvents.EventScriptBase.TriggerEvent () (at /github/workspace/UnityProject/Assets/Scripts/InGameEvents/EventScriptBase.cs:90)
InGameEvents.InGameEventsManager.TriggerSpecificEvent (System.Int32 eventIndex, InGameEvents.InGameEventType eventType, System.Boolean isFake, System.String adminName, System.Boolean announceEvent) (at /github/workspace/UnityProject/Assets/Scripts/InGameEvents/InGameEventsManager.cs:138)
AdminCommands.AdminCommandsManager.CmdTriggerGameEvent (System.String adminId, System.String adminToken, System.Int32 eventIndex, System.Boolean isFake, System.Boolean announceEvent, InGameEvents.InGameEventType eventType) (at /github/workspace/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs:82)
System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <437ba245d8404784b9fbab9b439ac908>:0)
Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.
System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <437ba245d8404784b9fbab9b439ac908>:0)
System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) (at <437ba245d8404784b9fbab9b439ac908>:0)
AdminCommands.ServerCommandVer`

Also fixes removal code.
