### PR TITLE
Asteroid digging fix

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjects/SpawnableLists/Tiles/DugSand.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/SpawnableLists/Tiles/DugSand.asset
@@ -13,6 +13,6 @@ MonoBehaviour:
   m_Name: DugSand
   m_EditorClassIdentifier: 
   contents:
-  - {fileID: 2351081241306927526, guid: 3d84de77e83e1134ea51dd84d20bc84b, type: 3}
-  - {fileID: 2351081241306927526, guid: 3d84de77e83e1134ea51dd84d20bc84b, type: 3}
-  - {fileID: 2351081241306927526, guid: 3d84de77e83e1134ea51dd84d20bc84b, type: 3}
+  - {fileID: 773312911048126984, guid: 6e4200f349a2e834c93abd60c2264641, type: 3}
+  - {fileID: 773312911048126984, guid: 6e4200f349a2e834c93abd60c2264641, type: 3}
+  - {fileID: 773312911048126984, guid: 6e4200f349a2e834c93abd60c2264641, type: 3}


### PR DESCRIPTION
### Purpose
Fixes #5221
Fixes digging asteroid tiles spawning sand piles stacks instead of sandblocks

