### PR TITLE
Spawn reference fix for canisters.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Canisters/CanisterBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Atmos/Canisters/CanisterBase.prefab
@@ -1,92 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-6176799362412192573
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3330777552754972672}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6d7277dcc993463cb6c7f79b663f36fc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  NetTabType: 10
---- !u!114 &3242550791702936155
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3330777552754972672}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cf6a312c50114272bc561c429cbb4175, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  Opened: 0
-  MaximumMoles: 1846.242
-  ReleasePressure: 101.325
-  Volume: 1
-  Temperature: 293.15
-  Gases:
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
---- !u!114 &4620245307892029763
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3330777552754972672}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 931d5444a5bf4c9aa3be62ecbf046740, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  gasContainer: {fileID: 3242550791702936155}
-  molesAdded: 15000
---- !u!114 &7067097863662868376
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3330777552754972672}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c9ae6b6bba5c4e3aa4780272577c9bcf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  UIBGTint: {r: 0.9882353, g: 0.81960785, b: 0.16470589, a: 1}
-  UIInnerPanelTint: {r: 0.99215686, g: 0.99215686, b: 0.65882355, a: 1}
-  ContentsName: Gas
-  objectBehaviour: {fileID: 195607162214552374}
-  container: {fileID: 0}
-  hasContainerInserted: 0
-  connector: {fileID: 0}
-  isConnected: 0
-  connectorRenderer: {fileID: 4787550694329366047}
-  connectorFuel: {fileID: 0}
-  connectorSprite: {fileID: 21300000, guid: a7172f3398019e044a68e8bb2fefbb72, type: 3}
 --- !u!1 &2770036439668985193
 GameObject:
   m_ObjectHideFlags: 0
@@ -115,7 +28,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 3327308291878936282}
+  m_Father: {fileID: 71571786451045753}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &4787550694329366047
@@ -168,6 +81,95 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &-6176799362412192573
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71571786451006913}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d7277dcc993463cb6c7f79b663f36fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetTabType: 10
+--- !u!114 &3242550791702936155
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71571786451006913}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf6a312c50114272bc561c429cbb4175, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  sheetsToSpawn: {fileID: 5770283965274354279, guid: b83b68cfa4a201748aeeece963a989c3,
+    type: 3}
+  Opened: 0
+  MaximumMoles: 1846.242
+  ReleasePressure: 101.325
+  Volume: 1
+  Temperature: 293.15
+  Gases:
+  - 0
+  - 0
+  - 0
+  - 0
+  - 0
+  - 0
+  - 0
+  - 0
+  - 0
+  - 0
+  - 0
+  - 0
+  - 0
+  - 0
+  - 0
+--- !u!114 &4620245307892029763
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71571786451006913}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 931d5444a5bf4c9aa3be62ecbf046740, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gasContainer: {fileID: 3242550791702936155}
+  molesAdded: 15000
+--- !u!114 &7067097863662868376
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71571786451006913}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c9ae6b6bba5c4e3aa4780272577c9bcf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  UIBGTint: {r: 0.9882353, g: 0.81960785, b: 0.16470589, a: 1}
+  UIInnerPanelTint: {r: 0.99215686, g: 0.99215686, b: 0.65882355, a: 1}
+  ContentsName: Gas
+  objectBehaviour: {fileID: 71571786450981893}
+  container: {fileID: 0}
+  hasContainerInserted: 0
+  connector: {fileID: 0}
+  isConnected: 0
+  connectorRenderer: {fileID: 4787550694329366047}
+  connectorFuel: {fileID: 0}
+  connectorSprite: {fileID: 21300000, guid: a7172f3398019e044a68e8bb2fefbb72, type: 3}
 --- !u!1 &8387653848795343260
 GameObject:
   m_ObjectHideFlags: 0
@@ -197,7 +199,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 3327308291878936282}
+  m_Father: {fileID: 71571786451045753}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &1969798539537519914
@@ -406,25 +408,25 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5d7892c86699e21499ad5f872fd4d512, type: 3}
---- !u!1 &3330777552754972672 stripped
+--- !u!1 &71571786451006913 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3370674530075112738, guid: 5d7892c86699e21499ad5f872fd4d512,
     type: 3}
   m_PrefabInstance: {fileID: 71571786451086626}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &3327308291878936282 stripped
+--- !u!4 &71571786451045753 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3373969533394793464, guid: 5d7892c86699e21499ad5f872fd4d512,
     type: 3}
   m_PrefabInstance: {fileID: 71571786451086626}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &195607162214552374 stripped
+--- !u!114 &71571786450981893 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 164567772411035156, guid: 5d7892c86699e21499ad5f872fd4d512,
     type: 3}
   m_PrefabInstance: {fileID: 71571786451086626}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3330777552754972672}
+  m_GameObject: {fileID: 71571786451006913}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Construction/BuildList/MetalConstructionList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Construction/BuildList/MetalConstructionList.asset
@@ -64,7 +64,7 @@ MonoBehaviour:
     spawnAmount: 1
     onePerTile: 1
   - name: Oxygen Canister
-    prefab: {fileID: 4045535016109707588, guid: dd86caf1f673b7642be83819773021d8,
+    prefab: {fileID: 1649348847854140549, guid: dd86caf1f673b7642be83819773021d8,
       type: 3}
     cost: 10
     buildTime: 5

--- a/UnityProject/Assets/Resources/ScriptableObjects/Machines/CargoData.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Machines/CargoData.asset
@@ -1114,14 +1114,13 @@ MonoBehaviour:
       TotalCreditExport: 500
     - OrderName: BZ Canister
       CreditsCost: 8000
-      Crate: {fileID: 5818151817506838785, guid: a7e39788d7a36384389f8e7f619dd9f3,
+      Crate: {fileID: 9113369063506965696, guid: a7e39788d7a36384389f8e7f619dd9f3,
         type: 3}
       Items: []
       TotalCreditExport: 500
     - OrderName: Carbon Dioxide Canister
       CreditsCost: 3000
-      Crate: {fileID: 3321916833831160622, guid: 9759789a5180a46419c8a7e2e50748e2,
-        type: 3}
+      Crate: {fileID: 62728662934464239, guid: 9759789a5180a46419c8a7e2e50748e2, type: 3}
       Items:
       - {fileID: 0}
       TotalCreditExport: 500
@@ -1148,19 +1147,19 @@ MonoBehaviour:
       TotalCreditExport: 500
     - OrderName: Nitrogen Canister
       CreditsCost: 2000
-      Crate: {fileID: 4045535016109707588, guid: 9944313d68658b341966d43e2c218eaa,
+      Crate: {fileID: 1649348847854140549, guid: 9944313d68658b341966d43e2c218eaa,
         type: 3}
       Items: []
       TotalCreditExport: 500
     - OrderName: Nitrous Oxide Canister
       CreditsCost: 3000
-      Crate: {fileID: 3300659230888592933, guid: 9f9ee7218e29057428d789e482e3477d,
+      Crate: {fileID: 218783801569881060, guid: 9f9ee7218e29057428d789e482e3477d,
         type: 3}
       Items: []
       TotalCreditExport: 500
     - OrderName: Oxygen Canister
       CreditsCost: 1500
-      Crate: {fileID: 4045535016109707588, guid: dd86caf1f673b7642be83819773021d8,
+      Crate: {fileID: 1649348847854140549, guid: dd86caf1f673b7642be83819773021d8,
         type: 3}
       Items: []
       TotalCreditExport: 500
@@ -1180,7 +1179,8 @@ MonoBehaviour:
       TotalCreditExport: 500
     - OrderName: Water Vapor Canister
       CreditsCost: 2500
-      Crate: {fileID: 24053578946406583, guid: c3b1e85e5c3e2e740bb058b62c306be4, type: 3}
+      Crate: {fileID: 3355883460558931318, guid: c3b1e85e5c3e2e740bb058b62c306be4,
+        type: 3}
       Items:
       - {fileID: 0}
       TotalCreditExport: 500

--- a/UnityProject/Assets/Scripts/Objects/GasContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/GasContainer.cs
@@ -11,6 +11,9 @@ namespace Objects
 		//max pressure for determining explosion effects - effects will be maximum at this contained pressure
 		private static readonly float MAX_EXPLOSION_EFFECT_PRESSURE = 148517f;
 
+		[SerializeField]
+		private GameObject sheetsToSpawn = null;
+
 		public GasMix GasMix { get; set; }
 
 		public bool Opened;
@@ -65,7 +68,7 @@ namespace Objects
 			metaDataLayer.UpdateSystemsAt(position, SystemType.AtmosSystem);
 			Chat.AddLocalDestroyMsgToChat(gameObject.ExpensiveName(), " exploded!", gameObject.TileWorldPosition());
 
-			Spawn.ServerPrefab("Metal", gameObject.TileWorldPosition().To3Int(), transform.parent, count: 2,
+			Spawn.ServerPrefab(sheetsToSpawn, gameObject.TileWorldPosition().To3Int(), transform.parent, count: 2,
 				scatterRadius: Spawn.DefaultScatterRadius, cancelIfImpassable: true);
 
 			ExplosionUtils.PlaySoundAndShake(tileWorldPosition, shakeIntensity, (int) shakeDistance);

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Canisters/CO2Canister.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Canisters/CO2Canister.asset
@@ -46,7 +46,7 @@ MonoBehaviour:
   soundOnHit: 
   IsItem: 0
   KeepOrientation: 0
-  Object: {fileID: 3321916833831160622, guid: 9759789a5180a46419c8a7e2e50748e2, type: 3}
+  Object: {fileID: 62728662934464239, guid: 9759789a5180a46419c8a7e2e50748e2, type: 3}
   Offset: 0
   Rotatable: 0
   IsWire: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Canisters/NitrogenCanister.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Canisters/NitrogenCanister.asset
@@ -46,7 +46,7 @@ MonoBehaviour:
   soundOnHit: 
   IsItem: 0
   KeepOrientation: 0
-  Object: {fileID: 4045535016109707588, guid: 9944313d68658b341966d43e2c218eaa, type: 3}
+  Object: {fileID: 1649348847854140549, guid: 9944313d68658b341966d43e2c218eaa, type: 3}
   Offset: 0
   Rotatable: 0
   IsWire: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Canisters/OxygenCanister.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Canisters/OxygenCanister.asset
@@ -46,7 +46,7 @@ MonoBehaviour:
   soundOnHit: 
   IsItem: 0
   KeepOrientation: 0
-  Object: {fileID: 4045535016109707588, guid: dd86caf1f673b7642be83819773021d8, type: 3}
+  Object: {fileID: 1649348847854140549, guid: dd86caf1f673b7642be83819773021d8, type: 3}
   Offset: 0
   Rotatable: 0
   IsWire: 0

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Canisters/PlasmaCanister.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Canisters/PlasmaCanister.asset
@@ -46,7 +46,7 @@ MonoBehaviour:
   soundOnHit: 
   IsItem: 0
   KeepOrientation: 0
-  Object: {fileID: 5892027926586772749, guid: dd553da79275dac409d269c0d6ec571c, type: 3}
+  Object: {fileID: 9152363990829424844, guid: dd553da79275dac409d269c0d6ec571c, type: 3}
   Offset: 0
   Rotatable: 0
   IsWire: 0


### PR DESCRIPTION
fixes #5008
<details>
<summary>Error</summary>

```
NullReferenceException: Object reference not set to an instance of an object
Spawn.Server (SpawnInfo info) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Lifecycle/Spawn.cs:278)
Spawn.ServerPrefab (System.String prefabName, System.Nullable`1[T] worldPosition, UnityEngine.Transform parent, System.Nullable`1[T] localRotation, System.Int32 count, System.Nullable`1[T] scatterRadius, System.Boolean cancelIfImpassable) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Lifecycle/Spawn.cs:206)
Objects.GasContainer.OnWillDestroyServer (DestructionInfo info) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Objects/GasContainer.cs:68)
UnityEngine.Events.InvokableCall`1[T1].Invoke (T1 args0) (at /home/builduser/buildslave/unity/build/Runtime/Export/UnityEvent/UnityEvent.cs:207)
UnityEngine.Events.UnityEvent`1[T0].Invoke (T0 arg0) (at /home/builduser/buildslave/unity/build/Runtime/Export/UnityEvent/UnityEvent/UnityEvent_1.cs:58)
Integrity.CheckDestruction () (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs:264)
Integrity.ApplyDamage (System.Single damage, AttackType attackType, DamageType damageType) (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs:221)
Explosions.ExplosionNode.Process () (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Explosions/ExplosionNode.cs:69)
Explosions.ExplosionManager.Step () (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Explosions/ExplosionManager.cs:35)
UpdateManager.ProcessDelayUpdate () (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs:294)
UpdateManager.Update () (at D:/github/corp-0/unitystation/UnityProject/Assets/Scripts/Managers/UpdateManager/UpdateManager.cs:273)
```

</details>

Issue was with spawning prefab by name, which was recently changed.
![MEtal](https://user-images.githubusercontent.com/42844726/91735787-7a331f00-ebb5-11ea-9723-d563b6ddaaf9.png)
![Metal1](https://user-images.githubusercontent.com/42844726/91735789-7b644c00-ebb5-11ea-806e-17cd9e3b62dc.PNG)

"Metal" is named now "MetalSheet".
But using reference is the best way to handle this issue.