### PR TITLE
Increase vendor list scroll speed

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/TabVendor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/TabVendor.prefab
@@ -305,7 +305,7 @@ MonoBehaviour:
   m_Elasticity: 0.1
   m_Inertia: 1
   m_DecelerationRate: 0.135
-  m_ScrollSensitivity: 1
+  m_ScrollSensitivity: 32
   m_Viewport: {fileID: 0}
   m_HorizontalScrollbar: {fileID: 0}
   m_VerticalScrollbar: {fileID: 0}

--- a/UnityProject/Assets/Scripts/UI/VendorItemEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/VendorItemEntry.cs
@@ -26,7 +26,17 @@ public class VendorItemEntry : DynamicEntry
 		vendorWindow = correspondingWindow;
 
 		var itemGO = vendorItem.Item;
-		var itemAttr = itemGO.GetComponent<ItemAttributesV2>();
+
+		if (itemGO != null)
+		{
+			// TODO This is unused. What was it for? Is this why soda machine entries are just called Drinking glass? (Issue #4942)
+			// I've just moved the line around to stop the NRE.
+			var itemAttr = itemGO.GetComponent<ItemAttributesV2>();
+		}
+		else
+		{
+			Logger.LogError($"{this} variable {nameof(itemGO)} was null!");
+		}
 
 		// try get human-readable item name
 		var itemNameStr = TextUtils.UppercaseFirst(itemGO.ExpensiveName());

--- a/UnityProject/Assets/Textures/TilePreviews/res/Prefabs/Items/Other/VendingRefills.meta
+++ b/UnityProject/Assets/Textures/TilePreviews/res/Prefabs/Items/Other/VendingRefills.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 50f8a165eb1976e4b9a2b450f8ae13b7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Increases vendor list scroll speed, from 1px per scroll to 32px.
- Stops and logs a vendor NRE when using the `YouTool` vendor. Something wrong with glowsticks?
