### PR TITLE
Fix for freezing vacuum when moving from shuttles

### DIFF
--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -472,11 +472,11 @@ public partial class PlayerSync
 		lastDirectionServer = Vector2Int.RoundToInt(newPos - oldPos);
 		ServerState = nextState;
 		//In case positions already match
-		TryNotifyPlayers();
 		if (lastDirectionServer != Vector2.zero)
 		{
 			CheckMovementServer();
 			OnStartMove().Invoke(oldPos.RoundToInt(), newPos.RoundToInt());
+			SyncMatrix();
 		}
 
 		TryUpdateServerTarget();


### PR DESCRIPTION
### Purpose
Fixes players sometimes being exposed to a freezing vacuum when moving inbetween two matrix (for example, shuttle to station)

### Notes:
this is a crude visual explanation of the bug:
![image](https://user-images.githubusercontent.com/701959/91791678-1bd46380-ebea-11ea-8b67-1234d81de3cb.png)

now the matrix will update at the start of the movement