### PR TITLE
Automatically animated UI icons 

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Security/Stun Baton.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Security/Stun Baton.prefab
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  spriteRenderer: {fileID: 8231327112697984416}
+  spriteHandler: {fileID: 2705650514114133371}
   soundToggle: Sparks01
   spriteActive: {fileID: 21300000, guid: 0e5edf73e36bedf4b8b621aff4559d78, type: 3}
   spriteInactive: {fileID: 21300000, guid: d692e3351e1ae8443a57daf8b9695ddd, type: 3}
@@ -240,9 +240,15 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 8127288814593014342}
   m_PrefabAsset: {fileID: 0}
---- !u!212 &8231327112697984416 stripped
-SpriteRenderer:
-  m_CorrespondingSourceObject: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+--- !u!114 &2705650514114133371 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
     type: 3}
   m_PrefabInstance: {fileID: 8127288814593014342}
   m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/Energy Sword.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/Energy Sword.prefab
@@ -1,5 +1,162 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &2350815963227468493
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7781396554342910705}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d3d65b4ce352374ba2f4a8645c9476c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  LightEmission: {fileID: 0}
+  objectLightEmission: {fileID: 5667522765297587855}
+  Intensity: 0
+  Colour: {r: 0, g: 0, b: 0, a: 0}
+  EnumSprite: 0
+  Size: 3.5
+  IsOn: 1
+  PlayerLightData:
+    Intensity: 0
+    Colour: {r: 0, g: 0, b: 0, a: 0}
+    EnumSprite: 0
+    Size: 12
+--- !u!114 &4821844458157436374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7781396554342910705}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 248d0e8833af4f35917b5fc3503b256c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  Sprites:
+    Blue:
+      SpriteInventoryIcon: {fileID: 11400000, guid: daeae19dda5100c4a95cc1947601b05f,
+        type: 2}
+      SpriteLeftHand: {fileID: 11400000, guid: 188fb81d206c495499410cad237a3977, type: 2}
+      SpriteRightHand: {fileID: 11400000, guid: 03c53a25d7c61354db5a5d2c65ac5049,
+        type: 2}
+      Palette:
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      IsPaletted: 0
+    Green:
+      SpriteInventoryIcon: {fileID: 11400000, guid: bc29df4853fc2d74dbc8ec751d904071,
+        type: 2}
+      SpriteLeftHand: {fileID: 11400000, guid: 8e666ee30af8a594fa6d5b00e378b42c, type: 2}
+      SpriteRightHand: {fileID: 11400000, guid: f365b364644b6d149a8935f9eadf13a5,
+        type: 2}
+      Palette:
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      IsPaletted: 0
+    Purple:
+      SpriteInventoryIcon: {fileID: 11400000, guid: 673a9786899740c42a4c1ab6a7b1bf35,
+        type: 2}
+      SpriteLeftHand: {fileID: 11400000, guid: 270de831ded35d048b5b0f22d247ee01, type: 2}
+      SpriteRightHand: {fileID: 11400000, guid: 0089285029263454994d039d64c12677,
+        type: 2}
+      Palette:
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      IsPaletted: 0
+    Rainbow:
+      SpriteInventoryIcon: {fileID: 11400000, guid: 576dd1204ecd1794e8c6d6bcb9fb9e74,
+        type: 2}
+      SpriteLeftHand: {fileID: 11400000, guid: 25ed6a0a3eeb90c43870560d54037fdd, type: 2}
+      SpriteRightHand: {fileID: 11400000, guid: 8baa3fe8736077b4689484f8e2ef99a7,
+        type: 2}
+      Palette:
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      IsPaletted: 0
+    Red:
+      SpriteInventoryIcon: {fileID: 11400000, guid: 1e0fcea3e4d339c468ede79557cc3686,
+        type: 2}
+      SpriteLeftHand: {fileID: 11400000, guid: b49d0ebe621a7074886e39064cd567c3, type: 2}
+      SpriteRightHand: {fileID: 11400000, guid: 160bf9a19629e8e4da93b9c2df1300e8,
+        type: 2}
+      Palette:
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      IsPaletted: 0
+    Off:
+      SpriteInventoryIcon: {fileID: 11400000, guid: ecf7a882f70db2040a4355d24e304b8e,
+        type: 2}
+      SpriteLeftHand: {fileID: 11400000, guid: 378feaec855e86046a42703c65fb8f7f, type: 2}
+      SpriteRightHand: {fileID: 11400000, guid: fa4db43f7801ae84c8913b38370ec295,
+        type: 2}
+      Palette:
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      - {r: 0, g: 0, b: 0, a: 0}
+      IsPaletted: 0
+  playerLightControl: {fileID: 2350815963227468493}
+  worldLight: {fileID: 6176213448508576191}
+  worldRenderer: {fileID: 5667522765297587855}
+  spriteHandler: {fileID: 4520221803203555702}
+  color: 0
+  activatedHitDamage: 30
+  activatedThrowDamage: 20
+  activatedVerbs:
+  - attacked
+  - slashed
+  - stabbed
+  - sliced
+  - torn
+  - ripped
+  - diced
+  - cut
+  activatedSize: 5
+  activatedHitSound: blade1
+  activatedLightIntensity: 1
+  activated: 0
 --- !u!1 &5667522765297587855
 GameObject:
   m_ObjectHideFlags: 0
@@ -98,150 +255,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5667522765297587855}
   m_Mesh: {fileID: 0}
---- !u!114 &2350815963227468493
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7781396554342910705}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3d3d65b4ce352374ba2f4a8645c9476c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  LightEmission: {fileID: 0}
-  Intensity: 0
-  Colour: {r: 0, g: 0, b: 0, a: 0}
-  EnumSprite: 0
-  Size: 3.5
-  IsOn: 1
-  CachedIntensity: 1
-  PlayerLightData:
-    Intensity: 0
-    Colour: {r: 0, g: 0, b: 0, a: 0}
-    EnumSprite: 0
-    Size: 12
---- !u!114 &4821844458157436374
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7781396554342910705}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 248d0e8833af4f35917b5fc3503b256c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  Sprites:
-    Blue:
-      SpriteInventoryIcon: {fileID: 0}
-      SpriteLeftHand: {fileID: 0}
-      SpriteRightHand: {fileID: 0}
-      Palette:
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      IsPaletted: 0
-    Green:
-      SpriteInventoryIcon: {fileID: 0}
-      SpriteLeftHand: {fileID: 0}
-      SpriteRightHand: {fileID: 0}
-      Palette:
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      IsPaletted: 0
-    Purple:
-      SpriteInventoryIcon: {fileID: 0}
-      SpriteLeftHand: {fileID: 0}
-      SpriteRightHand: {fileID: 0}
-      Palette:
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      IsPaletted: 0
-    Rainbow:
-      SpriteInventoryIcon: {fileID: 0}
-      SpriteLeftHand: {fileID: 0}
-      SpriteRightHand: {fileID: 0}
-      Palette:
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      IsPaletted: 0
-    Red:
-      SpriteInventoryIcon: {fileID: 0}
-      SpriteLeftHand: {fileID: 0}
-      SpriteRightHand: {fileID: 0}
-      Palette:
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      IsPaletted: 0
-    Off:
-      SpriteInventoryIcon: {fileID: 0}
-      SpriteLeftHand: {fileID: 0}
-      SpriteRightHand: {fileID: 0}
-      Palette:
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      - {r: 0, g: 0, b: 0, a: 0}
-      IsPaletted: 0
-  playerLightControl: {fileID: 2350815963227468493}
-  worldLight: {fileID: 6176213448508576191}
-  worldRenderer: {fileID: 5667522765297587855}
-  color: 0
-  activatedHitDamage: 30
-  activatedThrowDamage: 20
-  activatedVerbs:
-  - attacked
-  - slashed
-  - stabbed
-  - sliced
-  - torn
-  - ripped
-  - diced
-  - cut
-  activatedSize: 5
-  activatedHitSound: blade1
-  activatedLightIntensity: 1
-  activated: 0
 --- !u!1001 &4236242615490559816
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -251,10 +264,56 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 320078766397443646, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 320078766397443646, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
       propertyPath: PresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: ecf7a882f70db2040a4355d24e304b8e,
         type: 2}
+    - target: {fileID: 320078766397443646, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: ecf7a882f70db2040a4355d24e304b8e,
+        type: 2}
+    - target: {fileID: 320078766397443646, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 1e0fcea3e4d339c468ede79557cc3686,
+        type: 2}
+    - target: {fileID: 320078766397443646, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: daeae19dda5100c4a95cc1947601b05f,
+        type: 2}
+    - target: {fileID: 320078766397443646, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[3]
+      value: 
+      objectReference: {fileID: 11400000, guid: bc29df4853fc2d74dbc8ec751d904071,
+        type: 2}
+    - target: {fileID: 320078766397443646, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[4]
+      value: 
+      objectReference: {fileID: 11400000, guid: 673a9786899740c42a4c1ab6a7b1bf35,
+        type: 2}
+    - target: {fileID: 320078766397443646, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[5]
+      value: 
+      objectReference: {fileID: 11400000, guid: 576dd1204ecd1794e8c6d6bcb9fb9e74,
+        type: 2}
+    - target: {fileID: 320078766397443646, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: variantIndex
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5810504842801530893, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
       propertyPath: m_AssetId
@@ -326,6 +385,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 97e8ba546dc910e468cedb0c3566e0d2,
         type: 3}
+    - target: {fileID: 6036740337081534181, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
         type: 3}
       propertyPath: attackVerbs.Array.size
@@ -371,6 +435,24 @@ PrefabInstance:
       propertyPath: attackVerbs.Array.data[1]
       value: poked
       objectReference: {fileID: 0}
+    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 378feaec855e86046a42703c65fb8f7f,
+        type: 2}
+    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: itemSprites.SpriteInventoryIcon
+      value: 
+      objectReference: {fileID: 11400000, guid: ecf7a882f70db2040a4355d24e304b8e,
+        type: 2}
+    - target: {fileID: 6330548640132405979, guid: 93af1c166793efb498012ddc7370f8ec,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 385f2a45ff9d83f49b07586ddf26d1e0,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 93af1c166793efb498012ddc7370f8ec, type: 3}
 --- !u!1 &7781396554342910705 stripped
@@ -385,3 +467,15 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 4236242615490559816}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &4520221803203555702 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 320078766397443646, guid: 93af1c166793efb498012ddc7370f8ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 4236242615490559816}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/Energy Sword.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Melee/Resources/Energy Sword.prefab
@@ -6,7 +6,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7781396554342910705}
+  m_GameObject: {fileID: 4236242615490500172}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3d3d65b4ce352374ba2f4a8645c9476c, type: 3}
@@ -20,7 +20,7 @@ MonoBehaviour:
   Colour: {r: 0, g: 0, b: 0, a: 0}
   EnumSprite: 0
   Size: 3.5
-  IsOn: 1
+  IsOn: 0
   PlayerLightData:
     Intensity: 0
     Colour: {r: 0, g: 0, b: 0, a: 0}
@@ -32,7 +32,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7781396554342910705}
+  m_GameObject: {fileID: 4236242615490500172}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 248d0e8833af4f35917b5fc3503b256c, type: 3}
@@ -140,7 +140,7 @@ MonoBehaviour:
   playerLightControl: {fileID: 2350815963227468493}
   worldLight: {fileID: 6176213448508576191}
   worldRenderer: {fileID: 5667522765297587855}
-  spriteHandler: {fileID: 4520221803203555702}
+  spriteHandler: {fileID: 4236242615490386138}
   color: 0
   activatedHitDamage: 30
   activatedThrowDamage: 20
@@ -187,7 +187,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 3, y: 3, z: 3}
   m_Children: []
-  m_Father: {fileID: 7777312831022217093}
+  m_Father: {fileID: 4236242615490453967}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6176213448508576191
@@ -455,19 +455,19 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 93af1c166793efb498012ddc7370f8ec, type: 3}
---- !u!1 &7781396554342910705 stripped
+--- !u!1 &4236242615490500172 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5852210865295685049, guid: 93af1c166793efb498012ddc7370f8ec,
     type: 3}
   m_PrefabInstance: {fileID: 4236242615490559816}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &7777312831022217093 stripped
+--- !u!4 &4236242615490453967 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5847001516606818509, guid: 93af1c166793efb498012ddc7370f8ec,
     type: 3}
   m_PrefabInstance: {fileID: 4236242615490559816}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &4520221803203555702 stripped
+--- !u!114 &4236242615490386138 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 320078766397443646, guid: 93af1c166793efb498012ddc7370f8ec,
     type: 3}

--- a/UnityProject/Assets/Scripts/Food/Cigarette.cs
+++ b/UnityProject/Assets/Scripts/Food/Cigarette.cs
@@ -33,15 +33,6 @@ public class Cigarette : NetworkBehaviour, ICheckedInteractable<HandApply>,
 		fireSource = GetComponent<FireSource>();
 	}
 
-	private void Update()
-	{
-		if (isClient && isLit)
-		{
-			// update UI image on client (cigarette lit animation)
-			pickupable?.RefreshUISlotImage();
-		}
-	}
-
 	#region Interactions
 	public void ServerPerformInteraction(HandApply interaction)
 	{

--- a/UnityProject/Assets/Scripts/Food/Lighter.cs
+++ b/UnityProject/Assets/Scripts/Food/Lighter.cs
@@ -28,16 +28,6 @@ public class Lighter : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		pickupable = GetComponent<Pickupable>();
 	}
 
-	private void Update()
-	{
-		if (isClient)
-		{
-			// update UI image on client
-			// TODO: replace it with more general method
-			pickupable?.RefreshUISlotImage();
-		}
-	}
-
 	public bool WillInteract(HandActivate interaction, NetworkSide side)
 	{
 		return DefaultWillInteract.Default(interaction, side);
@@ -53,10 +43,10 @@ public class Lighter : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		GenerateActivationMessage(interaction.PerformerPlayerScript, interaction.HandSlot);
 
 		// update sprites and lighter logic
-		UpdateLit();
+		ServerUpdateLit();
 	}
 
-	private void UpdateLit()
+	private void ServerUpdateLit()
 	{
 		// toggle flame (will fire things around)
 		if (fireSource)
@@ -163,6 +153,6 @@ public class Lighter : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 	public void OnDespawnServer(DespawnInfo info)
 	{
 		isLit = false;
-		UpdateLit();
+		ServerUpdateLit();
 	}
 }

--- a/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandler.cs
@@ -46,6 +46,8 @@ public class SpriteHandler : MonoBehaviour
 
 	private NetworkIdentity NetworkIdentity;
 
+	private Pickupable pickupable;
+
 	private bool isSubCatalogueChanged = false;
 
 	[SerializeField]
@@ -415,6 +417,9 @@ public class SpriteHandler : MonoBehaviour
 			}
 
 			spriteRenderer.SetPropertyBlock(block);
+
+			// update UI icon if avaliable
+			pickupable?.RefreshUISlotImage();
 		}
 		else if (image != null)
 		{
@@ -477,6 +482,11 @@ public class SpriteHandler : MonoBehaviour
 		}
 
 		ImageComponentStatus(true);
+
+		if (pickupable == null)
+		{
+			pickupable = GetComponentInParent<Pickupable>();
+		}
 	}
 
 	private void ImageComponentStatus(bool Status)

--- a/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandler.cs
@@ -46,12 +46,58 @@ public class SpriteHandler : MonoBehaviour
 
 	private NetworkIdentity NetworkIdentity;
 
-	private Pickupable pickupable;
-
 	private bool isSubCatalogueChanged = false;
 
 	[SerializeField]
 	private List<SerialisationStanding> Sprites =new List<SerialisationStanding>();
+
+	/// <summary>
+	/// Invokes when sprite just changed by animation or other script
+	/// Null if sprite became hidden
+	/// </summary>
+	public event System.Action<Sprite> OnSpriteChanged;
+
+	/// <summary>
+	/// Current sprite from SpriteRender or Image
+	/// Null if sprite is hidden
+	/// </summary>
+	public Sprite CurrentSprite
+	{
+		get
+		{
+			if (spriteRenderer)
+			{
+				return spriteRenderer.sprite;
+			}
+			else if (image)
+			{
+				return image.sprite;
+			}
+
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Current sprite color from SpriteRender or Image
+	/// White means no color modification was added
+	/// </summary>
+	public Color CurrentColor
+	{
+		get
+		{
+			if (spriteRenderer)
+			{
+				return spriteRenderer.color;
+			}
+			else if (image)
+			{
+				return image.color;
+			}
+
+			return Color.white;
+		}
+	}
 
 	public NetworkIdentity GetMasterNetID()
 	{
@@ -417,9 +463,6 @@ public class SpriteHandler : MonoBehaviour
 			}
 
 			spriteRenderer.SetPropertyBlock(block);
-
-			// update UI icon if avaliable
-			pickupable?.RefreshUISlotImage();
 		}
 		else if (image != null)
 		{
@@ -428,8 +471,10 @@ public class SpriteHandler : MonoBehaviour
 			{
 				image.enabled = false;
 			}
-
 		}
+
+		// try to update UI icon if avaliable
+		OnSpriteChanged?.Invoke(value);
 	}
 
 	private bool HasImageComponent()
@@ -482,11 +527,6 @@ public class SpriteHandler : MonoBehaviour
 		}
 
 		ImageComponentStatus(true);
-
-		if (pickupable == null)
-		{
-			pickupable = GetComponentInParent<Pickupable>();
-		}
 	}
 
 	private void ImageComponentStatus(bool Status)

--- a/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandler.cs
@@ -99,6 +99,17 @@ public class SpriteHandler : MonoBehaviour
 		}
 	}
 
+	/// <summary>
+	/// Check if this sprite hander is rendering
+	/// </summary>
+	public bool IsHiden
+	{
+		get
+		{
+			return CurrentSprite == null || !gameObject.activeInHierarchy;
+		}
+	}
+
 	public NetworkIdentity GetMasterNetID()
 	{
 		return NetworkIdentity;
@@ -473,7 +484,6 @@ public class SpriteHandler : MonoBehaviour
 			}
 		}
 
-		// try to update UI icon if avaliable
 		OnSpriteChanged?.Invoke(value);
 	}
 
@@ -550,11 +560,13 @@ public class SpriteHandler : MonoBehaviour
 		}
 
 		GetImageComponent();
+		OnSpriteChanged?.Invoke(CurrentSprite);
 	}
 
 	private void OnDisable()
 	{
 		TryToggleAnimationState(false);
+		OnSpriteChanged?.Invoke(null);
 	}
 
 	private bool isPaletted()

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemImage.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemImage.cs
@@ -199,7 +199,7 @@ public class UI_ItemImage
 
 		var img = go.AddComponent<Image>();
 		var imgMat = Resources.Load<Material>("Materials/Palettable UI");
-		img.material = imgMat;
+		img.material = Object.Instantiate(imgMat);
 		img.alphaHitTestMinimumThreshold = 0.5f;
 
 		return img;

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemImage.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemImage.cs
@@ -71,13 +71,16 @@ public class UI_ItemImage
 		// hide previous image
 		ClearAll();
 		//determine the sprites to display based on the new item
-		var spriteHandlers = item.GetComponentsInChildren<SpriteHandler>();
+		var spriteHandlers = item.GetComponentsInChildren<SpriteHandler>(includeInactive: true);
 		spriteHandlers = spriteHandlers.Where(x => x.CurrentSprite != null && x != Highlight.instance.spriteRenderer).ToArray();
 
 		foreach (var handler in spriteHandlers)
 		{
 			// get unused image from stack and subscribe it handler updates
 			var image = ConnectFreeImageToHandler(handler);
+
+			// check if handler is hidden
+			image.gameObject.SetActive(!handler.IsHiden);
 
 			// set sprite
 			var sprite = handler.CurrentSprite;
@@ -242,7 +245,16 @@ public class UI_ItemImage
 
         private void OnHandlerSpriteChanged(Sprite sprite)
 		{
-			UIImage.sprite = sprite;
+			if (sprite)
+			{
+				UIImage.gameObject.SetActive (true);
+				UIImage.sprite = sprite;
+			}
+			else
+			{
+				UIImage.gameObject.SetActive(false);
+			}
+
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemImage.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemImage.cs
@@ -12,8 +12,8 @@ public class UI_ItemImage
 	private readonly GameObject root;
 	private bool hidden;
 
-	private Stack<Image> usedImages = new Stack<Image>();
-	private Stack<Image> freeImages = new Stack<Image>();
+	private Stack<ImageAndHandler> usedImages = new Stack<ImageAndHandler>();
+	private Stack<ImageAndHandler> freeImages = new Stack<ImageAndHandler>();
 	private Image overlay;
 
 	/// <summary>
@@ -27,9 +27,9 @@ public class UI_ItemImage
 			if (usedImages.Count != 0)
 			{
 				var firstImage = usedImages.Peek();
-				if (firstImage)
+				if (firstImage != null && firstImage.Handler)
 				{
-					return firstImage.sprite;
+					return firstImage.Handler.CurrentSprite;
 				}
 			}
 
@@ -56,10 +56,10 @@ public class UI_ItemImage
 	public void SetHidden(bool hidden)
 	{
 		this.hidden = hidden;
-		foreach (var image in usedImages)
+		foreach (var pair in usedImages)
 		{
-			image.enabled = !hidden;
-			image.preserveAspect = !hidden;
+			pair.UIImage.enabled = !hidden;
+			pair.UIImage.preserveAspect = !hidden;
 		}
 	}
 
@@ -71,21 +71,23 @@ public class UI_ItemImage
 		// hide previous image
 		ClearAll();
 		//determine the sprites to display based on the new item
-		var spriteRends = item.GetComponentsInChildren<SpriteRenderer>();
-		spriteRends = spriteRends.Where(x => x.sprite != null && x != Highlight.instance.spriteRenderer).ToArray();
+		var spriteHandlers = item.GetComponentsInChildren<SpriteHandler>();
+		spriteHandlers = spriteHandlers.Where(x => x.CurrentSprite != null && x != Highlight.instance.spriteRenderer).ToArray();
 
-		foreach (var render in spriteRends)
+		foreach (var handler in spriteHandlers)
 		{
-			var image = GetFreeImage();
+			// get unused image from stack and subscribe it handler updates
+			var image = ConnectFreeImageToHandler(handler);
 
 			// set sprite
-			var sprite = render.sprite;
+			var sprite = handler.CurrentSprite;
 			image.sprite = sprite;
 
 			// set color
-			var color = image.color;
+			var color = handler.CurrentColor;
 			image.color = color;
 
+			// I don't have any idea what is happening here or how to test it
 			// set palleted and color palette
 			var itemAttrs = item.GetComponent<ItemAttributesV2>();
 			if (itemAttrs.ItemSprites.SpriteInventoryIcon != null && itemAttrs.ItemSprites.IsPaletted)
@@ -151,28 +153,34 @@ public class UI_ItemImage
 	{
 		while (usedImages.Count != 0)
 		{
-			var img = usedImages.Pop();
-			freeImages.Push(img);
-			img.enabled = false;
+			var usedImage = usedImages.Pop();
+			freeImages.Push(usedImage);
+
+			// reset and hide used image
+			usedImage.Handler = null;
+			usedImage.UIImage.enabled = false;
 		}
 
 		SetOverlay(null);
 	}
 
-	private Image GetFreeImage()
+	private Image ConnectFreeImageToHandler(SpriteHandler handler)
 	{
-		Image ret;
+		ImageAndHandler pair;
 		if (freeImages.Count > 0)
 		{
-			ret = freeImages.Pop();
+			pair = freeImages.Pop();
 		}
 		else
 		{
-			ret = CreateNewImage();
+			var img = CreateNewImage();
+			pair = new ImageAndHandler(img);
 		}
 
-		usedImages.Push(ret);
-		return ret;
+		pair.Handler = handler;
+		usedImages.Push(pair);
+
+		return pair.UIImage;
 	}
 
 	private Image CreateNewImage(string name = "uiItemImage")
@@ -192,5 +200,49 @@ public class UI_ItemImage
 		img.alphaHitTestMinimumThreshold = 0.5f;
 
 		return img;
+	}
+
+	/// <summary>
+	/// This class subscribe UIImage to SpriteHandler updates
+	/// If SpriteHandler updates sprite this will also update it for UIImage
+	/// </summary>
+	private class ImageAndHandler
+	{
+		public Image UIImage { get; private set; }
+		private SpriteHandler handler;
+
+		public ImageAndHandler(Image image)
+		{
+			UIImage = image;
+		}
+
+		public SpriteHandler Handler
+		{
+			get
+			{
+				return handler;
+			}
+			set
+			{
+				// unsubscribe from old handler changes
+				if (handler != null)
+				{
+					handler.OnSpriteChanged -= OnHandlerSpriteChanged;
+				}
+
+				handler = value;
+
+				// subscribe to new handler changes
+				if (handler)
+				{
+					handler.OnSpriteChanged += OnHandlerSpriteChanged;
+				}
+			}
+		}
+
+        private void OnHandlerSpriteChanged(Sprite sprite)
+		{
+			UIImage.sprite = sprite;
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Weapons/Grenade.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Grenade.cs
@@ -26,8 +26,8 @@ public class Grenade : NetworkBehaviour, IPredictedInteractable<HandActivate>, I
 	public Pickupable pickupable;
 
 	// Zero and one sprites reserved for left and right hands
-	private const int LOCKED_SPRITE = 2;
-	private const int ARMED_SPRITE = 3;
+	private const int LOCKED_SPRITE = 1;
+	private const int ARMED_SPRITE = 2;
 
 	//whether this object has exploded
 	private bool hasExploded;
@@ -89,7 +89,7 @@ public class Grenade : NetworkBehaviour, IPredictedInteractable<HandActivate>, I
 		{
 			timerRunning = true;
 			UpdateTimer(timerRunning);
-			PlayPinSFX(originator.transform.position);
+			PlayPinSFX(gameObject.AssumedWorldPosServer());
 
 			if (unstableFuse)
 			{
@@ -107,21 +107,10 @@ public class Grenade : NetworkBehaviour, IPredictedInteractable<HandActivate>, I
 
 	private void UpdateSprite(int sprite)
 	{
-		// Update sprite in game
-		spriteHandler?.ChangeSprite(sprite);
-	}
-
-	/// <summary>
-	/// This coroutines make sure that sprite in hands is animated
-	/// TODO: replace this with more general aproach for animated icons
-	/// </summary>
-	/// <returns></returns>
-	private IEnumerator AnimateSpriteInHands()
-	{
-		while (timerRunning && !hasExploded)
+		if (isServer)
 		{
-			pickupable.RefreshUISlotImage();
-			yield return null;
+			// Update sprite in game
+			spriteHandler?.ChangeSprite(sprite);
 		}
 	}
 
@@ -159,7 +148,7 @@ public class Grenade : NetworkBehaviour, IPredictedInteractable<HandActivate>, I
 
 	private void PlayPinSFX(Vector3 position)
 	{
-		SoundManager.PlayNetworkedAtPos("armbomb", position, sourceObj: gameObject);
+		SoundManager.PlayNetworkedAtPos("armbomb", position);
 	}
 
 	private void UpdateTimer(bool timerRunning)
@@ -170,8 +159,6 @@ public class Grenade : NetworkBehaviour, IPredictedInteractable<HandActivate>, I
 		{
 			// Start playing arm animation
 			UpdateSprite(ARMED_SPRITE);
-			// Update grenade icon in hands
-			StartCoroutine(AnimateSpriteInHands());
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/Weapons/Melee/EnergySword.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Melee/EnergySword.cs
@@ -14,6 +14,7 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 	public ItemLightControl playerLightControl;
 	public LightSprite worldLight;
 	public GameObject worldRenderer;
+	public SpriteHandler spriteHandler;
 
 	[SyncVar(hook = nameof(SyncColor))]
 	public int color;
@@ -40,8 +41,6 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 	[SyncVar(hook = nameof(UpdateState))]
 	public bool activated;
 
-	private Pickupable pickupable;
-
 	public void Awake()
 	{
 		EnsureInit();
@@ -51,7 +50,6 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 	{
 		if (itemAttributes != null) return;
 		itemAttributes = GetComponent<ItemAttributesV2>();
-		pickupable = GetComponent<Pickupable>();
 		if (color == (int) SwordColor.Random)
 		{
 			color = Random.Range(1, 5);
@@ -98,7 +96,6 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		playerLightControl.Colour = lightColor;
 		playerLightControl.PlayerLightData.Colour = lightColor;
 		worldLight.Color = lightColor;
-		pickupable.RefreshUISlotImage();
 	}
 
 	public bool WillInteract(HandActivate interaction, NetworkSide side)
@@ -183,7 +180,6 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		UpdateSprite();
 		UpdateValues();
 		UpdateLight();
-		pickupable.RefreshUISlotImage();
 	}
 
 	private void UpdateSprite()
@@ -208,11 +204,16 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 					itemAttributes.SetSprites(Sprites.Red);
 					break;
 			}
+
+			spriteHandler?.ChangeSprite(color);
 		}
 		else
 		{
 			itemAttributes.SetSprites(Sprites.Off);
+			spriteHandler?.ChangeSprite(0);
 		}
+
+
 	}
 
 	private void UpdateValues()

--- a/UnityProject/Assets/Scripts/Weapons/Melee/StunBaton.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Melee/StunBaton.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 [RequireComponent(typeof(Pickupable))]
 public class StunBaton : NetworkBehaviour, IPredictedInteractable<HandActivate>
 {
-	public SpriteRenderer spriteRenderer;
+	public SpriteHandler spriteHandler;
 
 	/// <summary>
 	/// Sound played when turning this baton on/off
@@ -32,13 +32,6 @@ public class StunBaton : NetworkBehaviour, IPredictedInteractable<HandActivate>
 
 	public bool isActive => active;
 
-	private Pickupable pickupable;
-
-	private void Awake()
-	{
-		pickupable = GetComponent<Pickupable>();
-	}
-
 	public void ToggleState()
 	{
 		UpdateState(active, !active);
@@ -55,14 +48,12 @@ public class StunBaton : NetworkBehaviour, IPredictedInteractable<HandActivate>
 	{
 		if (active)
 		{
-			spriteRenderer.sprite = spriteActive;
+			spriteHandler?.SetSprite(spriteActive);
 		}
 		else
 		{
-			spriteRenderer.sprite = spriteInactive;
+			spriteHandler?.SetSprite(spriteInactive);
 		}
-
-		Inventory.RefreshUISlotImage(gameObject);
 	}
 
 	public void ClientPredictInteraction(HandActivate interaction)
@@ -77,7 +68,7 @@ public class StunBaton : NetworkBehaviour, IPredictedInteractable<HandActivate>
 
 	public void ServerPerformInteraction(HandActivate interaction)
 	{
-		SoundManager.PlayNetworkedAtPos(soundToggle, interaction.Performer.transform.position, sourceObj: interaction.Performer);
+		SoundManager.PlayNetworkedAtPos(soundToggle, interaction.Performer.AssumedWorldPosServer(), sourceObj: interaction.Performer);
 		ToggleState();
 	}
 }


### PR DESCRIPTION
### Purpose
Previously each animated item should had custom script to update animation frames in UI slots. That lead to a lot stupid, inefficient and repeatable code in different scripts with same line `pickupable.RefreshUISlotImage();`
This PR implements automatic way for UI_ItemImage to update image state based on current SpriteHandler state. Now SpriteHandler fires event when animation frame changed. Subscribed UI_ItemImage change its sprite respectively.

### Notes:
UI image will not be updated if SpriteRender sprite was replaced or animated by another script. It only works if SpriteHandlers have full control over SpriteRender. 
Not all occurrence of `pickupable?.RefreshUISlotImage();` was replaced or deleted. Old approach is still working, but it should be replaced in the future.
Cigarette, lighters and stun button was refactored for new approach. Other items should be refactored in different PR.
Energy sword was broken before this PR. Though now inventory animation works correctly, clothing animation still funny.

