### PR TITLE
NRE - Correction and Protection

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Sickness/PlayerSickness.cs
+++ b/UnityProject/Assets/Scripts/Health/Sickness/PlayerSickness.cs
@@ -18,7 +18,7 @@ namespace Health.Sickness
 			sicknessAfflictions = new List<SicknessAffliction>();
 		}
 
-		private void Awake()
+		private void Start()
 		{
 			playerHealth = GetComponent<PlayerHealth>();
 		}
@@ -30,7 +30,10 @@ namespace Health.Sickness
 		/// <param name="contractedTime">The time at which the player contracted the sickness</param>
 		public void Add(Sickness sickness, float contractedTime)
 		{
-			sicknessAfflictions.Add(new SicknessAffliction(sickness, contractedTime));
+			lock (sicknessAfflictions)
+			{
+				sicknessAfflictions.Add(new SicknessAffliction(sickness, contractedTime));
+			}
 
 			// Register the player as a sick player
 			SicknessManager.Instance.RegisterSickPlayer(this);
@@ -43,7 +46,10 @@ namespace Health.Sickness
 		/// <param name="sickness">The sickness to remove</param>
 		public void Remove(Sickness sickness)
 		{
-			sicknessAfflictions.Remove(sicknessAfflictions.Find(p => p.Sickness == sickness));
+			lock (sicknessAfflictions)
+			{
+				sicknessAfflictions.Remove(sicknessAfflictions.Find(p => p.Sickness == sickness));
+			}
 		}
 
 		/// <summary>
@@ -53,7 +59,10 @@ namespace Health.Sickness
 		/// <returns>True if the player already has this sickness active</returns>
 		public bool HasSickness(Sickness sickness)
 		{
-			return sicknessAfflictions.Exists(p => p.Sickness == sickness);
+			lock (sicknessAfflictions)
+			{
+				return sicknessAfflictions.Exists(p => p.Sickness == sickness);
+			}
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Health/Sickness/SicknessManager.cs
+++ b/UnityProject/Assets/Scripts/Health/Sickness/SicknessManager.cs
@@ -85,15 +85,18 @@ namespace Health.Sickness
 						foreach (PlayerSickness playerSickness in sickPlayers)
 						{
 							// Don't check sickness for dead players.
-							if (!playerSickness.playerHealth.IsDead)
+							if ((playerSickness.playerHealth != null) && (!playerSickness.playerHealth.IsDead))
 							{
 								playerSickness.sicknessAfflictions.RemoveAll(p => p.IsHealed);
 
-								foreach (SicknessAffliction sicknessAffliction in playerSickness.sicknessAfflictions)
+								lock (playerSickness.sicknessAfflictions)
 								{
-									CheckSicknessProgression(sicknessAffliction);
-									CheckSymptomOccurence(sicknessAffliction, playerSickness.playerHealth);
-									Thread.Sleep(100);
+									foreach (SicknessAffliction sicknessAffliction in playerSickness.sicknessAfflictions)
+									{
+										CheckSicknessProgression(sicknessAffliction);
+										CheckSymptomOccurence(sicknessAffliction, playerSickness.playerHealth);
+										Thread.Sleep(100);
+									}
 								}
 							}
 							Thread.Sleep(100);


### PR DESCRIPTION
Correction and protection against :

NullReferenceException: Object reference not set to an instance of an object
Health.Sickness.SicknessManager.ProcessSickness () (at Assets/Scripts/Health/Sickness/SicknessManager.cs:88)
System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) (at <437ba245d8404784b9fbab9b439ac908>:0)
System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) (at <437ba245d8404784b9fbab9b439ac908>:0)
System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) (at <437ba245d8404784b9fbab9b439ac908>:0)
System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) (at <437ba245d8404784b9fbab9b439ac908>:0)
System.Threading.ThreadHelper.ThreadStart () (at <437ba245d8404784b9fbab9b439ac908>:0)
UnityEngine.<>c:<RegisterUECatcher>b__0_0(Object, UnhandledExceptionEventArgs)

Also, protection of a multi-thread variable by adding locks on appropriate places.