### PR TITLE
Atmos pump, mixer, filter round start overlay

### DIFF
--- a/UnityProject/Assets/Resources/Icons/Obj/Power.meta
+++ b/UnityProject/Assets/Resources/Icons/Obj/Power.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ad52a691cd72d04494fdd5df3adf81a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Icons/Obj/Recycling.meta
+++ b/UnityProject/Assets/Resources/Icons/Obj/Recycling.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: caddf4e1ca49cd74982975978365a1f0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Icons/Obj/Robotics.meta
+++ b/UnityProject/Assets/Resources/Icons/Obj/Robotics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5aebcdd60304bab42a190cd86784c730
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/FluidPipe/Filter.cs
+++ b/UnityProject/Assets/Scripts/FluidPipe/Filter.cs
@@ -21,8 +21,16 @@ namespace Pipes
 		public override void Start()
 		{
 			pipeData.PipeAction = new MonoActions();
-			spriteHandlerOverlay.PushClear();
 			base.Start();
+
+			if (IsOn)
+			{
+				spriteHandlerOverlay.PushTexture();
+			}
+			else
+			{
+				spriteHandlerOverlay.PushClear();
+			}
 		}
 
 		public void TogglePower()

--- a/UnityProject/Assets/Scripts/FluidPipe/Mixer.cs
+++ b/UnityProject/Assets/Scripts/FluidPipe/Mixer.cs
@@ -23,8 +23,16 @@ namespace Pipes
 		public override void Start()
 		{
 			pipeData.PipeAction = new MonoActions();
-			spriteHandlerOverlay.PushClear();
 			base.Start();
+
+			if (IsOn)
+			{
+				spriteHandlerOverlay.PushTexture();
+			}
+			else
+			{
+				spriteHandlerOverlay.PushClear();
+			}
 		}
 
 		public void TogglePower()

--- a/UnityProject/Assets/Scripts/FluidPipe/Pump.cs
+++ b/UnityProject/Assets/Scripts/FluidPipe/Pump.cs
@@ -19,7 +19,15 @@ namespace Pipes
 		{
 			pipeData.PipeAction = new MonoActions();
 			base.Start();
-			spriteHandlerOverlay.PushClear();
+
+			if (IsOn)
+			{
+				spriteHandlerOverlay.PushTexture();
+			}
+			else
+			{
+				spriteHandlerOverlay.PushClear();
+			}
 		}
 
 		public override void Interaction(HandApply interaction)


### PR DESCRIPTION
### Purpose
Atmos pumps, mixers, and filters now check whether they're turned on at start of round and set their overlay sprite to match that state.
