### PR TITLE
Speedloaders, pistol size, projectile speed, and taser range.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Magazines/Resources/Rifles/BVOld_Magazine_357.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Magazines/Resources/Rifles/BVOld_Magazine_357.prefab
@@ -81,7 +81,7 @@ PrefabInstance:
     - target: {fileID: 3097138933977987719, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
       propertyPath: m_Name
-      value: Magazine_357
+      value: BVOld_Magazine_357
       objectReference: {fileID: 0}
     - target: {fileID: 3129732272286336819, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
@@ -97,6 +97,11 @@ PrefabInstance:
         type: 3}
       propertyPath: magazineSize
       value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3169463835222568116, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: isClip
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3176908863337649637, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Magazines/Resources/Rifles/BVOld_Magazine_38.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Magazines/Resources/Rifles/BVOld_Magazine_38.prefab
@@ -81,7 +81,7 @@ PrefabInstance:
     - target: {fileID: 3097138933977987719, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
       propertyPath: m_Name
-      value: Magazine_38
+      value: BVOld_Magazine_38
       objectReference: {fileID: 0}
     - target: {fileID: 3129732272286336819, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}
@@ -97,6 +97,11 @@ PrefabInstance:
         type: 3}
       propertyPath: magazineSize
       value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3169463835222568116, guid: 2c406df2572ceba47af8a9de4f9a50ba,
+        type: 3}
+      propertyPath: isClip
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3176908863337649637, guid: 2c406df2572ceba47af8a9de4f9a50ba,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Ballistics/BVOldGeneric Ballistic Gun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Ballistics/BVOldGeneric Ballistic Gun.prefab
@@ -15,8 +15,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   ammoPrefab: {fileID: 0}
-  genericInternalMag: {fileID: 2422759989583602921, guid: d819938d5d7681c4ba69845f60102a8c,
-    type: 3}
   casingPrefabOverride: {fileID: 0}
   allowMagazineRemoval: 1
   ammoType: 357
@@ -25,7 +23,6 @@ MonoBehaviour:
   burstCooldown: 0
   burstCount: 3
   SmartGun: 0
-  MagSize: 10
   CurrentRecoilVariance: 0
   FireCountDown: 0
   FiringSound: ShootGun01
@@ -34,7 +31,7 @@ MonoBehaviour:
   Projectile: {fileID: 1011412119081755325, guid: f1e541b806000994b970a77f497619ca,
     type: 3}
   ProjectilesFired: 1
-  ProjectileVelocity: 10
+  ProjectileVelocity: 20
   CameraRecoilConfig:
     Distance: 0
     RecoilDuration: 0
@@ -66,7 +63,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_Name
-      value: Generic Ballistic Gun
+      value: BVOldGeneric Ballistic Gun
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalPosition.x

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Ballistics/Resources/BVOldCombat_Shotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Ballistics/Resources/BVOldCombat_Shotgun_Ballistic.prefab
@@ -42,11 +42,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
-      propertyPath: ProjectileVelocity
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
-        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 2003804624138751089, guid: 4adcadc588a9b69449a7184abef7ad19,

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Ballistics/Resources/BVOldFlamethrower.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Ballistics/Resources/BVOldFlamethrower.prefab
@@ -15,11 +15,6 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
-      propertyPath: ProjectileVelocity
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
-        type: 3}
       propertyPath: WeaponType
       value: 1
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Ballistics/Resources/BVOldM90_Sniper_Rifle_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Ballistics/Resources/BVOldM90_Sniper_Rifle_Ballistic.prefab
@@ -57,6 +57,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 6235254427324400780, guid: 7bf36ad773bdc1f49b1d7b0b3314f2e4,
         type: 3}
+    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
+        type: 3}
+      propertyPath: ProjectileVelocity
+      value: 40
+      objectReference: {fileID: 0}
     - target: {fileID: 3623955159015093207, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Ballistics/Resources/BVOldRiot_Shotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Ballistics/Resources/BVOldRiot_Shotgun_Ballistic.prefab
@@ -58,11 +58,6 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
-      propertyPath: ProjectileVelocity
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
-        type: 3}
       propertyPath: ammoPrefab
       value: 
       objectReference: {fileID: 5857423046154764512, guid: 743525ecb25075c4a931a26989c82712,

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Ballistics/Resources/BVOldSawn_Shotgun_Ballistic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Ballistics/Resources/BVOldSawn_Shotgun_Ballistic.prefab
@@ -29,11 +29,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
         type: 3}
-      propertyPath: ProjectileVelocity
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 2645616468337568693, guid: f46dc50d35397f04f8f6be3fb49668ca,
-        type: 3}
       propertyPath: ammoType
       value: 15
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Energy/BVOldGeneric Energy Gun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Energy/BVOldGeneric Energy Gun.prefab
@@ -33,8 +33,6 @@ MonoBehaviour:
   syncInterval: 0.1
   ammoPrefab: {fileID: 742292832060491855, guid: 65ed747e8d0f44242ba0c8eacae5e478,
     type: 3}
-  genericInternalMag: {fileID: 2422759989583602921, guid: d819938d5d7681c4ba69845f60102a8c,
-    type: 3}
   casingPrefabOverride: {fileID: 0}
   allowMagazineRemoval: 0
   ammoType: 14
@@ -43,7 +41,6 @@ MonoBehaviour:
   burstCooldown: 0
   burstCount: 3
   SmartGun: 0
-  MagSize: 10
   CurrentRecoilVariance: 0
   FireCountDown: 0
   FiringSound: ShootLaser
@@ -52,7 +49,7 @@ MonoBehaviour:
   Projectile: {fileID: 3294328072042417454, guid: 49a8364f6515be34bac52c48c9214d85,
     type: 3}
   ProjectilesFired: 1
-  ProjectileVelocity: 27
+  ProjectileVelocity: 20
   CameraRecoilConfig:
     Distance: 0
     RecoilDuration: 0
@@ -80,7 +77,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_Name
-      value: Generic Energy Gun
+      value: BVOldGeneric Energy Gun
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalPosition.x

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Energy/Resources/BVOldTazer.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Weapons/Energy/Resources/BVOldTazer.prefab
@@ -428,11 +428,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 5951038657140010356, guid: 00552b9802a37ba4bbe1aca46515b240,
         type: 3}
-    - target: {fileID: -851605047464713454, guid: c456c86d5736aee499478a158376781e,
-        type: 3}
-      propertyPath: ProjectileVelocity
-      value: 18
-      objectReference: {fileID: 0}
     - target: {fileID: 4598361863285954486, guid: c456c86d5736aee499478a158376781e,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/ProtoKineticAccelerator.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/ProtoKineticAccelerator.prefab
@@ -31,7 +31,7 @@ MonoBehaviour:
   MaxRecoilVariance: 0
   Projectile: {fileID: 1560634355228308, guid: 904d4b4cb2c22314b82de3393f1cb254, type: 3}
   ProjectilesFired: 1
-  ProjectileVelocity: 18
+  ProjectileVelocity: 20
   CameraRecoilConfig:
     Distance: 0
     RecoilDuration: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifle.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifle.prefab
@@ -159,6 +159,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21396104557255652, guid: b0bb7b40f7e10864e9bba0bd2123cfcb,
         type: 3}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: ProjectileVelocity
+      value: 40
+      objectReference: {fileID: 0}
     - target: {fileID: 4729653154424643162, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: itemStorageCapacity

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Pistols/Cutthroat9Pistol.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Pistols/Cutthroat9Pistol.prefab
@@ -211,6 +211,11 @@ PrefabInstance:
       propertyPath: initialName
       value: Cutthroat 9 pistol
       objectReference: {fileID: 0}
+    - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: initialSize
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a940a8ef1ee65024fb0a322703040d98, type: 3}
 --- !u!4 &1633438751717143220 stripped

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/S3HunterShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/S3HunterShotgun.prefab
@@ -40,16 +40,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: MaxRecoilVariance
-      value: 0.05
-      objectReference: {fileID: 0}
-    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: ProjectileVelocity
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
       propertyPath: ammoPrefab
       value: 
       objectReference: {fileID: 3210688012413455863, guid: 7920d9c4fad7b044c99cec907164f7e8,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/Shotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/Shotgun.prefab
@@ -76,18 +76,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5749777290144094747, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}
-      propertyPath: MaxRecoilVariance
-      value: 0.05
-      objectReference: {fileID: 0}
-    - target: {fileID: 5749777290144094747, guid: b17740819c0bf4b44a53be1e477dc4d5,
-        type: 3}
       propertyPath: ProjectilesFired
       value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 5749777290144094747, guid: b17740819c0bf4b44a53be1e477dc4d5,
-        type: 3}
-      propertyPath: ProjectileVelocity
-      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 5749777290144094747, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}
@@ -105,6 +95,11 @@ PrefabInstance:
         type: 3}
       propertyPath: allowMagazineRemoval
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5749777290144094747, guid: b17740819c0bf4b44a53be1e477dc4d5,
+        type: 3}
+      propertyPath: MaxRecoilVariance
+      value: 0.05
       objectReference: {fileID: 0}
     - target: {fileID: 8669052444454122546, guid: b17740819c0bf4b44a53be1e477dc4d5,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/_GunBallisticBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/_GunBallisticBase.prefab
@@ -47,11 +47,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
-      propertyPath: ProjectileVelocity
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22,
-        type: 3}
       propertyPath: genericInternalMag
       value: 
       objectReference: {fileID: 2422759989583602921, guid: d819938d5d7681c4ba69845f60102a8c,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/TaserHybridV43.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/TaserHybridV43.prefab
@@ -203,11 +203,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7789201627290542266, guid: d589c17f6fd91da4190edfdd2cb5aa53,
         type: 3}
-      propertyPath: ProjectileVelocity
-      value: 18
-      objectReference: {fileID: 0}
-    - target: {fileID: 7789201627290542266, guid: d589c17f6fd91da4190edfdd2cb5aa53,
-        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 5951038657140010356, guid: 00552b9802a37ba4bbe1aca46515b240,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/TaserV42.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/TaserV42.prefab
@@ -52,11 +52,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 916841119618418725, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
-      propertyPath: ProjectileVelocity
-      value: 18
-      objectReference: {fileID: 0}
-    - target: {fileID: 916841119618418725, guid: 143d3926d4a5fa84f95f987c152b33a2,
-        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 5951038657140010356, guid: 00552b9802a37ba4bbe1aca46515b240,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/XRayCarbine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/XRayCarbine.prefab
@@ -52,11 +52,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 916841119618418725, guid: 143d3926d4a5fa84f95f987c152b33a2,
         type: 3}
-      propertyPath: ProjectileVelocity
-      value: 27
-      objectReference: {fileID: 0}
-    - target: {fileID: 916841119618418725, guid: 143d3926d4a5fa84f95f987c152b33a2,
-        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 8211143321156392977, guid: 3a7cdc8971e174749acec7fe7ccb4923,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/_GunEnergyBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/_GunEnergyBase.prefab
@@ -463,11 +463,6 @@ PrefabInstance:
       propertyPath: allowMagazineRemoval
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22,
-        type: 3}
-      propertyPath: ProjectileVelocity
-      value: 27
-      objectReference: {fileID: 0}
     - target: {fileID: 8109205671878849838, guid: da85b7a590e7c8444af73629fcb5dd22,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/_GunBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/_GunBase.prefab
@@ -30,7 +30,6 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   ammoPrefab: {fileID: 0}
-  genericInternalMag: {fileID: 0}
   casingPrefabOverride: {fileID: 0}
   allowMagazineRemoval: 1
   ammoType: 0
@@ -39,7 +38,6 @@ MonoBehaviour:
   burstCooldown: 0
   burstCount: 3
   SmartGun: 0
-  MagSize: 10
   CurrentRecoilVariance: 0
   FireCountDown: 0
   FiringSound: 
@@ -47,7 +45,7 @@ MonoBehaviour:
   MaxRecoilVariance: 0
   Projectile: {fileID: 0}
   ProjectilesFired: 0
-  ProjectileVelocity: 0
+  ProjectileVelocity: 20
   CameraRecoilConfig:
     Distance: 0
     RecoilDuration: 0
@@ -62,7 +60,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_Name
-      value: GunBase
+      value: _GunBase
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalPosition.x

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Electrode.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Electrode.prefab
@@ -111,7 +111,7 @@ PrefabInstance:
     - target: {fileID: 4384935311063686999, guid: 33dfe2b5f12db3a43af6d409a2b599e5,
         type: 3}
       propertyPath: maxDistance
-      value: 4
+      value: 7
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 1059985465387772996, guid: 33dfe2b5f12db3a43af6d409a2b599e5, type: 3}


### PR DESCRIPTION
### Purpose
- Make the old revolver "magazines" act like clips.
- Base pistol (Cutthroat 9) is now small.
- Projectile speed is now consistent across almost all guns, set to 20 by default (similar to /tg/ values according to testing).
  - This means that ballistic projectiles became faster across the board, while lasers actually became a bit slower.
  - Migraine sniper rifle now has a projectile speed of 40.
- Up the range of taser electrodes a bit to make them more practical to use.

