### PR TITLE
Resist out of lockers, break lock and no longer weld self in closet

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/ClosetBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/ClosetBase.prefab
@@ -46,6 +46,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -127,6 +128,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -240,6 +242,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -312,13 +315,16 @@ MonoBehaviour:
   lockLight: {fileID: 0}
   IsLockable: 0
   playerLimit: 3
+  breakoutTime: 120
   matsOnDestroy: {fileID: 5770283965274354279, guid: b83b68cfa4a201748aeeece963a989c3,
     type: 3}
   matsDroppedOnDestroy: 8
   soundOnOpenOrClose: OpenClose
-  soundOnEmag: grillehit
+  soundOnEmag: Grillehit
+  soundOnEscape: Rustle1
   doorOpened: {fileID: 21300000, guid: 64b240e12ad22cb448e547c57af09f62, type: 3}
   spriteRenderer: {fileID: 1122670086388767519}
+  lockOverlay: {fileID: 0}
   isEmagged: 0
   weldOverlay: {fileID: 877469643864734438}
   weldSprite: {fileID: 21300000, guid: d44b675064889f34bb7dbeff3f5e9655, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/Closets/SecureLockers/SecureLockerBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/Closets/SecureLockers/SecureLockerBase.prefab
@@ -60,6 +60,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -156,6 +157,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -233,6 +235,11 @@ PrefabInstance:
       propertyPath: lockLight
       value: 
       objectReference: {fileID: 1288521212679231080}
+    - target: {fileID: -9167103284037124715, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
+        type: 3}
+      propertyPath: lockOverlay
+      value: 
+      objectReference: {fileID: 5016332203342507869}
     - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -462,7 +462,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 		// Is the player trying to put something in the closet?
 		if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag))
 		{
-			if(IsClosed && !isEmagged)
+			if (IsClosed && !isEmagged)
 			{
 				SoundManager.PlayNetworkedAtPos(soundOnEmag, registerTile.WorldPositionServer, 1f, sourceObj: gameObject);
 				ServerHandleContentsOnStatusChange(false);
@@ -476,7 +476,6 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 			// Is the player trying to weld closet?
 			if (IsWeldable && interaction.Intent == Intent.Harm)
 			{
-				//TODO: Need to add an examine msg saying "Its welded shut
 				ToolUtils.ServerUseToolWithActionMessages(
 						interaction, weldTime,
 						$"You start {(IsWelded ? "unwelding" : "welding")} the {closetName} door...",
@@ -496,21 +495,26 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 				Inventory.ServerDrop(interaction.HandSlot, targetPosition - performerPosition);
 			}
 		}
-		else if(interaction.HandObject == null)
+		else if (interaction.HandObject == null)
 		{
 			// player want to close locker?
 			if (!isLocked && !isEmagged && !isWelded)
 			{
 				ServerToggleClosed();
 			}
-			else if(!AccessRestrictions.CheckAccess(interaction.Performer) && (isLocked || isWelded))
+			else if (!AccessRestrictions.CheckAccess(interaction.Performer) && (isLocked || isWelded))
 			{
 				Chat.AddExamineMsg(
 				interaction.Performer,
 				$"Can\'t open {closetName}");
 			}
+			else
+			{
+				//catch for case where there is no performer
+				//TODO: Add closet breakout code here
+			}
 		}
-
+				
 		// player trying to unlock locker?
 		if (IsLockable && AccessRestrictions != null)
 		{

--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -502,16 +502,24 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 			{
 				ServerToggleClosed();
 			}
-			else if (!AccessRestrictions.CheckAccess(interaction.Performer) && (isLocked || isWelded))
+			else if (isLocked || isWelded)
 			{
-				Chat.AddExamineMsg(
-				interaction.Performer,
-				$"Can\'t open {closetName}");
-			}
-			else
-			{
-				//catch for case where there is no performer
-				//TODO: Add closet breakout code here
+				if (IsLockable)
+				{ //This is to stop seeing cant open msg even though you can
+					if (!AccessRestrictions.CheckAccess(interaction.Performer))
+					{
+						Chat.AddExamineMsg(
+						interaction.Performer,
+						$"Can\'t open {closetName}");
+					}
+				}
+				else
+				{
+					Chat.AddExamineMsg(
+					interaction.Performer,
+					$"Can\'t open {closetName}");
+				}
+				
 			}
 		}
 				

--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -601,7 +601,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 			}
 
 			var bar = StandardProgressAction.Create(ProgressConfig, ProgressFinishAction)
-				.ServerStartProgress(target.RegisterTile(), 5f, performer);
+				.ServerStartProgress(target.RegisterTile(), breakoutTime, performer);
 			if (bar != null)
 			{
 				SoundManager.PlayNetworkedAtPos(soundOnEscape, registerTile.WorldPositionServer, 1f, sourceObj: gameObject);

--- a/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Closets/ClosetControl.cs
@@ -462,7 +462,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 		// Is the player trying to put something in the closet?
 		if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag))
 		{
-			if (IsClosed && !isEmagged)
+			if(IsClosed && !isEmagged)
 			{
 				SoundManager.PlayNetworkedAtPos(soundOnEmag, registerTile.WorldPositionServer, 1f, sourceObj: gameObject);
 				ServerHandleContentsOnStatusChange(false);
@@ -476,6 +476,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 			// Is the player trying to weld closet?
 			if (IsWeldable && interaction.Intent == Intent.Harm)
 			{
+				//TODO: Need to add an examine msg saying "Its welded shut
 				ToolUtils.ServerUseToolWithActionMessages(
 						interaction, weldTime,
 						$"You start {(IsWelded ? "unwelding" : "welding")} the {closetName} door...",
@@ -495,26 +496,21 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 				Inventory.ServerDrop(interaction.HandSlot, targetPosition - performerPosition);
 			}
 		}
-		else if (interaction.HandObject == null)
+		else if(interaction.HandObject == null)
 		{
 			// player want to close locker?
 			if (!isLocked && !isEmagged && !isWelded)
 			{
 				ServerToggleClosed();
 			}
-			else if (!AccessRestrictions.CheckAccess(interaction.Performer) && (isLocked || isWelded))
+			else if(!AccessRestrictions.CheckAccess(interaction.Performer) && (isLocked || isWelded))
 			{
 				Chat.AddExamineMsg(
 				interaction.Performer,
 				$"Can\'t open {closetName}");
 			}
-			else
-			{
-				//catch for case where there is no performer
-				//TODO: Add closet breakout code here
-			}
 		}
-				
+
 		// player trying to unlock locker?
 		if (IsLockable && AccessRestrictions != null)
 		{

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -462,7 +462,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 		// Is the player trying to put something in the closet?
 		if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag))
 		{
-			if(IsClosed && !isEmagged)
+			if (IsClosed && !isEmagged)
 			{
 				SoundManager.PlayNetworkedAtPos(soundOnEmag, registerTile.WorldPositionServer, 1f, sourceObj: gameObject);
 				ServerHandleContentsOnStatusChange(false);
@@ -476,7 +476,6 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 			// Is the player trying to weld closet?
 			if (IsWeldable && interaction.Intent == Intent.Harm)
 			{
-				//TODO: Need to add an examine msg saying "Its welded shut
 				ToolUtils.ServerUseToolWithActionMessages(
 						interaction, weldTime,
 						$"You start {(IsWelded ? "unwelding" : "welding")} the {closetName} door...",
@@ -496,21 +495,26 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 				Inventory.ServerDrop(interaction.HandSlot, targetPosition - performerPosition);
 			}
 		}
-		else if(interaction.HandObject == null)
+		else if (interaction.HandObject == null)
 		{
 			// player want to close locker?
 			if (!isLocked && !isEmagged && !isWelded)
 			{
 				ServerToggleClosed();
 			}
-			else if(!AccessRestrictions.CheckAccess(interaction.Performer) && (isLocked || isWelded))
+			else if (!AccessRestrictions.CheckAccess(interaction.Performer) && (isLocked || isWelded))
 			{
 				Chat.AddExamineMsg(
 				interaction.Performer,
 				$"Can\'t open {closetName}");
 			}
+			else
+			{
+				//catch for case where there is no performer
+				//TODO: Add closet breakout code here
+			}
 		}
-
+				
 		// player trying to unlock locker?
 		if (IsLockable && AccessRestrictions != null)
 		{

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -502,16 +502,24 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 			{
 				ServerToggleClosed();
 			}
-			else if (!AccessRestrictions.CheckAccess(interaction.Performer) && (isLocked || isWelded))
+			else if (isLocked || isWelded)
 			{
-				Chat.AddExamineMsg(
-				interaction.Performer,
-				$"Can\'t open {closetName}");
-			}
-			else
-			{
-				//catch for case where there is no performer
-				//TODO: Add closet breakout code here
+				if (IsLockable)
+				{ //This is to stop seeing cant open msg even though you can
+					if (!AccessRestrictions.CheckAccess(interaction.Performer))
+					{
+						Chat.AddExamineMsg(
+						interaction.Performer,
+						$"Can\'t open {closetName}");
+					}
+				}
+				else
+				{
+					Chat.AddExamineMsg(
+					interaction.Performer,
+					$"Can\'t open {closetName}");
+				}
+				
 			}
 		}
 				

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -601,7 +601,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 			}
 
 			var bar = StandardProgressAction.Create(ProgressConfig, ProgressFinishAction)
-				.ServerStartProgress(target.RegisterTile(), 5f, performer);
+				.ServerStartProgress(target.RegisterTile(), breakoutTime, performer);
 			if (bar != null)
 			{
 				SoundManager.PlayNetworkedAtPos(soundOnEscape, registerTile.WorldPositionServer, 1f, sourceObj: gameObject);

--- a/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
+++ b/UnityProject/Assets/Scripts/Objects/Closets/ClosetControl.cs
@@ -462,7 +462,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 		// Is the player trying to put something in the closet?
 		if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag))
 		{
-			if (IsClosed && !isEmagged)
+			if(IsClosed && !isEmagged)
 			{
 				SoundManager.PlayNetworkedAtPos(soundOnEmag, registerTile.WorldPositionServer, 1f, sourceObj: gameObject);
 				ServerHandleContentsOnStatusChange(false);
@@ -476,6 +476,7 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 			// Is the player trying to weld closet?
 			if (IsWeldable && interaction.Intent == Intent.Harm)
 			{
+				//TODO: Need to add an examine msg saying "Its welded shut
 				ToolUtils.ServerUseToolWithActionMessages(
 						interaction, weldTime,
 						$"You start {(IsWelded ? "unwelding" : "welding")} the {closetName} door...",
@@ -495,26 +496,21 @@ public class ClosetControl : NetworkBehaviour, ICheckedInteractable<HandApply>, 
 				Inventory.ServerDrop(interaction.HandSlot, targetPosition - performerPosition);
 			}
 		}
-		else if (interaction.HandObject == null)
+		else if(interaction.HandObject == null)
 		{
 			// player want to close locker?
 			if (!isLocked && !isEmagged && !isWelded)
 			{
 				ServerToggleClosed();
 			}
-			else if (!AccessRestrictions.CheckAccess(interaction.Performer) && (isLocked || isWelded))
+			else if(!AccessRestrictions.CheckAccess(interaction.Performer) && (isLocked || isWelded))
 			{
 				Chat.AddExamineMsg(
 				interaction.Performer,
 				$"Can\'t open {closetName}");
 			}
-			else
-			{
-				//catch for case where there is no performer
-				//TODO: Add closet breakout code here
-			}
 		}
-				
+
 		// player trying to unlock locker?
 		if (IsLockable && AccessRestrictions != null)
 		{

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -47,6 +47,11 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 	public bool IsCuffed => cuffed;
 
 	/// <summary>
+	/// Whether the character is trapped in a closet (or similar)
+	/// </summary>
+	public bool IsTrapped = false;
+
+	/// <summary>
 	/// Invoked on server side when the cuffed state is changed
 	/// </summary>
 	[NonSerialized]

--- a/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerNetworkActions.cs
@@ -180,6 +180,9 @@ public partial class PlayerNetworkActions : NetworkBehaviour
 					restraintOverlay.ServerBeginUnCuffAttempt();
 				}
 			}
+		}else if (playerScript.playerMove.IsTrapped) // Check if trapped.
+		{
+			playerScript.PlayerSync.TryEscapeContainer();
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -411,11 +411,11 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 	/// </summary>
 	private bool didWiggle = false;
 
-	private void TryEscapeContainer()
+	public void TryEscapeContainer()
 	{
 		if (Camera2DFollow.followControl.target.TryGetComponent(out ClosetControl closet))
 		{
-			InteractionUtils.RequestInteract(HandApply.ByLocalPlayer(closet.gameObject), closet);
+			CmdTryEscapeCloset();
 		}
 		else if (Camera2DFollow.followControl.target.TryGetComponent(out Disposals.DisposalVirtualContainer disposalContainer))
 		{
@@ -423,6 +423,17 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 		}
 	}
 
+	[Command]
+	private void CmdTryEscapeCloset()
+	{
+		if (pushPull?.parentContainer == null) return;
+		GameObject parentContainer = pushPull.parentContainer.gameObject;
+
+		if (parentContainer.TryGetComponent(out ClosetControl closet))
+		{
+			closet.PlayerTryEscaping(gameObject);
+		}
+	}
 	[Command]
 	private void CmdTryEscapeDisposals()
 	{

--- a/UnityProject/Assets/Scripts/UI/ProgressBar/StandardProgressActionType.cs
+++ b/UnityProject/Assets/Scripts/UI/ProgressBar/StandardProgressActionType.cs
@@ -12,5 +12,6 @@ public enum StandardProgressActionType
 	SelfHeal = 3,
 	CPR = 4,
 	Disrobe = 5,
-	Mop = 6
+	Mop = 6,
+	Escape = 7
 }


### PR DESCRIPTION
### Purpose

- To allow people to break out of welded/locked lockers using the Resist button or just moving whiles in a locked locker. #4997 
- Added the function to easily break locker locks, used when breaking out of lockers and when you emag lockers
- Added a "IsTrapped" bool to players, when a player enters any closet they are "Trapped", on Closet exit (forcefully or optionally) you are no longer trapped. 
- Added an "Escaping" enum to ProgressActions to be used when escaping anything. 
- Fixes #5163 
- Finishes features listed in #5013
- Can emag closets #3054, made some minor tweaks, now emag doesn't force the door open since we can now break locks on command. 
- Fixes #5068

### Notes:

- Made a UX decision to auto fire the resist out of locker function if you are trapped in a locker and its your only logical choice.
- Made a slight change to EMAG logic, now we dont force the door open but break the lock. The reason for focing open the door and keeping it open was so the lock light wouldnt be visable as we didnt have a realaible way to "Break" it, now we do. EMAGED lockers still cannot be repaired.  
- Added a new progress state on the player to be used when "escaping" anything, a TODO would be to see if climbing out of disposals should leverage this. 
- There is sound code for emagging and resisting out of lockers, however they don't seem to work, I have been told the sound manager is getting a rewrite, closets have had a emag sound for a very long time but from my testing I don't think it ever worked the way it should.

I understand this PR touches alot of places, outside of ClosetControl I have tried to be as sparten as possible with my changes, feel free to raise up any issues! 