### PR TITLE
Escaped prefix labels, changed scene labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,33 +1,30 @@
-Scene Changes:
+"Scene Changes":
   - UnityProject/Assets/**/*.unity
 
-SquareStation:
+"Scene: SquareStation":
   - UnityProject/Assets/Scenes/MainStations/SquareStation.unity
   
-PogStation:
+"Scene: PogStation":
   - UnityProject/Assets/Scenes/MainStations/PogStation.unity
 
-FallStation:
+"Scene: FallStation":
   - UnityProject/Assets/Scenes/MainStations/FallStation.unity
 
-OutpostStation:
+"Scene: OutpostStation":
   - UnityProject/Assets/Scenes/MainStations/OutpostStation.unity
 
-BoxStation:
+"Scene: BoxStation":
   - UnityProject/Assets/Scenes/MainStations/BoxStationV1.unity
 
-Documentation:
+"Documentation":
   - docs/**/*
 
-Sprite Work:
+"Sprite Work":
   - UnityProject/Assets/Textures/**/*.png
   - UnityProject/Assets/Textures/**/*.PNG
   - AssetLibrary/**/*.png
   - AssetLibrary/**/*.PNG
 
-UI:
+"UI":
   - UnityProject/Assets/Scripts/UI/**/*
   - UnityProject/Assets/Scenes/UI/**/*
-  
-  
-


### PR DESCRIPTION
~~*Requires labels to be updated before merging! Not sure how we can best test this.*~~ *Relevant labels have been renamed*

# Description

Escaped all keys in the label yaml. `js-yaml` *should* be able to handle this, but I only tested it in an online parser.

The escaped keys contain some changes. Map names now have a `Scene: ` prefix to make sure the labels appear next to each other on the list.

### For example:

```
Admin
BoxStation
Engineering
Squarestation
```
would now be:
```
Admin
Engineering
Scene: BoxStation
Scene: SquareStation
```