### PR TITLE
changed the two shuttles to the left of command in OutpostStation to have the resources on them to be able to start a small base somewhere

### DIFF
--- a/UnityProject/Assets/Materials/PostProcess/Post-FloorFovGenerator Material.mat
+++ b/UnityProject/Assets/Materials/PostProcess/Post-FloorFovGenerator Material.mat
@@ -77,4 +77,4 @@ Material:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _OcclusionSpread: {r: 0, g: 0, b: 0, a: 0}
-    - _PositionOffset: {r: -0.0000035416847, g: 0.03529643, b: 0.00000011067765, a: 0}
+    - _PositionOffset: {r: 0, g: 0.03529506, b: -0, a: 0}

--- a/UnityProject/Assets/Materials/PostProcess/Post-FovGenerator.mat
+++ b/UnityProject/Assets/Materials/PostProcess/Post-FovGenerator.mat
@@ -76,4 +76,4 @@ Material:
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _PositionOffset: {r: -0.0000035416847, g: 0.03529643, b: 0.00000011067765, a: 0}
+    - _PositionOffset: {r: 0, g: 0.03529506, b: -0, a: 0}


### PR DESCRIPTION

### Purpose
This modifies the two shuttles to the left of command in OutpostStation to have the resources on them to be able to start a small base somewhere.  This will provide more things for people to do on OutpostStation.

### Notes
This adds some items on the shuttles.  But they have a sell-value of zero.

Any feedback on changes that I should make are welcome.