### PR TITLE
Fixes Attriburte's ArticleName and ArticleDescription

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -8,7 +8,7 @@ using Mirror;
 
 [RequireComponent(typeof(Integrity))]
 [RequireComponent(typeof(CustomNetTransform))]
-public class Attributes : NetworkBehaviour, IRightClickable, IExaminable
+public class Attributes : NetworkBehaviour, IRightClickable, IExaminable, IServerSpawn
 {
 
 	[Tooltip("Display name of this item when spawned.")]

--- a/UnityProject/Assets/Scripts/Managers/CargoManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/CargoManager.cs
@@ -258,7 +258,7 @@ public class CargoManager : MonoBehaviour
 		OnCreditsUpdate?.Invoke();
 
 		var attributes = item.gameObject.GetComponent<Attributes>();
-		string exportName;
+		string exportName = System.String.Empty;
 		if (attributes)
 		{
 			if (string.IsNullOrEmpty(attributes.ExportName))


### PR DESCRIPTION
### Purpose
ArticleName and ArticleDescription were null upon initalisation and this would cause the exportName to be null. ExportName (inside CargoManager.cs) needs to be a valid string, otherwise it cannot find the key inside the exportedItems dictionary. They are now not null and will not cause this problem anymore.
