### PR TITLE
Fixes the spelling of tables construction messages

### DIFF
--- a/UnityProject/Assets/Scripts/Furniture/TableBuilding.cs
+++ b/UnityProject/Assets/Scripts/Furniture/TableBuilding.cs
@@ -40,7 +40,7 @@ public class TableBuilding : NetworkBehaviour, ICheckedInteractable<HandApply>
 		if (interaction.TargetObject != gameObject) return false;
 		//only try to interact if the user has a wrench, screwdriver in their hand
 		if (!Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench) &&
-			 !Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.MetalSheet) &&
+		    !Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.MetalSheet) &&
 			!Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.GlassSheet) &&
 			!Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.WoodenPlank) &&
 		!Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.PlasteelSheet)){ return false; }
@@ -53,81 +53,55 @@ public class TableBuilding : NetworkBehaviour, ICheckedInteractable<HandApply>
 		if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench))
 		{
 			ToolUtils.ServerUseToolWithActionMessages(interaction, 0.5f,
-						"You start deconstructing a table frame...",
-						$"{interaction.Performer.ExpensiveName()} starts deconstructing a table frame...",
-						"You are deconstructing a table frame.",
-						$"{interaction.Performer.ExpensiveName()} deconstructs a table frame.",
-						() => Disassemble(interaction));
+				"You start deconstructing the table frame...",
+				$"{interaction.Performer.ExpensiveName()} starts deconstructing the table frame...",
+				"You finish deconstructing the table frame.",
+				$"{interaction.Performer.ExpensiveName()} deconstructs the table frame.",
+				() => Disassemble(interaction));
 			SoundManager.PlayNetworkedAtPos("Wrench", gameObject.WorldPosServer(), 1f, sourceObj: gameObject);
-
-			return;
 		}
 		else if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.MetalSheet))
 		{
-			ToolUtils.ServerUseToolWithActionMessages(interaction, 0.5f,
-						"You start constructing a metal table...",
-						$"{interaction.Performer.ExpensiveName()} starts constructing a metal table...",
-						"You are constructing a metal table.",
-						$"{interaction.Performer.ExpensiveName()} constructs a metal table.",
-						() => SpawnTable(interaction, metalTable));
-			;
-			return;
+			Assemble(interaction, "metal", metalTable, "Deconstruct");
 		}
 		else if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.GlassSheet))
 		{
-			ToolUtils.ServerUseToolWithActionMessages(interaction, 0.5f,
-						"You start constructing a glass table...",
-						$"{interaction.Performer.ExpensiveName()} starts constructing a glass table...",
-						"You are constructing a glass table.",
-						$"{interaction.Performer.ExpensiveName()} constructs a glass table.",
-						() => SpawnTable(interaction, glassTable));
-			SoundManager.PlayNetworkedAtPos("GlassHit", gameObject.WorldPosServer(), 1f, sourceObj: gameObject);
-
-			return;
+			Assemble(interaction, "glass", glassTable, "GlassHit");
 		}
 		else if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.WoodenPlank))
 		{
-			ToolUtils.ServerUseToolWithActionMessages(interaction, 0.5f,
-						"You start constructing a wooden table...",
-						$"{interaction.Performer.ExpensiveName()} starts constructing a wooden table...",
-						"You are constructing a wooden table.",
-						$"{interaction.Performer.ExpensiveName()} constructs a wooden table.",
-						() => SpawnTable(interaction, woodTable));
-			SoundManager.PlayNetworkedAtPos("wood3", gameObject.WorldPosServer(), 1f, sourceObj: gameObject);
-
-			return;
+			Assemble(interaction, "wooden", glassTable, "wood3");
 		}
-		if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.PlasteelSheet))
+		else if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.PlasteelSheet))
 		{
-			ToolUtils.ServerUseToolWithActionMessages(interaction, 2f,
-						"You start constructing a reinforced table...",
-						$"{interaction.Performer.ExpensiveName()} starts constructing a reinforced table...",
-						"You are constructing a reinforced table.",
-						$"{interaction.Performer.ExpensiveName()} constructs a reinforced table.",
-						() => SpawnTable(interaction, reinforcedTable));
-			SoundManager.PlayNetworkedAtPos("Deconstruct", gameObject.WorldPosServer(), 1f, sourceObj: gameObject);
-
-			return;
+			Assemble(interaction, "reinforced", glassTable, "Deconstruct");
 		}
-
 	}
-	[Server]
+	private void Assemble(HandApply interaction, string tableType, LayerTile layerTile, string soundName)
+	{
+		ToolUtils.ServerUseToolWithActionMessages(interaction, 0.5f,
+			$"You start constructing a {tableType} table...",
+			$"{interaction.Performer.ExpensiveName()} starts constructing a {tableType} table...",
+			$"You finish assembling the {tableType} table.",
+			$"{interaction.Performer.ExpensiveName()} assembles a {tableType} table.",
+			() => SpawnTable(interaction, layerTile));
+		SoundManager.PlayNetworkedAtPos(soundName, gameObject.WorldPosServer(), 1f, sourceObj: gameObject);
+	}
+
 	private void Disassemble(HandApply interaction)
 	{
 		Spawn.ServerPrefab("Rods", gameObject.WorldPosServer(), count: 2);
 		Despawn.ServerSingle(gameObject);
 	}
-	[Server]
+
 	private void SpawnTable(HandApply interaction, LayerTile tableToSpawn)
 	{
-
-			var interactableTiles = InteractableTiles.GetAt(interaction.TargetObject.TileWorldPosition(), true);
-			Vector3Int cellPos = interactableTiles.WorldToCell(interaction.TargetObject.TileWorldPosition());
-			interaction.HandObject.GetComponent<Stackable>().ServerConsume(2);
-			interactableTiles.TileChangeManager.UpdateTile(cellPos, tableToSpawn);
-			interactableTiles.TileChangeManager.SubsystemManager.UpdateAt(cellPos);
-			Despawn.ServerSingle(gameObject);
+		var interactableTiles = InteractableTiles.GetAt(interaction.TargetObject.TileWorldPosition(), true);
+		Vector3Int cellPos = interactableTiles.WorldToCell(interaction.TargetObject.TileWorldPosition());
+		interaction.HandObject.GetComponent<Stackable>().ServerConsume(2);
+		interactableTiles.TileChangeManager.UpdateTile(cellPos, tableToSpawn);
+		interactableTiles.TileChangeManager.SubsystemManager.UpdateAt(cellPos);
+		Despawn.ServerSingle(gameObject);
 	}
 
 }
-


### PR DESCRIPTION
### Purpose
Fixes the spelling of tables construction messages as well as removing some copypaste

![image](https://user-images.githubusercontent.com/701959/91515249-24156180-e8bf-11ea-896e-8e7ff278998f.png)
fixes this