### PR TITLE
NRE when starting the game in Editor. #5243

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Occupations/DepartmentList.cs
+++ b/UnityProject/Assets/Scripts/Systems/Occupations/DepartmentList.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Light2D;
 using ScriptableObjects;
 using UnityEngine;
 
@@ -22,7 +23,11 @@ public class DepartmentList : SingletonScriptableObject<DepartmentList>
 	/// </summary>
 	public IEnumerable<Occupation> GetAllHeadJobs()
 	{
-		return departments.SelectMany(dept => dept.HeadOccupations);
+		// Log Errors for missing head jobs (Improves debugging)
+		departments.Where(p => p.HeadOccupations == null).ForEach(dept => Logger.LogError($"Missing head of department reference for department {dept.Description}"));
+
+		// Won't crash if a department is missing it's headOccupation reference.
+		return departments.Where(p => p.HeadOccupations != null).SelectMany(dept => dept.HeadOccupations);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Systems/Occupations/DepartmentList.cs
+++ b/UnityProject/Assets/Scripts/Systems/Occupations/DepartmentList.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using Light2D;
 using ScriptableObjects;
 using UnityEngine;
 
@@ -24,7 +23,8 @@ public class DepartmentList : SingletonScriptableObject<DepartmentList>
 	public IEnumerable<Occupation> GetAllHeadJobs()
 	{
 		// Log Errors for missing head jobs (Improves debugging)
-		departments.Where(p => p.HeadOccupations == null).ForEach(dept => Logger.LogError($"Missing head of department reference for department {dept.Description}"));
+		foreach (Department dept in departments.Where(p => p.HeadOccupations == null))
+			Logger.LogError($"Missing head of department reference for department {dept.Description}");
 
 		// Won't crash if a department is missing it's headOccupation reference.
 		return departments.Where(p => p.HeadOccupations != null).SelectMany(dept => dept.HeadOccupations);


### PR DESCRIPTION
NRE when starting the game in Editor. #5243
Seems that some jobs are missing their Head of department once in a while.
The cause of this is not known at the moment.  It's totally random.  Racing condition?

That correction prevents it from happening,

NullReferenceException: Object reference not set to an instance of an object
System.Collections.Generic.LargeArrayBuilder1[T].AddRange (System.Collections.Generic.IEnumerable1[T] items) (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
System.Collections.Generic.SparseArrayBuilder1[T].AddRange (System.Collections.Generic.IEnumerable1[T] items) (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
System.Collections.Generic.SparseArrayBuilder1[T].ReserveOrAdd (System.Collections.Generic.IEnumerable1[T] items) (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
System.Linq.Enumerable+SelectManySingleSelectorIterator2[TSource,TResult].ToArray () (at <351e49e2a5bf4fd6beabb458ce2255f3>:0) System.Linq.Enumerable.ToArray[TSource] (System.Collections.Generic.IEnumerable1[T] source) (at <351e49e2a5bf4fd6beabb458ce2255f3>:0)
JobAllocator.DetermineJobs (System.Collections.Generic.IEnumerable`1[T] players) (at Assets/Scripts/Managers/JobAllocator.cs:39)
GameModes.GameMode.StartRound () (at Assets/Scripts/Systems/GameModes/GameMode.cs:319)
GameManager+d__23.MoveNext () (at Assets/Scripts/Managers/GameManager.GameMode.cs:152)
UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) (at :0)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr, Boolean&)