### PR TITLE
Update canisters

### DIFF
--- a/UnityProject/Assets/Scripts/Editor/Objects/GasContainerEditor.cs
+++ b/UnityProject/Assets/Scripts/Editor/Objects/GasContainerEditor.cs
@@ -111,5 +111,3 @@ public class GasContainerEditor : Editor
 		return result;
 	}
 }
-
-

--- a/UnityProject/Assets/Scripts/Items/Stackable.cs
+++ b/UnityProject/Assets/Scripts/Items/Stackable.cs
@@ -112,7 +112,13 @@ public class Stackable : NetworkBehaviour, IServerLifecycle, ICheckedInteractabl
 		InitStacksWith();
 		SyncAmount(amount, initialAmount);
 		amountInit = true;
+
 		//check for stacking with things on the ground
+		registerTile.WaitForMatrixInit(OnMatrixInit);
+	}
+
+	private void OnMatrixInit(MatrixInfo info)
+	{
 		ServerStackOnGround(registerTile.LocalPositionServer);
 	}
 

--- a/UnityProject/Assets/Scripts/Objects/BurstCanister.cs
+++ b/UnityProject/Assets/Scripts/Objects/BurstCanister.cs
@@ -1,12 +1,10 @@
 ﻿using UnityEngine;
+using ScriptableObjects;
 
 public class BurstCanister : MonoBehaviour, ICheckedInteractable<HandApply>, IExaminable
 {
-	[Tooltip("The prefab to spawn when the burst canister is salvaged.")]
-	[SerializeField]
-	private GameObject metalPrefab = default;
 
-	[Tooltip("How much of the indicated prefab should spawn")]
+	[Tooltip("How many metal sheets should spawn.")]
 	[SerializeField] [Range(1, 5)]
 	private int spawnCount = 2;
 
@@ -55,12 +53,13 @@ public class BurstCanister : MonoBehaviour, ICheckedInteractable<HandApply>, IEx
 
 	private void SalvageMetal()
 	{
-		Spawn.ServerPrefab(metalPrefab, gameObject.RegisterTile().WorldPositionServer, count: spawnCount);
+		Spawn.ServerPrefab(CommonPrefabs.Instance.Metal, gameObject.RegisterTile().WorldPositionServer, count: spawnCount);
 		Despawn.ServerSingle(gameObject);
 	}
 
 	public string Examine(Vector3 worldPos = default)
 	{
+		if (!enabled) return default;
 		return "This canister has burst and is now useless. Perhaps you could salvage it?";
 	}
 

--- a/UnityProject/Assets/Scripts/Objects/GasContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/GasContainer.cs
@@ -34,7 +34,9 @@ namespace Objects.GasContainer
 		public float ServerInternalPressure => GasMix.Pressure;
 		private Vector3Int WorldPosition => gameObject.RegisterTile().WorldPosition;
 		private Vector3Int LocalPosition => gameObject.RegisterTile().LocalPosition;
-		
+
+		private bool gasIsInitialised = false;
+
 		#region Lifecycle
 
 		private void Awake()
@@ -44,7 +46,11 @@ namespace Objects.GasContainer
 
 		public void OnSpawnServer(SpawnInfo info)
 		{
-			UpdateGasMix();
+			if (!gasIsInitialised)
+			{
+				UpdateGasMix();
+			}
+
 			integrity.OnApplyDamage.AddListener(OnServerDamage);
 		}
 
@@ -157,6 +163,7 @@ namespace Objects.GasContainer
 
 		public void UpdateGasMix()
 		{
+			gasIsInitialised = true;
 			GasMix = GasMix.FromTemperature(Gases, Temperature, Volume);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Weapons/Melee/EnergySword.cs
+++ b/UnityProject/Assets/Scripts/Weapons/Melee/EnergySword.cs
@@ -37,7 +37,7 @@ public class EnergySword : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 	private List<string> offAttackVerbs;
 
 	[SerializeField]
-	private EswordSprites Sprites;
+	private EswordSprites Sprites = default;
 
 	private ItemAttributesV2 itemAttributes;
 	private ItemLightControl lightControl;


### PR DESCRIPTION
- Updates canisters
    - Canisters can be specified to be set open at roundstart, when mapping. Enables fixing #5070.
    - Canister tiers now affect the starting moles.
![canisters](https://user-images.githubusercontent.com/6926225/92432881-92c3ba80-f1ef-11ea-862c-ce868892c652.gif)
    - Fixes examining a healthy canister - it no longer incorrectly states that it has burst.
    - Fixes canisters not venting to environment when disconnected from a connector while the valve is open.
    - Fixes canisters still venting to environment when connected to a connector while the valve is open.
- Fixes `Stackable` NRE at roundstart.
- Fixes compiler warnings with canisters and energy swords.

> No scenes have been modified to reflect the changes.