### PR TITLE
Now warnText will be hidden when the UI is set for Joining

### DIFF
--- a/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
+++ b/UnityProject/Assets/Scripts/UI/PreRound/GUI_PreRoundWindow.cs
@@ -278,12 +278,12 @@ public class GUI_PreRoundWindow : MonoBehaviour
 	/// </summary>
 	public void SetUIForJoining()
 	{
+		warnText.SetActive(false);
 		joinPanel.SetActive(true);
 		timerPanel.SetActive(false);
 		playerWaitPanel.SetActive(false);
 		mainPanel.SetActive(true);
 		rejoiningRoundPanel.SetActive(false);
-
 		SetInfoScreenOn();
 	}
 


### PR DESCRIPTION
### Purpose
Ensures that warnText on the Lobby GUI_PreRoundWindow is hidden when the timer finishes to stop the message appearing when players' only option is to select the Join button.