### PR TITLE
Updates the sheets that come from a despawned table

### DIFF
--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/TileInteraction/DeconstructWhenItemUsed.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/TileInteraction/DeconstructWhenItemUsed.cs
@@ -39,6 +39,7 @@ public class DeconstructWhenItemUsed : TileInteraction
 	public override bool WillInteract(TileApply interaction, NetworkSide side)
 	{
 		if (!DefaultWillInteract.Default(interaction, side)) return false;
+		if (requiredTrait == CommonTraits.Instance.Wrench && interaction.Intent != Intent.Harm) return false;
 		if (requiredTrait == CommonTraits.Instance.Welder)
 		{
 			return Validations.HasUsedActiveWelder(interaction);

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/Table.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/Table.asset
@@ -20,14 +20,14 @@ MonoBehaviour:
   atmosPassable: 1
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  doesReflectBullet: 0
   passableException:
     m_keys: 02000000
     m_values: 01
   maxHealth: 100
+  damageDeflection: 0
   armor:
     Melee: 0
     Bullet: 0
@@ -39,24 +39,15 @@ MonoBehaviour:
     Acid: 50
     Magic: 0
     Bio: 0
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 60c558a8dfbf4ee4e8225a3484933424, type: 2}
   - {fileID: 11400000, guid: fc968a68963834c05a67838fe15fedec, type: 2}
   - {fileID: 11400000, guid: d27fd166098cf084abd6ebb4f8b2dd25, type: 2}
-  spawnOnDeconstruct: {fileID: 6254655335276451647, guid: ab486d104d39e584e935c8a5459a967c,
+  spawnOnDeconstruct: {fileID: 5770283965274354279, guid: b83b68cfa4a201748aeeece963a989c3,
     type: 3}
   spawnAmountOnDeconstruct: 2
+  lootOnDespawn: {fileID: 0}
+  soundOnHit: 
   connectCategory: 2
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/table_glass.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/table_glass.asset
@@ -20,14 +20,14 @@ MonoBehaviour:
   atmosPassable: 1
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  doesReflectBullet: 0
   passableException:
     m_keys: 02000000
     m_values: 01
   maxHealth: 70
+  damageDeflection: 0
   armor:
     Melee: 0
     Bullet: 0
@@ -39,23 +39,14 @@ MonoBehaviour:
     Acid: 100
     Magic: 0
     Bio: 0
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 1
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 60c558a8dfbf4ee4e8225a3484933424, type: 2}
   - {fileID: 11400000, guid: fc968a68963834c05a67838fe15fedec, type: 2}
-  spawnOnDeconstruct: {fileID: 5680136605834777345, guid: ea07289ba72453444a4ff1202b47a57d,
+  spawnOnDeconstruct: {fileID: 8579127030982015588, guid: 66a5287d0bf216847a2f4fe34228a0cf,
     type: 3}
   spawnAmountOnDeconstruct: 2
+  lootOnDespawn: {fileID: 0}
+  soundOnHit: 
   connectCategory: 2
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/table_poker.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/table_poker.asset
@@ -20,14 +20,14 @@ MonoBehaviour:
   atmosPassable: 1
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  doesReflectBullet: 0
   passableException:
     m_keys: 02000000
     m_values: 01
   maxHealth: 70
+  damageDeflection: 0
   armor:
     Melee: 0
     Bullet: 0
@@ -39,24 +39,15 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 60c558a8dfbf4ee4e8225a3484933424, type: 2}
   - {fileID: 11400000, guid: fc968a68963834c05a67838fe15fedec, type: 2}
   - {fileID: 11400000, guid: d27fd166098cf084abd6ebb4f8b2dd25, type: 2}
-  spawnOnDeconstruct: {fileID: 6254655335276451647, guid: 7543d187ee101c148ab143a796d9d175,
+  spawnOnDeconstruct: {fileID: 2663802320431471963, guid: 9ae38f6aa43b5cd4ba608cd31b462b24,
     type: 3}
   spawnAmountOnDeconstruct: 2
+  lootOnDespawn: {fileID: 0}
+  soundOnHit: 
   connectCategory: 2
   connectType: 1
   spriteSheet:

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/table_wood.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Tables/table_wood.asset
@@ -20,14 +20,14 @@ MonoBehaviour:
   atmosPassable: 1
   isSealed: 0
   SpawnWithNoAir: 0
-  oreCategory: 0
-  HealthStates: []
   passable: 0
   mineable: 0
+  doesReflectBullet: 0
   passableException:
     m_keys: 02000000
     m_values: 01
   maxHealth: 70
+  damageDeflection: 0
   armor:
     Melee: 0
     Bullet: 0
@@ -39,24 +39,15 @@ MonoBehaviour:
     Acid: 0
     Magic: 0
     Bio: 0
-  hitSounds: []
-  tileDestroyedRemains: []
-  healthStates: []
-  resistances:
-    LavaProof: 0
-    FireProof: 0
-    Flammable: 0
-    UnAcidable: 0
-    AcidProof: 0
-    Indestructable: 0
-    FreezeProof: 0
   tileInteractions:
   - {fileID: 11400000, guid: 60c558a8dfbf4ee4e8225a3484933424, type: 2}
   - {fileID: 11400000, guid: fc968a68963834c05a67838fe15fedec, type: 2}
   - {fileID: 11400000, guid: d27fd166098cf084abd6ebb4f8b2dd25, type: 2}
-  spawnOnDeconstruct: {fileID: 6254655335276451647, guid: 7543d187ee101c148ab143a796d9d175,
+  spawnOnDeconstruct: {fileID: 2663802320431471963, guid: 9ae38f6aa43b5cd4ba608cd31b462b24,
     type: 3}
   spawnAmountOnDeconstruct: 2
+  lootOnDespawn: {fileID: 0}
+  soundOnHit: 
   connectCategory: 2
   connectType: 1
   spriteSheet:


### PR DESCRIPTION
## Purpose
Updates the sheets that come from a despawned table to stop a NRE. Also allows wrenches to be placed on tables unless the harm intent is selected, which will cause the table to be deconstructed. Fixes #4940.