### PR TITLE
Temporarily remove emags. Uplink stuff, including basic minibombs.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Effects/Explosions/SyndicateMiniBombExplosion.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Effects/Explosions/SyndicateMiniBombExplosion.prefab
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1059518790872729420
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1059518790872729423}
+  - component: {fileID: 1087697603680455443}
+  m_Layer: 0
+  m_Name: SyndicateMiniBombExplosion
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1059518790872729423
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1059518790872729420}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1087697603680455443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1059518790872729420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6b8d82cf0e1fe54bb75a283c2a2881e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  unstableRadius: 0
+  damage: 220
+  radius: 4
+  explosionType: 1
+  shakeDistance: 8
+  minDamage: 2
+  maxEffectDuration: 0.25
+  minEffectDuration: 0.05

--- a/UnityProject/Assets/Resources/Prefabs/Effects/Explosions/SyndicateMiniBombExplosion.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Effects/Explosions/SyndicateMiniBombExplosion.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 902b411850c4a0945b451f3f1333652b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Botany/Produce/combustible lemon.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Botany/Produce/combustible lemon.prefab
@@ -233,7 +233,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  initialIntegrity: 100
   soundOnHit: 
+  damageDeflection: 0
   Armor:
     Melee: 0
     Bullet: 0
@@ -254,7 +256,6 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
-  initialIntegrity: 100
 --- !u!114 &6657982718786730346
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -417,7 +418,7 @@ MonoBehaviour:
   fuseLength: 3
   maxDamage: 125
   maxRadius: 5
-  spriteHandler: {fileID: 0}
+  spriteHandler: {fileID: 628184727406542681}
   lemonPotencyOverride: 0
 --- !u!1 &6770754434974323192
 GameObject:
@@ -430,7 +431,6 @@ GameObject:
   - component: {fileID: 6765313202082436898}
   - component: {fileID: 6845515435948111746}
   - component: {fileID: 628184727406542681}
-  - component: {fileID: 2427945517095408565}
   m_Layer: 10
   m_Name: Sprite
   m_TagString: Untagged
@@ -467,6 +467,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -515,26 +516,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   NetworkThis: 1
-  SubCatalogue: []
+  SubCatalogue:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 11400000, guid: 79557dda1b863f54891194179a2e7a64, type: 2}
+  - {fileID: 11400000, guid: 7b1b3779f4ffb2f4a8043d5ada077e2f, type: 2}
   PresentSpriteSet: {fileID: 11400000, guid: 79557dda1b863f54891194179a2e7a64, type: 2}
-  Sprites: []
+  pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
---- !u!114 &2427945517095408565
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6770754434974323192}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  NetworkThis: 1
-  SubCatalogue: []
-  PresentSpriteSet: {fileID: 11400000, guid: 79557dda1b863f54891194179a2e7a64, type: 2}
   Sprites: []
-  variantIndex: 0
-  palette: []

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Beltwear/Holsters/SyndicateHolster.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Beltwear/Holsters/SyndicateHolster.prefab
@@ -78,6 +78,17 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 245b8f13ca739ad47859855d23665fc3,
         type: 3}
+    - target: {fileID: 3919968998321081025, guid: f81f054e54c0164459e94a191cf3ac9e,
+        type: 3}
+      propertyPath: initialName
+      value: syndicate holster
+      objectReference: {fileID: 0}
+    - target: {fileID: 3919968998321081025, guid: f81f054e54c0164459e94a191cf3ac9e,
+        type: 3}
+      propertyPath: initialDescription
+      value: A two pouched hip holster that uses chameleon technology to disguise
+        itself and any guns in it.
+      objectReference: {fileID: 0}
     - target: {fileID: 4559416078757244025, guid: f81f054e54c0164459e94a191cf3ac9e,
         type: 3}
       propertyPath: itemStorageStructure

--- a/UnityProject/Assets/Resources/Prefabs/Items/Economy/Cash/SpaceCash1000.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Economy/Cash/SpaceCash1000.prefab
@@ -88,6 +88,22 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 292917c4f4a4c8d45941451bb6b8fec3,
         type: 3}
+    - target: {fileID: 4147525243360405716, guid: 66c1a2c68cdf38f4a9cd469080bad2b4,
+        type: 3}
+      propertyPath: stacksWith.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4147525243360405716, guid: 66c1a2c68cdf38f4a9cd469080bad2b4,
+        type: 3}
+      propertyPath: stacksWith.Array.data[0]
+      value: 
+      objectReference: {fileID: 7235659444419165720}
+    - target: {fileID: 4147525243360405716, guid: 66c1a2c68cdf38f4a9cd469080bad2b4,
+        type: 3}
+      propertyPath: stacksWith.Array.data[1]
+      value: 
+      objectReference: {fileID: 3018258961753464460, guid: 77ec42a4f01231a45b5ffc3e82d99722,
+        type: 3}
     - target: {fileID: 5893262307858330876, guid: 66c1a2c68cdf38f4a9cd469080bad2b4,
         type: 3}
       propertyPath: SubCatalogue.Array.data[0]
@@ -102,3 +118,9 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 66c1a2c68cdf38f4a9cd469080bad2b4, type: 3}
+--- !u!1 &7235659444419165720 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 328496622264291195, guid: 66c1a2c68cdf38f4a9cd469080bad2b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6982043981772714339}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Economy/Cash/SpaceCash1000Five.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Economy/Cash/SpaceCash1000Five.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5587062119640703124
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6443468240034273719, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: initialAmount
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6443468240034273719, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: stacksWith.Array.data[1]
+      value: 
+      objectReference: {fileID: 7235659444419165720, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+    - target: {fileID: 7235659444419165720, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_Name
+      value: SpaceCash1000Five
+      objectReference: {fileID: 0}
+    - target: {fileID: 7240024367976514412, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7240024367976514412, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7240024367976514412, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7240024367976514412, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7240024367976514412, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7240024367976514412, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7240024367976514412, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7240024367976514412, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7240024367976514412, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7240024367976514412, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7240024367976514412, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7349325341320790956, guid: 552cb08d7db47c14e81ddaf7ca4fd55c,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 552cb08d7db47c14e81ddaf7ca4fd55c, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Economy/Cash/SpaceCash1000Five.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Economy/Cash/SpaceCash1000Five.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 77ec42a4f01231a45b5ffc3e82d99722
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Explosive/Grenade.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Explosive/Grenade.prefab
@@ -120,7 +120,7 @@ PrefabInstance:
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: SubCatalogue.Array.size
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -132,19 +132,23 @@ PrefabInstance:
         type: 3}
       propertyPath: SubCatalogue.Array.data[0]
       value: 
-      objectReference: {fileID: 11400000, guid: d3618c58d1706d946923dd52e5fb6dd5,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: SubCatalogue.Array.data[1]
       value: 
-      objectReference: {fileID: 11400000, guid: 6fc4547c2b620f84486e7dac49b114d5,
-        type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: SubCatalogue.Array.data[2]
       value: 
-      objectReference: {fileID: 11400000, guid: f92d0aacc426db9428d37a3aada55b7d,
+      objectReference: {fileID: 11400000, guid: 862044f28473eea48b26540d26308e4c,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[3]
+      value: 
+      objectReference: {fileID: 11400000, guid: fa5716d8e1281d2479b9303fcc86bef5,
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Explosive/SyndicateMinibomb.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Explosive/SyndicateMinibomb.prefab
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5613035357065394051
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2450954382432651964, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 1ea1b2edd277e374c8cb6a83a1b12d3c,
+        type: 2}
+    - target: {fileID: 2450954382432651964, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 1ea1b2edd277e374c8cb6a83a1b12d3c,
+        type: 2}
+    - target: {fileID: 2450954382432651964, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[3]
+      value: 
+      objectReference: {fileID: 11400000, guid: 404e172e3159a264a8b1dfe4922ce733,
+        type: 2}
+    - target: {fileID: 8189812989746650713, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: initialDescription
+      value: A syndicate manufactured explosive used to sow destruction and chaos.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189812989746650713, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: initialName
+      value: syndicate minibomb
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189812989746650713, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 51cb6b2e3ac072f42bb6ebca5c6dc94d,
+        type: 2}
+    - target: {fileID: 8189812989746650713, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: a643748f5a00ca847baab9001f8c0391,
+        type: 2}
+    - target: {fileID: 8481510294924968551, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: b10b1b45b2886c54997a9fd21f458d7f,
+        type: 3}
+    - target: {fileID: 8561801018043092111, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8594439505056330043, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_Name
+      value: SyndicateMinibomb
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599085903787527247, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599085903787527247, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599085903787527247, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599085903787527247, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599085903787527247, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599085903787527247, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599085903787527247, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599085903787527247, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599085903787527247, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599085903787527247, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8599085903787527247, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9197874253917913631, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: fuseLength
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9197874253917913631, guid: 838a4732b2dece64497d074b7a700be6,
+        type: 3}
+      propertyPath: explosionPrefab
+      value: 
+      objectReference: {fileID: 1087697603680455443, guid: 902b411850c4a0945b451f3f1333652b,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 838a4732b2dece64497d074b7a700be6, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Explosive/SyndicateMinibomb.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Explosive/SyndicateMinibomb.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0469b3922aa40e04d9c576979353df72
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Items/SecureBriefcaseSyndicatePopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Items/SecureBriefcaseSyndicatePopulator.asset
@@ -15,5 +15,5 @@ MonoBehaviour:
   Contents:
   - {fileID: 8734328976324889014, guid: d3c71176f32c1274b929f3a88695a795, type: 3}
   - {fileID: 8734328976324889014, guid: 83442ea1bc97ef04db1f9962a2f7021d, type: 3}
-  - {fileID: 7235659444419165720, guid: 552cb08d7db47c14e81ddaf7ca4fd55c, type: 3}
+  - {fileID: 3018258961753464460, guid: 77ec42a4f01231a45b5ffc3e82d99722, type: 3}
   MergeMode: 0

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/OperativeHolsterCapacity.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/OperativeHolsterCapacity.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: OperativeHolsterCapacity
   m_EditorClassIdentifier: 
   MaxItemSize: 4
-  Whitelist: []
-  Required:
+  Whitelist:
   - {fileID: 11400000, guid: 661df715b71a96d43a15c87691675f10, type: 2}
   - {fileID: 11400000, guid: a6adad4523390e74b900fb3fce5d1c23, type: 2}
   - {fileID: 11400000, guid: e8985b79e43678340a5da4ca4ef37d67, type: 2}
@@ -23,4 +22,5 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 14180412be5e2674182d86f790137f6f, type: 2}
   - {fileID: 11400000, guid: df0bff890a4657e459e7f19e84e47f5d, type: 2}
   - {fileID: 11400000, guid: 93d9bd23d2af8ae41b4a0664dd809bbf, type: 2}
+  Required: []
   Blacklist: []

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/ShoulderHolsterCapacity.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/ShoulderHolsterCapacity.asset
@@ -13,12 +13,12 @@ MonoBehaviour:
   m_Name: ShoulderHolsterCapacity
   m_EditorClassIdentifier: 
   MaxItemSize: 2
-  Whitelist: []
-  Required:
+  Whitelist:
   - {fileID: 11400000, guid: 9de8996f385ec584399d6aa64bc676b3, type: 2}
   - {fileID: 11400000, guid: a6adad4523390e74b900fb3fce5d1c23, type: 2}
   - {fileID: 11400000, guid: e8985b79e43678340a5da4ca4ef37d67, type: 2}
   - {fileID: 11400000, guid: ad8a6873f4f12504094b58741204ea6a, type: 2}
   - {fileID: 11400000, guid: 17a405825a3b91049abaedff4c27bd1b, type: 2}
   - {fileID: 11400000, guid: 14180412be5e2674182d86f790137f6f, type: 2}
+  Required: []
   Blacklist: []

--- a/UnityProject/Assets/Resources/ScriptableObjects/PDA/UplinkCategoryList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/PDA/UplinkCategoryList.asset
@@ -36,6 +36,12 @@ MonoBehaviour:
     - cost: 4
       item: {fileID: 661569839832110917, guid: 7cbde3b57839c144e933398cfd78e132, type: 3}
       name: .357 Speedloader
+  - categoryName: Explosives
+    itemList:
+    - cost: 6
+      item: {fileID: 4224399380362315448, guid: 0469b3922aa40e04d9c576979353df72,
+        type: 3}
+      name: Syndicate Minibomb
   - categoryName: Stealthy Weapons
     itemList:
     - cost: 2
@@ -70,10 +76,6 @@ MonoBehaviour:
       item: {fileID: 3668676918291703395, guid: 00019cd41de95b244ac165825679fd64,
         type: 3}
       name: Chest Rig
-    - cost: 4
-      item: {fileID: 3086828684011793880, guid: 92d97624df4de9c44b21713ad3a016cc,
-        type: 3}
-      name: Cryptographic Sequencer
     - cost: 1
       item: {fileID: 2636666438991721797, guid: da5c775edced9c242be7c64d8f159b8f,
         type: 3}
@@ -91,5 +93,9 @@ MonoBehaviour:
       item: {fileID: 5781789070524544926, guid: b3d899ee0b9aba44799b8fcd80844a7d,
         type: 3}
       name: Syndicate Briefcase Full of Cash
+    - cost: 2
+      item: {fileID: 8743402964508765710, guid: 8c0cd43087354414196842dd7f64a46a,
+        type: 3}
+      name: Syndicate Smokes
   - categoryName: Bundles
     itemList: []


### PR DESCRIPTION
### Purpose
- Temporarily removes emags due to the results of the poll.
![image](https://user-images.githubusercontent.com/38266309/95712324-6f8a9180-0c19-11eb-80de-d9b1f51d1448.png)
- Syndicate briefcase now holds five stacks of money.
- Adds syndicate smokes to uplink.
- Fix holsters not being able to hold anything.
- Add basic syndicate minibombs.
- Fix sprites for grenades. Now they will only flash when armed.
  - Combustible lemons flash too.
