### PR TITLE
reduces BURNING_DAMAGE damage by half

### DIFF
--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -101,7 +101,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	private static OverlayTile LARGE_ASH;
 
 	// damage incurred each tick while an object is on fire
-	private static float BURNING_DAMAGE = 0.08f;
+	private static float BURNING_DAMAGE = 0.04f;
 
 	private static readonly float BURN_RATE = 1f;
 


### PR DESCRIPTION
### Purpose
Hopefully Fixes #2536 by halving the amount of damage dealt in a burning status update hook.

### Notes:
Could not test nor compare after several tries, and with the lack of activity on the issue thread; just posted.

