### PR TITLE
Adds a ContainsKey check into RemoveHandler

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/EventManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/EventManager.cs
@@ -75,7 +75,8 @@ public class EventManager : MonoBehaviour
 
 	public static void RemoveHandler(EVENT evnt, Action action)
 	{
-		if (eventTable.ContainsKey(evnt) && eventTable[evnt] != null)
+		if (!eventTable.ContainsKey(evnt)) return;
+		if (eventTable[evnt] != null)
 		{
 			eventTable[evnt] -= action;
 		}

--- a/UnityProject/Assets/Scripts/Managers/EventManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/EventManager.cs
@@ -75,7 +75,7 @@ public class EventManager : MonoBehaviour
 
 	public static void RemoveHandler(EVENT evnt, Action action)
 	{
-		if (eventTable[evnt] != null)
+		if (eventTable.ContainsKey(evnt) && eventTable[evnt] != null)
 		{
 			eventTable[evnt] -= action;
 		}


### PR DESCRIPTION

### Purpose
Stops the RemoveHandler funciton of the EventManager class from checking if the event key is null before checking the dictionary key exists existance.

#### Notes
I was getting an KeyNotFoundException with RemoveHandler, so I thought this might help. Should there be a eventTable.ContainsKey(evnt) for the second if statement as well?
