### PR TITLE
Fix the PKA and Plascutters

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PlasmaCutter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PlasmaCutter.prefab
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 65a8731c836944efb4baf302526fc662, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Projectile: {fileID: 5076580856386662130, guid: f65f1f0bd0295df468272b3d767985a7,
+    type: 3}
 --- !u!1001 &7248905475842763370
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Mining/PlasmaCutterAdvanced.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Mining/PlasmaCutterAdvanced.prefab
@@ -13,6 +13,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: aceda5d47f145de4e836cbc3609f1e39,
         type: 2}
+    - target: {fileID: 5865673803328853950, guid: a12add7b219842843b678dec171704cb,
+        type: 3}
+      propertyPath: oreEff
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 5865673803328853950, guid: a12add7b219842843b678dec171704cb,
+        type: 3}
+      propertyPath: sheetEff
+      value: 100
+      objectReference: {fileID: 0}
     - target: {fileID: 6403070459685052080, guid: a12add7b219842843b678dec171704cb,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/ElectricalMagazines/InternalMagazinePlasmaCutter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/ElectricalMagazines/InternalMagazinePlasmaCutter.prefab
@@ -15,7 +15,7 @@ PrefabInstance:
     - target: {fileID: 1053198998585859953, guid: 279de6cf129850f4b8a22d99511dfd03,
         type: 3}
       propertyPath: magazineSize
-      value: 28
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 1053198998585859953, guid: 279de6cf129850f4b8a22d99511dfd03,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/ElectricalMagazines/InternalMagazinePlasmaCutterAdvanced.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/AmmoBoxes/InternalMagazines/ElectricalMagazines/InternalMagazinePlasmaCutterAdvanced.prefab
@@ -90,5 +90,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1791094763296440269, guid: 8671f227240c2ab468b1568a2a321d0d,
         type: 3}
+    - target: {fileID: 8220544047955423549, guid: 89f916fe2ec00a748bb6533ddef5dde6,
+        type: 3}
+      propertyPath: magazineSize
+      value: 100
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 89f916fe2ec00a748bb6533ddef5dde6, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/CommonTraitsSingleton.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/CommonTraitsSingleton.asset
@@ -54,6 +54,7 @@ MonoBehaviour:
   Breakable: {fileID: 11400000, guid: 86782de91b339c1438d9f4e310d321f4, type: 2}
   Rods: {fileID: 11400000, guid: d823ef2f0f86bd240b865220bbd5c6a3, type: 2}
   SolidPlasma: {fileID: 11400000, guid: 70d28796af421c64a8770cb93c818bd4, type: 2}
+  OrePlasma: {fileID: 11400000, guid: 9f843295728958e48bcfe5215296ee90, type: 2}
   NukeDisk: {fileID: 11400000, guid: bb50eda6fc15bef468df0a46c50b2fed, type: 2}
   Insulated: {fileID: 11400000, guid: 1213038ef37bbdf498fd3434a3459ce0, type: 2}
   BudgetInsulated: {fileID: 11400000, guid: e8a69967443cc16429de324b9dfe1852, type: 2}
@@ -63,3 +64,6 @@ MonoBehaviour:
   ReactorRod: {fileID: 11400000, guid: a83bf55c94468e545ab67c06fd7b2469, type: 2}
   Pickaxe: {fileID: 11400000, guid: 1c4515f9903c29c4f8832bd2f32684ad, type: 2}
   CanPryDoor: {fileID: 11400000, guid: bf45f5f358fa083d281cc05cdfd81580, type: 2}
+  RawCottonBundle: {fileID: 0}
+  RawDurathreadBundle: {fileID: 0}
+  Loomable: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
+++ b/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
@@ -50,6 +50,7 @@ public class CommonTraits : SingletonScriptableObject<CommonTraits>
 	public ItemTrait Breakable;
 	public ItemTrait Rods;
 	public ItemTrait SolidPlasma;
+	public ItemTrait OrePlasma;
 	public ItemTrait NukeDisk;
 	public ItemTrait Insulated;
 	public ItemTrait BudgetInsulated;

--- a/UnityProject/Assets/Scripts/Items/Weapons/GunPKA.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/GunPKA.cs
@@ -5,6 +5,7 @@ using Weapons;
 
 public class GunPKA : Gun
 {
+	public GameObject Projectile;
 
 	bool allowRecharge = true;
 	public float rechargeTime = 2.0f;
@@ -30,7 +31,8 @@ public class GunPKA : Gun
 	{
 		allowRecharge = false;
 		yield return WaitFor.Seconds(rechargeTime);
-		CurrentMagazine.ExpendAmmo(-1);
+		CurrentMagazine.ServerSetAmmoRemains(1);
+		CurrentMagazine.LoadProjectile(CurrentMagazine.Projectile, CurrentMagazine.ProjectilesFired);
 		SoundManager.PlayNetworkedAtPos("ReloadKinetic", gameObject.AssumedWorldPosServer(), sourceObj: serverHolder);
 		allowRecharge = true;
 	}

--- a/UnityProject/Assets/Scripts/Items/Weapons/MagazineBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/MagazineBehaviour.cs
@@ -92,7 +92,7 @@ public class MagazineBehaviour : NetworkBehaviour, IServerSpawn, IExaminable, IC
 			containedProjectilesFired.Add(ProjectilesFired);
 		}
 	}
-	
+
 	/// <summary>
 	/// Changes size of magazine and reloads it. Be sure to call this on every client and the server if you do, or face the consequences.
 	/// Also sets the contained ammunition to full.
@@ -134,6 +134,11 @@ public class MagazineBehaviour : NetworkBehaviour, IServerSpawn, IExaminable, IC
 	/// <returns></returns>
 	public virtual void ExpendAmmo(int amount = 1)
 	{
+		if (amount < 0)
+		{
+			Logger.LogWarning("Attempted to expend a negitive amount of ammo", Category.Firearms); // dont use this method to replenish ammo
+		}
+
 		if (ClientAmmoRemains < amount)
 		{
 			Logger.LogWarning("Client ammo count is too low, cannot expend that much ammo. Make sure" +
@@ -205,6 +210,16 @@ public class MagazineBehaviour : NetworkBehaviour, IServerSpawn, IExaminable, IC
 		ServerSetAmmoRemains(serverAmmoRemains + toTransfer);
 
 		return ("Loaded " + toTransfer + (toTransfer == 1 ? " piece" : " pieces") + " of ammunition.");
+	}
+
+	/// <summary>
+	/// method to add info to the projectile array,
+	/// should be used when ammo is being increased outside of the reload logic
+	/// </summary>
+	public void LoadProjectile(GameObject projectile,int projectilesfired)
+	{
+		containedBullets.Add(projectile);
+		containedProjectilesFired.Add(projectilesfired);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Items/Weapons/PlasmaRefill.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/PlasmaRefill.cs
@@ -5,6 +5,12 @@ namespace Weapons
 {
 	public class PlasmaRefill : MonoBehaviour, ICheckedInteractable<HandApply>, ICheckedInteractable<InventoryApply>
 	{
+		public int oreEff = 20;
+
+		// sheets should be about twice as efficent as ore
+		public int sheetEff = 40;
+		private int consumed;
+		private int refilledAmmo;
 		private MagazineBehaviour magazineBehaviour;
 
 		private void Start()
@@ -16,34 +22,92 @@ namespace Weapons
 		{
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
 
-			if (Validations.HasItemTrait(interaction.HandObject,
-				CommonTraits.Instance.SolidPlasma) == false) return false;
+			if (!Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.SolidPlasma)
+			 && !Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.OrePlasma))
+			{
+				return false;
+			}
 
 			return true;
 		}
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-			if (!Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.SolidPlasma)) return;
+
+			// check if what is trying to be used as fuel
+			// can actually be used as fuel
+			// and if it can, define a variable stating what
+			// fuel is being used
+			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.SolidPlasma))
+			{
+				refilledAmmo = sheetEff;
+			}
+			else if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.OrePlasma))
+			{
+				refilledAmmo = oreEff;
+			}
+			else
+			{
+				return;
+			}
 			var needAmmo = magazineBehaviour.magazineSize - magazineBehaviour.ServerAmmoRemains;
 			if (needAmmo <= 0) return;
 
 			var stackable = interaction.HandObject.GetComponent<Stackable>();
-			Refill(stackable, needAmmo);
+			Refill(stackable, needAmmo, refilledAmmo);
 		}
 
-		private void Refill(Stackable stackable, int needAmmo)
+		private void Refill(Stackable stackable, int needAmmo, int refilledAmmo)
 		{
+			// get the amount of plasma being used to refill us
 			var plasmaInStack = stackable.Amount;
-			if (needAmmo >= plasmaInStack)
+
+			consumed = 0;
+			// calculate the amount of fuel we would need to
+			// refill us to capacity
+			for (int i = needAmmo; i > 0;i -= refilledAmmo)
 			{
-				magazineBehaviour.ExpendAmmo(-plasmaInStack);
+				consumed++;
+			}
+
+			if (plasmaInStack < consumed)
+			{
+				// we do not have enough fuel to full refill, so calculate how much
+				// we can fill with the amount we have
+				magazineBehaviour.ServerSetAmmoRemains(magazineBehaviour.ServerAmmoRemains + (plasmaInStack * refilledAmmo));
+				// plasmaInStack * refilledAmmo is the amount of ammo we can refill,
+				// add this to the current amount of ammo we have as we are using a set method
+				// we shouldnt need to clamp this value as it wont refill us to capacity
+
+				// add the amount of projectiles we are loading to the clip's array
+				for (int i = (plasmaInStack * refilledAmmo); i > 0; i--)
+				{
+					magazineBehaviour.LoadProjectile(magazineBehaviour.Projectile, 1);
+				}
+				// consume the entire stack because the amount cant fill us to capacity
 				stackable.ServerConsume(plasmaInStack);
 			}
-			else if (needAmmo < plasmaInStack)
+			else
 			{
-				magazineBehaviour.ExpendAmmo(-needAmmo);
-				stackable.ServerConsume(needAmmo);
+				// we have enough fuel to fill our ammo to capacity
+				// so dont bother calculating stuff and set our ammo to max
+				magazineBehaviour.ServerSetAmmoRemains(magazineBehaviour.magazineSize);
+
+				// add the amount of projectiles we are loading to the clip's array
+				for (int i = needAmmo; i > 0; i--)
+				{
+					magazineBehaviour.LoadProjectile(magazineBehaviour.Projectile, 1);
+				}
+				// consume the amount that will leave us refilled to max and leave the rest
+				stackable.ServerConsume(consumed);
+			}
+
+			if (needAmmo < plasmaInStack)
+			{
+				for (int i = plasmaInStack; i > 0; i--)
+				{
+					magazineBehaviour.LoadProjectile(magazineBehaviour.Projectile, 1);
+				}
 			}
 		}
 
@@ -52,8 +116,11 @@ namespace Weapons
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
 
 			if (interaction.FromSlot.Item == null) return false;
-			if (Validations.HasItemTrait(interaction.FromSlot.Item.gameObject,
-				CommonTraits.Instance.SolidPlasma) == false) return false;
+			if (!Validations.HasItemTrait(interaction.FromSlot.Item.gameObject, CommonTraits.Instance.SolidPlasma)
+			 && !Validations.HasItemTrait(interaction.FromSlot.Item.gameObject, CommonTraits.Instance.OrePlasma))
+			{
+				return false;
+			}
 
 			return true;
 		}
@@ -62,9 +129,24 @@ namespace Weapons
 		{
 			var needAmmo = magazineBehaviour.magazineSize - magazineBehaviour.ServerAmmoRemains;
 			if (needAmmo <= 0) return;
-
+			// check if what is trying to be used as fuel
+			// can actually be used as fuel
+			// and if it can, define a variable stating what
+			// fuel is being used
+			if (Validations.HasItemTrait(interaction.FromSlot.Item.gameObject, CommonTraits.Instance.SolidPlasma))
+			{
+				refilledAmmo = sheetEff;
+			}
+			else if (Validations.HasItemTrait(interaction.FromSlot.Item.gameObject, CommonTraits.Instance.OrePlasma))
+			{
+				refilledAmmo = oreEff;
+			}
+			else
+			{
+				return;
+			}
 			var stackable = interaction.FromSlot.Item.GetComponent<Stackable>();
-			Refill(stackable, needAmmo);
+			Refill(stackable, needAmmo, refilledAmmo);
 		}
 	}
 }


### PR DESCRIPTION
partial fix for #5273

switches both the pka and plascutters over to using the ServerSetAmmo method instead of using ExpendAmmo with a negitive value.