### PR TITLE
Switches lavaland spawning to on by default

### DIFF
--- a/UnityProject/Assets/StreamingAssets/config/gameConfig.json
+++ b/UnityProject/Assets/StreamingAssets/config/gameConfig.json
@@ -1,7 +1,7 @@
 {
 	"RandomEventsAllowed": true,
 
-	"SpawnLavaLand": false,
+	"SpawnLavaLand": true,
 
 	"MinPlayersForCountdown": 1,
 
@@ -16,8 +16,8 @@
 	"RespawnAllowed": false,
 
 	"ShuttleDepartTime": 180,
-	
+
 	"GibbingAllowed": false,
-	
+
 	"ShuttleGibbingAllowed": true
 }


### PR DESCRIPTION
With bods physics optimisations lavaland spawns from 1min to now only 3 seconds

CL: lavaland now spawns by default
