### PR TITLE
New minor antag: Fugitives

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/GameManager.prefab
@@ -70,7 +70,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameManager: {fileID: 5243784332070655206}
-  CommandStatusString: 
-  EscapeShuttleTimeString: 
+  paperPrefab: {fileID: 8734328976324889014, guid: d3c71176f32c1274b929f3a88695a795,
+    type: 3}
   CurrentAlertLevel: 1
   coolDownAlertChange: 5

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/AntagData.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/AntagData.asset
@@ -16,6 +16,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6eb4b2c2fcd1e8f4bba13a622f480144, type: 2}
   - {fileID: 11400000, guid: 4bc36e6d8aa946c4081073eabc2472eb, type: 2}
   - {fileID: 11400000, guid: c060c33698c0f81449f0735a800740ca, type: 2}
+  - {fileID: 11400000, guid: 8e452e9949d197548ad09c2b68d7d879, type: 2}
   SharedObjectives:
   - {fileID: 11400000, guid: 180a8d8c464973b4ebcf1d9778e8b895, type: 2}
   - {fileID: 11400000, guid: 62560f1cff23ba84b9fe8e661f199730, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Antags/Cargonian.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Antags/Cargonian.asset
@@ -14,6 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   antagName: Rebel
   antagJobType: 49
+  playSound: 0
   spawnSound: Notice1
   textColor: {r: 1, g: 0, b: 0, a: 1}
   backgroundColor: {r: 0.54901963, g: 0, b: 0, a: 0.19607843}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Antags/Fugitive.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Antags/Fugitive.asset
@@ -1,0 +1,55 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3397c9ff83bb41259c6baa2752d0f57e, type: 3}
+  m_Name: Fugitive
+  m_EditorClassIdentifier: 
+  antagName: Fugitive
+  antagJobType: 50
+  playSound: 0
+  spawnSound: Notice1
+  textColor: {r: 1, g: 0.3909036, b: 0, a: 1}
+  backgroundColor: {r: 0, g: 0, b: 0, a: 0.19607843}
+  numberOfObjectives: 1
+  canUseSharedObjectives: 0
+  needsEscapeObjective: 1
+  coreObjectives:
+  - {fileID: 11400000, guid: 748ac891cd195d145b7386127b0de87b, type: 2}
+  antagOccupation: {fileID: 11400000, guid: 664fc7dd82e0d0f4aadd3a166f9bdb23, type: 2}
+  showInPreferences: 1
+  timeToSendWarning: {x: 5, y: 15}
+  warnMessage: 'We have reliable information to think there is a dangerous fugitive
+    from SuperJail in your station.
+
+    It is your duty to capture and bring them
+    to Centcom or neutralize the threat as soon as possible!
+
+
+    Prisoner number:
+    {1}.
+
+    Prisoner name: {0}.
+
+    Category: EXTREMELY DANGEROUS.
+
+
+    <color=blue><size=32>New
+    Station Objectives:</size></color>
+
+    <size=24>- Find the fugitive
+
+
+    -
+    Arrest the fugitive and bring them to Centcom when the escape shuttle is called
+
+
+    -
+    If the fugitive is threatening the station production, neutralize immediately.</size>'

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Antags/Fugitive.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Antags/Fugitive.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e452e9949d197548ad09c2b68d7d879
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Objectives/Not Cuffed.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Objectives/Not Cuffed.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b94cdf0047c9440b905e4a53bc9fe704, type: 3}
+  m_Name: Not Cuffed
+  m_EditorClassIdentifier: 
+  objectiveName: Don't get arrested
+  IsUnique: 1
+  description: Get to the end free as a bird.

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Objectives/Not Cuffed.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Objectives/Not Cuffed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 748ac891cd195d145b7386127b0de87b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/GameModes/Traitor.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/GameModes/Traitor.asset
@@ -25,4 +25,5 @@ MonoBehaviour:
   allocateJobsToAntags: 1
   possibleAntags:
   - {fileID: 11400000, guid: c060c33698c0f81449f0735a800740ca, type: 2}
+  - {fileID: 11400000, guid: 8e452e9949d197548ad09c2b68d7d879, type: 2}
   nonAntagJobTypes: 060000001600000017000000230000002100000011000000

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/FugitivePopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/FugitivePopulator.asset
@@ -1,0 +1,44 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0e76afb59ec4485caa0a5cc0f2d142e9, type: 3}
+  m_Name: FugitivePopulator
+  m_EditorClassIdentifier: 
+  Entries:
+  - NamedSlot: 3
+    Prefab: {fileID: 7106618204054676533, guid: aa1e5a44ff182415dac90bed74ef8bfa,
+      type: 3}
+  - NamedSlot: 6
+    Prefab: {fileID: 3011710637427380133, guid: f1436853dd14162fe97690f8e7714773,
+      type: 3}
+  - NamedSlot: 12
+    Prefab: {fileID: 0}
+  - NamedSlot: 5
+    Prefab: {fileID: 0}
+  - NamedSlot: 8
+    Prefab: {fileID: 7331803544451838430, guid: d554409601a0f744090f24e47955cb9a,
+      type: 3}
+  - NamedSlot: 0
+    Prefab: {fileID: 0}
+  - NamedSlot: 2
+    Prefab: {fileID: 0}
+  - NamedSlot: 10
+    Prefab: {fileID: 0}
+  - NamedSlot: 9
+    Prefab: {fileID: 0}
+  - NamedSlot: 1
+    Prefab: {fileID: 0}
+  - NamedSlot: 15
+    Prefab: {fileID: 0}
+  skirtVariant: {fileID: 4192430521890778298, guid: d3b0186c86ba4f44d8cf26cb50345ae4,
+    type: 3}
+  duffelVariant: {fileID: 0}
+  satchelVariant: {fileID: 0}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/FugitivePopulator.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/FugitivePopulator.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc124411c427acc43b9f28182ce2b9a9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Occupations/Fugitive.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Occupations/Fugitive.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c58d5c5a6190436e9d4ae8e32a26ee6a, type: 3}
+  m_Name: Fugitive
+  m_EditorClassIdentifier: 
+  jobType: 50
+  inventoryPopulator: {fileID: 11400000, guid: dc124411c427acc43b9f28182ce2b9a9, type: 2}
+  limit: 2
+  priority: 0
+  allowedAccess: 
+  spells: []
+  progress: 50
+  choiceColor: {r: 1, g: 0.49574816, b: 0, a: 1}
+  previewSprite: {fileID: 0}
+  displayName: 
+  difficulty: 4
+  descriptionShort: 
+  descriptionLong: 
+  customProperties:
+    m_keys: []
+    m_values: 
+  isTargeteable: 0

--- a/UnityProject/Assets/Resources/ScriptableObjects/Occupations/Fugitive.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Occupations/Fugitive.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 664fc7dd82e0d0f4aadd3a166f9bdb23
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Antagonists/Antags/Fugitive.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/Fugitive.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading.Tasks;
+using NaughtyAttributes;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+namespace Antagonists
+{
+	[CreateAssetMenu(menuName="ScriptableObjects/Antagonist/Fugitive")]
+	public class Fugitive: Antagonist
+	{
+		[SerializeField]
+		[Tooltip("Min and max time in minutes it takes for Centcom to send a warning to the station about this fugitive." +
+		         "The real time will be a random time from the min to max values.")]
+		private Vector2 timeToSendWarning = default;
+
+		[SerializeField][TextArea(3, 10)]
+		[Tooltip("The warning message that will be printed to command when Centcom alerts about this fugitive" +
+		         "{0} will be changed on runtime to the real name of the fugitive." +
+		         "{1} is just a random number to give some flavor.")]
+		private string warnMessage = "We have reliable information to think there is a dangerous fugitive " +
+		                             "from SuperJail in your station.\n" +
+		                             "It is your duty to capture and bring them to Centcom or neutralize the threat " +
+		                             "as soon as possible!\n\n" +
+		                             "Prisoner number: {1}.\n" +
+		                             "Prisoner name: {0}.\n" +
+		                             "Category: EXTREMELY DANGEROUS.\n\n" +
+		                             "<color=blue><size=32>New Station Objectives:</size></color>\n\n" +
+		                             "<size=24>- Find the fugitive\n\n" +
+		                             "- Arrest the fugitive and bring them to Centcom " +
+		                             "when the escape shuttle is called\n\n" +
+		                             "- If the fugitive is threatening the station production, neutralize immediately." +
+		                             "</size>";
+
+		private async Task StationWarning(string fugitiveName)
+		{
+			await Task.Delay(TimeSpan.FromMinutes(Random.Range(timeToSendWarning.x, timeToSendWarning.y)));
+			int fugitiveNumber = Random.Range(1111, 9999);
+			warnMessage = string.Format(warnMessage, fugitiveName, fugitiveNumber);
+
+			GameManager.Instance.CentComm.MakeCommandReport(warnMessage, CentComm.UpdateSound.notice);
+		}
+
+		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
+		{
+			var newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest.JoinedViewer, AntagOccupation,
+				spawnRequest.CharacterSettings);
+
+			UpdateChatMessage.Send(newPlayer, ChatChannel.Local, ChatModifier.Whisper,
+				"I can't believe we managed to break out of a Nanotrasen superjail! Sadly though," +
+				" our work is not done. The emergency teleport at the station logs everyone who uses it," +
+				" and where they went. It won't be long until Centcom tracks where we've gone off to." +
+				" I need to move in the shadows and keep out of sight," +
+				" I'm not going back.");
+
+			_ = StationWarning(newPlayer.ExpensiveName());
+
+			return newPlayer;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Antagonists/Antags/Fugitive.cs.meta
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/Fugitive.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3397c9ff83bb41259c6baa2752d0f57e
+timeCreated: 1600288970

--- a/UnityProject/Assets/Scripts/Antagonists/Antags/NuclearOperative.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Antags/NuclearOperative.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Antagonists

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/NotCuffed.cs
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/NotCuffed.cs
@@ -1,0 +1,26 @@
+﻿using UnityEngine;
+
+namespace Antagonists
+{
+	/// <summary>
+	/// Try to be alive and not under arrest at the end of the round.
+	/// </summary>
+	[CreateAssetMenu(menuName="ScriptableObjects/Objectives/NotCuffed")]
+	public class NotCuffed: Objective
+	{
+		protected override void Setup() {}
+
+		protected override bool CheckCompletion()
+		{
+			ItemStorage itemStorage = Owner.body.GetComponent<ItemStorage>();
+
+			//for whatever reason this is null, give the guy the greentext
+			if (itemStorage == null)
+			{
+				return true;
+			}
+
+			return itemStorage.GetNamedItemSlot(NamedSlot.handcuffs).IsEmpty;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Antagonists/Objectives/NotCuffed.cs.meta
+++ b/UnityProject/Assets/Scripts/Antagonists/Objectives/NotCuffed.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b94cdf0047c9440b905e4a53bc9fe704
+timeCreated: 1600294684

--- a/UnityProject/Assets/Scripts/Managers/CentComm.cs
+++ b/UnityProject/Assets/Scripts/Managers/CentComm.cs
@@ -9,13 +9,16 @@ using Random = UnityEngine.Random;
 ///------------
 /// CENTRAL COMMAND HQ
 ///------------
-public class CentComm : MonoBehaviour, IInitialise
+public class CentComm : MonoBehaviour
 {
 	public GameManager gameManager;
 
+	[SerializeField][Tooltip("Reference to the paper prefab. Needed to send reports.")]
+	private GameObject paperPrefab;
+
 	public StatusDisplayUpdateEvent OnStatusDisplayUpdate = new StatusDisplayUpdateEvent();
-	public string CommandStatusString;
-	public string EscapeShuttleTimeString;
+	[NonSerialized] public string CommandStatusString;
+	[NonSerialized] public string EscapeShuttleTimeString;
 
 	public void UpdateStatusDisplay(StatusDisplayChannel channel, string text)
 	{
@@ -35,20 +38,19 @@ public class CentComm : MonoBehaviour, IInitialise
 	//Server only:
 	private List<Vector2> AsteroidLocations = new List<Vector2>();
 	private int PlasmaOrderRequestAmt;
-	private GameObject paperPrefab;
 	public DateTime lastAlertChange;
 	public double coolDownAlertChange = 5;
 
 	public static string CaptainAnnounceTemplate =
 		"\n\n<color=white><size=60><b>Captain Announces</b></size></color>\n\n"
-	  + "<color=#FF151F><b>{0}</b></color>\n\n";
+		+ "<color=#FF151F><b>{0}</b></color>\n\n";
 
 	public static string CentCommAnnounceTemplate =
 		"\n\n<color=white><size=60><b>Central Command Update</b></size></color>\n\n"
-	  + "<color=#FF151F><b>{0}</b></color>\n\n";
+		+ "<color=#FF151F><b>{0}</b></color>\n\n";
 	public static string PriorityAnnouncementTemplate =
 		"\n\n<color=white><size=60><b>Priority Announcement</b></size></color>\n\n"
-	  + "<color=#FF151F>{0}</color>\n\n";
+		+ "<color=#FF151F>{0}</color>\n\n";
 
 	public static string ShuttleCallSubTemplate =
 		"\n\nThe emergency shuttle has been called. It will arrive in {0} " +
@@ -59,8 +61,8 @@ public class CentComm : MonoBehaviour, IInitialise
 
 	public static string ShuttleRecallSubTemplate =
 		"\n\nThe emergency shuttle has been recalled. " +
-	// Not traced yet, but eventually will:
-	//		+"Recall signal traced. Results can be viewed on any communications console.";
+		// Not traced yet, but eventually will:
+		//		+"Recall signal traced. Results can be viewed on any communications console.";
 		"\n\n{0}";
 
 	public static string CentCommReportTemplate =
@@ -80,11 +82,6 @@ public class CentComm : MonoBehaviour, IInitialise
 		"Enemy communication intercepted. Security level elevated.";
 
 	public InitialisationSystems Subsystem => InitialisationSystems.CentComm;
-
-	void IInitialise.Initialise()
-	{
-		paperPrefab = Resources.Load<GameObject>("Paper");
-	}
 
 
 	private void OnEnable()
@@ -166,15 +163,15 @@ public class CentComm : MonoBehaviour, IInitialise
 	private void SendExtendedUpdate()
 	{
 		MakeAnnouncement(CentCommAnnounceTemplate, string.Format(InitialUpdateTemplate, ExtendedInitialUpdate),
-						UpdateSound.notice);
+			UpdateSound.notice);
 		SpawnReports(StationObjectiveReport());
 	}
 	private void SendAntagUpdate()
 	{
 		SoundManager.PlayNetworked("InterceptMessage");
 		MakeAnnouncement(CentCommAnnounceTemplate,
-						string.Format(InitialUpdateTemplate,AntagInitialUpdate+"\n\n"+AlertLevelStrings[AlertLevelString.UpToBlue]),
-						UpdateSound.alert);
+			string.Format(InitialUpdateTemplate,AntagInitialUpdate+"\n\n"+AlertLevelStrings[AlertLevelString.UpToBlue]),
+			UpdateSound.alert);
 		SpawnReports(StationObjectiveReport());
 		SpawnReports(AntagThreatReport);
 		ChangeAlertLevel(AlertLevel.Blue, false);

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnPoint.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnPoint.cs
@@ -40,6 +40,7 @@ public class SpawnPoint : NetworkStartPosition
 			{JobDepartment.DeathSquad, new [] {JobType.DEATHSQUAD}},
 			{JobDepartment.CentComm, new[] {JobType.CENTCOMM_OFFICER, JobType.CENTCOMM_INTERN}},
 			{JobDepartment.EmergencyResponseTeam, new[] {JobType.ERT_COMMANDER, JobType.ERT_SECURITY, JobType.ERT_MEDIC, JobType.ERT_ENGINEER, JobType.ERT_CHAPLAIN, JobType.ERT_JANITOR, JobType.ERT_CLOWN}},
+			{JobDepartment.MaintSpawns, new[] {JobType.FUGITIVE}}
 		};
 
 	public IEnumerable<JobType> JobRestrictions =>

--- a/UnityProject/Assets/Scripts/Occupations/JobDepartments.cs
+++ b/UnityProject/Assets/Scripts/Occupations/JobDepartments.cs
@@ -37,4 +37,5 @@
 	CentComm,
 	DeathSquad,
 	EmergencyResponseTeam,
+	MaintSpawns
 }

--- a/UnityProject/Assets/Scripts/Occupations/JobType.cs
+++ b/UnityProject/Assets/Scripts/Occupations/JobType.cs
@@ -58,7 +58,9 @@ public enum JobType
 	ERT_JANITOR = 46,
 	ERT_CLOWN = 47,
 	TRAITOR = 48,
-	CARGONIAN = 49
+	CARGONIAN = 49,
+	PRISONER = 50,
+	FUGITIVE = 51
 }
 
 public static class JobCategories

--- a/UnityProject/Assets/Scripts/UI/Animations/Managers.meta
+++ b/UnityProject/Assets/Scripts/UI/Animations/Managers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e52b7ce72d1403ebc13e9acc4b75336
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Standard Assets/DentedPixel/Documentation/assets/css.meta
+++ b/UnityProject/Assets/Standard Assets/DentedPixel/Documentation/assets/css.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e97022d0a6f24a4c8f292418127b17d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Standard Assets/DentedPixel/Documentation/classes.meta
+++ b/UnityProject/Assets/Standard Assets/DentedPixel/Documentation/classes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3cb8db324019fee4a9ede216ab636bb5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Standard Assets/DentedPixel/Documentation/elements.meta
+++ b/UnityProject/Assets/Standard Assets/DentedPixel/Documentation/elements.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 74d4fa7abd57d1c46a118ad64b7562a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Standard Assets/DentedPixel/Editor.meta
+++ b/UnityProject/Assets/Standard Assets/DentedPixel/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d1c5cb23b88019498c612baa3f6d82d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Standard Assets/DentedPixel/Framework.meta
+++ b/UnityProject/Assets/Standard Assets/DentedPixel/Framework.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 42eaeaf4f5a55234788b50c0e85a063c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
> There's nothing more refreshing than freedom, and these fugitives are willing to kill for it.

## Why?
Fugitives are a special antag that can randomly spawn in a traitor round. Their only objective is to get to the end of the round alive and free (not cuffed). They spawn in a special spawn point called MaintSpawns (or arrivals if not mapped) wearing the prisoner jumpsuit, no ID and a handy toolbox to make their way to freedom.

After a random amount of time (5 to 15 minutes by default, might need tweaking), Centcom sends the station a report and ask them to neutralize the threat.

The intention is to diversify a little the rounds with some mechanically simple antags.

## Notes
- Since the antag system doesn't support weighted antags yet, fugitives are just as likely to spawn as normal traitors. If a player doesn't want to spawn as fugitive, they can simply disable the chance in the antag preferences.
- Some maps are just awful for fugitives, like Fall that has no maints and is very small.