### PR TITLE
Add lots of useless (for now) ammo casings, ammo boxes, and magazines (both internal and external).

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/DeskLamp.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/DeskLamp.prefab
@@ -158,6 +158,18 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.EquippedData
       value: 
       objectReference: {fileID: 4900000, guid: 9b2e620f08bbf5040828d2f017c27292, type: 3}
+    - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: bb5bff19a5059524692ce06df4ead773,
+        type: 2}
+    - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 7355a6f4be7e7e5438b984db678f38a9,
+        type: 2}
     - target: {fileID: 5334267868750357690, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: Size

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Flare.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Flare.prefab
@@ -127,6 +127,18 @@ PrefabInstance:
       propertyPath: itemSprites.LeftHand.EquippedData
       value: 
       objectReference: {fileID: 4900000, guid: faf7a5dd0ce7e9843b235f758d410d9a, type: 3}
+    - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 290d275b8000e664da2a6f952ee19231,
+        type: 2}
+    - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 448c9f91cc815d94c8d5181c27d1f468,
+        type: 2}
     - target: {fileID: 5334267868750357690, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: Colour.r

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Glowsticks/Glowstick.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Glowsticks/Glowstick.prefab
@@ -236,6 +236,16 @@ PrefabInstance:
       propertyPath: itemSprites.LeftHand.EquippedData
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 5334267868750357690, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: Colour.r

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/GreenDeskLamp.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/GreenDeskLamp.prefab
@@ -103,6 +103,18 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.EquippedData
       value: 
       objectReference: {fileID: 4900000, guid: 5d6aa2b2a8127e748b57f4ad9e560645, type: 3}
+    - target: {fileID: 7570201031302275217, guid: c141da4e786e96c40b854e3daf1737d0,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 37c4a6d4eba154147b6f50a35f9b4b47,
+        type: 2}
+    - target: {fileID: 7570201031302275217, guid: c141da4e786e96c40b854e3daf1737d0,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: cde22e8f459e8884d857a3737b646f2e,
+        type: 2}
     - target: {fileID: 7859536243489094831, guid: c141da4e786e96c40b854e3daf1737d0,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Lantern.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Lantern.prefab
@@ -123,6 +123,18 @@ PrefabInstance:
       propertyPath: itemSprites.RightHand.EquippedData
       value: 
       objectReference: {fileID: 4900000, guid: 70761113e1be11849a0e7bda508715fe, type: 3}
+    - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 25034c6ed31c85849a9e42765e09a2e0,
+        type: 2}
+    - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: b428569555771fb498af1297f60c2bd2,
+        type: 2}
     - target: {fileID: 5334267868750357690, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: Size

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Penlight.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Penlight.prefab
@@ -92,6 +92,18 @@ PrefabInstance:
       propertyPath: initialSize
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 1242547b095a25d4b870d7c2e4868aff,
+        type: 2}
+    - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 1549ce680737125459163cf36dcbc345,
+        type: 2}
     - target: {fileID: 5334267868750357690, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: Size

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Seclite.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Seclite.prefab
@@ -143,6 +143,18 @@ PrefabInstance:
       propertyPath: initialTraits.Array.data[2]
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 574dc4ea1a49e1e4ab6ee3798d95486f,
+        type: 2}
+    - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 6468df7a93b0efe418685e661ece4c00,
+        type: 2}
     - target: {fileID: 5334267868750357690, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: Size

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 65f320910964e414bab4dfe4f80e33fe
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox.45.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox.45.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4185738880498745861
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1367725800532977169, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: initialName
+      value: ammo box (.45)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447548746969270643, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoBox.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 1549955644806952135, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650371861022734895, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 31ba99d48923b3a4a8abf9352995ba1d,
+        type: 3}
+    - target: {fileID: 4706445082373976820, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 06a1c410879866b468283b260dbd2eca,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fae459459df71d4999b6618dc06f219, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox.45.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox.45.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7c365d1d37de1d7479184c063fca0961
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox10mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox10mm.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1602383921664509945
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1367725800532977169, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: initialName
+      value: ammo box (10mm)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447548746969270643, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoBox10mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 1549955644806952135, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650371861022734895, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 9280b8ffd4dd2cd448b53d3d0e5b5d11,
+        type: 3}
+    - target: {fileID: 4706445082373976820, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: d284ab0138034cf498dd97af0dd3d418,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fae459459df71d4999b6618dc06f219, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox10mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox10mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 484e383fa03fd3c409e2ae16b703400f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox40mmGrenades.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox40mmGrenades.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2185383112152338103
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1367725800532977169, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: initialName
+      value: ammo box (40mm grenades)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447548746969270643, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoBox40mmGrenades
+      objectReference: {fileID: 0}
+    - target: {fileID: 1549955644806952135, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650371861022734895, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: cdabdc7e166c85c4f83e5735aae59c7c,
+        type: 3}
+    - target: {fileID: 4706445082373976820, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: c1d36dc76abd5d04ca6da77a51693973,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fae459459df71d4999b6618dc06f219, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox40mmGrenades.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox40mmGrenades.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 19fb6e6a3e54bc54e8215d5cbb5163b9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox7.62x38mmR.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox7.62x38mmR.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1703292292136494600
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1367725800532977169, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: initialName
+      value: ammo box (7.62x38mmR)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447548746969270643, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoBox7.62x38mnR
+      objectReference: {fileID: 0}
+    - target: {fileID: 1549955644806952135, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650371861022734895, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 9280b8ffd4dd2cd448b53d3d0e5b5d11,
+        type: 3}
+    - target: {fileID: 4706445082373976820, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: d284ab0138034cf498dd97af0dd3d418,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fae459459df71d4999b6618dc06f219, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox7.62x38mmR.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox7.62x38mmR.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 51021ec2fd02b4e468627e7b855c7947
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox9mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox9mm.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &734319818685463720
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1367725800532977169, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: initialName
+      value: ammo box (9mm)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447548746969270643, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoBox9mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 1549955644806952135, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650371861022734895, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 26bcf747fd5de07479bc2af66c281f40,
+        type: 3}
+    - target: {fileID: 4706445082373976820, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 7eb998137c54fd64488d5fb72419cbe7,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fae459459df71d4999b6618dc06f219, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox9mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBox9mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ab4970d9db5f46142898594bb93b5d35
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBoxBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBoxBase.prefab
@@ -1,0 +1,112 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1447113495907317193
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_Name
+      value: AmmoBoxBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 5eafba0d7388d428c8e08ed1b5d5d260,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: f763e36d537f85448bbe6364b9035a67,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 35166b345a1bb1d468a755ae81a1b5b4,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: throwDamage
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: throwSpeed
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialName
+      value: ammo box (null_reference_exception)
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialDescription
+      value: A box of ammo.
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBoxBase.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBoxBase.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3fae459459df71d4999b6618dc06f219
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBoxFoamDarts.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBoxFoamDarts.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &388852284683407274
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1367725800532977169, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: initialName
+      value: ammo box (Foam Darts)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447548746969270643, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoBoxFoamDarts
+      objectReference: {fileID: 0}
+    - target: {fileID: 1549955644806952135, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650371861022734895, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 20c01d5e47bb85446996ad3eb2158d58,
+        type: 3}
+    - target: {fileID: 4706445082373976820, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 4e694a181ac77544499c012a82775998,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fae459459df71d4999b6618dc06f219, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBoxFoamDarts.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBoxFoamDarts.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cd26a108df3c1ac4098c55b854d97a8c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBoxFoamDartsFoamDartsRiot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBoxFoamDartsFoamDartsRiot.prefab
@@ -1,0 +1,88 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3514941620123180479
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1218214240896367469, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1252072018076597165, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1252072018076597165, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1252072018076597165, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1252072018076597165, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1252072018076597165, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1252072018076597165, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1252072018076597165, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1252072018076597165, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1252072018076597165, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1252072018076597165, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1252072018076597165, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1257563116079482585, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoBoxFoamDartsFoamDartsRiot
+      objectReference: {fileID: 0}
+    - target: {fileID: 1405746923732219269, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: fb32f770b513ef241a84817020031175,
+        type: 3}
+    - target: {fileID: 4915078429666164062, guid: cd26a108df3c1ac4098c55b854d97a8c,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 073930ebafba5324189bdbf61037750f,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cd26a108df3c1ac4098c55b854d97a8c, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBoxFoamDartsFoamDartsRiot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/AmmoBoxFoamDartsFoamDartsRiot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c371c5907c4625940aff4277249124d4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c30597aaf7197f346b0696bb69814259
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mm.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2454052199701803256
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 6fb93acdcc2fa3f429410ba8940f5d1c,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: box magazine (7.12x82mm)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 1f1179fcb5dee2a4cbf747b470f49bf7,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: BoxMagazine7.12x82mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e9d40516785485e4186335c8a0127177
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmArmorPenetrating.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmArmorPenetrating.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1781318122266356276
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8794075376680898992, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: initialName
+      value: box magazine (7.12x82mm armor-piercing)
+      objectReference: {fileID: 0}
+    - target: {fileID: 9000248426970939090, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_Name
+      value: BoxMagazine7.12x82mmArmorPenetrating
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9039705054833066854, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e9d40516785485e4186335c8a0127177, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmArmorPenetrating.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmArmorPenetrating.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 65d9c77d70577854184c5137096e84da
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmHollow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmHollow.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8149612745417422298
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8794075376680898992, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: initialName
+      value: box magazine (7.12x82mm hollow-point)
+      objectReference: {fileID: 0}
+    - target: {fileID: 9000248426970939090, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_Name
+      value: BoxMagazine7.12x82mmHollow
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9039705054833066854, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e9d40516785485e4186335c8a0127177, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmHollow.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmHollow.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bef46d3ead6840548bca44c50cf2b0f0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmIncendiary.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmIncendiary.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5371716649771061128
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8794075376680898992, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: initialName
+      value: box magazine (7.12x82mm incendiary )
+      objectReference: {fileID: 0}
+    - target: {fileID: 9000248426970939090, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_Name
+      value: BoxMagazine7.12x82mmIncendiary
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9039705054833066854, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e9d40516785485e4186335c8a0127177, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmIncendiary.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmIncendiary.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8cb730de5c4649342af6adfafb1fc788
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmMatch.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmMatch.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2483411647316028327
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8794075376680898992, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: initialName
+      value: box magazine (7.12x82mm match)
+      objectReference: {fileID: 0}
+    - target: {fileID: 9000248426970939090, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_Name
+      value: BoxMagazine7.12x82mmMatch
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004046277741806502, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9039705054833066854, guid: e9d40516785485e4186335c8a0127177,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e9d40516785485e4186335c8a0127177, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmMatch.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/BoxMagazine7.12x82mmMatch.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e9e53c4c86ce8b847a9357dd556d29cb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/DrumMagazine.45.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/DrumMagazine.45.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &9044809808923849480
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 5106bed076d4dda428e43dbfe28a31e2,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: drum magazine (.45)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: ccfed9fe58fb4a640a127697b48e56e3,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: DrumMagazine.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/DrumMagazine.45.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/DrumMagazine.45.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9505db5c84437ce4692422e1ef11cef2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/MagazineBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/MagazineBase.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5404175315067553625
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447548746969270643, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoBoxBase
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fae459459df71d4999b6618dc06f219, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/MagazineBase.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/MagazineBase.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d57fa00554efcec4abd669e2d6b24edc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine.45.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine.45.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &687072788564112777
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 4a5d8b13cee6b1c4b917ba1cd11e1503,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: pistol magazine (.45)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 384bafc463c2fb549b2670189ed84df2,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: PistolMagazine.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine.45.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine.45.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3c72e186adf24734087d5196c6da19ea
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine.50AE.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine.50AE.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5483276788775581468
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: e3dcc30a96ecf674c81847d064854300,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: handgun magazine (.50 AE)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: b1fdd71973d54a04da2f9877513cd8c8,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: PistolMagazine.50AE
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine.50AE.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine.50AE.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a65c9499c9842d84798d2b981cc16662
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine10mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine10mm.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4324741950153386992
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 1c7a995e702f0bd45b4b524d35c4767e,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: pistol magazine (10mm)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialDescription
+      value: A gun magazine.
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: f4b29a15c4846d24d829d1f4071b90d5,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: PistolMagazine10mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine10mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine10mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b207c10b72e178346bee8cf182f264eb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mm.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3055183057780687761
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 4e6eff93c5e0b0a4ab6b8258fef03d1c,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: pistol magazine (9mm)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 04727509e2ec2f246a52c5cf199bfb2c,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: PistolMagazine9mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 678d8623073f29f4cb23d4cb26359cd4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mmArmorPiercing.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mmArmorPiercing.prefab
@@ -1,0 +1,99 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8533041330966121278
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2434735188447524412, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 22858e927a645cb43bdd1d11a00785d2,
+        type: 2}
+    - target: {fileID: 8242272600229782233, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: initialDescription
+      value: A gun magazine. Loaded with rounds which penetrate armour, but are less
+        effective against normal targets.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8242272600229782233, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: initialName
+      value: pistol magazine (9mm armor-piercing)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8399202269906357691, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_Name
+      value: PistolMagazine9mmArmorPiercing
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8438549908676571151, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8538262400951484135, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: ae22b2a8c5472174fbe6b6854f23323f,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 678d8623073f29f4cb23d4cb26359cd4, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mmArmorPiercing.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mmArmorPiercing.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 796601fd29f46de47aea93cd84ab063f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mmHollowPoint.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mmHollowPoint.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5882446024097031102
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8242272600229782233, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: initialName
+      value: pistol magazine (9mm hollow-point)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8242272600229782233, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: initialDescription
+      value: A gun magazine. Loaded with hollow-point rounds, extremely effective
+        against unarmored targets, but nearly useless against protective clothing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8399202269906357691, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_Name
+      value: PistolMagazine9mmHollowPoint
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8438549908676571151, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8538262400951484135, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 3cb0c35df3125dc4ca82dc0c0882edb9,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 678d8623073f29f4cb23d4cb26359cd4, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mmHollowPoint.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mmHollowPoint.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0d6120c86021a9248ac45d3b4af5cc4e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mmIncendiary.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mmIncendiary.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1391535757950964516
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2434735188447524412, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: c3a3ac9177b279b4f9828a9af901abb9,
+        type: 2}
+    - target: {fileID: 8242272600229782233, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: initialName
+      value: pistol magazine (9mm incendiary)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8242272600229782233, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: initialDescription
+      value: A gun magazine. Loaded with rounds which ignite the target.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8399202269906357691, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_Name
+      value: PistolMagazine9mmIncendiary
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8438549908676571151, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8538262400951484135, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 2f45ced7e410cd34a8c43922aed014b3,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 678d8623073f29f4cb23d4cb26359cd4, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mmIncendiary.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/PistolMagazine9mmIncendiary.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0bcb562e4cfbd464e8ef507e59b99145
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/RifleMagazine10mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/RifleMagazine10mm.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6477829496076696160
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4011383383968898653, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 513bbd14db5465d4a930f43cfd050a71,
+        type: 2}
+    - target: {fileID: 6925587641645225606, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 3f3743ca41e153b4eb35236bdc1b8035,
+        type: 3}
+    - target: {fileID: 7128447074449515994, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_Name
+      value: RifleMagazine10mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 7133375222699792558, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7133375222699792558, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7133375222699792558, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7133375222699792558, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7133375222699792558, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7133375222699792558, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7133375222699792558, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7133375222699792558, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7133375222699792558, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7133375222699792558, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7133375222699792558, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167867211737094254, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7205986369602161336, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: initialDescription
+      value: A well-worn magazine fitted for the surplus rifle.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7205986369602161336, guid: b207c10b72e178346bee8cf182f264eb,
+        type: 3}
+      propertyPath: initialName
+      value: rifle magazine (10mm)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b207c10b72e178346bee8cf182f264eb, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/RifleMagazine10mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/RifleMagazine10mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fd84884e25579bc4682c97d3bb04d3fc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine.45.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine.45.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3952869574688234739
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: c455e9b9305a9814a9c501174fc8181e,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: SMG magazine (.45)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 09a07cf33e8a4de41aea6c464d845714,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: SMGMagazine.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine.45.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine.45.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 251c85198dd9873499087ca7a48dd1f7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine.45ArmorPiercing.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine.45ArmorPiercing.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6145194029875250283
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7508253555952636633, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_Name
+      value: SMGMagazine.45ArmorPiercing
+      objectReference: {fileID: 0}
+    - target: {fileID: 7612940772725288813, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7989164050574687675, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: initialName
+      value: SMG magazine (.45 armor-piercing )
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 251c85198dd9873499087ca7a48dd1f7, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine.45ArmorPiercing.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine.45ArmorPiercing.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3ff692322b59b2c42910672d01e80be0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine.45Incendiary.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine.45Incendiary.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7944013438262220124
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503330080626225069, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7508253555952636633, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_Name
+      value: SMGMagazine.45Incendiary
+      objectReference: {fileID: 0}
+    - target: {fileID: 7612940772725288813, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7989164050574687675, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+      propertyPath: initialName
+      value: SMG magazine (.45 incendiary)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 251c85198dd9873499087ca7a48dd1f7, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine.45Incendiary.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine.45Incendiary.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6350e652bf2cf6f4798e94b428abe26a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine9mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine9mm.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6357001894867140255
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: be519d1e5a7d98d478c963dec6229bfc,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: SMG magazine (9mm)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 667cf33ed7e534c49a0b516e7c15e84f,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: SMGMagazine9mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine9mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine9mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ba2490615a21da647b877d027f930840
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine9mmArmorPiercing.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine9mmArmorPiercing.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8704078666505657049
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 17104026913251287, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: initialName
+      value: SMG magazine (9mm armor-piercing)
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 491277951223558325, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_Name
+      value: SMGMagazine9mmArmorPiercing
+      objectReference: {fileID: 0}
+    - target: {fileID: 523942757792173313, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ba2490615a21da647b877d027f930840, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine9mmArmorPiercing.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine9mmArmorPiercing.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b23195defd6a2704488df17261844866
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine9mmIncendiary.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine9mmIncendiary.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4806389044564352809
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 17104026913251287, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: initialName
+      value: SMG Magazine (9mm incendiary)
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 487194227295194561, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 491277951223558325, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_Name
+      value: SMGMagazine9mmIncendiary
+      objectReference: {fileID: 0}
+    - target: {fileID: 523942757792173313, guid: ba2490615a21da647b877d027f930840,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ba2490615a21da647b877d027f930840, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine9mmIncendiary.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SMGMagazine9mmIncendiary.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0d8fef8ae4773ff478006494920a88d3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12g.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12g.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1309745578503457720
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: bbb46477ea7fa5b49967ce74f1a0b60e,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: shotgun magazine (12g buckshot slugs)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialDescription
+      value: A drum magazine.
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 9860b1a9859bb774c8eed60739a9a3c4,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: ShotgunMagazine12g
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12g.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12g.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 98da9a96ac84b28439d4baced674700d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gBioterror.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gBioterror.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2302102539398883170
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1838309391298199061, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 2499145c460938043a93ae6bd2e57dc9,
+        type: 2}
+    - target: {fileID: 5343935634496596720, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: initialName
+      value: shotgun magazine (12g bioterror)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5531796456047199634, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_Name
+      value: ShotgunMagazine12gBioterror
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5571188075281479718, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5635434756998985422, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 5fdab8698cdcb3940ac9249479260e1b,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 98da9a96ac84b28439d4baced674700d, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gBioterror.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gBioterror.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3632ce410700a184599562dcc576c4d8
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gDragonsBreath.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gDragonsBreath.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7181529833811635215
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1838309391298199061, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 51fc110990d54d84aa726a63fe1dc4df,
+        type: 2}
+    - target: {fileID: 5343935634496596720, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: initialName
+      value: shotgun magazine (12g dragon's breath)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5531796456047199634, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_Name
+      value: ShotgunMagazine12gDragon
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5571188075281479718, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5635434756998985422, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 285600435c058754fba8df224d0fb044,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 98da9a96ac84b28439d4baced674700d, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gDragonsBreath.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gDragonsBreath.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 857e3b9968507b6419c8eefb3f1dfd9b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gMeteor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gMeteor.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8293756700551861361
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1838309391298199061, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 8249ef9479c13214ab0eb33e1ef83b7e,
+        type: 2}
+    - target: {fileID: 5343935634496596720, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: initialName
+      value: shotgun magazine (12g meteor slugs)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5531796456047199634, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_Name
+      value: ShotgunMagazine12gMeteor
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5571188075281479718, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5635434756998985422, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: e985a0c331430864490ecd465be2d30c,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 98da9a96ac84b28439d4baced674700d, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gMeteor.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gMeteor.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f182212bbfe21e141bf3a9eba0999a00
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gSlug.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gSlug.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5342943940038820416
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5531796456047199634, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_Name
+      value: ShotgunMagazine12g
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 98da9a96ac84b28439d4baced674700d, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gSlug.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gSlug.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 76134a5adbe62c94595b6b00b216189a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gTaser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gTaser.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5584880688578453978
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1838309391298199061, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 014e35a078f189c428b5857831528ab1,
+        type: 2}
+    - target: {fileID: 5343935634496596720, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: initialName
+      value: shotgun magazine (12g taser slugs)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5531796456047199634, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_Name
+      value: ShotgunMagazine12gStun
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5537001681630345446, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5571188075281479718, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5635434756998985422, guid: 98da9a96ac84b28439d4baced674700d,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 6d5adcd5414fdac4ca1fc912c7e093c6,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 98da9a96ac84b28439d4baced674700d, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gTaser.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ShotgunMagazine12gTaser.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d97599904148a944192f80e81940777e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SniperRounds.50.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SniperRounds.50.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &604001211451525798
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 3f504db34af033248a10a3bc503b59e9,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: sniper rounds (.50)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: b0f54856aa5b2ed46b24bdb2a66ed776,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: SniperRounds.50
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SniperRounds.50.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SniperRounds.50.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SniperRounds.50Penetrator.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SniperRounds.50Penetrator.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8128758300947861274
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5793186483055078382, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: initialName
+      value: sniper rounds (.50 penetrator)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5793186483055078382, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: initialDescription
+      value: An extremely powerful round capable of passing straight through cover
+        and anyone unfortunate enough to be behind it.
+      objectReference: {fileID: 0}
+    - target: {fileID: 6235254427324400780, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_Name
+      value: SniperRoundsPenetrator
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6276935161051642168, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SniperRounds.50Penetrator.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SniperRounds.50Penetrator.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1ff4434fc7fc4854a96c3553a2bfea85
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SniperRounds.50Soporific.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SniperRounds.50Soporific.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5788215380711914877
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 274171926177971979, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 44b841bf1cf98714497da2d501261b14,
+        type: 2}
+    - target: {fileID: 5793186483055078382, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: initialName
+      value: sniper rounds (.50 soporific)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5793186483055078382, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: initialDescription
+      value: Soporific sniper rounds, designed for happy days and dead quiet nights...
+      objectReference: {fileID: 0}
+    - target: {fileID: 6087150639765223376, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 11071ffe51963c34fb51cb4f37e4cbf7,
+        type: 3}
+    - target: {fileID: 6235254427324400780, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_Name
+      value: SniperRounds.50Soporific
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6240741128023194104, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6276935161051642168, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SniperRounds.50Soporific.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SniperRounds.50Soporific.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a6df792f59ac82341bcd9b5f48ecc88b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SpecializedMagazine.75.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SpecializedMagazine.75.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3214041206793136787
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 2daf3255695487a44adcc3bdc2076f30,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: specialized magazine (.75)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 794b419eecdcf7b42a3e1f1ef1947325,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: SpecializedMagazine.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SpecializedMagazine.75.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/SpecializedMagazine.75.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 48fb45b026de3524f96ca5d6436a248b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/StechkinPistolMagazine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/StechkinPistolMagazine.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3117813036626966260
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: stechkin pistol magazine (9mm)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: StechkinPistolMagazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/StechkinPistolMagazine.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/StechkinPistolMagazine.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dc4ea858a033ead4083623ef37dbeaef
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToploaderMagazine5.56mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToploaderMagazine5.56mm.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4034582372151923286
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: fecacb92d1b21a94fbab6d104eaae75d,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: toploader magazine (5.56mm)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 9b43d1dd28ad11a429d4beb94f7f6136,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: ToploaderMagazine5.56mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToploaderMagazine5.56mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToploaderMagazine5.56mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5a643a1e715e7bd42af8563fcac22ee2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToploaderMagazine5.56mmPhasic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToploaderMagazine5.56mmPhasic.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2623940438413940331
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7530097647210078664, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7568281933657694472, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7568281933657694472, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7568281933657694472, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7568281933657694472, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7568281933657694472, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7568281933657694472, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7568281933657694472, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7568281933657694472, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7568281933657694472, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7568281933657694472, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7568281933657694472, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7571802707091528828, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: m_Name
+      value: ToploaderMagazine5.56mmPhasic
+      objectReference: {fileID: 0}
+    - target: {fileID: 8068736144130831134, guid: 5a643a1e715e7bd42af8563fcac22ee2,
+        type: 3}
+      propertyPath: initialName
+      value: toploader magazine (5.56mm phasic)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5a643a1e715e7bd42af8563fcac22ee2, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToploaderMagazine5.56mmPhasic.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToploaderMagazine5.56mmPhasic.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3059ceba0a1fa2d48820de96b52d1e6b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d2e3341a278d6bd44812d151f7578549
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftBoxMagazine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftBoxMagazine.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4158274793302343196
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1250843745268640460, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: initialName
+      value: donksoft box magazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 1533349136993711858, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 4b14f529cabfc134d9ce53c6bdae90cf,
+        type: 3}
+    - target: {fileID: 1594921804251691034, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1708686657731708334, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_Name
+      value: DonksoftBoxMagazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 4823467634323291689, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 3999593f952a0104aade24ff4ccff74c,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8e8424eb1a0a54f4380ff97f6a51d872, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftBoxMagazine.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftBoxMagazine.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0bc76d43c20ede548ac2af69f6644adf
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftBoxMagazineRiot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftBoxMagazineRiot.prefab
@@ -1,0 +1,88 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5937245385444696944
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3238831462574082286, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 6e54f079a68ca214eab125c8ea76c7af,
+        type: 3}
+    - target: {fileID: 3315583441666538418, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_Name
+      value: DonksoftBoxMagazineRiot
+      objectReference: {fileID: 0}
+    - target: {fileID: 3319385690346030790, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3319385690346030790, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3319385690346030790, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3319385690346030790, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3319385690346030790, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3319385690346030790, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3319385690346030790, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3319385690346030790, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3319385690346030790, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3319385690346030790, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3319385690346030790, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3429319639133144582, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8882592312452038709, guid: 0bc76d43c20ede548ac2af69f6644adf,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 9121eb003c0ebee499b57cb8cdad567b,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0bc76d43c20ede548ac2af69f6644adf, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftBoxMagazineRiot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftBoxMagazineRiot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cf7c052772ad66843bf796211554acd0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftSMGMagazine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftSMGMagazine.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5956763928504979827
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1250843745268640460, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: initialName
+      value: donksoft SMG magazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 1533349136993711858, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 096909c2c7b26b64ebd61fe75d08d8fa,
+        type: 3}
+    - target: {fileID: 1594921804251691034, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1708686657731708334, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_Name
+      value: DonksoftSMGMagazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 4823467634323291689, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 05629d047e426094b873e19efdec36f8,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8e8424eb1a0a54f4380ff97f6a51d872, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftSMGMagazine.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftSMGMagazine.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 575c7259047dae94189596259407a197
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftSMGMagazineRiot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftSMGMagazineRiot.prefab
@@ -1,0 +1,88 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7756856747301790640
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1178477978968436570, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 832066b2f8b6e9949b0fba8bdf4c7a05,
+        type: 2}
+    - target: {fileID: 4938445299905735017, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4976291143140403625, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4976291143140403625, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4976291143140403625, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4976291143140403625, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4976291143140403625, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4976291143140403625, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4976291143140403625, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4976291143140403625, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4976291143140403625, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4976291143140403625, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4976291143140403625, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4980088718429394141, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_Name
+      value: DonksoftSMGMagazineRiot
+      objectReference: {fileID: 0}
+    - target: {fileID: 5182835928012367745, guid: 575c7259047dae94189596259407a197,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 3a0304a6418ce564298baa48570b4649,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 575c7259047dae94189596259407a197, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftSMGMagazineRiot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/DonksoftSMGMagazineRiot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d2ffc415ffc580240b5e4cf3ec895ea1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForcePistolMagazine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForcePistolMagazine.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8063062472530043149
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1250843745268640460, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: initialName
+      value: foam force pistol magazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 1533349136993711858, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: f4b29a15c4846d24d829d1f4071b90d5,
+        type: 3}
+    - target: {fileID: 1594921804251691034, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1708686657731708334, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_Name
+      value: FoamForcePistolMagazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 4823467634323291689, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 1c7a995e702f0bd45b4b524d35c4767e,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8e8424eb1a0a54f4380ff97f6a51d872, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForcePistolMagazine.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForcePistolMagazine.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 215c07b6aa6d556439078165149ba3a5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForcePistolMagazineRiot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForcePistolMagazineRiot.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &575695077603433265
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8664991443309795799, guid: 215c07b6aa6d556439078165149ba3a5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8664991443309795799, guid: 215c07b6aa6d556439078165149ba3a5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8664991443309795799, guid: 215c07b6aa6d556439078165149ba3a5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8664991443309795799, guid: 215c07b6aa6d556439078165149ba3a5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8664991443309795799, guid: 215c07b6aa6d556439078165149ba3a5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8664991443309795799, guid: 215c07b6aa6d556439078165149ba3a5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8664991443309795799, guid: 215c07b6aa6d556439078165149ba3a5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8664991443309795799, guid: 215c07b6aa6d556439078165149ba3a5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8664991443309795799, guid: 215c07b6aa6d556439078165149ba3a5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8664991443309795799, guid: 215c07b6aa6d556439078165149ba3a5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8664991443309795799, guid: 215c07b6aa6d556439078165149ba3a5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8670478144276522147, guid: 215c07b6aa6d556439078165149ba3a5,
+        type: 3}
+      propertyPath: m_Name
+      value: FoamForcePistolMagazine
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 215c07b6aa6d556439078165149ba3a5, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForcePistolMagazineRiot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForcePistolMagazineRiot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bbae0629eb6f8e94c8db10678b31b14b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForceSMGMagazine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForceSMGMagazine.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3865412201036636445
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1250843745268640460, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: initialName
+      value: foam force SMG magazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 1533349136993711858, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 667cf33ed7e534c49a0b516e7c15e84f,
+        type: 3}
+    - target: {fileID: 1594921804251691034, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1704044382101453018, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1708686657731708334, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: m_Name
+      value: FoamForceSMGMagazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 4823467634323291689, guid: 8e8424eb1a0a54f4380ff97f6a51d872,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: be519d1e5a7d98d478c963dec6229bfc,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8e8424eb1a0a54f4380ff97f6a51d872, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForceSMGMagazine.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForceSMGMagazine.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 622826a49d3855f40be742325988c4de
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForceSMGMagazineRiot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForceSMGMagazineRiot.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2355256222125545065
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2450319646932851143, guid: 622826a49d3855f40be742325988c4de,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2450319646932851143, guid: 622826a49d3855f40be742325988c4de,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2450319646932851143, guid: 622826a49d3855f40be742325988c4de,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2450319646932851143, guid: 622826a49d3855f40be742325988c4de,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2450319646932851143, guid: 622826a49d3855f40be742325988c4de,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2450319646932851143, guid: 622826a49d3855f40be742325988c4de,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2450319646932851143, guid: 622826a49d3855f40be742325988c4de,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2450319646932851143, guid: 622826a49d3855f40be742325988c4de,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2450319646932851143, guid: 622826a49d3855f40be742325988c4de,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2450319646932851143, guid: 622826a49d3855f40be742325988c4de,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2450319646932851143, guid: 622826a49d3855f40be742325988c4de,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2455247520712074419, guid: 622826a49d3855f40be742325988c4de,
+        type: 3}
+      propertyPath: m_Name
+      value: FoamForceSMGMagazine
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 622826a49d3855f40be742325988c4de, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForceSMGMagazineRiot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/FoamForceSMGMagazineRiot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 48614d28a76e7cf49b57a3fcd97d31a8
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/ToyMagazineBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/ToyMagazineBase.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5287151527229606788
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: foam force META magazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: ToyMagazineBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/ToyMagazineBase.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/ToyMagazines/ToyMagazineBase.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8e8424eb1a0a54f4380ff97f6a51d872
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/UziMagazine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/UziMagazine.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2318990824152340037
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: d050b9663815e4d459c7c34eae482ecd,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: uzi magazine (9mm)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 8ed0e406922d1f8419c8cb02cbca1e72,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: UziMagazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/UziMagazine.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/UziMagazine.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 817c16204fef2b34f812fc1016235e36
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/WT550Magazine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/WT550Magazine.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &683970719057341346
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 842131404161660333, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 17fa71927af2186458701951432b2843,
+        type: 2}
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialName
+      value: wt550 magazine (4.6x30mm)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 43b942592a3f9fe4a90147607cd9ae39,
+        type: 3}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: WT550Magazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/WT550Magazine.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/WT550Magazine.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 215fd0235adde3345a8b9d0f1082535d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/WT550MagazineArmorPiercing.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/WT550MagazineArmorPiercing.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5772425893017049593
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 203270778159881743, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: f9b0a0d9d756ab6458fa04f74840ee4f,
+        type: 2}
+    - target: {fileID: 5870912918899428074, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: initialName
+      value: wt550 magazine (4.6x30mm armor-piercing)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6153538979878164180, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: f8d34a4bbc411da4a9adb38e08dd7cf5,
+        type: 3}
+    - target: {fileID: 6196956513285920828, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6310728925908395400, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_Name
+      value: WT550MagazineArmorPiercing
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 215fd0235adde3345a8b9d0f1082535d, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/WT550MagazineArmorPiercing.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/WT550MagazineArmorPiercing.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6ff6db6f2e98bf848a8a0a1d8376e9d1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/WT550MagazineIncendiary.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/WT550MagazineIncendiary.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3577097212056399790
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 203270778159881743, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 69bb729a658f2a04d8eb0ad9675e12d9,
+        type: 2}
+    - target: {fileID: 5870912918899428074, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: initialName
+      value: wt550 magazine (4.6x30mm incendiary)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6153538979878164180, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: d7971ed10d754f34e943e38d3a4a4d8a,
+        type: 3}
+    - target: {fileID: 6196956513285920828, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6307208426613709052, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6310728925908395400, guid: 215fd0235adde3345a8b9d0f1082535d,
+        type: 3}
+      propertyPath: m_Name
+      value: WT550MagazineIncendiary
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 215fd0235adde3345a8b9d0f1082535d, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/WT550MagazineIncendiary.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/ExternalMagazines/WT550MagazineIncendiary.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 49ee2bc0354bc0949a709fe7a8d122ca
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ff98fa4618f85614f9ab35359e36ce97
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBase.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4004713736806742586
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6342299245117104456, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: initialDescription
+      value: Oh god, this shouldn't be here
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636107547650964854, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Color.a
+      value: 0.29803923
+      objectReference: {fileID: 0}
+    - target: {fileID: 6839214368423611946, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6843860766685623134, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6880920390388757406, guid: d57fa00554efcec4abd669e2d6b24edc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d57fa00554efcec4abd669e2d6b24edc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBase.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBase.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 279de6cf129850f4b8a22d99511dfd03
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBoltAction.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBoltAction.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7878835930908917341
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4340418770804641687, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 2817cc103e3fa5543b69878737228fde,
+        type: 2}
+    - target: {fileID: 7561096614868355492, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7600489401807614992, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineBoltAction
+      objectReference: {fileID: 0}
+    - target: {fileID: 7749473724758755148, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: e31e47f1f8f786d4a80653d7f7888899,
+        type: 3}
+    - target: {fileID: 8041113790362737522, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: initialName
+      value: bolt action rifle internal magazine
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 279de6cf129850f4b8a22d99511dfd03, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBoltAction.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBoltAction.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d02ff8c97e3e1a04a883dbe5bf0beb6d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBoltActionArcaneBarrage.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBoltActionArcaneBarrage.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2397479169308205785
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1940949741191087747, guid: d10218c54fffc044994ea27f516323e0,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineBoltActionEnchanted
+      objectReference: {fileID: 0}
+    - target: {fileID: 1944466116985273335, guid: d10218c54fffc044994ea27f516323e0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1944466116985273335, guid: d10218c54fffc044994ea27f516323e0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1944466116985273335, guid: d10218c54fffc044994ea27f516323e0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1944466116985273335, guid: d10218c54fffc044994ea27f516323e0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1944466116985273335, guid: d10218c54fffc044994ea27f516323e0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1944466116985273335, guid: d10218c54fffc044994ea27f516323e0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1944466116985273335, guid: d10218c54fffc044994ea27f516323e0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1944466116985273335, guid: d10218c54fffc044994ea27f516323e0,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1944466116985273335, guid: d10218c54fffc044994ea27f516323e0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1944466116985273335, guid: d10218c54fffc044994ea27f516323e0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1944466116985273335, guid: d10218c54fffc044994ea27f516323e0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d10218c54fffc044994ea27f516323e0, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBoltActionArcaneBarrage.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBoltActionArcaneBarrage.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8ced4cf7d7fa1804aae55d078ca4785b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBoltActionEnchanted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBoltActionEnchanted.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2216546030665665742
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 301006007775382093, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineBoltAction
+      objectReference: {fileID: 0}
+    - target: {fileID: 305929758516033337, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 305929758516033337, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 305929758516033337, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 305929758516033337, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 305929758516033337, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 305929758516033337, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 305929758516033337, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 305929758516033337, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 305929758516033337, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 305929758516033337, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 305929758516033337, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d02ff8c97e3e1a04a883dbe5bf0beb6d, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBoltActionEnchanted.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineBoltActionEnchanted.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d10218c54fffc044994ea27f516323e0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinder38.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinder38.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &754399040006926046
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 589061417500173719, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 8167bb14edb1ea941839408a1b6b1338,
+        type: 3}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 782836474257692363, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineCylinder38
+      objectReference: {fileID: 0}
+    - target: {fileID: 813185847307758463, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 878390030489663913, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: initialName
+      value: detective revolver cylinder
+      objectReference: {fileID: 0}
+    - target: {fileID: 6889151283462925644, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: aef0c35f3a3221943b2f7a7556e1a26f,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 697318e0925068143a28d0a4fb8b5f10, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinder38.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinder38.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7a103e9d0eb3d0a4d9f2e3a8266c0231
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinder762.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinder762.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6382089033246886725
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 589061417500173719, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 85df76d34d1e72b409a3d13d46f7d834,
+        type: 3}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 782836474257692363, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineCylinder762
+      objectReference: {fileID: 0}
+    - target: {fileID: 813185847307758463, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 878390030489663913, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: initialName
+      value: Nagant revolver cylinder
+      objectReference: {fileID: 0}
+    - target: {fileID: 6889151283462925644, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: f697b336c13ef1845937efdac2128f8c,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 697318e0925068143a28d0a4fb8b5f10, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinder762.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinder762.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0fade050883b59443991d5b4b2a66e96
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinderBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinderBase.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7180828491628438235
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4340418770804641687, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 93bf57552eef5424a9677ef6d7179beb,
+        type: 2}
+    - target: {fileID: 7561096614868355492, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7600489401807614992, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineCylinderBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 7749473724758755148, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 36a97a4f3aabe0647990fe22b958d1f5,
+        type: 3}
+    - target: {fileID: 8041113790362737522, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: initialName
+      value: revolver cylinder
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 279de6cf129850f4b8a22d99511dfd03, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinderBase.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinderBase.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 697318e0925068143a28d0a4fb8b5f10
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinderRussian.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinderRussian.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8714190046380876577
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 589061417500173719, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 502198350ca58a244977515a9d52b799,
+        type: 3}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 782836474257692363, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineCylinderRussian
+      objectReference: {fileID: 0}
+    - target: {fileID: 813185847307758463, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 878390030489663913, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: initialName
+      value: Russian revolver cylinder
+      objectReference: {fileID: 0}
+    - target: {fileID: 6889151283462925644, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: e4f65ba55ce6f5f4c8e335a2e076be77,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 697318e0925068143a28d0a4fb8b5f10, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinderRussian.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineCylinderRussian.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b73e69badd307444ea1fedc49b20d806
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineGatlingGunFusionCore.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineGatlingGunFusionCore.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3810339033577476336
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4340418770804641687, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: be7be92a5d207e14e8803c676e81527d,
+        type: 2}
+    - target: {fileID: 7561096614868355492, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7600489401807614992, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineGatlingGunFusionCore
+      objectReference: {fileID: 0}
+    - target: {fileID: 7749473724758755148, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: c7d349b35b8786f4bb88b4ac5a78761a,
+        type: 3}
+    - target: {fileID: 8041113790362737522, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: initialName
+      value: gatling gun fusion core
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 279de6cf129850f4b8a22d99511dfd03, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineGatlingGunFusionCore.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineGatlingGunFusionCore.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 15daf2999c375ae44a9f494aea40087e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineGrenadeMulti.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineGrenadeMulti.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &577405111261533026
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 589061417500173719, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 04e6c7b8c7a088b4495ed951d549e6a7,
+        type: 3}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 778757148782701503, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 782836474257692363, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineGrenadeMulti
+      objectReference: {fileID: 0}
+    - target: {fileID: 813185847307758463, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 878390030489663913, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: initialName
+      value: grenade launcher internal magazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6889151283462925644, guid: 697318e0925068143a28d0a4fb8b5f10,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 94a1420132f6fea459c684a80d4048a2,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 697318e0925068143a28d0a4fb8b5f10, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineGrenadeMulti.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineGrenadeMulti.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5c81f0700645def468bfc5dcf5fd3a2d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineGrenadeSingle.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineGrenadeSingle.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7518433803731978329
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4340418770804641687, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: a5c72997fec95324f9de4016a0c3d8c2,
+        type: 2}
+    - target: {fileID: 7561096614868355492, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7600489401807614992, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineGrenadeSingle
+      objectReference: {fileID: 0}
+    - target: {fileID: 7749473724758755148, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: dc8cd6b7bd7c9f84eaabc5895733a00c,
+        type: 3}
+    - target: {fileID: 8041113790362737522, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: initialName
+      value: grenade launcher internal magazine
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 279de6cf129850f4b8a22d99511dfd03, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineGrenadeSingle.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineGrenadeSingle.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 747c190858b67c84d9a9218621a2f190
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineRocketLauncher.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineRocketLauncher.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5039288676805360138
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4340418770804641687, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: ba4463881b8a2414fab0c64b31130f44,
+        type: 2}
+    - target: {fileID: 7561096614868355492, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7600489401807614992, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineRocketLauncher
+      objectReference: {fileID: 0}
+    - target: {fileID: 7749473724758755148, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: ba6e4bd8fd2214b4e9cbde06743806bd,
+        type: 3}
+    - target: {fileID: 8041113790362737522, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: initialName
+      value: rocket launcher internal magazine
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 279de6cf129850f4b8a22d99511dfd03, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineRocketLauncher.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineRocketLauncher.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 895e8d0909213b44094eb90767c8b1cd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgun.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5867645696372319906
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4340418770804641687, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 67a06d03112b69949904e8fe7d764059,
+        type: 2}
+    - target: {fileID: 7561096614868355492, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7595847401659255140, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7600489401807614992, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineShotgun
+      objectReference: {fileID: 0}
+    - target: {fileID: 7749473724758755148, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: f42c8cbb7874c87418b1a0a81611faa1,
+        type: 3}
+    - target: {fileID: 8041113790362737522, guid: 279de6cf129850f4b8a22d99511dfd03,
+        type: 3}
+      propertyPath: initialName
+      value: shotgun internal magazine
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 279de6cf129850f4b8a22d99511dfd03, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgun.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgun.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 863f3c5765447184b8b0d23ff0b9ddff
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunCombat.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunCombat.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8545134968073152445
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4040938859939369650, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineShotgunCombat
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143445675893075718, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4244002627406733806, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 2e6f5f7cdeffe584f94fe5f84bce1345,
+        type: 3}
+    - target: {fileID: 4537894287203892688, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: initialName
+      value: combat shotgun internal magazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877450284545386805, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 6951d1acf1f988f4caa092597d21f0ef,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 863f3c5765447184b8b0d23ff0b9ddff, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunCombat.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunCombat.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 290140d90b29b7b40823586216f597ca
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunDoubleBarrel.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunDoubleBarrel.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1484758268063539013
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4040938859939369650, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineShotgunDoubleBarrel
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143445675893075718, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4244002627406733806, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 781bef48d37d9c748836e3457afbeae0,
+        type: 3}
+    - target: {fileID: 4537894287203892688, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: initialName
+      value: double-barrel shotgun internal magazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877450284545386805, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 8fa9714320a32e947afac4d56ab8be39,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 863f3c5765447184b8b0d23ff0b9ddff, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunDoubleBarrel.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunDoubleBarrel.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7920d9c4fad7b044c99cec907164f7e8
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunDualFeed.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunDualFeed.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &660586462648111323
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4040938859939369650, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineShotgunDualFeed
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143445675893075718, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4244002627406733806, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 16f8edce2ec3b9f4da4e9be1ee2585e1,
+        type: 3}
+    - target: {fileID: 4537894287203892688, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: initialName
+      value: dual feed shotgun internal tube
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877450284545386805, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: e2f15ba769acfcb4ea4669e9065339a3,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 863f3c5765447184b8b0d23ff0b9ddff, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunDualFeed.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunDualFeed.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4cc9fd651e73d8d48b911c08311a1845
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunImprovised.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunImprovised.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4516535884033249837
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4040938859939369650, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineShotgunImprovised
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143445675893075718, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4244002627406733806, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 976ca5797b4c6f54982e3ed71b24d36e,
+        type: 3}
+    - target: {fileID: 4537894287203892688, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: initialName
+      value: improvised shotgun internal magazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877450284545386805, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 80b6946b53e48b944b0b60b7ee05ce56,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 863f3c5765447184b8b0d23ff0b9ddff, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunImprovised.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunImprovised.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4a6e2f5fc0231d74fb2bb97ddc3fd9d8
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunLethal.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunLethal.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5601132611789263405
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4040938859939369650, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineShotgun
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 863f3c5765447184b8b0d23ff0b9ddff, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunLethal.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunLethal.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3aa4b5b45a2d036428a43751f9e37313
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunRiot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunRiot.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7592492012767531602
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4040938859939369650, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineShotgunRiot
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143445675893075718, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4244002627406733806, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 6b2f1574ebf9614419c43191aa66d366,
+        type: 3}
+    - target: {fileID: 4537894287203892688, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: initialName
+      value: riot shotgun internal magazine
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877450284545386805, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 281b21add084733448db245b3d4c8070,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 863f3c5765447184b8b0d23ff0b9ddff, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunRiot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunRiot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 743525ecb25075c4a931a26989c82712
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunToy.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunToy.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6434012825686200718
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037422484015181766, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4040938859939369650, guid: 863f3c5765447184b8b0d23ff0b9ddff,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineShotgun
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 863f3c5765447184b8b0d23ff0b9ddff, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunToy.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineShotgunToy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 721ddd4a34986b74394f6d2493d07fb4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineToyCrossbow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineToyCrossbow.prefab
@@ -1,0 +1,88 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &53350067988617244
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3753864498523797691, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: d571172eca170b0459acda7e704f0e14,
+        type: 2}
+    - target: {fileID: 6974472119906827912, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7011535935488867912, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7011535935488867912, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7011535935488867912, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7011535935488867912, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7011535935488867912, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7011535935488867912, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7011535935488867912, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7011535935488867912, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7011535935488867912, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7011535935488867912, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7011535935488867912, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7016178210582250300, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_Name
+      value: InternalMagazineToyCrossbow
+      objectReference: {fileID: 0}
+    - target: {fileID: 7183115460357025888, guid: 721ddd4a34986b74394f6d2493d07fb4,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 43e879403b53d094a9a79b9be6af9684,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 721ddd4a34986b74394f6d2493d07fb4, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineToyCrossbow.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/InternalMagazineToyCrossbow.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4aa80491623d49245995aa12a947e28f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.357.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.357.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2105687542511984182
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1367725800532977169, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: initialDescription
+      value: Designed to quickly reload revolvers.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1367725800532977169, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: initialName
+      value: speed loader (.357)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447548746969270643, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Name
+      value: SpeedLoader.357
+      objectReference: {fileID: 0}
+    - target: {fileID: 1549955644806952135, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650371861022734895, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 304231f58b8ed7f4a9942ee2cdc2a284,
+        type: 3}
+    - target: {fileID: 4706445082373976820, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 5fc839a5bac00d04daebb0d747731685,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fae459459df71d4999b6618dc06f219, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.357.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.357.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7cbde3b57839c144e933398cfd78e132
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.357Match.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.357Match.prefab
@@ -1,0 +1,88 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5447962832945694201
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 628933689286339313, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 661569839832110917, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_Name
+      value: SpeedLoader.357Match
+      objectReference: {fileID: 0}
+    - target: {fileID: 665930640891996721, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665930640891996721, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665930640891996721, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665930640891996721, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665930640891996721, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665930640891996721, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665930640891996721, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 665930640891996721, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665930640891996721, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665930640891996721, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 665930640891996721, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1135968098873243687, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: initialDescription
+      value: Designed to quickly reload revolvers. These rounds are manufactured
+        within extremely tight tolerances, making them easy to show off trickshots
+        with.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1135968098873243687, guid: 7cbde3b57839c144e933398cfd78e132,
+        type: 3}
+      propertyPath: initialName
+      value: speed loader (.357 match)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7cbde3b57839c144e933398cfd78e132, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.357Match.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.357Match.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f4a53ac905b990c428362ebaa6e783b0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4281917659012963605
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1367725800532977169, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: initialName
+      value: speed loader (.38)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1367725800532977169, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: initialDescription
+      value: Designed to quickly reload revolvers."
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447548746969270643, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Name
+      value: SpeedLoader.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 1549955644806952135, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650371861022734895, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 59fd0dc2ca435f0459d3b4ec07cff7cb,
+        type: 3}
+    - target: {fileID: 4706445082373976820, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 2ee34e7be2a6c8d448e3f1b774e9aeae,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fae459459df71d4999b6618dc06f219, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4262f7c3dbc59a8499d9f780d06bd0ad
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38DumDum.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38DumDum.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6069337567804772777
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2996950057520413444, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: initialDescription
+      value: Designed to quickly reload revolvers. DumDum bullets shatter on impact
+        and shred the target's innards, likely getting caught inside.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2996950057520413444, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: initialName
+      value: speed loader (.38 DumDum)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3381887893271538130, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3421280542771565670, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_Name
+      value: SpeedLoader.38DumDum
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4262f7c3dbc59a8499d9f780d06bd0ad, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38DumDum.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38DumDum.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 67d09c5efe50b2744b2f886f9820f7f6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38HotShot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38HotShot.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8781159414944101287
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2996950057520413444, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: initialName
+      value: speed loader (.38 Hot-Shot)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2996950057520413444, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: initialDescription
+      value: Designed to quickly reload revolvers. Hot Shot bullets contain an incendiary
+        payload.
+      objectReference: {fileID: 0}
+    - target: {fileID: 3381887893271538130, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3421280542771565670, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_Name
+      value: SpeedLoader.38HotShot
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4262f7c3dbc59a8499d9f780d06bd0ad, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38HotShot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38HotShot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3fd776b431fa51c4981c5ab90c7d553a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38Iceblox.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38Iceblox.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7492757715328309293
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2996950057520413444, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: initialDescription
+      value: Designed to quickly reload revolvers. Iceblox bullets contain a cryogenic
+        payload.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2996950057520413444, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: initialName
+      value: speed loader (.38 Iceblox)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3381887893271538130, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3421280542771565670, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_Name
+      value: SpeedLoader.38Iceblox
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4262f7c3dbc59a8499d9f780d06bd0ad, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38Iceblox.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38Iceblox.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7682f60a870624245a68baeecb5153bf
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38Rubber.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38Rubber.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &898597113581050068
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2996950057520413444, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: initialDescription
+      value: Designed to quickly reload revolvers. These rounds are incredibly bouncy
+        and MOSTLY nonlethal, making them great to show off trickshots with.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2996950057520413444, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: initialName
+      value: speed loader (.38 rubber)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3381887893271538130, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3421280542771565670, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_Name
+      value: SpeedLoader.38Rubber
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4262f7c3dbc59a8499d9f780d06bd0ad, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38Rubber.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38Rubber.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 111c6e0e841c81a4dbbf5d548ac77cd6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38TRAC.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38TRAC.prefab
@@ -1,0 +1,88 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3731995174458859897
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2996950057520413444, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: initialDescription
+      value: Designed to quickly reload revolvers. These rounds are manufactured
+        within extremely tight tolerances, making them easy to show off trickshots
+        with.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2996950057520413444, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: initialName
+      value: speed loader (.38 TRAC)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3381887893271538130, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3416357067512785170, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3421280542771565670, guid: 4262f7c3dbc59a8499d9f780d06bd0ad,
+        type: 3}
+      propertyPath: m_Name
+      value: SpeedLoader.38TRAC
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4262f7c3dbc59a8499d9f780d06bd0ad, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38TRAC.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/SpeedLoader.38TRAC.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 51f300832d29f1d4ea34973715e5536c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/StripperClip7.62mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/StripperClip7.62mm.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &564386621307643862
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1367725800532977169, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: initialName
+      value: stripper clip (7.62mm)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1367725800532977169, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: initialDescription
+      value: A stripper clip.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1442624996090196999, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1447548746969270643, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Name
+      value: StripperClip7.62mn
+      objectReference: {fileID: 0}
+    - target: {fileID: 1549955644806952135, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650371861022734895, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 65793765a33c2494abaa76a59ade0034,
+        type: 3}
+    - target: {fileID: 4706445082373976820, guid: 3fae459459df71d4999b6618dc06f219,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 96d9512d635dee045bc7210d2913e66f,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3fae459459df71d4999b6618dc06f219, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/StripperClip7.62mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/StripperClip7.62mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 510b866cfa944c64ba28c57a73c4e113
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a8b426e50429fd34fa06d31a1e8a3678
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/AmmoCasingBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/AmmoCasingBase.prefab
@@ -1,0 +1,102 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2280179955598536563
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_Name
+      value: BulletCasingBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 7050608a943742a4e850f78aa99b6c09,
+        type: 3}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialDescription
+      value: A bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialName
+      value: bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 3e088c6c232d4894ab39e95b28c63f9a,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: e29916dde8f376d4db1e627d8f754119,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/AmmoCasingBase.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/AmmoCasingBase.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 31d01d60b659392429fe6a6384563082
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/AmmoCasingSpent.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/AmmoCasingSpent.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &37376128601120179
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: spent bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoCasingSpent
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/AmmoCasingSpent.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/AmmoCasingSpent.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 64cc9da9faa5e6c448bf7f78b93ae052
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f4287759713351a40ac951bf38c27164
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.357.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.357.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7394890657105541409
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .357 bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: .357 bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.357
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.357.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.357.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5bd4694ba27611b46b8e2161fa3132af
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.357Match.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.357Match.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &955122042474747213
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8695496732523698012, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731120187480168348, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731120187480168348, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731120187480168348, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731120187480168348, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731120187480168348, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731120187480168348, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731120187480168348, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731120187480168348, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731120187480168348, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731120187480168348, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8731120187480168348, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8734918038045534952, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.357Match
+      objectReference: {fileID: 0}
+    - target: {fileID: 9211324795576567178, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .357 bullet casing, manufactured to exceedingly high standards.
+      objectReference: {fileID: 0}
+    - target: {fileID: 9211324795576567178, guid: 5bd4694ba27611b46b8e2161fa3132af,
+        type: 3}
+      propertyPath: initialName
+      value: .357 match bullet casing
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5bd4694ba27611b46b8e2161fa3132af, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.357Match.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.357Match.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 68fd1a472b398354b9a4872d9eaf7c87
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1229916463750450679
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: .38 bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .38 bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ddfe5a6d629eafb418fe9879b98bda39
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38DumDum.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38DumDum.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4062503150944414922
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 602167641720205660, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .38 DumDum bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 602167641720205660, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: initialName
+      value: .38 DumDum bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1060262307968998974, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.38DumDum
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090710499093668746, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ddfe5a6d629eafb418fe9879b98bda39, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38DumDum.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38DumDum.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: da128d36b925a5c48a0eaee60d0ff18f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38HotShot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38HotShot.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6961219919802650970
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 602167641720205660, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .38 Hot Shot bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 602167641720205660, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: initialName
+      value: .38 Hot Shot bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1060262307968998974, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.38HotShot
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090710499093668746, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ddfe5a6d629eafb418fe9879b98bda39, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38HotShot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38HotShot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 017b870a01b0250428d3effe8d86c515
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38Iceblox.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38Iceblox.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7050804347063837480
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 602167641720205660, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .38 Iceblox bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 602167641720205660, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: initialName
+      value: .38 Iceblox bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1060262307968998974, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.38Iceblox
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090710499093668746, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ddfe5a6d629eafb418fe9879b98bda39, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38Iceblox.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38Iceblox.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c1e1567b6c4ef85429f8ee16a0965a74
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38Match.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38Match.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1903852498198474984
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 602167641720205660, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .38 bullet casing, manufactured to exceedingly high standards.
+      objectReference: {fileID: 0}
+    - target: {fileID: 602167641720205660, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: initialName
+      value: .38 match bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1060262307968998974, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.38Match
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090710499093668746, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ddfe5a6d629eafb418fe9879b98bda39, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38Match.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38Match.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1b823044cd1ff2b489a183a2fa42ca06
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38Rubber.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38Rubber.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7674989532061555276
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 602167641720205660, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .38 rubber bullet casing, manufactured to exceedingly bouncy standards.
+      objectReference: {fileID: 0}
+    - target: {fileID: 602167641720205660, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: initialName
+      value: .38 rubber bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1060262307968998974, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.38Rubber
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090710499093668746, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ddfe5a6d629eafb418fe9879b98bda39, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38Rubber.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38Rubber.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c4869b67293f8214b9c8982ebdca121e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38TRAC.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38TRAC.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2566259111739886126
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 602167641720205660, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .38 "TRAC" bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 602167641720205660, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: initialName
+      value: .38 TRAC bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055334159043404618, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1060262307968998974, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.38TRAC
+      objectReference: {fileID: 0}
+    - target: {fileID: 1090710499093668746, guid: ddfe5a6d629eafb418fe9879b98bda39,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ddfe5a6d629eafb418fe9879b98bda39, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38TRAC.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.38TRAC.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0894d3b9d8beaf343969924eb9648a2c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.45.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.45.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7567875401220442251
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .45 bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: .45 bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.45.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.45.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 55081c8632462ac4b935fa1133a475cc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.45ArmorPiercing.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.45ArmorPiercing.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2104600001584541902
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8092018907690234912, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: initialName
+      value: .45 armor-piercing bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 8092018907690234912, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .45 armor-piercing bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8548178330402364226, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.45ArmorPiercing
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8589788901008025334, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 55081c8632462ac4b935fa1133a475cc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.45ArmorPiercing.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.45ArmorPiercing.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e5cc2926b3c1afa47ade1bc10e6559cf
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.45Incendiary.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.45Incendiary.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8507541447698052368
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8092018907690234912, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .45 incendiary bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8092018907690234912, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: initialName
+      value: .45 armor-piercing bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 8548178330402364226, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.45Incendiary
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8553101805598762550, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8589788901008025334, guid: 55081c8632462ac4b935fa1133a475cc,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 55081c8632462ac4b935fa1133a475cc, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.45Incendiary.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.45Incendiary.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e2b6ecf903695934a8c983b6d23a037b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &9005218800606943966
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: .50 bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .50 bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2114072713808011413, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 8d96f567558eb0f4d9df4675300985a7,
+        type: 3}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.50
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5395694184195221582, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 4d14d249b023e974bbb4dac0cc97eac8,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5fcdd7b5846d1734381c1bf52c4ffdba
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50AE.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50AE.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8320118491200629467
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: .50 AE bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .50 AE bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.50AE
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50AE.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50AE.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 19f30b1bd0d3b284e8cef025ed87fd5a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50Penetrator.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50Penetrator.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1095228251270531432
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7118932224558036131, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160638452673988887, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.50Penetrator
+      objectReference: {fileID: 0}
+    - target: {fileID: 7327963592474437237, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: initialName
+      value: .50 penetrator round bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 7327963592474437237, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .50 caliber penetrator round casing.
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5fcdd7b5846d1734381c1bf52c4ffdba, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50Penetrator.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50Penetrator.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 62302001b39236e4c91b50f3ab1724fb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50Soporific.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50Soporific.prefab
@@ -1,0 +1,99 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5052343739520597114
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3898337770535416464, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 820c1ce155e94894196c45066e30e6a8,
+        type: 2}
+    - target: {fileID: 7038641501412784715, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 1219ff07e513ef14291ed78cc02a0c80,
+        type: 3}
+    - target: {fileID: 7118932224558036131, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7155147354398962787, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7160638452673988887, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.50Soporific
+      objectReference: {fileID: 0}
+    - target: {fileID: 7327963592474437237, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: initialDescription
+      value: A .50 bullet casing, specialised in sending the target to sleep, instead
+        of hell.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7327963592474437237, guid: 5fcdd7b5846d1734381c1bf52c4ffdba,
+        type: 3}
+      propertyPath: initialName
+      value: .50 soporific bullet casing
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5fcdd7b5846d1734381c1bf52c4ffdba, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50Soporific.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo.50Soporific.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aa0d150c3ee5f394fbeb7afdde02d793
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mm.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3522982404379321611
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: 10mm bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 10mm bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo10mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: af14a150888c6514aad0d267281c7d17
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mmArmorPiercing.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mmArmorPiercing.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5275343724374499042
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3003614059255601568, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 10mm armor-piercing bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 3003614059255601568, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: initialName
+      value: 10mm armor-piercing bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 3375259073770376054, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3405673111843075778, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo10mmArmorPiercing
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: af14a150888c6514aad0d267281c7d17, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mmArmorPiercing.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mmArmorPiercing.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a41e7b18d3c99474ca9654747d683c5d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mmHollowPoint.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mmHollowPoint.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1931203953756934354
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3003614059255601568, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 10mm hollow-point bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 3003614059255601568, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: initialName
+      value: 10mm hollow-point bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 3375259073770376054, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3405673111843075778, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo10mmHollowPoint
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: af14a150888c6514aad0d267281c7d17, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mmHollowPoint.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mmHollowPoint.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b70f1e4aeb74efd47acedf64ed25964a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mmIncendiary.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mmIncendiary.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &120143483059856028
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3003614059255601568, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 10mm incendiary bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 3003614059255601568, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: initialName
+      value: 10mm incendiary bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 3375259073770376054, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3405673111843075778, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo10mmIncendiary
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3409475085447531446, guid: af14a150888c6514aad0d267281c7d17,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: af14a150888c6514aad0d267281c7d17, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mmIncendiary.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo10mmIncendiary.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e2dae2930a68db140a3e70bffdace75c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo4.6x30mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo4.6x30mm.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3464277078667714176
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 4.6x30mm bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: 4.6x30mm bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo4.6x30mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo4.6x30mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo4.6x30mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f384b48623b6e474dbdfd434f5958455
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo4.6x30mmArmorPiercing.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo4.6x30mmArmorPiercing.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6314963663010138641
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2979495506238235179, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: initialName
+      value: 4.6x30mm armor-piercing bullet casing"
+      objectReference: {fileID: 0}
+    - target: {fileID: 2979495506238235179, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 4.6x30mm armor-piercing bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323907541871636733, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3437603126134050121, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo4.6x30mmArmorPiercing
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f384b48623b6e474dbdfd434f5958455, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo4.6x30mmArmorPiercing.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo4.6x30mmArmorPiercing.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3157b1f7cd76dbe408c2033dda90516c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo4.6x30mmIncendiary.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo4.6x30mmIncendiary.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1143491715540036056
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2979495506238235179, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 4.6x30mm incendiary bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2979495506238235179, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: initialName
+      value: 4.6x30mm incendiary bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323907541871636733, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3433805550039232573, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3437603126134050121, guid: f384b48623b6e474dbdfd434f5958455,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo4.6x30mmIncendiary
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f384b48623b6e474dbdfd434f5958455, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo4.6x30mmIncendiary.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo4.6x30mmIncendiary.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 67c9d7e166d2eca41a0cb7f3c5218f53
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo40mmHEShell.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo40mmHEShell.prefab
@@ -1,0 +1,99 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7557489874095482227
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A cased high-explosive grenade that can only be activated once fired
+        out of a grenade launcher.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: 40mm HE shell
+      objectReference: {fileID: 0}
+    - target: {fileID: 2114072713808011413, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: b7968f32d249ee443900f42ea813d675,
+        type: 3}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo40mmHEShell
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5395694184195221582, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 589342d2850abdf4faa0380b722440a8,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo40mmHEShell.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo40mmHEShell.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d4ee42b30251c994dad60d85ad6facd9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo5.56mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo5.56mm.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6755815148010702034
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: 5.56mm bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 5.56mm bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo5.56mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo5.56mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo5.56mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7f0fc409f45116c4db12e075d68024d0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo5.56mmPhasic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo5.56mmPhasic.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8301408329148064012
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4784580267020637979, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo5.56mmPhasic
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788940792733346415, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788940792733346415, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788940792733346415, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788940792733346415, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788940792733346415, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788940792733346415, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788940792733346415, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788940792733346415, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788940792733346415, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788940792733346415, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788940792733346415, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4895988935813360303, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4939222643289503865, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 5.56mm phasic bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 4939222643289503865, guid: 7f0fc409f45116c4db12e075d68024d0,
+        type: 3}
+      propertyPath: initialName
+      value: 5.56mm phasic bullet casing
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7f0fc409f45116c4db12e075d68024d0, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo5.56mmPhasic.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo5.56mmPhasic.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 28637cd413a0f62489fcb244570e5612
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mm.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8111755893783191707
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: 7.12x82mm bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 7.12x82mm bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo7.12x82mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e1b6777d67d2e244f8149d1eb84fc582
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmArmorPiercing.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmArmorPiercing.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2890227201406118057
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7626953478813211696, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 7.12x82mm bullet casing designed with a hardened-tipped core to help
+        penetrate armored targets.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7626953478813211696, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: initialName
+      value: 7.12x82mm armor-piercing bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971880326410833638, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8013587585863168850, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo7.12x82mmArmorPiercing
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e1b6777d67d2e244f8149d1eb84fc582, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmArmorPiercing.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmArmorPiercing.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6fab7e0ae57334144b7be8681158ea1f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmHollowPoint.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmHollowPoint.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4871982148261780111
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7626953478813211696, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 7.12x82mm bullet casing designed to cause more damage to unarmored
+        targets.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7626953478813211696, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: initialName
+      value: 7.12x82mm hollow-point bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971880326410833638, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8013587585863168850, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo7.12x82mmHollowPoint
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e1b6777d67d2e244f8149d1eb84fc582, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmHollowPoint.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmHollowPoint.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 429a61681771ea947b04c58872cda991
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmIncendiary.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmIncendiary.prefab
@@ -1,0 +1,88 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1084908999229524137
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7626953478813211696, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 7.12x82mm bullet casing designed with a chemical-filled capsule on
+        the tip that when bursted, reacts with the atmosphere to produce a fireball,
+        engulfing the target in flames.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7626953478813211696, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: initialName
+      value: 7.12x82mm incendiary bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971880326410833638, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8013587585863168850, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo7.12x82mmIncendiary
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e1b6777d67d2e244f8149d1eb84fc582, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmIncendiary.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmIncendiary.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bd0aa0e776b871143802f0a11b5044ac
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmMatch.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmMatch.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7310865888126190122
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7626953478813211696, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 7.12x82mm bullet casing manufactured to unfailingly high standards,
+        you could pull off some cool trickshots with this.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7626953478813211696, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: initialName
+      value: 7.12x82mm match bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971880326410833638, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009222387029429798, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8013587585863168850, guid: e1b6777d67d2e244f8149d1eb84fc582,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo7.12x82mmMatch
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e1b6777d67d2e244f8149d1eb84fc582, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmMatch.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.12x82mmMatch.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3203b8800c2ad6c4eaa921e20781e1d5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.62.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.62.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7890033429995526111
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 7.62 bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: 7.62 bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 2114072713808011413, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: d2714bc590d189e47b06c9ff78783845,
+        type: 3}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo7.62
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5395694184195221582, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: f7f80a1e2b02494478e315917c8da6f0,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.62.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.62.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fff5813656af4fd47b39c37274081680
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.62Enchanted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.62Enchanted.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6048241557212591075
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8271918220710590818, guid: fff5813656af4fd47b39c37274081680,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271918220710590818, guid: fff5813656af4fd47b39c37274081680,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271918220710590818, guid: fff5813656af4fd47b39c37274081680,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271918220710590818, guid: fff5813656af4fd47b39c37274081680,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271918220710590818, guid: fff5813656af4fd47b39c37274081680,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271918220710590818, guid: fff5813656af4fd47b39c37274081680,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271918220710590818, guid: fff5813656af4fd47b39c37274081680,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271918220710590818, guid: fff5813656af4fd47b39c37274081680,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271918220710590818, guid: fff5813656af4fd47b39c37274081680,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271918220710590818, guid: fff5813656af4fd47b39c37274081680,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8271918220710590818, guid: fff5813656af4fd47b39c37274081680,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8275438994216272918, guid: fff5813656af4fd47b39c37274081680,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo7.62
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fff5813656af4fd47b39c37274081680, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.62Enchanted.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.62Enchanted.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6ef81c244ffd78f41b991f672b30c801
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.62x38mmR.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.62x38mmR.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5125289331575973327
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: 7.62x38mmR bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 7.62x38mmR bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo7.62x38mmR
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.62x38mmR.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo7.62x38mmR.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 34a19588c324dec49836cbb094eae959
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mm.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6432746379272701834
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: 9mm bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 9mm bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo9mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5d37ebc7a0cbd0948a172b21dd46ca54
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mmArmorPiercing.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mmArmorPiercing.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2248701124803272805
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4616025213351328545, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: initialName
+      value: 9mm armor-piercing bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 4616025213351328545, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 9mm armor-piercing bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 5107909693011956803, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo9mmArmorPiercing
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5149520195437373943, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5d37ebc7a0cbd0948a172b21dd46ca54, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mmArmorPiercing.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mmArmorPiercing.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8e8f219fc15aa4f48aa046e7deb49bf0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mmHollowPoint.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mmHollowPoint.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3463078427399412578
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4616025213351328545, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 10mm hollow-point bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 4616025213351328545, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: initialName
+      value: 9mm hollow-point bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 5107909693011956803, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo9mmHollowPoint
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5149520195437373943, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5d37ebc7a0cbd0948a172b21dd46ca54, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mmHollowPoint.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mmHollowPoint.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0b455f7f0f9cae148ba47e10e0344c07
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mmIncendiary.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mmIncendiary.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7643116694962477360
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4616025213351328545, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 9mm incendiary bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 4616025213351328545, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: initialName
+      value: 9mm incendiary bullet casing
+      objectReference: {fileID: 0}
+    - target: {fileID: 5107909693011956803, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo9mmIncendiary
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5111993416739514679, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5149520195437373943, guid: 5d37ebc7a0cbd0948a172b21dd46ca54,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5d37ebc7a0cbd0948a172b21dd46ca54, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mmIncendiary.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/Ammo9mmIncendiary.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fb2f985ccda42454dabee5e7eea28c45
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0baf27561e842c045b4e584f1fb7b925
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunBeanbag.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunBeanbag.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7903129341822748143
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 571a8e442b1fb5f4ea5817bd4ed173a3,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: A weak beanbag slug for riot control.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: beanbag slug
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunBeanbag
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 37c5293324d7cee4396c01014e3c4057,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunBeanbag.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunBeanbag.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bf1d55b22809f3e4e8a87c956c84505c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunBuckshot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunBuckshot.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3773156240232378683
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: cad84018d792fd34db0ffc90f49e8db0,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 12 gauge buckshot shell.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: buckshot shell
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunBuckshot
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 9805842498c776341b28a76a919c26ea,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunBuckshot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunBuckshot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 275e5e346ea26524b98998796d344f4f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunDart.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunDart.prefab
@@ -1,0 +1,149 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &7977984259891811504
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2173327031778298339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d54c3d183673c904882b6d1e8484ca73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nameOverride: 
+  backgroundColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  iconOverride: {fileID: 0}
+  backgroundSprite: {fileID: 0}
+--- !u!114 &6819762402639647083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2173327031778298339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6adedb9416d7b647b6c3811ff2f0824, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  UseStandardExamine: 1
+  ExamineAmount: 0
+  ExamineContent: 0
+  traitWhitelist: []
+  reagentWhitelist: []
+  transferMode: 3
+  possibleTransferAmounts: []
+  transferAmount: 1
+  maxCapacity: 30
+  reactionSet: {fileID: 0}
+  initialReagentMix:
+    temperature: 273.15
+    reagents:
+      m_keys: []
+      m_values: []
+  destroyOnEmpty: 0
+--- !u!1001 &7757525757479138524
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 3fde3940dc8b5214cb221ef2c0900b86,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: A dart for use in shotguns. Can be injected with up to 30 units of any
+        chemical.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: shotgun dart
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunDart
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: fa4c29ae92a182c4bbae02bb810fc9c2,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}
+--- !u!1 &2173327031778298339 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+    type: 3}
+  m_PrefabInstance: {fileID: 7757525757479138524}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunDart.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunDart.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a18d0e7c3f533b14ca95700fbcd78944
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunDartBioterror.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunDartBioterror.prefab
@@ -1,0 +1,146 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7205390183559176909
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1784744727563445889, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialDescription
+      value: A shotgun dart filled with deadly toxins.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2173327031778298339, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunDartBioterror
+      objectReference: {fileID: 0}
+    - target: {fileID: 2178254905553335447, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2178254905553335447, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2178254905553335447, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2178254905553335447, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2178254905553335447, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2178254905553335447, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2178254905553335447, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2178254905553335447, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2178254905553335447, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2178254905553335447, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2178254905553335447, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2286985232632018007, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6819762402639647083, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.size
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6819762402639647083, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.size
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6819762402639647083, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: a26bde4a2f046cd008ef52a1b5cd738d,
+        type: 2}
+    - target: {fileID: 6819762402639647083, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[0]
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6819762402639647083, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: cb9c638146fd60b78b89e6dd43e10c16,
+        type: 2}
+    - target: {fileID: 6819762402639647083, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[1]
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6819762402639647083, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: acf5aada393318ae79eda0faba3acc14,
+        type: 2}
+    - target: {fileID: 6819762402639647083, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[2]
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6819762402639647083, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[3]
+      value: 
+      objectReference: {fileID: 11400000, guid: 57b5e2d1f4d4ebf38bcb325c1c1913f4,
+        type: 2}
+    - target: {fileID: 6819762402639647083, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[3]
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6819762402639647083, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_keys.Array.data[4]
+      value: 
+      objectReference: {fileID: 11400000, guid: 4e39afaaf9adfc737963607ff47aac06,
+        type: 2}
+    - target: {fileID: 6819762402639647083, guid: a18d0e7c3f533b14ca95700fbcd78944,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[4]
+      value: 6
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a18d0e7c3f533b14ca95700fbcd78944, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunDartBioterror.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunDartBioterror.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
-guid: 43d13513d22d1b6448505304f560e67d
-NativeFormatImporter:
+guid: 4c7eccf9fc5ca0040b80d95d799d4e26
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunDragonsBreath.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunDragonsBreath.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1519851959622897430
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 2199fe1cac1182b419b3744c4292d397,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: A shotgun shell which fires a spread of incendiary pellets.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: dragon's breath shell
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunDragonsBreath
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: a2e4d80192eda4d4c99caf4fc98a2f9b,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunDragonsBreath.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunDragonsBreath.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 51a91d79467b1aa449bef767dafdf942
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunFRAG12.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunFRAG12.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6485816807786468043
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: f86ca8276bcff704a9e94922df26c7d1,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: A high explosive breaching round for a 12 gauge shotgun.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: FRAG-12 slug
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunFRAG12
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 89ad8bc0b4cfe2f43926a76510159def,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunFRAG12.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunFRAG12.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a1a68d58b434bf145bec4d02f09440c5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunImprovised.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunImprovised.prefab
@@ -1,0 +1,99 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5652480475427774172
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 8d7ed7d533e1b0141a376da5879cd1c5,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: An extremely weak shotgun shell with multiple small pellets made out
+        of metal shards.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: improvised shell
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunImprovised
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 1aacccf807645984bb146909be0d153d,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunImprovised.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunImprovised.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 673ec23cb9beaa74f9ded556d3582813
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunIncendiary.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunIncendiary.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6601023797680942793
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 535e28b137290974682a2b645b0cb53b,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: incendiary slug
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: An incendiary-coated shotgun slug.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunIncendiary
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 1bce5427ae982fd4fb457f68c4701ad6,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunIncendiary.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunIncendiary.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 96546cff0c0c6bf4589adf5a845c4e18
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunIon.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunIon.prefab
@@ -1,0 +1,100 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4696642889878476278
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: a5d35b5094f52dd4bb4992bbe49bc04f,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: An advanced shotgun shell which uses a subspace ansible crystal to produce
+        an effect similar to a standard ion rifle. The unique properties of the crystal
+        split the pulse into a spread of individually weaker bolts.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: ion shell
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunIon
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 787deda9bbe403843a4b6389bb1dc471,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunIon.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunIon.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3f794c433436b6c4f94ac936e1b4819e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunMeteor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunMeteor.prefab
@@ -1,0 +1,99 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1303506066569957156
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 09dd1860315f53c41b646740b9812e3c,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: A shotgun shell rigged with CMC technology, which launches a massive
+        slug when fired.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: meteor slug shell
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunMeteor
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 09ea0f296d146194f9c6f8302167afaa,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunMeteor.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunMeteor.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 47a837010dc800f41844b25a647c72b4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunPulse.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunPulse.prefab
@@ -1,0 +1,97 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &3606723374139455456
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: c8e12314c44bdcc43a6d9e51624427da,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: A delicate device which can be loaded into a shotgun. The primer acts
+        as a button which triggers the gain medium and fires a powerful energy blast.
+        While the heat and power drain limit it to one use, it can still allow an
+        operator to engage targets that ballistic ammunition would have difficulty
+        with.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunPulse
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 3d9c681a71e3df444812a377f0eca156,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunPulse.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunPulse.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2f15e202979f59345b092118c8d15047
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunRubberShot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunRubberShot.prefab
@@ -1,0 +1,99 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5357753161241589396
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 571a8e442b1fb5f4ea5817bd4ed173a3,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: A shotgun casing filled with densely-packed rubber balls, used to incapacitate
+        crowds from a distance.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: rubber shot
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunRubberShot
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 37c5293324d7cee4396c01014e3c4057,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunRubberShot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunRubberShot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 432e896112672f64eb635fb0b74b167e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunScatterLaser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunScatterLaser.prefab
@@ -1,0 +1,99 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2624828269156296940
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: d15e3a5fd91e7504fad4fc3bdec5ddcf,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: An advanced shotgun shell that uses a micro laser to replicate the effects
+        of a scatter laser weapon in a ballistic package.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: scatter laser shell
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunScatterLaser
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: df8040cc0797e254e8dff8ae1ed48ace,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunScatterLaser.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunScatterLaser.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 224e6d9bfdf21434dacb68de112682d9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunSlug.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunSlug.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7648859886471655158
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: shotgun slug
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A 12 gauge lead slug.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2114072713808011413, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: a561e677df854b2468b278606f87f282,
+        type: 3}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunSlug
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5395694184195221582, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 36a1ed5c62d09ad4fa71569e475b8d9d,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunSlug.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunSlug.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b564e5d916b891446903adc342af08bd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunTaser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunTaser.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7058025035732428056
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 0989b29305ea27f4c952fcbb65e7ad0a,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: taser slug
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: A stunning taser slug.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunTaser
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: bcba333d957893f47a2298e8fe6b35a8,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunTaser.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunTaser.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c73c711153fdb9f49a6c6b8e45d4d1db
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunTech.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunTech.prefab
@@ -1,0 +1,99 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1113851020876934635
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2361978366132242104, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 3fde3940dc8b5214cb221ef2c0900b86,
+        type: 2}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialDescription
+      value: A high-tech shotgun shell which can be loaded with materials to produce
+        unique effects.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8317281327444857437, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: initialName
+      value: unloaded technological shell
+      objectReference: {fileID: 0}
+    - target: {fileID: 8364667066244186251, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8467174088351874367, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoShotgunTech
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472101962198712395, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8606524453913874019, guid: b564e5d916b891446903adc342af08bd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: fa4c29ae92a182c4bbae02bb810fc9c2,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b564e5d916b891446903adc342af08bd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunTech.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/BallisticAmmo/ShotgunAmmo/AmmoShotgunTech.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 002c3e91b10951043a1862f6202d3be8
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1e74803b588080439c0cb7f0b5f726c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/Ammo.75.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/Ammo.75.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5127999395879228316
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1283843238675585462, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 0fa64ef0fb30ef348b300b0612dcd0cd,
+        type: 3}
+    - target: {fileID: 1347949146380736350, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1378335696131893994, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_Name
+      value: Ammo.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1570999493726520712, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: initialDescription
+      value: A miniaturized rocket in .75 caliber.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1570999493726520712, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: initialName
+      value: .75 bolt
+      objectReference: {fileID: 0}
+    - target: {fileID: 5072964358972903789, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: c5e1875e035d3774f885560b339c7cde,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a2087e57fe27fd8419f779b3abb9cf91, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/Ammo.75.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/Ammo.75.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9c6f3897e2ac7e84181a1962dbfcfc7b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/AmmoCasingCaselessBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/AmmoCasingCaselessBase.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &902850165689612579
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A caseless bullet casing.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoCasingCaselessBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/AmmoCasingCaselessBase.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/AmmoCasingCaselessBase.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a2087e57fe27fd8419f779b3abb9cf91
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/AmmoRocketPM9HE.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/AmmoRocketPM9HE.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &9101648509990566412
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1283843238675585462, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: be8de26f45f88a449a93c037a92ada31,
+        type: 3}
+    - target: {fileID: 1347949146380736350, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1378335696131893994, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoRocketPM9HE
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1570999493726520712, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: initialDescription
+      value: An 84mm High-Explosive rocket. Fire at people and pray.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1570999493726520712, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: initialName
+      value: PM-9HE
+      objectReference: {fileID: 0}
+    - target: {fileID: 5072964358972903789, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: a9e17c14818b7994d9e704e62f461ecd,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a2087e57fe27fd8419f779b3abb9cf91, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/AmmoRocketPM9HE.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/AmmoRocketPM9HE.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d449122ab9878fd4dab243529623d4a8
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/AmmoRocketPM9HEDP.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/AmmoRocketPM9HEDP.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &2849660723803734356
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4046843994653551457, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: fa8d387aaab3dba41882c9b992dbd8a4,
+        type: 2}
+    - target: {fileID: 7746968368750542724, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: initialDescription
+      value: An 84mm High-Explosive Dual-Purpose rocket. Pointy end toward mechs
+      objectReference: {fileID: 0}
+    - target: {fileID: 7746968368750542724, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: initialName
+      value: PM-9HEDP
+      objectReference: {fileID: 0}
+    - target: {fileID: 7852990787764874578, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7885618348377886950, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoRocketPM9HEDP
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889420597262396818, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889420597262396818, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889420597262396818, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889420597262396818, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889420597262396818, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889420597262396818, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889420597262396818, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889420597262396818, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889420597262396818, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889420597262396818, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889420597262396818, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8043056781892051898, guid: d449122ab9878fd4dab243529623d4a8,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 37fa66199a6b1c641b4f4e06f30c44d5,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d449122ab9878fd4dab243529623d4a8, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/AmmoRocketPM9HEDP.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/AmmoRocketPM9HEDP.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0a2c8403248b90e42a4daf4fb6abfd09
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/FoamDart.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/FoamDart.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &564620911124968292
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1283843238675585462, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 4846cebd7e251d04f97372ee16914446,
+        type: 3}
+    - target: {fileID: 1347949146380736350, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1378335696131893994, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_Name
+      value: FoamDart
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383545319761565598, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1570999493726520712, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: initialDescription
+      value: It's nerf or nothing! Ages 8 and up.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1570999493726520712, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: initialName
+      value: foam dart
+      objectReference: {fileID: 0}
+    - target: {fileID: 5072964358972903789, guid: a2087e57fe27fd8419f779b3abb9cf91,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: b229198c337b4544eb0ad306ef2bba67,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a2087e57fe27fd8419f779b3abb9cf91, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/FoamDart.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/FoamDart.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c85b28d3e2e443540933f905c954c98d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/FoamDartRiot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/FoamDartRiot.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8861946449201072974
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1303968071525807852, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: initialDescription
+      value: Whose smart idea was it to use toys as crowd control? Ages 18 and up.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1303968071525807852, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: initialName
+      value: riot foam dart
+      objectReference: {fileID: 0}
+    - target: {fileID: 1506094094740792570, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1506094094740792570, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1506094094740792570, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1506094094740792570, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1506094094740792570, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1506094094740792570, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1506094094740792570, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1506094094740792570, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1506094094740792570, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1506094094740792570, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1506094094740792570, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1510177817998055822, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_Name
+      value: FoamDartRiot
+      objectReference: {fileID: 0}
+    - target: {fileID: 1540529183909536826, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1586620729596046034, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 7d26fe79e042b7a4fa46f61f0e6dc8b2,
+        type: 3}
+    - target: {fileID: 4734168928443458057, guid: c85b28d3e2e443540933f905c954c98d,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: c0790faf2fe0a3a4d8e5a147634b715d,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c85b28d3e2e443540933f905c954c98d, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/FoamDartRiot.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/CaselessAmmo/FoamDartRiot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: da6a3431e038e8042a1797d4de5e23b5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/EnergyAmmo.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/EnergyAmmo.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5edb6a8f6a2b3c546894eb5368bb0711
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/EnergyAmmo/AmmoEnergyBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/EnergyAmmo/AmmoEnergyBase.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4636526519299588635
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: The part of the gun that makes the laser go pew.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: energy weapon lens
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoEnergyBase
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/EnergyAmmo/AmmoEnergyBase.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/EnergyAmmo/AmmoEnergyBase.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c6221bcd39e8b9a4b8315cd50d85c9b7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/SpecialAmmo.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/SpecialAmmo.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 86308b7ea799a4e4cac55c2068cdf5c2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/SpecialAmmo/AmmoCasingDartSynthesiser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/SpecialAmmo/AmmoCasingDartSynthesiser.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &482497546002763930
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A high-power spring, linked to an energy-based dart synthesiser.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: dart synthesiser
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoCasingDartSynthesiser
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/SpecialAmmo/AmmoCasingDartSynthesiser.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/SpecialAmmo/AmmoCasingDartSynthesiser.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 869f7e7384a25bd47a9312a2bd36114b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/SpecialAmmo/AmmoSyringeGunSpring.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/SpecialAmmo/AmmoSyringeGunSpring.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4399193036367803808
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialName
+      value: syringe gun spring
+      objectReference: {fileID: 0}
+    - target: {fileID: 1822513943335648427, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: initialDescription
+      value: A high-power spring that throws syringes.
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176208296632151677, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2280866994825352137, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_Name
+      value: AmmoSyringeGunSpring
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284668968090087101, guid: 31d01d60b659392429fe6a6384563082,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 31d01d60b659392429fe6a6384563082, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/SpecialAmmo/AmmoSyringeGunSpring.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoCasings/SpecialAmmo/AmmoSyringeGunSpring.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4dc3d54c38a37124a9b80fa806b34317
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab
@@ -56,7 +56,7 @@ MonoBehaviour:
   minDistanceBetweenSpaceBodies: 200
   solarSystemRadius: 600
   CentComm: {fileID: 5244294626086762232}
-  QuickLoad: 0
+  QuickLoad: 1
 --- !u!114 &5244294626086762232
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AmmoBox.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AmmoBox.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: AmmoBox
+  m_EditorClassIdentifier: 
+  traitDescription: A box that holds ammo, not a magazine.

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AmmoBox.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AmmoBox.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 284ffa4db1798cb4185c4efe209dc766
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AmmoCasing.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AmmoCasing.asset
@@ -9,12 +9,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9d1de2691495b304e9843ac3335b626d, type: 3}
-  m_Name: toy_foamdart
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: AmmoCasing
   m_EditorClassIdentifier: 
-  Variance:
-  - Frames:
-    - sprite: {fileID: 21300000, guid: ae2be9ab9e7a3bc4bab72893ef4af62f, type: 3}
-      secondDelay: 0
-  IsPalette: 0
-  setID: 9357
+  traitDescription: An individual cartridge, casing, or any other spent or unspent
+    piece of ammo.

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AmmoCasing.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AmmoCasing.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3e088c6c232d4894ab39e95b28c63f9a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AmmoMagazine.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AmmoMagazine.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: AmmoMagazine
+  m_EditorClassIdentifier: 
+  traitDescription: A magazine of some sort, holds ammo.

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AmmoMagazine.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Usage/AmmoMagazine.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e97648598582a134b94dc1e17fb1ef56
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
 - Adds lots of ammo boxes, and magazines that are variants of said ammo boxes, and internal magazine objects that are variants of said magazines.
 - Adds lots of ammo (casing) variants.

### Notes:
  - Everything included in this PR is completely useless. Nothing has unique components. The ammo boxes/magazines don't even hold ammo. They are merely placeholders for when the behavior behind ammo boxes, magazines, and cartridges gets implemented/improved, if ever.
  - I gave the internal magazine objects sprites that correspond to the guns that they go into. This is to better identify them visually. Their alpha levels have been reduced, making them transparent.
