### PR TITLE
Fix PDAs

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/TabPDA.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/TabPDA.prefab
@@ -3589,6 +3589,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4330847031761449293}
+  - component: {fileID: 8835462812452530474}
+  - component: {fileID: 3162506428660867889}
   - component: {fileID: 4193310021264659341}
   m_Layer: 0
   m_Name: TabPDA
@@ -3618,6 +3620,63 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 990, y: 990}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8835462812452530474
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4609695511057080137}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a14ed3befbaf4893bc7f04d3a44e9639, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  disableDrag: 0
+  resetPositionOnDisable: 0
+--- !u!114 &3162506428660867889
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4609695511057080137}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 13
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 8835462812452530474}
+          m_MethodName: BeginDrag
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - eventID: 5
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 8835462812452530474}
+          m_MethodName: OnDrag
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!114 &4193310021264659341
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Input System/InteractionV2/Validations.cs
+++ b/UnityProject/Assets/Scripts/Input System/InteractionV2/Validations.cs
@@ -246,7 +246,17 @@ public static class Validations
 		}
 
 		var result = false;
-		if (reachRange == ReachRange.Unlimited)
+
+		// Check if target is in player's inventory.
+		// This was added so NetTabs (NetTab.ValidatePeepers()) can be used on items in an inventory.
+		if (target.TryGetComponent(out Pickupable pickupable) && pickupable.ItemSlot != null)
+		{
+			if (pickupable.ItemSlot.RootPlayer().gameObject == playerScript.gameObject)
+			{
+				result = true;
+			}
+		}
+		else if (reachRange == ReachRange.Unlimited)
 		{
 			result = true;
 		}

--- a/UnityProject/Assets/Scripts/UI/Net/NetTab.cs
+++ b/UnityProject/Assets/Scripts/UI/Net/NetTab.cs
@@ -227,8 +227,12 @@ public class NetTab : Tab
 	{
 		foreach (var peeper in Peepers.ToArray())
 		{
-			var validate = peeper.Script && Validations.CanApply(peeper.Script, Provider, NetworkSide.Server);
-			if (!validate) TabUpdateMessage.Send(peeper.GameObject, Provider, Type, TabAction.Close);
+			bool canApply = Validations.CanApply(peeper.Script, Provider, NetworkSide.Server);
+
+			if (!peeper.Script || !canApply)
+			{
+				TabUpdateMessage.Send(peeper.GameObject, Provider, Type, TabAction.Close);
+			}
 		}
 	}
 	public void CloseTab()


### PR DESCRIPTION
- Items in the player's inventory are now considered in range for `NetTab` interactions.
    - This means PDAs can now be used as intended, without needing to click twice and have the window disappear all the time.
- The PDA window is now draggable.

> More fixes coming, probably.