### PR TITLE
Fixes players spawning in subscenes exhibiting space exposure symptoms

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
@@ -135,9 +135,16 @@ public partial class GameManager
 
 		foreach (var job in GameMode.PossibleAntags)
 		{
-			if (job.AntagOccupation != null && job.AntagOccupation.JobType == JobType.SYNDICATE)
+			if (job.AntagOccupation == null) continue;
+
+			// We wait an extra frame after loading each additional scene so that MatrixInfo is ready for player spawning.
+			// If MatrixInfo is not ready, players that spawn in the additional scenes (wizard ship, syndicate base)
+			// will spawn on the wrong matrix and so will exhibit space exposure symptoms.
+
+			if (job.AntagOccupation.JobType == JobType.SYNDICATE)
 			{
 				yield return StartCoroutine(SubSceneManager.Instance.LoadSyndicate());
+				yield return WaitFor.EndOfFrame;
 				break;
 			}
 		}


### PR DESCRIPTION
- Fixes players spawning in additional scenes at roundstart exhibiting space exposure symptoms.
    - This was because additional scenes are loaded at roundstart (as the scenes depend on the gamemode, which is determined at that time) and so `MatrixInfo` was not ready, meaning players were defaulting to the mainstation matrix.