### PR TITLE
Make mice turn into "DeadMouse" prefab when killed

### DIFF
--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/MouseAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/MouseAI.cs
@@ -23,14 +23,18 @@ namespace NPC
 			mood = GetComponent<MobMood>();
 		}
 
-		protected override void MonitorExtras()
+		protected override void UpdateMe()
 		{
 			if (health.IsDead)
 			{
 				Spawn.ServerPrefab(deadMouse, gameObject.RegisterTile().WorldPosition);
 				Despawn.ServerSingle(gameObject);
 			}
+			base.UpdateMe();
+		}
 
+		protected override void MonitorExtras()
+		{
 			base.MonitorExtras();
 			// If mouse not happy, mouse chew cable. Feed mouse. Or kill mouse, that would work too.
 			CheckMoodLevel();


### PR DESCRIPTION
### Purpose
Makes mice turn into "DeadMouse" prefab when killed
Fixes #5285 