### PR TITLE
Adjusting reaction inheritance. Removing upright sprite component from atmos pipe objects.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Chemistry/BVOld_MixingBowl.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Chemistry/BVOld_MixingBowl.prefab
@@ -47,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -97,9 +98,10 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 0}
-  Sprites: []
+  pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
+  Sprites: []
 --- !u!114 &-2645903112132741243
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -409,7 +411,7 @@ PrefabInstance:
         type: 3}
       propertyPath: reactionSet
       value: 
-      objectReference: {fileID: 11400000, guid: 701922900047cd742b7b5ede817b7837,
+      objectReference: {fileID: 11400000, guid: 498c0d2290747084c8ca13bdc8f60579,
         type: 2}
     - target: {fileID: 9018167180428263240, guid: f866b44bcdd7d734885f7c49999d85c9,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Food/Drinks/_DrinkBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Food/Drinks/_DrinkBase.prefab
@@ -159,11 +159,5 @@ PrefabInstance:
       propertyPath: maxCapacity
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2002631705224524847, guid: 6eb9748e1eaf8dc4598a50e5b09df3b3,
-        type: 3}
-      propertyPath: reactionSet
-      value: 
-      objectReference: {fileID: 11400000, guid: 5e9cd20e17eb54a49b4676ae98d5a6a1,
-        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6eb9748e1eaf8dc4598a50e5b09df3b3, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/3WayManifold.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/3WayManifold.prefab
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c88bb5b421259954781bcdfb75018051, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
   Colour: {r: 1, g: 1, b: 1, a: 1}
   SpriteHandler: {fileID: 3611509593911475594}
   registerItem: {fileID: 0}
@@ -275,6 +277,7 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents:
     - {fileID: 7343457972493425774, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
+    - {fileID: 4188173932925032876, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
 --- !u!1 &7446904160649250317 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/4WayManifold.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/4WayManifold.prefab
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c88bb5b421259954781bcdfb75018051, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
   Colour: {r: 1, g: 1, b: 1, a: 1}
   SpriteHandler: {fileID: 2866152876217359191}
   registerItem: {fileID: 0}
@@ -107,6 +109,7 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents:
     - {fileID: 7343457972493425774, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
+    - {fileID: 4188173932925032876, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
 --- !u!1 &8250737373743472848 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/BentFluidPipe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/BentFluidPipe.prefab
@@ -133,7 +133,8 @@ PrefabInstance:
       propertyPath: SpriteHandler
       value: 
       objectReference: {fileID: 1529018625693911448}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 3625116594980674352, guid: ec0acc4f3411c554ebfa43f6dc6d375c, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: ec0acc4f3411c554ebfa43f6dc6d375c, type: 3}
 --- !u!114 &1529018625693911448 stripped
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/BentHeatPipes.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/BentHeatPipes.prefab
@@ -128,5 +128,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300008, guid: d4ce524e0e39e574abdffd9d1427aa96,
         type: 3}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 4947065797079711444, guid: ba7654faafb5b8e4ca4ce7c5f4ca196e, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: ba7654faafb5b8e4ca4ce7c5f4ca196e, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/FluidPipe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/FluidPipe.prefab
@@ -146,7 +146,8 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: fb9b0f659fcbf2949bea820a94136a69,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 4188173932925032876, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
 --- !u!114 &7394214632308695747 stripped
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/HeatPipe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/HeatPipe.prefab
@@ -387,5 +387,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 37b032df553771e4d848ee2fa642bca6,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 4188173932925032876, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/HeatPipeAdapter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/HeatPipeAdapter.prefab
@@ -12,10 +12,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c88bb5b421259954781bcdfb75018051, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
   Colour: {r: 1, g: 1, b: 1, a: 1}
-  pipeTile: {fileID: 11400000, guid: 60485b5f9fbec594682cb01accda73ab, type: 2}
   SpriteHandler: {fileID: 0}
-  objectBehaviour: {fileID: 0}
+  registerItem: {fileID: 0}
+  pipeTile: {fileID: 11400000, guid: 60485b5f9fbec594682cb01accda73ab, type: 2}
 --- !u!1001 &1027771722991696777
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -326,6 +328,7 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents:
     - {fileID: 7343457972493425774, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
+    - {fileID: 4188173932925032876, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
 --- !u!1 &3875517383552655441 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemConnector.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemConnector.prefab
@@ -110,7 +110,8 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 7462202553335776702, guid: c7c6619435930be4e91730eea5485a29, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: c7c6619435930be4e91730eea5485a29, type: 3}
 --- !u!114 &4974515496910963949 stripped
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemFilter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemFilter.prefab
@@ -105,7 +105,8 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 7462202553335776702, guid: c7c6619435930be4e91730eea5485a29, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: c7c6619435930be4e91730eea5485a29, type: 3}
 --- !u!114 &385601727615132378 stripped
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemFilterFlipped.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemFilterFlipped.prefab
@@ -90,5 +90,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 77b84b19a81d74544a47748bfbd8916c,
         type: 3}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 5875906568581929769, guid: cd09f64dd236ae541abf991d8e00da65, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: cd09f64dd236ae541abf991d8e00da65, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemMetre.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemMetre.prefab
@@ -216,7 +216,8 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 0ea0c6301632edf46afa524310e9baf4,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 114577415631634126, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
 --- !u!1 &6354841859598439861 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemMixer.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemMixer.prefab
@@ -105,7 +105,8 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 7462202553335776702, guid: c7c6619435930be4e91730eea5485a29, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: c7c6619435930be4e91730eea5485a29, type: 3}
 --- !u!114 &5961850752556827364 stripped
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemMixerFlipped.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemMixerFlipped.prefab
@@ -90,5 +90,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 8093872234220313838, guid: c62ec0b9f508c6b41b1dc1c6f8cd9181,
         type: 3}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 463370423983717143, guid: f3c7b7569520f694cb13c4a36184aefb, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: f3c7b7569520f694cb13c4a36184aefb, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemScrubber.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemScrubber.prefab
@@ -105,7 +105,8 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 7462202553335776702, guid: c7c6619435930be4e91730eea5485a29, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: c7c6619435930be4e91730eea5485a29, type: 3}
 --- !u!114 &7513937976670775506 stripped
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemVent.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/ItemVent.prefab
@@ -110,7 +110,8 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 7462202553335776702, guid: c7c6619435930be4e91730eea5485a29, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: c7c6619435930be4e91730eea5485a29, type: 3}
 --- !u!114 &2877499132637700073 stripped
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/PumpItem.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/PumpItem.prefab
@@ -115,7 +115,8 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 7462202553335776702, guid: c7c6619435930be4e91730eea5485a29, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: c7c6619435930be4e91730eea5485a29, type: 3}
 --- !u!114 &8381221248912251745 stripped
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/UnaryVentItem.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/LiquidPipes/UnaryVentItem.prefab
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9323f97f0b3359f4d95d4edc908db8ba, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
   Colour: {r: 1, g: 1, b: 1, a: 1}
   SpriteHandler: {fileID: 6187828189299825911}
   registerItem: {fileID: 0}
@@ -103,6 +105,7 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents:
     - {fileID: 7343457972493425774, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
+    - {fileID: 4188173932925032876, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 59bffb44a6861484ca22d6edb4fbf5e5, type: 3}
 --- !u!1 &43219343248451440 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Filter.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Filter.prefab
@@ -47,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -153,7 +154,6 @@ MonoBehaviour:
     CustomLogic: 0
     NetCompatible: 0
     mixAndVolume:
-      Volume: 0.1
       Mix:
         temperature: 273.15
         reagents:
@@ -305,7 +305,8 @@ PrefabInstance:
       propertyPath: variantIndex
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 90804091474310291, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
 --- !u!1 &5402039977891859153 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/FilterFlipped.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/FilterFlipped.prefab
@@ -122,5 +122,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 08a3f9e4e431c0945b748f87bc69081c,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 84a45367bc0e3144593bd956f9858dee, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/GasConnector.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/GasConnector.prefab
@@ -39,7 +39,6 @@ MonoBehaviour:
     CustomLogic: 0
     NetCompatible: 0
     mixAndVolume:
-      Volume: 0.05
       Mix:
         temperature: 273.15
         reagents:
@@ -182,7 +181,8 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 4bcb8d8cce82a384fbc97ab57e0f7ca1,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 90804091474310291, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
 --- !u!1 &89826352100901616 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Metre.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Metre.prefab
@@ -262,7 +262,8 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 5bb3843dc3ab6c84eb50d98e2d3e0ea8,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 90804091474310291, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
 --- !u!1 &290815033769572229 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Mixer.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Mixer.prefab
@@ -47,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -140,7 +141,6 @@ MonoBehaviour:
     CustomLogic: 0
     NetCompatible: 0
     mixAndVolume:
-      Volume: 0.1
       Mix:
         temperature: 273.15
         reagents:
@@ -301,7 +301,8 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 3b79750e2969f1d48aaf1e860e1052be,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 90804091474310291, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
 --- !u!1 &3547153461055112373 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/MixerFlipped.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/MixerFlipped.prefab
@@ -127,5 +127,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 44c6e1cebd153de4da2480cc8b7a48ef,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: bf2be194ab71aa846a4677dfc06911ec, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Pump.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Pump.prefab
@@ -39,7 +39,6 @@ MonoBehaviour:
     CustomLogic: 0
     NetCompatible: 0
     mixAndVolume:
-      Volume: 50
       Mix:
         temperature: 273.15
         reagents:
@@ -117,6 +116,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -302,7 +302,8 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 3350f04c621ef4745b15c30a5614332b,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 90804091474310291, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
 --- !u!1 &3876953017801636264 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Scrubber.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Scrubber.prefab
@@ -118,6 +118,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -306,7 +307,8 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 6edfe9ee88d60e046ab116d8b095140c,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 90804091474310291, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
 --- !u!1 &7627266873688313229 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/UnaryVent.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/UnaryVent.prefab
@@ -47,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -141,7 +142,6 @@ MonoBehaviour:
     CustomLogic: 0
     NetCompatible: 0
     mixAndVolume:
-      Volume: 0.05
       Mix:
         temperature: 273.15
         reagents:
@@ -282,7 +282,8 @@ PrefabInstance:
       propertyPath: variantIndex
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 90804091474310291, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
 --- !u!1 &5583053235923205949 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Vent.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/LiquidPipes/Vent.prefab
@@ -1,5 +1,107 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7562452079414481989
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2944484590394730014}
+  - component: {fileID: 1748587250563468710}
+  - component: {fileID: 5171997616811968670}
+  m_Layer: 10
+  m_Name: SpritePipe
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2944484590394730014
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7562452079414481989}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 9124035769058563170}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1748587250563468710
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7562452079414481989}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 776718967
+  m_SortingLayer: 1
+  m_SortingOrder: 3
+  m_Sprite: {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.64, y: 0.64}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &5171997616811968670
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7562452079414481989}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetworkThis: 1
+  SubCatalogue: []
+  PresentSpriteSet: {fileID: 11400000, guid: 61d0fd3d04c4c844b9b008adec3e6fcb, type: 2}
+  pushTextureOnStartUp: 1
+  variantIndex: 0
+  palette: []
+  Sprites: []
 --- !u!114 &211491395895552323
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -70,107 +172,6 @@ MonoBehaviour:
   SelfSufficient: 0
   MaxTransferMoles: 100
   MaxOutletPressure: 110
---- !u!1 &7562452079414481989
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2944484590394730014}
-  - component: {fileID: 1748587250563468710}
-  - component: {fileID: 5171997616811968670}
-  m_Layer: 10
-  m_Name: SpritePipe
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2944484590394730014
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7562452079414481989}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 9124035769058563170}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1748587250563468710
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7562452079414481989}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c122dd7923e087c48bf08da9da455514, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 776718967
-  m_SortingLayer: 1
-  m_SortingOrder: 3
-  m_Sprite: {fileID: 21300000, guid: 6dd8897b3868b3945a0e8c941b0699f7, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.64, y: 0.64}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!114 &5171997616811968670
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7562452079414481989}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  NetworkThis: 1
-  SubCatalogue: []
-  PresentSpriteSet: {fileID: 11400000, guid: 61d0fd3d04c4c844b9b008adec3e6fcb, type: 2}
-  pushTextureOnStartUp: 1
-  variantIndex: 0
-  palette: []
-  Sprites: []
 --- !u!1001 &4956413113634608369
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -305,7 +306,8 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 42b9b9089fd5ed44692feb53ca55fb6b,
         type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 90804091474310291, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
 --- !u!1 &9118280692232901304 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/ScriptableObjects/Chemistry/ReactionSets/Default.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Chemistry/ReactionSets/Default.asset
@@ -12,7 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d6ae085312b071098d3dbb5d8da0511, type: 3}
   m_Name: Default
   m_EditorClassIdentifier: 
-  parents: []
+  parents:
+  - {fileID: 11400000, guid: 5e9cd20e17eb54a49b4676ae98d5a6a1, type: 2}
+  - {fileID: 11400000, guid: 701922900047cd742b7b5ede817b7837, type: 2}
   reactions:
   - {fileID: 11400000, guid: 5f8820e0f9670bd30ba49f549b1ac994, type: 2}
   - {fileID: 11400000, guid: 2c91aa3e713bbcd3bb3965eb4ea7f867, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Chemistry/ReactionSets/MixingBowl.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Chemistry/ReactionSets/MixingBowl.asset
@@ -12,8 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d6ae085312b071098d3dbb5d8da0511, type: 3}
   m_Name: MixingBowl
   m_EditorClassIdentifier: 
-  parents:
-  - {fileID: 11400000, guid: 2d5f766d9268838aa8d819bee2a442a7, type: 2}
+  parents: []
   reactions:
   - {fileID: 11400000, guid: b77703c1947bbc04ebc4fa98579437da, type: 2}
   - {fileID: 11400000, guid: 6dfbcf309344bfb45993ca33bd2c7ab2, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Chemistry/ReactionSets/NormalBowl.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Chemistry/ReactionSets/NormalBowl.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: NormalBowl
   m_EditorClassIdentifier: 
   parents:
-  - {fileID: 11400000, guid: 701922900047cd742b7b5ede817b7837, type: 2}
+  - {fileID: 11400000, guid: 2d5f766d9268838aa8d819bee2a442a7, type: 2}
   reactions:
   - {fileID: 11400000, guid: 7b923b829bfdf3149ae31aec2952c28b, type: 2}
   - {fileID: 11400000, guid: ab75532cf857ce04693a6919bed87352, type: 2}


### PR DESCRIPTION
### Purpose
- Default chemical reaction set now inherits from drink and some food reactions again. Bowl recipe reactions are still unique to bowls.
- Removes upright sprite component from atmos pipe objects so that they keep their rotation.