### PR TITLE
Fixes #5132 and makes Atmos pressure and temperature functions more readable and intuitive at a glance

### DIFF
--- a/UnityProject/Assets/Scripts/FluidPipe/PipeFunctions.cs
+++ b/UnityProject/Assets/Scripts/FluidPipe/PipeFunctions.cs
@@ -312,7 +312,7 @@ namespace Pipes
 
 				var Temperature = (value / WholeHeatCapacity);
 				Mix.Temperature = Temperature;
-				gasMix.Temperature = Temperature;
+				gasMix.SetTemperature(Temperature);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
@@ -160,7 +160,7 @@ namespace Atmospherics
 					meanGasMix.Gases[j] += node.GasMix.Gases[j];
 				}
 
-				meanGasMix.Pressure += node.GasMix.Pressure;
+				meanGasMix.SetPressure(meanGasMix.Pressure + node.GasMix.Pressure);
 
 				if (!node.IsOccupied)
 				{
@@ -182,7 +182,7 @@ namespace Atmospherics
 					meanGasMix.Gases[j] /= targetCount;
 				}
 
-				meanGasMix.Pressure /= targetCount;
+				meanGasMix.SetPressure(meanGasMix.Pressure / targetCount);
 			}
 
 			return meanGasMix;
@@ -196,7 +196,7 @@ namespace Atmospherics
 				atmos.Gases[i] = gasMix.Gases[i];
 			}
 
-			atmos.Pressure = gasMix.Pressure;
+			atmos.SetPressure(gasMix.Pressure);
 
 			return atmos;
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Gas.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Gas.cs
@@ -12,7 +12,7 @@ namespace Atmospherics
 		public static readonly Gas Plasma = new Gas("Plasma", 200, 40f, true, 0.4f, "PlasmaAir", -4, 0);
 		public static readonly Gas Oxygen = new Gas("Oxygen", 20, 31.9988f, false, 0.4f, "NONE", -3, 0);
 		public static readonly Gas Nitrogen = new Gas("Nitrogen", 20, 28.0134f, false, 0.4f, "NONE", -3, 0);
-		public static readonly Gas CarbonDioxide = new Gas("Carbon Dioxide", 30, 44.01f, false, 0.4f, "NONE", -3, 0);
+		public static readonly Gas CarbonDioxide = new Gas("Carbon Dioxide", 20, 44.01f, false, 0.4f, "NONE", -3, 0);
 
 		public static readonly Gas NitrousOxide = new Gas("Nitrous Oxide", 40, 44.01f, true, 0.4f, "NO2", -5, 10);
 		public static readonly Gas Hydrogen = new Gas("Hydrogen", 30, 44.01f, false, 0.4f, "NONE", -3, 0);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Gas.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Gas.cs
@@ -12,7 +12,7 @@ namespace Atmospherics
 		public static readonly Gas Plasma = new Gas("Plasma", 200, 40f, true, 0.4f, "PlasmaAir", -4, 0);
 		public static readonly Gas Oxygen = new Gas("Oxygen", 20, 31.9988f, false, 0.4f, "NONE", -3, 0);
 		public static readonly Gas Nitrogen = new Gas("Nitrogen", 20, 28.0134f, false, 0.4f, "NONE", -3, 0);
-		public static readonly Gas CarbonDioxide = new Gas("Carbon Dioxide", 20, 44.01f, false, 0.4f, "NONE", -3, 0);
+		public static readonly Gas CarbonDioxide = new Gas("Carbon Dioxide", 30, 44.01f, false, 0.4f, "NONE", -3, 0);
 
 		public static readonly Gas NitrousOxide = new Gas("Nitrous Oxide", 40, 44.01f, true, 0.4f, "NO2", -5, 10);
 		public static readonly Gas Hydrogen = new Gas("Hydrogen", 30, 44.01f, false, 0.4f, "NONE", -3, 0);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/BZFormation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/BZFormation.cs
@@ -36,7 +36,7 @@ namespace Atmospherics
 			gasMix.RemoveGas(Gas.NitrousOxide, reactionEfficiency);
 			gasMix.RemoveGas(Gas.Plasma, 2 * reactionEfficiency);
 
-			gasMix.Temperature = Mathf.Max((gasMix.Temperature * oldHeatCap + energyReleased)/gasMix.WholeHeatCapacity, 2.7f);
+			gasMix.SetTemperature(Mathf.Max((gasMix.Temperature * oldHeatCap + energyReleased)/gasMix.WholeHeatCapacity, 2.7f));
 
 			return 0f;
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/FreonFireReaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/FreonFireReaction.cs
@@ -66,7 +66,7 @@ namespace Atmospherics
 				var newHeatCap = gasMix.WholeHeatCapacity;
 				if (newHeatCap > 0.0003f)
 				{
-					gasMix.Temperature = (gasMix.Temperature * oldHeatCap + energyReleased) / newHeatCap;
+					gasMix.SetTemperature((gasMix.Temperature * oldHeatCap + energyReleased) / newHeatCap);
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/FreonFormation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/FreonFormation.cs
@@ -33,7 +33,7 @@ namespace Atmospherics
 
 			if (energyUsed > 0)
 			{
-				gasMix.Temperature = Mathf.Max((gasMix.Temperature * oldHeatCap - energyUsed)/gasMix.WholeHeatCapacity, 2.7f);
+				gasMix.SetTemperature(Mathf.Max((gasMix.Temperature * oldHeatCap - energyUsed)/gasMix.WholeHeatCapacity, 2.7f));
 			}
 
 			return 0f;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/FusionReaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/FusionReaction.cs
@@ -84,7 +84,7 @@ namespace Atmospherics
 				var newHeatCap = gasMix.WholeHeatCapacity;
 				if (newHeatCap > 0.0003f && (gasMix.Temperature <= AtmosDefines.FUSION_MAXIMUM_TEMPERATURE || reactionEnergy <= 0))
 				{
-					gasMix.Temperature = Mathf.Clamp(((gasMix.Temperature * oldHeatCap + reactionEnergy) / newHeatCap), 2.7f, Single.PositiveInfinity);
+					gasMix.SetTemperature(Mathf.Clamp(((gasMix.Temperature * oldHeatCap + reactionEnergy) / newHeatCap), 2.7f, Single.PositiveInfinity));
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/HyperNobliumFormation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/HyperNobliumFormation.cs
@@ -30,7 +30,7 @@ namespace Atmospherics
 
 			gasMix.AddGas(Gas.HyperNoblium, reactionEfficiency);
 
-			gasMix.Temperature = Mathf.Max((gasMix.Temperature * oldHeatCap - energyUsed)/gasMix.WholeHeatCapacity, 2.7f);
+			gasMix.SetTemperature(Mathf.Max((gasMix.Temperature * oldHeatCap - energyUsed)/gasMix.WholeHeatCapacity, 2.7f));
 
 			return 0f;
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/MiasmaDecomposition.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/MiasmaDecomposition.cs
@@ -25,7 +25,7 @@ namespace Atmospherics
 
 			gasMix.AddGas(Gas.Oxygen, cleanedAir);
 
-			gasMix.Temperature += cleanedAir * 0.002f;
+			gasMix.SetTemperature(gasMix.Temperature + cleanedAir * 0.002f);
 
 			return 0f;
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/NO2Decomposition.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/NO2Decomposition.cs
@@ -30,7 +30,7 @@ namespace Atmospherics
 				var newHeatCap = gasMix.WholeHeatCapacity;
 				if (newHeatCap > 0.0003f)
 				{
-					gasMix.Temperature = (gasMix.Temperature + energyReleased) / newHeatCap;
+					gasMix.SetTemperature((gasMix.Temperature + energyReleased) / newHeatCap);
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/NO2Formation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/NO2Formation.cs
@@ -38,7 +38,7 @@ namespace Atmospherics
 
 			if (energyUsed > 0)
 			{
-				gasMix.Temperature = Mathf.Max((gasMix.Temperature * oldHeatCap - energyUsed)/gasMix.WholeHeatCapacity, 2.7f);
+				gasMix.SetTemperature(Mathf.Max((gasMix.Temperature * oldHeatCap - energyUsed)/gasMix.WholeHeatCapacity, 2.7f));
 			}
 
 			return 0f;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/NitrylFormation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/NitrylFormation.cs
@@ -34,7 +34,7 @@ namespace Atmospherics
 
 			if (energyUsed > 0)
 			{
-				gasMix.Temperature = Mathf.Max((gasMix.Temperature * oldHeatCap - energyUsed)/gasMix.WholeHeatCapacity, 2.7f);
+				gasMix.SetTemperature(Mathf.Max((gasMix.Temperature * oldHeatCap - energyUsed)/gasMix.WholeHeatCapacity, 2.7f));
 			}
 
 			return 0f;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/PlasmaFireReaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/PlasmaFireReaction.cs
@@ -69,7 +69,7 @@ namespace Atmospherics
 				}
 
 				float heatCapacity = gasMix.WholeHeatCapacity;
-				gasMix.Temperature = (temperature * heatCapacity + (Reactions.EnergyPerMole * TotalmolestoCO2)) / gasMix.WholeHeatCapacity;
+				gasMix.SetTemperature((temperature * heatCapacity + (Reactions.EnergyPerMole * TotalmolestoCO2)) / gasMix.WholeHeatCapacity);
 				consumed = TotalmolestoCO2;
 			}
 			return (consumed);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/StimBallReaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/StimBallReaction.cs
@@ -34,7 +34,7 @@ namespace Atmospherics
 			gasMix.RemoveGas(Gas.Pluoxium, 10 * pluoxUsed);
 			gasMix.RemoveGas(Gas.Stimulum, 20 * stimUsed);
 
-			gasMix.Temperature = Mathf.Clamp((gasMix.Temperature * oldHeatCap + energyReleased)/gasMix.WholeHeatCapacity, 2.7f, Single.PositiveInfinity);
+			gasMix.SetTemperature(Mathf.Clamp((gasMix.Temperature * oldHeatCap + energyReleased)/gasMix.WholeHeatCapacity, 2.7f, Single.PositiveInfinity));
 
 			return 0f;
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/StimulumFormation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/StimulumFormation.cs
@@ -34,7 +34,7 @@ namespace Atmospherics
 			gasMix.RemoveGas(Gas.Plasma, heatScale);
 			gasMix.RemoveGas(Gas.Nitryl,  heatScale);
 
-			gasMix.Temperature = Mathf.Max((gasMix.Temperature * oldHeatCap + stimEnergyChange)/gasMix.WholeHeatCapacity, 2.7f);
+			gasMix.SetTemperature(Mathf.Max((gasMix.Temperature * oldHeatCap + stimEnergyChange)/gasMix.WholeHeatCapacity, 2.7f));
 
 			return 0f;
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/TritiumFireReaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/TritiumFireReaction.cs
@@ -50,7 +50,7 @@ namespace Atmospherics
 				var newHeatCap = gasMix.WholeHeatCapacity;
 				if (newHeatCap > 0.0003f)
 				{
-					gasMix.Temperature = (gasMix.Temperature * oldHeatCap + energyReleased) / newHeatCap;
+					gasMix.SetTemperature((gasMix.Temperature * oldHeatCap + energyReleased) / newHeatCap);
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Hotspot.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Hotspot.cs
@@ -71,7 +71,7 @@ namespace Atmospherics
 			else
 			{
 				GasMix removed = node.GasMix.RemoveVolume(Volume);
-				removed.Temperature = Temperature;
+				removed.SetTemperature(Temperature);
 				float consumed = Reactions.React(ref removed);
 				Volume = consumed * 40;
 				Temperature = removed.Temperature;


### PR DESCRIPTION
Modified Accessors for Temperature and Pressure to allow proper setting of Temperature based on Pressure or vice versa without having an infinite loop. Replaced the setter call in other files as needed.

Simplified GasMix functions and procedures for better readability and easier understanding of functions at a glance.

Fixes #5132 - CO2 and O2 now have constant pressure and temperature on exchange.