### PR TITLE
Stops Ghostchat Being Repeated & Fixes "Chat" Logger Messages

### DIFF
--- a/UnityProject/Assets/Scripts/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Chat/Chat.cs
@@ -68,7 +68,6 @@ public partial class Chat : MonoBehaviour
 			discordMessage += $"[{channel}] ";
 		}
 
-		Instance.addChatLogServer.Invoke(chatEvent);
 		discordMessage += $"\n```css\n{chatEvent.speaker}: {chatEvent.message}\n```\n";
 
 		//Sends All Chat messages to a discord webhook

--- a/UnityProject/Assets/Scripts/Messages/Server/ServerMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/ServerMessage.cs
@@ -35,7 +35,7 @@ public abstract class ServerMessage : GameMessageBase
 		Logger.LogTraceFormat("SentToAllExcept {1}: {0}", Category.NetMessage, this, excluded.name);
 	}
 
-	public void SendTo(GameObject recipient)
+	public virtual void SendTo(GameObject recipient)
 	{
 		if (recipient == null)
 		{

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateChatMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateChatMessage.cs
@@ -53,4 +53,33 @@ public class UpdateChatMessage : ServerMessage
 		msg.SendTo(recipient);
 		return msg;
 	}
+
+	public override void SendTo(GameObject recipient)
+	{
+		if (recipient == null)
+		{
+			return;
+		}
+
+		NetworkConnection connection = recipient.GetComponent<NetworkIdentity>().connectionToClient;
+
+		if (connection == null)
+		{
+			return;
+		}
+
+		//			only send to players that are currently controlled by a client
+		if (PlayerList.Instance.ContainsConnection(connection))
+		{
+			connection.Send(this, 0);
+			Logger.LogTraceFormat("SentTo {0}: {1}", Category.Chat, recipient.name, this);
+		}
+		else
+		{
+			Logger.LogTraceFormat("Not sending message {0} to {1}", Category.Chat, this, recipient.name);
+		}
+
+		//Obsolete version:
+		//NetworkServer.SendToClientOfPlayer(recipient, GetMessageType(), this);
+	}
 }


### PR DESCRIPTION
Fixes #5108 

Added override to UpdateChatMessage that separates chat messages from netmessages in the logger.
Removed duplicate call to "addChatLogServer" that fixes issue #5108 (and maybe some unknown chat duplicate scenarios we don't know of?)