### PR TITLE
Fix PKA not dealing damage on tiles

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_KineticShot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_KineticShot.prefab
@@ -10,13 +10,14 @@ GameObject:
   m_Component:
   - component: {fileID: 4714298942886824}
   - component: {fileID: 9042530041850991039}
-  - component: {fileID: 2209393079759289604}
   - component: {fileID: -8693131252183625486}
   - component: {fileID: 9003359558003690106}
   - component: {fileID: 1493011074598266216}
   - component: {fileID: -4913459525873161872}
   - component: {fileID: -3158571087591883880}
   - component: {fileID: -3976592693929525579}
+  - component: {fileID: 4697119868486705460}
+  - component: {fileID: -8786824185363748805}
   m_Layer: 15
   m_Name: Bullet_KineticShot
   m_TagString: Untagged
@@ -52,20 +53,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   distance: 4
   maskData: {fileID: 11400000, guid: b3e8cb63acff04f4d9bad4da9027eb40, type: 2}
---- !u!114 &2209393079759289604
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1560634355228308}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bfd6a460ba2f4e059e697e8df62ff18a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  damageData: {fileID: 11400000, guid: 85c028573e7db4840a963fb98f8f51d5, type: 2}
-  layersToHit: 0100000005000000
 --- !u!114 &-8693131252183625486
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -144,3 +131,29 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   damageData: {fileID: 11400000, guid: 85c028573e7db4840a963fb98f8f51d5, type: 2}
+--- !u!114 &4697119868486705460
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1560634355228308}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e8a221919d054780a9c6a23ee9d12bc9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  damageData: {fileID: 11400000, guid: 85c028573e7db4840a963fb98f8f51d5, type: 2}
+  layersToHit: 0500000001000000
+--- !u!114 &-8786824185363748805
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1560634355228308}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fca858c9710046ec96b850b6fb19c3d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/Behaviours/ProjectileDamageIntegrityKinetic.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/Behaviours/ProjectileDamageIntegrityKinetic.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using ScriptableObjects.Gun;
 
 namespace Weapons.Projectiles.Behaviours
@@ -11,6 +12,7 @@ namespace Weapons.Projectiles.Behaviours
 	{
 		private GameObject shooter;
 		private Gun weapon;
+		private ProjectileKineticDamageCalculation projectileKineticDamage;
 
 		[SerializeField] private DamageData damageData = null;
 
@@ -34,12 +36,7 @@ namespace Weapons.Projectiles.Behaviours
 				return false;
 			}
 
-			float pressure = MatrixManager.AtPoint(
-				(Vector3Int)hit.point.To2Int(),
-				true
-			).MetaDataLayer.Get(hit.transform.localPosition.RoundToInt()).GasMix.Pressure;
-
-			var newDamage = DamageByPressureModifier(pressure);
+			float newDamage = projectileKineticDamage.DamageByPressureModifier(damageData.Damage);
 
 			integrity.ApplyDamage(newDamage, damageData.AttackType, damageData.DamageType);
 
@@ -58,16 +55,15 @@ namespace Weapons.Projectiles.Behaviours
 			return true;
 		}
 
-		private float DamageByPressureModifier(float pressure)
-		{
-			float newDamage = damageData.Damage - (damageData.Damage * (pressure / 135));
-			return Mathf.Clamp(newDamage, 0, damageData.Damage);
-		}
-
 		private void OnDisable()
 		{
 			weapon = null;
 			shooter = null;
+		}
+
+		private void Awake()
+		{
+			projectileKineticDamage = GetComponent<ProjectileKineticDamageCalculation>();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/Behaviours/ProjectileDamageLivingHealthKinetic.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/Behaviours/ProjectileDamageLivingHealthKinetic.cs
@@ -1,4 +1,5 @@
-﻿using ScriptableObjects.Gun;
+﻿using System;
+using ScriptableObjects.Gun;
 using UnityEngine;
 
 namespace Weapons.Projectiles.Behaviours
@@ -12,6 +13,7 @@ namespace Weapons.Projectiles.Behaviours
 		private GameObject shooter;
 		private Gun weapon;
 		private BodyPartType targetZone;
+		private ProjectileKineticDamageCalculation projectileKineticDamage;
 
 
 		[SerializeField] private DamageData damageData = null;
@@ -37,12 +39,7 @@ namespace Weapons.Projectiles.Behaviours
 				return false;
 			}
 
-			float pressure = MatrixManager.AtPoint(
-				(Vector3Int)hit.point.To2Int(),
-				true
-			).MetaDataLayer.Get(hit.transform.localPosition.RoundToInt()).GasMix.Pressure;
-
-			var newDamage = DamageByPressureModifier(pressure);
+			var newDamage = projectileKineticDamage.DamageByPressureModifier(damageData.Damage);
 
 			livingHealth.ApplyDamageToBodypart(shooter, newDamage, damageData.AttackType, damageData.DamageType, targetZone);
 
@@ -57,16 +54,15 @@ namespace Weapons.Projectiles.Behaviours
 			return true;
 		}
 
-		private float DamageByPressureModifier(float pressure)
-		{
-			float newDamage = damageData.Damage - (damageData.Damage * (pressure / 135));
-			return Mathf.Clamp(newDamage, 0, damageData.Damage);
-		}
-
 		private void OnDisable()
 		{
 			shooter = null;
 			weapon = null;
+		}
+
+		private void Awake()
+		{
+			projectileKineticDamage = GetComponent<ProjectileKineticDamageCalculation>();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/Behaviours/ProjectileDamageTileKinetic.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/Behaviours/ProjectileDamageTileKinetic.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ScriptableObjects.Gun;
+using UnityEngine;
+
+namespace Weapons.Projectiles.Behaviours
+{
+	public class ProjectileDamageTileKinetic: MonoBehaviour, IOnHitInteractTile
+	{
+		[SerializeField] private DamageData damageData = null;
+
+		[Tooltip("Tile layers to damage(Walls, Window, etc.)")]
+		[SerializeField] private LayerType[] layersToHit = null;
+
+		private ProjectileKineticDamageCalculation projectileKineticDamage;
+
+		public bool Interact(RaycastHit2D hit, InteractableTiles interactableTiles, Vector3 worldPosition)
+		{
+			var layerToHit = GetLayerToHitOrGetNull(interactableTiles.MetaTileMap.DamageableLayers);
+			if (layerToHit == null) return false;
+
+			float newDamage = projectileKineticDamage.DamageByPressureModifier(damageData.Damage);
+
+			layerToHit.TilemapDamage.ApplyDamage(damageData.Damage, damageData.AttackType, worldPosition);
+
+			return true;
+		}
+
+		private Layer GetLayerToHitOrGetNull(IEnumerable<Layer> layers)
+		{
+			return layers.FirstOrDefault(layer => layersToHit.Any(l => l == layer.LayerType));
+		}
+
+		private void Awake()
+		{
+			projectileKineticDamage = GetComponent<ProjectileKineticDamageCalculation>();
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/Behaviours/ProjectileDamageTileKinetic.cs.meta
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/Behaviours/ProjectileDamageTileKinetic.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e8a221919d054780a9c6a23ee9d12bc9
+timeCreated: 1597544876

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/Behaviours/ProjectileKineticDamageCalculation.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/Behaviours/ProjectileKineticDamageCalculation.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using UnityEngine;
+
+namespace Weapons.Projectiles.Behaviours
+{
+	public class ProjectileKineticDamageCalculation: MonoBehaviour, IOnShoot
+	{
+		private float pressure;
+
+		public void OnShoot(Vector2 direction, GameObject shooter, Gun weapon, BodyPartType targetZone = BodyPartType.Chest)
+		{
+			pressure = GetPressureOnPoint(shooter);
+		}
+
+		private static float GetPressureOnPoint(GameObject shooter)
+		{
+			var localPosition = shooter.transform.localPosition;
+
+			float pressure = MatrixManager.AtPoint(
+				localPosition.RoundToInt(), true
+			).MetaDataLayer.Get(localPosition.RoundToInt()).GasMix.Pressure;
+
+			return pressure;
+		}
+
+		public float DamageByPressureModifier(float maxDamage)
+		{
+			float newDamage = maxDamage - (maxDamage * (pressure / 135));
+			newDamage = (float)Math.Round(newDamage);
+
+			return Mathf.Clamp(newDamage, 0, maxDamage);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Weapons/Projectiles/Behaviours/ProjectileKineticDamageCalculation.cs.meta
+++ b/UnityProject/Assets/Scripts/Weapons/Projectiles/Behaviours/ProjectileKineticDamageCalculation.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fca858c9710046ec96b850b6fb19c3d7
+timeCreated: 1597549825


### PR DESCRIPTION
Yet another tweak to PKA's. Problem was we were getting the pressure at point of impact and for tiles, that's a NaN as there is no pressure inside walls and windows.

I did another IOnShoot and store pressure on position of shooter instead but I will admit it is late in the night and I have been getting dumber lately so inspect this and tell me if everything is alright.