### PR TITLE
Power generator examine sheets in storage

### DIFF
--- a/UnityProject/Assets/Scripts/Electricity/PowerSupplies/PowerGenerator.cs
+++ b/UnityProject/Assets/Scripts/Electricity/PowerSupplies/PowerGenerator.cs
@@ -101,8 +101,18 @@ public class PowerGenerator : NetworkBehaviour, ICheckedInteractable<HandApply>,
 
 	public string Examine(Vector3 worldPos = default)
 	{
-		return $"The generator is {(HasFuel() ? "fueled" : "unfueled")} and " +
-				$"{(isOn ? "running" : "not running")}.";
+		var examineText=$"The generator is {(HasFuel() ? "fueled" : "unfueled")} and " +
+								$"{(isOn ? "running" : "not running")}. ";
+		if (itemSlot.Item)
+		{
+			var stackable = itemSlot.Item.GetComponent<Stackable>();
+			examineText += $"There's {stackable.Amount} sheets left in the storage compartment.";
+		}
+		else
+		{
+			examineText += $"There's no more sheets left in the storage compartment.";
+		}
+		return examineText;
 	}
 
 	public bool WillInteract(HandApply interaction, NetworkSide side)


### PR DESCRIPTION
### Purpose
Power generators will now inform the amount of sheets left in storage on examine.
Fixes #5194

