### PR TITLE
Player list connection validation.

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -318,7 +318,7 @@ public partial class PlayerList : NetworkBehaviour
 	[Server]
 	public void RemoveByConnection(NetworkConnection connection)
 	{
-		if (connection == null || connection.address == null || connection.identity.name == null)
+		if (connection?.address == null || connection.identity == null)
 		{
 			Logger.Log($"Unknown player disconnected: verifying playerlists for integrity - connection, its address and identity was null.", Category.Connections);
 			ValidatePlayerListRecords();


### PR DESCRIPTION
fixes 
<details>
<summary>PlayerList NRE </summary>

```
NullReferenceException: Object reference not set to an instance of an object
PlayerList.RemoveByConnection (Mirror.NetworkConnection connection) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Managers/PlayerList.cs:321)
CustomNetworkManager.OnServerDisconnect (Mirror.NetworkConnection conn) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Managers/NetworkManagement/CustomNetworkManager.cs:195)
Mirror.NetworkManager.OnServerDisconnectInternal (Mirror.NetworkConnection conn, Mirror.DisconnectMessage msg) (at D:/github/corp-0/unitystation/UnityProject/Assets/Standard Assets/Mirror/Runtime/NetworkManager.cs:1112)
Mirror.MessagePacker+<>c__DisplayClass6_0`2[T,C].<MessageHandler>b__0 (Mirror.NetworkConnection conn, Mirror.NetworkReader reader, System.Int32 channelId) (at D:/github/corp-0/unitystation/UnityProject/Assets/Standard Assets/Mirror/Runtime/MessagePacker.cs:146)
Mirror.NetworkConnection.InvokeHandler (System.Int32 msgType, Mirror.NetworkReader reader, System.Int32 channelId) (at D:/github/corp-0/unitystation/UnityProject/Assets/Standard Assets/Mirror/Runtime/NetworkConnection.cs:219)
Mirror.NetworkConnection.InvokeHandler[T] (T msg, System.Int32 channelId) (at D:/github/corp-0/unitystation/UnityProject/Assets/Standard Assets/Mirror/Runtime/NetworkConnection.cs:247)
Mirror.NetworkServer.OnDisconnected (Mirror.NetworkConnection conn) (at D:/github/corp-0/unitystation/UnityProject/Assets/Standard Assets/Mirror/Runtime/NetworkServer.cs:503)
Mirror.NetworkServer.OnDisconnected (System.Int32 connectionId) (at D:/github/corp-0/unitystation/UnityProject/Assets/Standard Assets/Mirror/Runtime/NetworkServer.cs:497)
UnityEngine.Events.InvokableCall`1[T1].Invoke (T1 args0) (at /home/builduser/buildslave/unity/build/Runtime/Export/UnityEvent/UnityEvent.cs:207)
UnityEngine.Events.UnityEvent`1[T0].Invoke (T0 arg0) (at /home/builduser/buildslave/unity/build/Runtime/Export/UnityEvent/UnityEvent/UnityEve
```

</details>
