### PR TITLE
Remove extra frames from quantum pad beam sprite.

### DIFF
--- a/UnityProject/Assets/Textures/objects/telescience/telescience_qpad-beam.asset
+++ b/UnityProject/Assets/Textures/objects/telescience/telescience_qpad-beam.asset
@@ -24,10 +24,6 @@ MonoBehaviour:
       secondDelay: 0.05
     - sprite: {fileID: 21300008, guid: f572209bc9e11714aafac67188e0bfce, type: 3}
       secondDelay: 0.05
-    - sprite: {fileID: 21300008, guid: f572209bc9e11714aafac67188e0bfce, type: 3}
-      secondDelay: 0.05
-    - sprite: {fileID: 21300008, guid: f572209bc9e11714aafac67188e0bfce, type: 3}
-      secondDelay: 0.05
     - sprite: {fileID: -6364802179404708633, guid: f572209bc9e11714aafac67188e0bfce,
         type: 3}
       secondDelay: 0.05


### PR DESCRIPTION
### Purpose
- Title, removes a few redundant frames from the beaming animation for the quantum pad so that it doesn't hang on the yellow section for longer than it's supposed to.