### PR TITLE
Atmospheric optimisation

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Scrubber.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Scrubber.prefab
@@ -69,7 +69,7 @@ MonoBehaviour:
     MonoPipe: {fileID: 0}
   Colour: {r: 1, g: 1, b: 1, a: 1}
   SelfSufficient: 0
-  MMinimumPressure: 90
+  MMinimumPressure: 101
   MaxInternalPressure: 8000
   MaxTransferMoles: 100
 --- !u!1 &8584966427123999583
@@ -184,7 +184,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300160, guid: ab114164e53d9954dac5b33964df4cf3,
+      objectReference: {fileID: 21300088, guid: ab114164e53d9954dac5b33964df4cf3,
         type: 3}
     - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}

--- a/UnityProject/Assets/Scripts/FluidPipe/PipeData.cs
+++ b/UnityProject/Assets/Scripts/FluidPipe/PipeData.cs
@@ -216,7 +216,7 @@ namespace Pipes
 			{
 				matrix.GetMetaDataNode(ZeroedLocation).GasMix += ToSpill.Item2;
 			}
-			metaDataLayer.UpdateSystemsAt(ZeroedLocation);
+			metaDataLayer.UpdateSystemsAt(ZeroedLocation, SystemType.AtmosSystem);
 		}
 
 		public void NetHookUp(PipeData NewConnection)

--- a/UnityProject/Assets/Scripts/Health/RespiratoryHealth/RespiratorySystem.cs
+++ b/UnityProject/Assets/Scripts/Health/RespiratoryHealth/RespiratorySystem.cs
@@ -120,7 +120,7 @@ public class RespiratorySystem : MonoBehaviour //Do not turn into NetBehaviour
 		{
 			breathGasMix.RemoveGas(Gas.Oxygen, oxygenUsed);
 			node.GasMix.AddGas(Gas.CarbonDioxide, oxygenUsed);
-			registerTile.Matrix.MetaDataLayer.UpdateSystemsAt(registerTile.LocalPositionClient);
+			registerTile.Matrix.MetaDataLayer.UpdateSystemsAt(registerTile.LocalPositionClient, SystemType.AtmosSystem);
 		}
 
 		gasMix += breathGasMix;

--- a/UnityProject/Assets/Scripts/Objects/GasContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/GasContainer.cs
@@ -62,7 +62,7 @@ namespace Objects
 				GasMix.Pressure / MAX_EXPLOSION_EFFECT_PRESSURE);
 			var shakeDistance = Mathf.Lerp(1, 64, GasMix.Pressure / MAX_EXPLOSION_EFFECT_PRESSURE);
 			node.GasMix += GasMix;
-			metaDataLayer.UpdateSystemsAt(position);
+			metaDataLayer.UpdateSystemsAt(position, SystemType.AtmosSystem);
 			Chat.AddLocalDestroyMsgToChat(gameObject.ExpensiveName(), " exploded!", gameObject.TileWorldPosition());
 
 			Spawn.ServerPrefab("Metal", gameObject.TileWorldPosition().To3Int(), transform.parent, count: 2,
@@ -100,7 +100,7 @@ namespace Objects
 
 					GasMix *= (1 - ratio);
 
-					metaDataLayer.UpdateSystemsAt(position);
+					metaDataLayer.UpdateSystemsAt(position, SystemType.AtmosSystem);
 
 					Volume = GasMix.Volume;
 					Temperature = GasMix.Temperature;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -196,8 +196,8 @@ public class MetaDataLayer : MonoBehaviour
 	}
 
 
-	public void UpdateSystemsAt(Vector3Int localPosition)
+	public void UpdateSystemsAt(Vector3Int localPosition, SystemType ToUpDate = SystemType.All)
 	{
-		subsystemManager.UpdateAt(localPosition);
+		subsystemManager.UpdateAt(localPosition, ToUpDate);
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 
 public class AtmosSystem : SubsystemBehaviour
 {
+	public override SystemType SubsystemType => SystemType.AtmosSystem;
+
 	public override void Initialize()
 	{
 		BoundsInt bounds = metaTileMap.GetBounds();

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -10,6 +10,9 @@ using UnityEngine;
 /// </summary>
 public class MetaDataSystem : SubsystemBehaviour
 {
+	// for Conditional updating
+	public override SystemType SubsystemType =>SystemType.MetaDataSystem;
+
 	// Set higher priority to ensure that it is executed before other systems
 	public override int Priority => 100;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SubsystemManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SubsystemManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -36,7 +37,7 @@ public class SubsystemManager : NetworkBehaviour
 		systems.Add(system);
 	}
 
-	public void UpdateAt(Vector3Int localPosition)
+	public void UpdateAt(Vector3Int localPosition, SystemType ToUpDate = SystemType.All)
 	{
 		if (!initialized)
 		{
@@ -48,7 +49,18 @@ public class SubsystemManager : NetworkBehaviour
 
 		for (int i = 0; i < systems.Count; i++)
 		{
-			systems[i].UpdateAt(localPosition);
+			if (ToUpDate.HasFlag(systems[i].SubsystemType))
+			{
+				systems[i].UpdateAt(localPosition);
+			}
 		}
 	}
+}
+[Flags]
+public enum SystemType
+{
+	None = 0,
+	AtmosSystem = 1 << 0,
+	MetaDataSystem = 1 << 1,
+	All = ~None
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SystemBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/SystemBehaviour.cs
@@ -3,9 +3,12 @@
 
 public abstract class SubsystemBehaviour : MonoBehaviour
 	{
+
 		protected MetaDataLayer metaDataLayer;
 		protected MetaTileMap metaTileMap;
 		protected SubsystemManager subsystemManager;
+
+		public virtual SystemType SubsystemType => SystemType.None;
 
 		public virtual int Priority => 0;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/AirVent.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/AirVent.cs
@@ -107,7 +107,7 @@ namespace Pipes
 
 
 			metaNode.GasMix = (Gasonnnode + TransferringGas);
-			metaDataLayer.UpdateSystemsAt(registerTile.LocalPositionServer);
+			metaDataLayer.UpdateSystemsAt(registerTile.LocalPositionServer, SystemType.AtmosSystem);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/Scrubber.cs
@@ -91,7 +91,7 @@ namespace Pipes
 				pipeData.mixAndVolume.Add(TransferringGas);
 			}
 
-			metaDataLayer.UpdateSystemsAt(registerTile.LocalPositionServer);
+			metaDataLayer.UpdateSystemsAt(registerTile.LocalPositionServer, SystemType.AtmosSystem);
 		}
 	}
 }


### PR DESCRIPTION

shouldn't update meta tile neighbours when scrubbers and vents are active