### PR TITLE
Adds action buttons for flashlights

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/MagBoots/MagBootsAdvanced.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/MagBoots/MagBootsAdvanced.prefab
@@ -53,6 +53,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: eea9a35b28b06ea449b920a12e16fc9e,
         type: 2}
+    - target: {fileID: 2030712609210181219, guid: 020aa37cdb1748149b33f0786b431160,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: eea9a35b28b06ea449b920a12e16fc9e,
+        type: 2}
+    - target: {fileID: 2030712609210181219, guid: 020aa37cdb1748149b33f0786b431160,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: a40424dd0653f68468f809c79cf8c095,
+        type: 2}
     - target: {fileID: 5256588606818913296, guid: 020aa37cdb1748149b33f0786b431160,
         type: 3}
       propertyPath: Resistances.LavaProof

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/MagBoots/MagBootsSWAT.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/MagBoots/MagBootsSWAT.prefab
@@ -241,6 +241,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: ca34816765d2db64bb0c7512377ebddc,
         type: 2}
+    - target: {fileID: 7305287980261651847, guid: b032e09c1bd8c5449b888c4353d665ba,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: ca34816765d2db64bb0c7512377ebddc,
+        type: 2}
+    - target: {fileID: 7305287980261651847, guid: b032e09c1bd8c5449b888c4353d665ba,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: d0fc01ff2f1b80f41a89df0af4b7ddcb,
+        type: 2}
     - target: {fileID: 7519530382760861061, guid: b032e09c1bd8c5449b888c4353d665ba,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/MagBoots/MagBootsSyndicate.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/MagBoots/MagBootsSyndicate.prefab
@@ -53,6 +53,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: d9ea50e268d3f764b925b51c4284d5a7,
         type: 2}
+    - target: {fileID: 2030712609210181219, guid: 020aa37cdb1748149b33f0786b431160,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: d9ea50e268d3f764b925b51c4284d5a7,
+        type: 2}
+    - target: {fileID: 2030712609210181219, guid: 020aa37cdb1748149b33f0786b431160,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: a9bdfe7a2308aaf409338ecbbb604838,
+        type: 2}
     - target: {fileID: 5259255436095103056, guid: 020aa37cdb1748149b33f0786b431160,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/Hardhats/HardHat.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/Hardhats/HardHat.prefab
@@ -113,6 +113,8 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   spriteHandler: {fileID: 4377197623706982477}
+  hasActionButton: 1
+  flashlightAction: {fileID: 11400000, guid: 9cf6b1b6994732d4cb5f023e0cefaf19, type: 2}
 --- !u!114 &3714036432172209818
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/HardsuitHelmetBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/HardsuitHelmets/HardsuitHelmetBase.prefab
@@ -15,6 +15,8 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   spriteHandler: {fileID: 8498819338256920512}
+  hasActionButton: 1
+  flashlightAction: {fileID: 11400000, guid: 9cf6b1b6994732d4cb5f023e0cefaf19, type: 2}
 --- !u!114 &2932610463863930541
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/PDA/PDAs/PDABase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/PDA/PDAs/PDABase.prefab
@@ -145,6 +145,7 @@ MonoBehaviour:
   defaultRingtone: TwoBeep
   willResetName: 0
   flashlightAction: {fileID: 11400000, guid: cdcecaa96c17cbcb99c4a982c1fce206, type: 2}
+  baseSpriteHandler: {fileID: 6198316859901323168}
 --- !u!114 &3562618048956884338
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -881,6 +882,18 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+--- !u!114 &6198316859901323168 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+    type: 3}
+  m_PrefabInstance: {fileID: 234557215263547549}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &239048463826641235 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/DeskLamp.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/DeskLamp.prefab
@@ -72,6 +72,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: fa5d6bd6559137c4b85c6867eefbb9b8,
         type: 3}
+    - target: {fileID: 5091645988084169630, guid: 6f371050bff8b32438f91c7c680900bb,
+        type: 3}
+      propertyPath: hasActionButton
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5295069687449651132, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: initialTraits.Array.size

--- a/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Flashlight.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Tools/Lights/Flashlight.prefab
@@ -113,6 +113,8 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   spriteHandler: {fileID: 1932141341405303641}
+  hasActionButton: 1
+  flashlightAction: {fileID: 11400000, guid: 9cf6b1b6994732d4cb5f023e0cefaf19, type: 2}
 --- !u!114 &5334267868750357690
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/AssistantPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/AssistantPopulator.asset
@@ -21,8 +21,9 @@ MonoBehaviour:
       type: 3}
   - NamedSlot: 12
     Prefab: {fileID: 234969413023505447, guid: 49b38681833f4d74ba6d4ab654a5d8cf, type: 3}
-  - NamedSlot: 16
-    Prefab: {fileID: 835768756810601639, guid: 3d08b6dbf08774e8681378945dec4edf, type: 3}
+  - NamedSlot: 1
+    Prefab: {fileID: 7825727919603877131, guid: 4cd28b6f34d9ccb408e30bc9ec8640e6,
+      type: 3}
   skirtVariant: {fileID: 6313332283237824220, guid: 4c734bb9f1d853f40bb830ca96ef0260,
     type: 3}
   duffelVariant: {fileID: 0}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/BartenderPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/BartenderPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
   - NamedSlot: 0
     Prefab: {fileID: 8215266403122399935, guid: a9e6210024846bd47b0410272526dadb,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 7021795450186175728, guid: 2cd2a675f71214f4c82c0f558de54176,
       type: 3}
   skirtVariant: {fileID: 1263341537948385592, guid: 872a07241939db44a92aae9b275b6063,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/BotanistPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/BotanistPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
   - NamedSlot: 10
     Prefab: {fileID: 5002772168956495688, guid: d43607a44ab318a4b8d4c67c1d1be07b,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 8548862809460329693, guid: 4bc83a98564d9b34e85de548a0f81db7,
       type: 3}
   - NamedSlot: 11

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/CaptainPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/CaptainPopulator.asset
@@ -38,7 +38,7 @@ MonoBehaviour:
     Prefab: {fileID: 835768756810601639, guid: abc31c8bb060f48aa9503d37fd4afb9b, type: 3}
   - NamedSlot: 15
     Prefab: {fileID: 682681175474864026, guid: 6501bec31b8a67944b283b95d03a939c, type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 3218814424912328504, guid: ad558afe51d974245ab485cd4f075cff,
       type: 3}
   skirtVariant: {fileID: 1413430109667973815, guid: 1538131c6d4be324784f652fab62fbdc,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/CargoTechnicianPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/CargoTechnicianPopulator.asset
@@ -24,7 +24,7 @@ MonoBehaviour:
   - NamedSlot: 11
     Prefab: {fileID: 6373161644663410599, guid: 470aa22391333488fa49f383cc8c1a26,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 1026386849108251522, guid: 8cf0dd2db47073946bf5e6943b550e56,
       type: 3}
   skirtVariant: {fileID: 1966734932007505171, guid: d0f1a9b75fd9b4c4498f65e576a9d815,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ChaplainPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ChaplainPopulator.asset
@@ -29,7 +29,7 @@ MonoBehaviour:
   - NamedSlot: 8
     Prefab: {fileID: 7781396554342910705, guid: d70fb70bc4fe6534a85996e49221bb53,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 6586518312683095324, guid: 09cf4bd34ff9fac49b4af08c0ff0e011,
       type: 3}
   skirtVariant: {fileID: 3694014063137355943, guid: eef5ab2615dd4924184c5c1f2ebddd96,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ChemistPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ChemistPopulator.asset
@@ -30,7 +30,7 @@ MonoBehaviour:
   - NamedSlot: 9
     Prefab: {fileID: 6841223995504525407, guid: 9836e3299e1fcf54cb6028cd4310ed3c,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 3643366884528902870, guid: 4967427bdc1e16e44a2866a0a44bd63b,
       type: 3}
   skirtVariant: {fileID: 6618757841128137006, guid: 0a840a47782653a47a8bcefb93b92131,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ChiefMedicalOfficerPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ChiefMedicalOfficerPopulator.asset
@@ -33,7 +33,7 @@ MonoBehaviour:
   - NamedSlot: 15
     Prefab: {fileID: 3208390474611170935, guid: 7e37d93965c2ed84b8b552ce1f8676ee,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 721918711566469298, guid: 0859ce907cb34834fb946780082be1fe, type: 3}
   skirtVariant: {fileID: 4378271014137224303, guid: af6be5511dead5243992d41249e1f1c5,
     type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ClownPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ClownPopulator.asset
@@ -26,11 +26,14 @@ MonoBehaviour:
     Prefab: {fileID: 835768756810601639, guid: 3d08b6dbf08774e8681378945dec4edf, type: 3}
   - NamedSlot: 17
     Prefab: {fileID: 100328150011014054, guid: 4e87468c82c280b418f8bf0d5f3e7882, type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 1107613870088279786, guid: 0eeb98d5950dd9e44918398bac5850b2,
       type: 3}
   - NamedSlot: 10
     Prefab: {fileID: 3145692860339046607, guid: f5f82171dfc8a15d4a9d4db66e775ee9,
+      type: 3}
+  - NamedSlot: 16
+    Prefab: {fileID: 7785875528613525472, guid: 4569acb573d85cc4d851531fdaedc4d2,
       type: 3}
   skirtVariant: {fileID: 0}
   duffelVariant: {fileID: 6038150883887207532, guid: 2322f92228a795d43ac92141d1fecb8a,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/CookPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/CookPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
   - NamedSlot: 0
     Prefab: {fileID: 3921521694364753778, guid: 4dddb342829e74925b4e0ca0d8cc5150,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 6954445710136611615, guid: 6631aee0a7f5c2148acd4b45d35a39b9,
       type: 3}
   skirtVariant: {fileID: 8595759586749855722, guid: 20b5c706c9fa6d6488022b9b64d732b8,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/CuratorPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/CuratorPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
   - NamedSlot: 0
     Prefab: {fileID: 3921521694364753778, guid: b67b665e16e3047c28f852c453112321,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 6141936300289500480, guid: 691d7b346716e824a84a6aa0a6375bf3,
       type: 3}
   skirtVariant: {fileID: 0}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/DetectivePopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/DetectivePopulator.asset
@@ -37,7 +37,7 @@ MonoBehaviour:
   - NamedSlot: 13
     Prefab: {fileID: 7019925540262486990, guid: 17bff0f4a8f4944489fa4b33de34bb8a,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 9196465849278631762, guid: d7b1d69dd5699794abff919652c9539a,
       type: 3}
   skirtVariant: {fileID: 5302982331206035619, guid: bb7d1020ce10a7348b237ddd07a02fc2,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/GeneticistPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/GeneticistPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
   - NamedSlot: 10
     Prefab: {fileID: 8541207335635205697, guid: 3eb130e231b60914a8b231815835140b,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 4685602324805225724, guid: b28456c6b73dae843ac930742beca4a5,
       type: 3}
   skirtVariant: {fileID: 2283914521931275349, guid: a925b6dda477c1148bfd2997307dec63,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/HeadOfPersonnelPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/HeadOfPersonnelPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
   - NamedSlot: 15
     Prefab: {fileID: 3208390474611170935, guid: 7e37d93965c2ed84b8b552ce1f8676ee,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 8420368425496545348, guid: 8666356dbd72e2a4fb7121b0eb53909c,
       type: 3}
   skirtVariant: {fileID: 3014020063061563662, guid: 7aed3ab769eed2841b559ecec3774a85,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/JanitorPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/JanitorPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
   - NamedSlot: 11
     Prefab: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 4793099437346693035, guid: 7011699b61000fd4cabe5779f41df18b,
       type: 3}
   skirtVariant: {fileID: 4011149429169960813, guid: cad85b5dad5b95d468fc34d2c6a01947,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/LawyerPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/LawyerPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
       type: 3}
   - NamedSlot: 8
     Prefab: {fileID: 448357460697814289, guid: 1a1b6f4ded6f86441bbb000972ea2089, type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 1047399489842994746, guid: 3b35afb3299e55040bc5fffef053ec61,
       type: 3}
   skirtVariant: {fileID: 5502800332140862390, guid: 45c3cbada4660604e8fb72afd758c4e2,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/MedicalDoctorPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/MedicalDoctorPopulator.asset
@@ -30,7 +30,7 @@ MonoBehaviour:
   - NamedSlot: 11
     Prefab: {fileID: 6373161644663410599, guid: 47e758de6e8330e8ba5c0cf96801afa8,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 2507239260135449736, guid: 65fb9b668a4683f439f01743a7e8065d,
       type: 3}
   skirtVariant: {fileID: 5920421737069179531, guid: 4d0474175ab0fcc49acc7daf8c3dc271,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/MimePopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/MimePopulator.asset
@@ -35,7 +35,7 @@ MonoBehaviour:
   - NamedSlot: 11
     Prefab: {fileID: 6373161644663410599, guid: 2b5931e1b579b4c4087b5dd741deed96,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 7376813222016106005, guid: 6634e203c6278bf419ff48e270276a1f,
       type: 3}
   - NamedSlot: 16

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/QuartermasterPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/QuartermasterPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
   - NamedSlot: 6
     Prefab: {fileID: 3011710637427380133, guid: c9cafc4cfdf774b66b6d76a563646fd7,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 1026386849108251522, guid: b618bdd7fd1e18a438d1c9a2266b3f9a,
       type: 3}
   skirtVariant: {fileID: 6394343562670262404, guid: 8bcfe12b1602c0b4089d1a9e639a2873,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ResearchDirectoryPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ResearchDirectoryPopulator.asset
@@ -30,7 +30,7 @@ MonoBehaviour:
   - NamedSlot: 15
     Prefab: {fileID: 3208390474611170935, guid: 7e37d93965c2ed84b8b552ce1f8676ee,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 7853875053529408824, guid: 5d31b061c31044246b806450981d3d42,
       type: 3}
   skirtVariant: {fileID: 5537561582803630187, guid: 43592ac65d77dc04e8f030bb04e26d3e,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/RoboticistPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/RoboticistPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
   - NamedSlot: 10
     Prefab: {fileID: 5064226321362517998, guid: 08cfe1b88b57ef54480353de29933380,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 2255089484867526446, guid: 7ec661cb1c2fa694a83b107497f9ccae,
       type: 3}
   skirtVariant: {fileID: 6710415053653577436, guid: 676e9af4e37de5645a97d7ad338cfcef,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ScientistPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ScientistPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
   - NamedSlot: 10
     Prefab: {fileID: 5064226321362517998, guid: 08cfe1b88b57ef54480353de29933380,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 9033961008344408314, guid: 5981f27a31b4a3a4ab24b1f0e533c89e,
       type: 3}
   skirtVariant: {fileID: 5032308470899878357, guid: 52c38364bd286a7498241ec0af93ed9e,

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ShaftMinerPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/ShaftMinerPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
   - NamedSlot: 11
     Prefab: {fileID: 6373161644663410599, guid: 7cae22bda0476431ba677333bd759b73,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 4956109687747413898, guid: 17e3e160b30fe8e479519ff94a686eb7,
       type: 3}
   skirtVariant: {fileID: 0}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/VirologistPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/VirologistPopulator.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
   - NamedSlot: 10
     Prefab: {fileID: 9131202711572530880, guid: 0c198ac94169aed40ab72b2afc2d4cc5,
       type: 3}
-  - NamedSlot: 16
+  - NamedSlot: 1
     Prefab: {fileID: 6584826353967766240, guid: fec5e137505f9594fa5e1d4199fa51a1,
       type: 3}
   skirtVariant: {fileID: 4172758320385125961, guid: 7294d72d86040fa45a54a16e2c0a36bf,

--- a/UnityProject/Assets/Resources/ScriptableObjects/UIActionsGraphics/MagBoots.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/UIActionsGraphics/MagBoots.asset
@@ -16,9 +16,7 @@ MonoBehaviour:
   callOnServer: 1
   actionName: Toggle Magboots
   description: 
-  Sprites:
-  - {fileID: 11400000, guid: e7a9c4058739e964dacc0b6f7eeb548f, type: 2}
-  - {fileID: 11400000, guid: 178404daa0d55514f90c2cb30bacd44e, type: 2}
+  Sprites: []
   Backgrounds: []
   PreventBeingControlledBy: 
   DisableOnEvent: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/UIActionsGraphics/ToggleFlashlight.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/UIActionsGraphics/ToggleFlashlight.asset
@@ -10,11 +10,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 175001bada3c3ba47945b92e3bfa2bd2, type: 3}
-  m_Name: PdaLight
+  m_Name: ToggleFlashlight
   m_EditorClassIdentifier: 
   callOnClient: 1
   callOnServer: 1
-  actionName: Toggle PDA Light
+  actionName: Toggle Flashlight
   description: 
   Sprites: []
   Backgrounds: []

--- a/UnityProject/Assets/Resources/ScriptableObjects/UIActionsGraphics/ToggleFlashlight.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/UIActionsGraphics/ToggleFlashlight.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9cf6b1b6994732d4cb5f023e0cefaf19
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Others/ItemMagBoots.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/ItemMagBoots.cs
@@ -8,10 +8,6 @@ using Atmospherics;
 public class ItemMagBoots : NetworkBehaviour,
 	IServerActionGUI, IClientInventoryMove, IServerInventoryMove
 {
-	[Tooltip("For UI button, 0 = off, 1 = on.")]
-	[SerializeField]
-	private Sprite[] sprites = new Sprite[2];
-
 	[Tooltip("The speed debuff to apply to run speed.")]
 	[SerializeField]
 	private float runSpeedDebuff = 1.5f;
@@ -23,7 +19,7 @@ public class ItemMagBoots : NetworkBehaviour,
 	private SpriteHandler spriteHandler;
 	private ConnectedPlayer player;
 	private ItemAttributesV2 itemAttributesV2;
-	private Pickupable pick;
+	private Pickupable pickupable;
 	private PlayerMove playerMove;
 
 	private bool isOn = false;
@@ -36,17 +32,18 @@ public class ItemMagBoots : NetworkBehaviour,
 
 	private void Awake()
 	{
-		pick = GetComponent<Pickupable>();
+		pickupable = GetComponent<Pickupable>();
 		spriteHandler = GetComponentInChildren<SpriteHandler>();
 		itemAttributesV2 = GetComponent<ItemAttributesV2>();
-		pick.RefreshUISlotImage();
+		pickupable.RefreshUISlotImage();
 	}
 
 	private void ToggleState()
 	{
 		isOn = !isOn;
 		spriteHandler.ChangeSprite(isOn ? (int) SpriteState.On : (int) SpriteState.Off);
-		//pick.RefreshUISlotImage();
+		UIActionManager.SetSpriteSO(this, spriteHandler.GetCurrentSpriteSO());
+		pickupable.RefreshUISlotImage();
 	}
 
 	public void OnInventoryMoveServer(InventoryMove info)
@@ -143,7 +140,7 @@ public class ItemMagBoots : NetworkBehaviour,
 		{
 			case ClientInventoryMoveType.Added when pna.GetActiveItemInSlot(NamedSlot.feet)?.gameObject == gameObject:
 				UIActionManager.ToggleLocal(this, true);
-				UIActionManager.SetSprite(this, sprites[(int) SpriteState.Off]);
+				UIActionManager.SetSpriteSO(this, spriteHandler.GetCurrentSpriteSO());
 				break;
 			case ClientInventoryMoveType.Removed when pna.GetActiveItemInSlot(NamedSlot.feet)?.gameObject != gameObject:
 				UIActionManager.ToggleLocal(this, false);
@@ -151,14 +148,7 @@ public class ItemMagBoots : NetworkBehaviour,
 		}
 	}
 
-	public void CallActionClient()
-	{
-		if (!PlayerManager.LocalPlayerScript.IsDeadOrGhost)
-		{
-			int index = isOn ? (int) SpriteState.On : (int) SpriteState.Off;
-			UIActionManager.SetSprite(this, index);
-		}
-	}
+	public void CallActionClient() { }
 
 	public void CallActionServer(ConnectedPlayer SentByPlayer)
 	{

--- a/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Sprite Handler/SpriteHandler.cs
@@ -679,6 +679,26 @@ public class SpriteHandler : MonoBehaviour
 		SetImageSprite(Frame.sprite);
 	}
 
+	/// <summary>
+	/// Gets the current sprite SO, if it exists.
+	/// </summary>
+	public SpriteDataSO GetCurrentSpriteSO()
+	{
+		return PresentSpriteSet;
+	}
+
+	/// <summary>
+	/// Gets the sprite SO from the SO catalogue of the given index, if it exists.
+	/// </summary>
+	public SpriteDataSO GetSpriteSO(int index)
+	{
+		if (index < CatalogueCount)
+		{
+			return SubCatalogue[index];
+		}
+
+		return default;
+	}
 
 #if UNITY_EDITOR
 	IEnumerator EditorAnimations()

--- a/UnityProject/Assets/Scripts/UI/Action/UIAction.cs
+++ b/UnityProject/Assets/Scripts/UI/Action/UIAction.cs
@@ -28,8 +28,12 @@ public class UIAction : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
 			return;
 		}
 
-		IconFront.SetCatalogue(actionData.Sprites,0, NetWork: false);
-		if (actionData.Backgrounds.Count > 0) {
+		if (actionData.Sprites.Count > 0)
+		{
+			IconFront.SetCatalogue(actionData.Sprites, 0, NetWork: false);
+		}
+		if (actionData.Backgrounds.Count > 0)
+		{
 			IconBackground.SetCatalogue(actionData.Backgrounds,0 ,NetWork: false);
 		}
 	}

--- a/UnityProject/Assets/Scripts/UI/Action/UIActionManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Action/UIActionManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using UnityEngine;
@@ -39,7 +39,7 @@ public class UIActionManager : MonoBehaviour
 
 
 	/// <summary>
-	/// Toggle it locally (clientside)
+	/// Set the action button visibility, locally (clientside)
 	/// </summary>
 	public static void ToggleLocal(IActionGUI iActionGUI, bool show)
 	{
@@ -59,7 +59,7 @@ public class UIActionManager : MonoBehaviour
 	}
 
 	/// <summary>
-	/// Toggle with network sync
+	/// Set the action button visibility for the given player, with network sync
 	/// </summary>
 	public static void Toggle(IActionGUI iActionGUI, bool show, GameObject recipient)
 	{
@@ -81,7 +81,6 @@ public class UIActionManager : MonoBehaviour
 		return false;
 	}
 
-
 	public static void SetSprite(IActionGUI iActionGUI, Sprite sprite)
 	{
 		if (Instance.DicIActionGUI.ContainsKey(iActionGUI))
@@ -94,7 +93,21 @@ public class UIActionManager : MonoBehaviour
 		}
 	}
 
-
+	/// <summary>
+	/// Sets the sprite of the action button.
+	/// </summary>
+	public static void SetSpriteSO(IActionGUI iActionGUI, SpriteDataSO sprite, bool networked = true)
+	{
+		if (Instance.DicIActionGUI.ContainsKey(iActionGUI))
+		{
+			var _UIAction = Instance.DicIActionGUI[iActionGUI];
+			_UIAction.IconFront.SetSpriteSO(sprite, Network: networked);
+		}
+		else
+		{
+			Logger.Log("iActionGUI Not present", Category.UI);
+		}
+	}
 
 	public static void SetSprite(IActionGUI iActionGUI, int Location)
 	{

--- a/UnityProject/Assets/Textures/clothing/shoes/MagBoots/MagBootsAdvancedData.asset
+++ b/UnityProject/Assets/Textures/clothing/shoes/MagBoots/MagBootsAdvancedData.asset
@@ -13,12 +13,12 @@ MonoBehaviour:
   m_Name: MagBootsAdvancedData
   m_EditorClassIdentifier: 
   Base:
-    SpriteEquipped: {fileID: 11400000, guid: ebb8dd7a068c7e1418be929d3f2b6381, type: 2}
+    SpriteEquipped: {fileID: 11400000, guid: 49f20cec52040ea40891991196528205, type: 2}
     SpriteInHandsLeft: {fileID: 11400000, guid: 4e0aedacbcc1539469ec0609f1c41ce5,
       type: 2}
     SpriteInHandsRight: {fileID: 11400000, guid: 652954f902db4e34d8147519b1dc0af7,
       type: 2}
-    SpriteItemIcon: {fileID: 11400000, guid: d9ea50e268d3f764b925b51c4284d5a7, type: 2}
+    SpriteItemIcon: {fileID: 11400000, guid: eea9a35b28b06ea449b920a12e16fc9e, type: 2}
     Palette:
     - {r: 0, g: 0, b: 0, a: 0}
     - {r: 0, g: 0, b: 0, a: 0}
@@ -30,10 +30,10 @@ MonoBehaviour:
     - {r: 0, g: 0, b: 0, a: 0}
     IsPaletted: 0
   Base_Adjusted:
-    SpriteEquipped: {fileID: 11400000, guid: e4d4bbda761a7944b9df38c829a38274, type: 2}
+    SpriteEquipped: {fileID: 11400000, guid: 11098cd312720df4aa1760416bc3adfd, type: 2}
     SpriteInHandsLeft: {fileID: 0}
     SpriteInHandsRight: {fileID: 0}
-    SpriteItemIcon: {fileID: 11400000, guid: a9bdfe7a2308aaf409338ecbbb604838, type: 2}
+    SpriteItemIcon: {fileID: 11400000, guid: a40424dd0653f68468f809c79cf8c095, type: 2}
     Palette:
     - {r: 0, g: 0, b: 0, a: 0}
     - {r: 0, g: 0, b: 0, a: 0}

--- a/UnityProject/Assets/Textures/clothing/shoes/MagBoots/MagBootsData.asset
+++ b/UnityProject/Assets/Textures/clothing/shoes/MagBoots/MagBootsData.asset
@@ -31,8 +31,10 @@ MonoBehaviour:
     IsPaletted: 0
   Base_Adjusted:
     SpriteEquipped: {fileID: 11400000, guid: b3bbe47aee4f1874f9023b4ea56663d7, type: 2}
-    SpriteInHandsLeft: {fileID: 0}
-    SpriteInHandsRight: {fileID: 0}
+    SpriteInHandsLeft: {fileID: 11400000, guid: 2cf212a811f9b2a4fbdc8ed218497618,
+      type: 2}
+    SpriteInHandsRight: {fileID: 11400000, guid: 0e372fc0180f03f4da271acee31591fd,
+      type: 2}
     SpriteItemIcon: {fileID: 11400000, guid: 178404daa0d55514f90c2cb30bacd44e, type: 2}
     Palette:
     - {r: 0, g: 0, b: 0, a: 0}

--- a/UnityProject/Assets/Textures/clothing/shoes/MagBoots/MagBootsSyndicateData.asset
+++ b/UnityProject/Assets/Textures/clothing/shoes/MagBoots/MagBootsSyndicateData.asset
@@ -13,35 +13,6 @@ MonoBehaviour:
   m_Name: MagBootsSyndicateData
   m_EditorClassIdentifier: 
   Base:
-    Equipped:
-      Texture: {fileID: 2800000, guid: 8831362a0695c54468d3680be77d9c31, type: 3}
-      Sprites:
-      - {fileID: 21300000, guid: 8831362a0695c54468d3680be77d9c31, type: 3}
-      - {fileID: 21300002, guid: 8831362a0695c54468d3680be77d9c31, type: 3}
-      - {fileID: 21300004, guid: 8831362a0695c54468d3680be77d9c31, type: 3}
-      - {fileID: 21300006, guid: 8831362a0695c54468d3680be77d9c31, type: 3}
-      EquippedData: {fileID: 4900000, guid: 68c3548f761d9a74c84c6d08af7c849c, type: 3}
-    InHandsLeft:
-      Texture: {fileID: 2800000, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      Sprites:
-      - {fileID: -5817153989918580940, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      - {fileID: 5357307529486282379, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      - {fileID: 4832873261703664317, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      - {fileID: -5615777089997092489, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      EquippedData: {fileID: 4900000, guid: f6af00a610ec5664f83feeb67b41bb0a, type: 3}
-    InHandsRight:
-      Texture: {fileID: 2800000, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      Sprites:
-      - {fileID: -8695199725890209218, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      - {fileID: 5447486932713673051, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      - {fileID: -533869239110968400, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      - {fileID: -5498656428679322037, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      EquippedData: {fileID: 4900000, guid: 8dc9897013b6aa64c9832f0bb1baf955, type: 3}
-    ItemIcon:
-      Texture: {fileID: 2800000, guid: b5273e1a9b09da04b96fe9877f83de82, type: 3}
-      Sprites:
-      - {fileID: 21300000, guid: b5273e1a9b09da04b96fe9877f83de82, type: 3}
-      EquippedData: {fileID: 0}
     SpriteEquipped: {fileID: 11400000, guid: ebb8dd7a068c7e1418be929d3f2b6381, type: 2}
     SpriteInHandsLeft: {fileID: 11400000, guid: 4e0aedacbcc1539469ec0609f1c41ce5,
       type: 2}
@@ -59,139 +30,17 @@ MonoBehaviour:
     - {r: 0, g: 0, b: 0, a: 0}
     IsPaletted: 0
   Base_Adjusted:
-    Equipped:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
-    InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
-    InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
-    ItemIcon:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
-    SpriteEquipped: {fileID: 0}
-    SpriteInHandsLeft: {fileID: 0}
-    SpriteInHandsRight: {fileID: 0}
-    SpriteItemIcon: {fileID: 0}
-    Palette:
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    IsPaletted: 0
-  DressVariant:
-    Equipped:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
-    InHandsLeft:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
-    InHandsRight:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
-    ItemIcon:
-      Texture: {fileID: 0}
-      Sprites: []
-      EquippedData: {fileID: 0}
-    SpriteEquipped: {fileID: 0}
-    SpriteInHandsLeft: {fileID: 0}
-    SpriteInHandsRight: {fileID: 0}
-    SpriteItemIcon: {fileID: 0}
-    Palette:
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    - {r: 0, g: 0, b: 0, a: 0}
-    IsPaletted: 0
-  Variants:
-  - Equipped:
-      Texture: {fileID: 2800000, guid: 8831362a0695c54468d3680be77d9c31, type: 3}
-      Sprites:
-      - {fileID: 21300000, guid: 8831362a0695c54468d3680be77d9c31, type: 3}
-      - {fileID: 21300002, guid: 8831362a0695c54468d3680be77d9c31, type: 3}
-      - {fileID: 21300004, guid: 8831362a0695c54468d3680be77d9c31, type: 3}
-      - {fileID: 21300006, guid: 8831362a0695c54468d3680be77d9c31, type: 3}
-      EquippedData: {fileID: 4900000, guid: 68c3548f761d9a74c84c6d08af7c849c, type: 3}
-    InHandsLeft:
-      Texture: {fileID: 2800000, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      Sprites:
-      - {fileID: -5817153989918580940, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      - {fileID: 5357307529486282379, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      - {fileID: 4832873261703664317, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      - {fileID: -5615777089997092489, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      EquippedData: {fileID: 4900000, guid: f6af00a610ec5664f83feeb67b41bb0a, type: 3}
-    InHandsRight:
-      Texture: {fileID: 2800000, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      Sprites:
-      - {fileID: -8695199725890209218, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      - {fileID: 5447486932713673051, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      - {fileID: -533869239110968400, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      - {fileID: -5498656428679322037, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      EquippedData: {fileID: 4900000, guid: 8dc9897013b6aa64c9832f0bb1baf955, type: 3}
-    ItemIcon:
-      Texture: {fileID: 2800000, guid: b5273e1a9b09da04b96fe9877f83de82, type: 3}
-      Sprites:
-      - {fileID: 21300000, guid: b5273e1a9b09da04b96fe9877f83de82, type: 3}
-      EquippedData: {fileID: 0}
-    SpriteEquipped: {fileID: 11400000, guid: ebb8dd7a068c7e1418be929d3f2b6381, type: 2}
-    SpriteInHandsLeft: {fileID: 11400000, guid: 4e0aedacbcc1539469ec0609f1c41ce5,
-      type: 2}
-    SpriteInHandsRight: {fileID: 11400000, guid: 652954f902db4e34d8147519b1dc0af7,
-      type: 2}
-    SpriteItemIcon: {fileID: 11400000, guid: d9ea50e268d3f764b925b51c4284d5a7, type: 2}
-    Palette: []
-    IsPaletted: 0
-  - Equipped:
-      Texture: {fileID: 2800000, guid: 73ab3e52cfba5fd4cae5069767190cac, type: 3}
-      Sprites:
-      - {fileID: 21300000, guid: 73ab3e52cfba5fd4cae5069767190cac, type: 3}
-      - {fileID: 21300002, guid: 73ab3e52cfba5fd4cae5069767190cac, type: 3}
-      - {fileID: 21300004, guid: 73ab3e52cfba5fd4cae5069767190cac, type: 3}
-      - {fileID: 21300006, guid: 73ab3e52cfba5fd4cae5069767190cac, type: 3}
-      EquippedData: {fileID: 4900000, guid: 4ea9acacb882a4d439b42c57503383da, type: 3}
-    InHandsLeft:
-      Texture: {fileID: 2800000, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      Sprites:
-      - {fileID: -5817153989918580940, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      - {fileID: 5357307529486282379, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      - {fileID: 4832873261703664317, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      - {fileID: -5615777089997092489, guid: 2a4ed28ece05c7e47b75b237247d0323, type: 3}
-      EquippedData: {fileID: 4900000, guid: f6af00a610ec5664f83feeb67b41bb0a, type: 3}
-    InHandsRight:
-      Texture: {fileID: 2800000, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      Sprites:
-      - {fileID: -8695199725890209218, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      - {fileID: 5447486932713673051, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      - {fileID: -533869239110968400, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      - {fileID: -5498656428679322037, guid: f36b28fdbba3655408414a2ae9e174fb, type: 3}
-      EquippedData: {fileID: 4900000, guid: 8dc9897013b6aa64c9832f0bb1baf955, type: 3}
-    ItemIcon:
-      Texture: {fileID: 2800000, guid: 7052a2badb26047458afe3961f54863b, type: 3}
-      Sprites:
-      - {fileID: 21300000, guid: 7052a2badb26047458afe3961f54863b, type: 3}
-      EquippedData: {fileID: 0}
     SpriteEquipped: {fileID: 11400000, guid: e4d4bbda761a7944b9df38c829a38274, type: 2}
-    SpriteInHandsLeft: {fileID: 11400000, guid: 4e0aedacbcc1539469ec0609f1c41ce5,
-      type: 2}
-    SpriteInHandsRight: {fileID: 11400000, guid: 652954f902db4e34d8147519b1dc0af7,
-      type: 2}
+    SpriteInHandsLeft: {fileID: 0}
+    SpriteInHandsRight: {fileID: 0}
     SpriteItemIcon: {fileID: 11400000, guid: a9bdfe7a2308aaf409338ecbbb604838, type: 2}
-    Palette: []
+    Palette:
+    - {r: 0, g: 0, b: 0, a: 0}
+    - {r: 0, g: 0, b: 0, a: 0}
+    - {r: 0, g: 0, b: 0, a: 0}
+    - {r: 0, g: 0, b: 0, a: 0}
+    - {r: 0, g: 0, b: 0, a: 0}
+    - {r: 0, g: 0, b: 0, a: 0}
+    - {r: 0, g: 0, b: 0, a: 0}
+    - {r: 0, g: 0, b: 0, a: 0}
     IsPaletted: 0


### PR DESCRIPTION
- Adds an action button for flashlights and all its derivatives (hardhats, helmets, etc.). Fixes #4993.
![action buttons](https://user-images.githubusercontent.com/6926225/93016615-b3887780-f616-11ea-8097-181fa5f07b21.gif)
- `SpriteHandler` now has methods for getting `SpriteSO`s, and action button sprites can now be set with a `SpriteSO`.
- Fixes magboots not having the correct worn sprites, icon sprite states incorrect and action button not toggling sprite state.
- Fixes PDA light action button.
- Fixes assistant spawning with an extra headset instead of a PDA.
- Fixes PDAs spawning in pockets when they could have spawned on belt slots.
- Fixes PDA compiler warning.

> Note: tested on headless. Looks like action button sprite state isn't being set properly. Cosmetic only.
> All tests pass locally.

