### PR TITLE
Fixed MissingRef exception for UI_ItemImage

### DIFF
--- a/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemImage.cs
+++ b/UnityProject/Assets/Scripts/UI/UI Bottom/UI_ItemImage.cs
@@ -245,6 +245,15 @@ public class UI_ItemImage
 
         private void OnHandlerSpriteChanged(Sprite sprite)
 		{
+			if (!UIImage)
+			{
+				// looks like image was deleted from scene
+				// this happens when item is moved in container
+				// and player close this container
+				handler.OnSpriteChanged -= OnHandlerSpriteChanged;
+				return;
+			}
+
 			if (sprite)
 			{
 				UIImage.gameObject.SetActive (true);


### PR DESCRIPTION
### Purpose
Quick fix for UI_ItemImage. 
Fixed MissingRef exception when player place animated object in container and close inventory menu.