### PR TITLE
Fixing of non-starting events

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Living/HumanHealth/PlayerHealth.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/HumanHealth/PlayerHealth.cs
@@ -78,6 +78,9 @@ public class PlayerHealth : LivingHealthBehaviour
 	/// <param name="">The sickness to add</param>
 	public void AddSickness(Sickness sickness)
 	{
+		if (IsDead)
+			return;
+
 		if ((!playerSickness.HasSickness(sickness)) && (!immunedSickness.Contains(sickness)))
 			playerSickness.Add(sickness, Time.time);
 	}

--- a/UnityProject/Assets/Scripts/Health/Sickness/SicknessManager.cs
+++ b/UnityProject/Assets/Scripts/Health/Sickness/SicknessManager.cs
@@ -84,13 +84,17 @@ namespace Health.Sickness
 
 						foreach (PlayerSickness playerSickness in sickPlayers)
 						{
-							playerSickness.sicknessAfflictions.RemoveAll(p => p.IsHealed);
-
-							foreach (SicknessAffliction sicknessAffliction in playerSickness.sicknessAfflictions)
+							// Don't check sickness for dead players.
+							if (!playerSickness.playerHealth.IsDead)
 							{
-								CheckSicknessProgression(sicknessAffliction);
-								CheckSymptomOccurence(sicknessAffliction, playerSickness.playerHealth);
-								Thread.Sleep(100);
+								playerSickness.sicknessAfflictions.RemoveAll(p => p.IsHealed);
+
+								foreach (SicknessAffliction sicknessAffliction in playerSickness.sicknessAfflictions)
+								{
+									CheckSicknessProgression(sicknessAffliction);
+									CheckSymptomOccurence(sicknessAffliction, playerSickness.playerHealth);
+									Thread.Sleep(100);
+								}
 							}
 							Thread.Sleep(100);
 						}

--- a/UnityProject/Assets/Scripts/InGameEvents/EventScriptBase.cs
+++ b/UnityProject/Assets/Scripts/InGameEvents/EventScriptBase.cs
@@ -79,12 +79,12 @@ namespace InGameEvents
 
 		public virtual void OnEventStart()
 		{
-			OnEventStart(null);
+			Invoke(nameof(OnEventStartTimed), StartTimer);
 		}
 
 		public virtual void OnEventStart(string serializedEventParameters = null)
 		{
-			Invoke(nameof(OnEventStartTimed), StartTimer);
+			OnEventStart();
 		}
 
 		public virtual void OnEventStartTimed()

--- a/UnityProject/Assets/Scripts/InGameEvents/InGameEventScripts/EventSickness.cs
+++ b/UnityProject/Assets/Scripts/InGameEvents/InGameEventScripts/EventSickness.cs
@@ -36,7 +36,10 @@ namespace InGameEvents
 			Sickness sickness = SicknessManager.Instance.Sicknesses[sicknessEventParameters.SicknessIndex];
 
 			foreach (ConnectedPlayer player in PlayerList.Instance.AllPlayers.PickRandom(sicknessEventParameters.PlayerToInfect).ToList())
-				player.Script.playerHealth.AddSickness(sickness);
+			{
+				if ((player.Script != null) && (player.Script.playerHealth != null))
+					player.Script.playerHealth.AddSickness(sickness);
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/AdminTools/EventsManagerPage.cs
+++ b/UnityProject/Assets/Scripts/UI/AdminTools/EventsManagerPage.cs
@@ -53,19 +53,22 @@ public class EventsManagerPage : AdminPage
 			index = 0;
 		}
 
-		// Instead of triggering the event right away, if we have an extra parameter page, we show it
-		List<EventScriptBase> listEvents = InGameEventsManager.Instance.GetListFromEnum(eventType);
-		if (listEvents[index - 1].parametersPageType != ParametersPageType.None)
+		if (index != 0) // Index 0 (Random Event) will never have a parameter page
 		{
-			GameObject parameterPage = eventsParametersPages.eventParameterPages.FirstOrDefault(p => p.ParametersPageType == listEvents[index - 1].parametersPageType).ParameterPage;
-
-			if (parameterPage)
+			// Instead of triggering the event right away, if we have an extra parameter page, we show it
+			List<EventScriptBase> listEvents = InGameEventsManager.Instance.GetListFromEnum(eventType);
+			if (listEvents[index - 1].parametersPageType != ParametersPageType.None)
 			{
-				parameterPage.SetActive(true);
-				parameterPage.GetComponent<SicknessParametersPage>().SetBasicEventParameters(index, isFakeToggle.isOn, announceToggle.isOn, InGameEventType.Fun);
-				return;
+				GameObject parameterPage = eventsParametersPages.eventParameterPages.FirstOrDefault(p => p.ParametersPageType == listEvents[index - 1].parametersPageType).ParameterPage;
+
+				if (parameterPage)
+				{
+					parameterPage.SetActive(true);
+					parameterPage.GetComponent<SicknessParametersPage>().SetBasicEventParameters(index, isFakeToggle.isOn, announceToggle.isOn, InGameEventType.Fun);
+					return;
+				}
 			}
-		}		
+		}
 		
 		ServerCommandVersionFourMessageClient.Send(ServerData.UserID, PlayerList.Instance.AdminToken, index, isFakeToggle.isOn, announceToggle.isOn, eventType, "CmdTriggerGameEvent");
 	}


### PR DESCRIPTION
Some events were not starting because of Sickness event commit.
With that fix, everything is starting.

The OnEventStart overload with no parameters was never called anymore.

Prevent dead people from having symptoms or getting infected

Also, prevent a NRE when a player doesn't have a PlayerScript or PlayerHealth component.

Fixing a NRE (List index out ouf bound) when clicking start event when event type was "Random"