### PR TITLE
Add links to action badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 
 _Unitystation has been active since late 2016_
 
-Visit us on Steam:
+Visit us on Steam:  
 [<img src="https://user-images.githubusercontent.com/7613738/35184899-b6a0aa8e-fdfb-11e7-91a8-bad8f19937b4.jpg" width="300">](http://store.steampowered.com/app/801140/Unitystation/)
 
-See project updates on Patreon:
+See project updates on Patreon:  
 [<img src="https://vignette.wikia.nocookie.net/everyone-else-is-a-returnee/images/6/68/Patreon.png/revision/latest?cb=20161230133220&format=original" width="150">](https://www.patreon.com/unitystation)
 
 ## Talk to us
-Please join us on Discord:
+Please join us on Discord:  
 [<img src="https://www.seoclerk.com/pics/want57772-1PlHGI1515438378.png" width="75">](https://discord.gg/H6EunER)
 
 ## Feel like getting involved?

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # unitystation
-![Tests](https://github.com/unitystation/unitystation/workflows/Tests/badge.svg) ![Build Project](https://github.com/unitystation/unitystation/workflows/Build%20Project/badge.svg?branch=develop)
-[![GitHub last commit](https://img.shields.io/github/last-commit/unitystation/unitystation.svg)](https://github.com/unitystation/unitystation/commits/develop) [![Discord](https://img.shields.io/discord/273774715741667329.svg)](https://discord.gg/H6EunER) [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-<br>
-![built-with-resentment](http://forthebadge.com/images/badges/built-with-resentment.svg) ![contains-technical-debt](http://forthebadge.com/images/badges/contains-technical-debt.svg)<br />
+[![Tests](https://github.com/unitystation/unitystation/workflows/Tests/badge.svg)](https://github.com/unitystation/unitystation/actions?query=workflow%3ATests)
+[![Build Project](https://github.com/unitystation/unitystation/workflows/Build%20Project/badge.svg?branch=develop)](https://github.com/unitystation/unitystation/actions?query=workflow%3ABuild+branch%3Adevelop)
+[![GitHub last commit](https://img.shields.io/github/last-commit/unitystation/unitystation.svg)](https://github.com/unitystation/unitystation/commits/develop)
+[![Discord](https://img.shields.io/discord/273774715741667329.svg)](https://discord.gg/H6EunER)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+
+![built-with-resentment](http://forthebadge.com/images/badges/built-with-resentment.svg)
+![contains-technical-debt](http://forthebadge.com/images/badges/contains-technical-debt.svg)
 
 _Unitystation has been active since late 2016_
 
-Visit us on Steam:<br>
+Visit us on Steam:
 [<img src="https://user-images.githubusercontent.com/7613738/35184899-b6a0aa8e-fdfb-11e7-91a8-bad8f19937b4.jpg" width="300">](http://store.steampowered.com/app/801140/Unitystation/)
 
-See project updates on Patreon:<br>
+See project updates on Patreon:
 [<img src="https://vignette.wikia.nocookie.net/everyone-else-is-a-returnee/images/6/68/Patreon.png/revision/latest?cb=20161230133220&format=original" width="150">](https://www.patreon.com/unitystation)
 
 ## Talk to us
-Please join us on Discord:<br>
+Please join us on Discord:
 [<img src="https://www.seoclerk.com/pics/want57772-1PlHGI1515438378.png" width="75">](https://discord.gg/H6EunER)
 
 ## Feel like getting involved?
@@ -33,8 +37,7 @@ All code before [commit 44695c862d6d84cfc99354d6dfba1f0b70f20407 on 2017/03/12 a
 _If you have committed code to this repository before this time, please contact us if you want your code distributed under GNU AGPL v3 instead_
 (Including tools unless their readme specifies otherwise.)
 
-See [LICENCE](https://github.com/unitystation/unitystation/blob/develop/LICENSE) and [GPLv3.txt](https://github.com/unitystation/unitystation/blob/develop/docs/GPLv3.txt) for more details.
-<br>
-![cc-by-nd](http://forthebadge.com/images/badges/cc-by-nd.svg) <br>
-All assets including icons and sound are under a [Creative Commons 3.0 BY-SA license](https://creativecommons.org/licenses/by-sa/3.0/) unless otherwise indicated.
+See [LICENCE](https://github.com/unitystation/unitystation/blob/develop/LICENSE) and [GPLv3.txt](https://github.com/unitystation/unitystation/blob/develop/docs/GPLv3.txt) for more details.  
+![cc-by-nd](http://forthebadge.com/images/badges/cc-by-nd.svg)
 
+All assets including icons and sound are under a [Creative Commons 3.0 BY-SA license](https://creativecommons.org/licenses/by-sa/3.0/) unless otherwise indicated.


### PR DESCRIPTION
I'm not sure about `Build Project` workflow, I don't see it in https://github.com/unitystation/unitystation/tree/develop/.github/workflows, last run I could find happened 29 days ago.
Also GitHub does not let allow `Build%20Project` as query for some reason, it only shows 7 months old successful builds.
I used `Build` in query instead.

Rendered version can be seen here: https://github.com/Fogapod/unitystation/blob/badges/README.md