### PR TITLE
Fix local variable in Gun.cs Init.

### DIFF
--- a/UnityProject/Assets/Scripts/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Gun.cs
@@ -228,9 +228,9 @@ namespace Weapons
 				Logger.LogTraceFormat("Auto-populate internal magazine for {0}", Category.Inventory, name);
 
 				//Make generic magazine and modify it to fit weapon
-				GameObject ammoPrefab = genericInternalMag;
+				GameObject internalMag = genericInternalMag;
 
-				Inventory.ServerAdd(Spawn.ServerPrefab(ammoPrefab).GameObject, magSlot);
+				Inventory.ServerAdd(Spawn.ServerPrefab(internalMag).GameObject, magSlot);
 
 				if (CurrentMagazine == null)
 				{


### PR DESCRIPTION
should fix

<details>
<summary>Error</summary>

```
Compact_Combat_Shotgun_Ballistic has null current magazine
UnityEngine.Debug:LogError(Object)
Weapons.Gun:Init() (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Weapons/Gun.cs:237)
Weapons.Gun:OnSpawnServer(SpawnInfo) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Weapons/Gun.cs:216)
Spawn:_ServerFireClientServerSpawnHooks(SpawnResult) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Lifecycle/Spawn.cs:378)
Spawn:Server(SpawnInfo) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Lifecycle/Spawn.cs:315)
Spawn:ServerPrefab(GameObject, SpawnDestination, Int32, Nullable`1) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Lifecycle/Spawn.cs:154)
SpawnableList:SpawnAt(SpawnDestination) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Lifecycle/Spawnable/SpawnableList.cs:27)
ClosetControl:OnSpawnServer(SpawnInfo) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Closets/ClosetControl.cs:182)
GameManager:OnRoundStart() (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Managers/GameManager.cs:375)
EventManager:Broadcast(EVENT) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Managers/EventManager.cs:95)
GameManager:StartRound() (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Managers/GameManager.cs:415)
GameManager:Update() (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Managers/GameManager.cs:331)
```

</details>