### PR TITLE
Attempting to fix staging NRE with playerlist.RemovedByConnection

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -318,9 +318,9 @@ public partial class PlayerList : NetworkBehaviour
 	[Server]
 	public void RemoveByConnection(NetworkConnection connection)
 	{
-		if (connection == null)
+		if (connection == null || connection.address == null || connection.identity.name == null)
 		{
-			Logger.Log($"Unknown player disconnected: verifying playerlists for integrity - connection was null.", Category.Connections);
+			Logger.Log($"Unknown player disconnected: verifying playerlists for integrity - connection, its address and identity was null.", Category.Connections);
 			ValidatePlayerListRecords();
 			return;
 		}


### PR DESCRIPTION
### Purpose
Meant to just test on staging to stop a particular NRE from appearing, could possibly fix the hanging, but I doubt it. If this doesn't do anything, please revert this commit.

It simply modifies the if statement before the NRE occured to also check if either the connection.address or the connection.identity.name are null.

##Notes
Here is the staging error that it relates to:
NullReferenceException: Object reference not set to an instance of an object
PlayerList.RemoveByConnection (Mirror.NetworkConnection connection) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Managers/PlayerList.cs:331)
CustomNetworkManager.OnServerDisconnect (Mirror.NetworkConnection conn) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs:195)
Mirror.NetworkManager.OnServerDisconnectInternal (Mirror.NetworkConnection conn, Mirror.DisconnectMessage msg) (at D:/github/corp-0/unitystation/UnityProject/Assets/Mirror/Runtime/NetworkManager.cs:1112)
Mirror.MessagePacker+<>c__DisplayClass6_0`2[T,C].<MessageHandler>b__0 (Mirror.NetworkConnection conn, Mirror.NetworkReader reader, System.Int32 channelId) (at D:/github/corp-0/unitystation/UnityProject/Assets/Mirror/Runtime/MessagePacker.cs:146)
Mirror.NetworkConnection.InvokeHandler (System.Int32 msgType, Mirror.NetworkReader reader, System.Int32 channelId) (at D:/github/corp-0/unitystation/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:219)
Mirror.NetworkConnection.InvokeHandler[T] (T msg, System.Int32 channelId) (at D:/github/corp-0/unitystation/UnityProject/Assets/Mirror/Runtime/NetworkConnection.cs:247)
Mirror.NetworkServer.OnDisconnected (Mirror.NetworkConnection conn) (at D:/github/corp-0/unitystation/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs:503)
Mirror.NetworkServer.OnDisconnected (System.Int32 connectionId) (at D:/github/corp-0/unitystation/UnityProject/Assets/Mirror/Runtime/NetworkServer.cs:497)
UnityEngine.Events.InvokableCall`1[T1].Invoke (T1 args0) (at /home/builduser/buildslave/unity/build/Runtime/Export/UnityEvent/UnityEvent.cs:207)
UnityEngine.Events.UnityEvent`1[T0].Invoke (T0 arg0) (at /home/builduser/buildslave/unity/build/Runtime/Export/UnityEvent/UnityEvent/UnityEvent_1.cs:58)
Mirror.TelepathyTransport.ProcessServerMessage () (at D:/github/corp-0/unitystation/