### PR TITLE
New ItemStorage methods

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
+++ b/UnityProject/Assets/Scripts/Core/Lighting/LightSource.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using Light2D;
 using Lighting;
 using Mirror;
@@ -12,8 +12,6 @@ public class LightSource : ObjectTrigger, ICheckedInteractable<HandApply>, IAPCP
 	public Color EmergencyColour;
 
 	public LightSwitchV2 relatedLightSwitch;
-	private float coolDownTime = 2.0f;
-	private bool isInCoolDown;
 
 	[SerializeField]
 	private LightMountState InitialState = LightMountState.On;
@@ -238,47 +236,77 @@ public class LightSource : ObjectTrigger, ICheckedInteractable<HandApply>, IAPCP
 	{
 		if (!DefaultWillInteract.Default(interaction, side)) return false;
 		if (interaction.HandObject != null && interaction.Intent == Intent.Harm) return false;
+
 		return true;
 	}
+
 	public void ServerPerformInteraction(HandApply interaction)
 	{
-		if (isInCoolDown) return;
-		StartCoroutine(CoolDown());
-		var handObject = interaction.HandObject;
-		var performer = interaction.Performer;
-		if (handObject == null)
+		if (interaction.HandObject == null)
 		{
-			if (mState == LightMountState.On &&
-			    !Validations.HasItemTrait(interaction.PerformerPlayerScript.Equipment.GetClothingItem(NamedSlot.hands).GameObjectReference, CommonTraits.Instance.BlackGloves))
-			{
-				interaction.PerformerPlayerScript.playerHealth.ApplyDamageToBodypart(gameObject, 10f, AttackType.Energy, DamageType.Burn,
-					interaction.HandSlot.NamedSlot == NamedSlot.leftHand ? BodyPartType.LeftArm : BodyPartType.RightArm);
-				Chat.AddExamineMsgFromServer(performer, $"<color=red>You burn your hand on the bulb while attempting to remove it!</color>");
-				return;
-			}
-			Spawn.ServerPrefab(itemInMount,performer.WorldPosServer());
-			ServerChangeLightState(LightMountState.MissingBulb);
+			TryRemoveBulb(interaction);
 		}
-		else if (Validations.HasItemTrait(handObject, CommonTraits.Instance.LightReplacer) && mState  != LightMountState.MissingBulb)
+		else if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.LightReplacer))
 		{
-			Spawn.ServerPrefab(itemInMount,performer.WorldPosServer());
-			ServerChangeLightState(LightMountState.MissingBulb);
+			TryReplaceBulb(interaction);
 		}
-		else if (Validations.HasItemTrait(handObject, traitRequired) && mState  == LightMountState.MissingBulb)
+		else if (Validations.HasItemTrait(interaction.HandObject, traitRequired))
 		{
+			TryAddBulb(interaction);
+		}
+	}
 
-			if (Validations.HasItemTrait(handObject, CommonTraits.Instance.Broken))
-			{
-				ServerChangeLightState(LightMountState.Broken);
-			}
-			else
-			{
-				ServerChangeLightState(
-					(switchState && (powerState == PowerStates.On))
-					? LightMountState.On : (powerState != PowerStates.OverVoltage)
-					? LightMountState.Emergency : LightMountState.Off);
-			}
-			Despawn.ServerSingle(handObject);
+	private void TryRemoveBulb(HandApply interaction)
+	{
+		var handSlot = interaction.PerformerPlayerScript.ItemStorage.GetNamedItemSlot(NamedSlot.hands);
+
+		if (mState == LightMountState.On && handSlot.IsOccupied &&
+				!Validations.HasItemTrait(handSlot.ItemObject, CommonTraits.Instance.BlackGloves))
+		{
+			var playerHealth = interaction.PerformerPlayerScript.playerHealth;
+			var burntBodyPart = interaction.HandSlot.NamedSlot == NamedSlot.leftHand ? BodyPartType.LeftArm : BodyPartType.RightArm;
+			playerHealth.ApplyDamageToBodypart(gameObject, 10f, AttackType.Energy, DamageType.Burn, burntBodyPart);
+
+			Chat.AddExamineMsgFromServer(interaction.Performer,
+					"<color=red>You burn your hand on the bulb while attempting to remove it!</color>");
+			return;
+		}
+
+		var spawnedItem = Spawn.ServerPrefab(itemInMount, interaction.Performer.WorldPosServer()).GameObject;
+		ItemSlot bestHand = interaction.PerformerPlayerScript.ItemStorage.GetBestHand();
+		if (bestHand != null && spawnedItem != null)
+		{
+			Inventory.ServerAdd(spawnedItem, bestHand);
+		}
+
+		ServerChangeLightState(LightMountState.MissingBulb);
+	}
+
+	private void TryAddBulb(HandApply interaction)
+	{
+		if (mState != LightMountState.MissingBulb) return;
+
+		if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Broken))
+		{
+			ServerChangeLightState(LightMountState.Broken);
+		}
+		else
+		{
+			ServerChangeLightState(
+				(switchState && (powerState == PowerStates.On))
+				? LightMountState.On : (powerState != PowerStates.OverVoltage)
+				? LightMountState.Emergency : LightMountState.Off);
+		}
+
+		Despawn.ServerSingle(interaction.HandObject);
+	}
+
+	private void TryReplaceBulb(HandApply interaction)
+	{
+		if (mState != LightMountState.MissingBulb)
+		{
+			Spawn.ServerPrefab(itemInMount, interaction.Performer.WorldPosServer());
+			ServerChangeLightState(LightMountState.MissingBulb);
 		}
 	}
 
@@ -390,12 +418,5 @@ public class LightSource : ObjectTrigger, ICheckedInteractable<HandApply>, IAPCP
 		Gizmos.DrawLine(relatedLightSwitch.transform.position, gameObject.transform.position);
 		Gizmos.DrawSphere(relatedLightSwitch.transform.position, 0.25f);
 
-	}
-
-	private IEnumerator CoolDown()
-	{
-		isInCoolDown = true;
-		yield return WaitFor.Seconds(coolDownTime);
-		isInCoolDown = false;
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
+++ b/UnityProject/Assets/Scripts/Items/PDA/PDALogic.cs
@@ -451,9 +451,6 @@ namespace Items.PDA
 			}
 		}
 
-		// Surely there is already a method that does what this one does?
-		// Numerous things would benefit, Canister.cs and removing bulbs from fixtures come to mind.
-		// The only addition, really, is it includes hands (and prioritises them) as a potential slot.
 		private ItemSlot GetBestSlot(GameObject item)
 		{
 			var player = GetPlayerByParentInventory();
@@ -463,26 +460,7 @@ namespace Items.PDA
 			}
 
 			var playerStorage = player.GetComponent<PlayerScript>().ItemStorage;
-
-			var activeHand = playerStorage.GetActiveHandSlot();
-			if (activeHand.IsEmpty)
-			{
-				return activeHand;
-			}
-
-			var leftHand = playerStorage.GetNamedItemSlot(NamedSlot.leftHand);
-			if (leftHand != activeHand && leftHand.IsEmpty)
-			{
-				return leftHand;
-			}
-
-			var rightHand = playerStorage.GetNamedItemSlot(NamedSlot.rightHand);
-			if (rightHand != activeHand && rightHand.IsEmpty)
-			{
-				return rightHand;
-			}
-
-			return playerStorage.GetBestSlotFor(item);
+			return playerStorage.GetBestHandOrSlotFor(item);
 		}
 
 		#endregion Inventory
@@ -549,7 +527,7 @@ namespace Items.PDA
 		[Server]
 		public bool HasAccess(Access access)
 		{
-			return accessSyncList.Contains((int) access);
+			return accessSyncList.Contains((int)access);
 		}
 
 		[Server]
@@ -563,7 +541,7 @@ namespace Items.PDA
 		public void ServerRemoveAccess(Access access)
 		{
 			if (!HasAccess(access)) return;
-			accessSyncList.Remove((int) access);
+			accessSyncList.Remove((int)access);
 		}
 
 		// Adds the indicated access to this IDCard
@@ -571,7 +549,7 @@ namespace Items.PDA
 		public void ServerAddAccess(Access access)
 		{
 			if (HasAccess(access)) return;
-			accessSyncList.Add((int) access);
+			accessSyncList.Add((int)access);
 		}
 
 		#endregion IDAccess

--- a/UnityProject/Assets/Scripts/Objects/Canisters/Canister.cs
+++ b/UnityProject/Assets/Scripts/Objects/Canisters/Canister.cs
@@ -221,13 +221,19 @@ namespace Objects.GasContainer
 		}
 
 		/// <summary>
-		/// Respawns the modified container back into the world
+		/// Respawns the modified container back into the world - or into the player's hand, if possible.
 		/// </summary>
 		public void RetrieveInsertedContainer()
 		{
+			var gasContainer = InsertedContainer;
 			EjectInsertedContainer();
-			ItemStorage player = networkTab.LastInteractedPlayer().GetComponent<PlayerScript>().ItemStorage;
-			HandInsert(player);
+
+			var playerScript = networkTab.LastInteractedPlayer().GetComponent<PlayerScript>();
+			var bestHand = playerScript.ItemStorage.GetBestHand();
+			if (bestHand != null)
+			{
+				Inventory.ServerAdd(gasContainer, bestHand);
+			}
 		}
 
 		private void EjectInsertedContainer()
@@ -236,28 +242,6 @@ namespace Objects.GasContainer
 			InsertedContainer = null;
 			ServerOnExternalTankInserted.Invoke(false);
 			RefreshOverlays();
-		}
-
-		/// <summary>
-		/// Checks to see if it can put it in any hand, if it cant it will do nothing meaning the item should just drop.
-		/// </summary>
-		/// <param name="player"></param>
-		private void HandInsert(ItemStorage player)
-		{
-			ItemSlot activeHand = player.GetActiveHandSlot();
-			if (Inventory.ServerAdd(InsertedContainer, activeHand)) return;
-			switch (activeHand.NamedSlot)
-			{
-				case NamedSlot.leftHand:
-					ItemSlot rSlot = player.GetNamedItemSlot(NamedSlot.rightHand);
-					Inventory.ServerAdd(InsertedContainer, rSlot);
-					break;
-
-				case NamedSlot.rightHand:
-					ItemSlot lSlot = player.GetNamedItemSlot(NamedSlot.leftHand);
-					Inventory.ServerAdd(InsertedContainer, lSlot);
-					break;
-			}
 		}
 
 		#region Interaction

--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemStorage.cs
@@ -319,6 +319,54 @@ public class ItemStorage : MonoBehaviour, IServerLifecycle, IServerInventoryMove
 	}
 
 	/// <summary>
+	/// Returns the active hand slot if not occupied, else the hand that is free.
+	/// Returns null if no hands were available.
+	/// </summary>
+	public ItemSlot GetBestHand()
+	{
+		if (playerNetworkActions == null)
+		{
+			return default;
+		}
+
+		var activeHand = GetNamedItemSlot(playerNetworkActions.activeHand);
+		if (activeHand.IsEmpty)
+		{
+			return activeHand;
+		}
+
+		var leftHand = GetNamedItemSlot(NamedSlot.leftHand);
+		if (leftHand != activeHand && leftHand.IsEmpty)
+		{
+			return leftHand;
+		}
+
+		var rightHand = GetNamedItemSlot(NamedSlot.rightHand);
+		if (rightHand != activeHand && rightHand.IsEmpty)
+		{
+			return rightHand;
+		}
+
+		return default;
+	}
+
+	/// <summary>
+	/// Returns the active hand slot if not occupied, else the hand that is free.
+	/// If no hand is free, defaults to <see cref="GetBestSlotFor(GameObject)"/> behaviour.
+	/// </summary>
+	public ItemSlot GetBestHandOrSlotFor(GameObject item)
+	{
+		ItemSlot bestHand = GetBestHand();
+
+		if (bestHand != null)
+		{
+			return bestHand;
+		}
+
+		return GetBestSlotFor(item);
+	}
+
+	/// <summary>
 	/// Gets all slots in which a gas container can be stored and used
 	/// </summary>
 	/// <returns></returns>


### PR DESCRIPTION
- New `ItemStorage` methods:
    - `GetBestHand()`: returns an empty hand, prioritising the active hand. If no hand is empty, then returns `null`.
    - `GetBestHandOrSlotFor(GameObject item)`: the former, but defaults to `GetBestSlotFor(GameObject item)` behaviour if no hand was available.
- PDAs, canisters and light mounts now utilize these methods.
    - Light tubes no longer spawn on the floor when removing them from light mounts.
- Tidies up light mount interaction logic, removes manual cooldown (this should be handled by `IF2`).
