### PR TITLE
Fixes disposal bin, DirectionalPassable, Disposal intake, pushing in editor

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/DirectionalWindow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/DirectionalWindow.prefab
@@ -1,5 +1,66 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1716766423784078090
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6436439715640028678}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  registerTile: {fileID: 0}
+  floorDecal: {fileID: 0}
+  isInitiallyNotPushable: 1
+  pushPullSound: 
+  soundDelayTime: 0
+  soundMinimumPitchVariance: 1
+  soundMaximumPitchVariance: 1
+  OnPullingSomethingChangedServer:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &-7987623581128504728
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6436439715640028678}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 813ab4b5d9bc9fb488ddec0397a19373, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  matrixDebugLogging: 0
+  objectType: 1
+  AtmosPassable: 1
+  Passable: 1
+  passableExclusionsToThis: []
+  isLeavableOnAll: 0
+  isEnterableOnAll: 0
+  isAtmosPassableOnAll: 0
+  leavableSides:
+    Up: 1
+    Down: 0
+    Left: 1
+    Right: 1
+  enterableSides:
+    Up: 1
+    Down: 0
+    Left: 1
+    Right: 1
+  atmosphericPassableSides:
+    Up: 1
+    Down: 0
+    Left: 1
+    Right: 1
 --- !u!114 &-5694877607498037915
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -61,48 +122,6 @@ MonoBehaviour:
   indexLeft: 3
   spriteHandlers:
   - {fileID: 1946156532474512604}
---- !u!114 &1716766423784078090
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6436439715640028678}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c23c49138f42840a1bc22ade283c1694, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  registerTile: {fileID: 0}
-  floorDecal: {fileID: 0}
-  isInitiallyNotPushable: 1
-  pushPullSound: 
-  soundDelayTime: 0
-  soundMinimumPitchVariance: 1
-  soundMaximumPitchVariance: 1
-  OnPullingSomethingChangedServer:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &7975151385294962407
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6436439715640028678}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f0eb35888c6dfb4dbac823eb8cad23b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  matrixDebugLogging: 0
-  objectType: 1
-  OneDirectionRestricted: 1
-  isClosed: 1
 --- !u!114 &9012874896178120669
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Disposals/DisposalIntake.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Disposals/DisposalIntake.prefab
@@ -17,11 +17,26 @@ MonoBehaviour:
   matrixDebugLogging: 0
   objectType: 1
   AtmosPassable: 1
-  Passable: 1
-  PassableUp: 0
-  PassableDown: 1
-  PassableLeft: 0
-  PassableRight: 0
+  Passable: 0
+  passableExclusionsToThis: []
+  isLeavableOnAll: 1
+  isEnterableOnAll: 0
+  isAtmosPassableOnAll: 1
+  leavableSides:
+    Up: 0
+    Down: 0
+    Left: 0
+    Right: 0
+  enterableSides:
+    Up: 0
+    Down: 1
+    Left: 0
+    Right: 0
+  atmosphericPassableSides:
+    Up: 0
+    Down: 0
+    Left: 0
+    Right: 0
 --- !u!114 &1627647419430524646
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/TableInteractionClimb.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/TileInteraction/TableInteractionClimb.cs
@@ -76,7 +76,7 @@ public class TableInteractionClimb : TileInteraction
 		}).ServerStartProgress(interaction.UsedObject.RegisterTile(), 3.0f, interaction.Performer);
 		
 		Chat.AddActionMsgToChat(interaction.Performer,
-			"You begin cimbing onto the table...",
+			"You begin climbing onto the table...",
 			$"{interaction.Performer.ExpensiveName()} begins climbing onto the table...");
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Directionals/DirectionalPassable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/DirectionalPassable.cs
@@ -1,105 +1,216 @@
 ﻿using System;
 using UnityEngine;
+using NaughtyAttributes;
 
-/// <summary>
-/// Allows only some sides of an objects's tile to be passable. Useful for things such as directional windows, disposal intakes.
-/// Must be the sole RegisterTile-derived component on the object, else it is glitchy.
-/// </summary>
-[RequireComponent(typeof(Directional))]
-public class DirectionalPassable : RegisterObject
+namespace Core.Directionals
 {
-	[Header("Set which sides are passable when in orientation Down")]
-	public bool PassableUp;
-	public bool PassableDown;
-	public bool PassableLeft;
-	public bool PassableRight;
-
-	bool passableOnAll = false;
-	public bool PassableOnAll => passableOnAll;
-
-	public Directional Directional { get; private set; }
-
-	#region RegisterObject Overrides
-
-	protected override void Awake()
+	/// <summary>
+	/// Allows only some sides of an objects's tile to be passable. Useful for things such as directional windows, disposal intakes.
+	/// Must be the sole RegisterTile-derived component on the object, else it is glitchy.
+	/// </summary>
+	[RequireComponent(typeof(Directional))]
+	public class DirectionalPassable : RegisterObject
 	{
-		base.Awake();
-		Directional = GetComponent<Directional>();
-	}
+		[InfoBox("Set Passable or Atmos Passable checked if any side is passable by default, or any atmos passable side", EInfoBoxType.Normal)]
+		[Header("Overrides")]
+		[SerializeField]
+		private bool isLeavableOnAll = default;
+		[SerializeField]
+		private bool isEnterableOnAll = default;
+		[SerializeField]
+		private bool isAtmosPassableOnAll = default;
 
-	public override bool IsPassableTo(Vector3Int to, bool isServer)
-	{
-		return CheckPassable(to);
-	}
+		[Header("Set which sides are passable when in orientation Down")]
+		[SerializeField]
+		private PassableSides leavableSides;
+		[SerializeField]
+		private PassableSides enterableSides;
+		[SerializeField]
+		private PassableSides atmosphericPassableSides;
 
-	public override bool IsPassable(Vector3Int from, bool isServer, GameObject context = null)
-	{
-		return CheckPassable(from);
-	}
+		public Directional Directional { get; private set; }
 
-	#endregion RegisterObject Overrides
+		public bool IsLeavableOnAll => isLeavableOnAll;
+		public bool IsEnterableOnAll => isEnterableOnAll;
+		public bool IsAtmosPassableOnAll => isAtmosPassableOnAll;
 
-	public void AllowPassableOnAllSides()
-	{
-		passableOnAll = true;
-		Passable = true;
-	}
+		#region RegisterObject Overrides
 
-	public void DenyPassableOnAllSides()
-	{
-		passableOnAll = false;
-		Passable = false;
-	}
-
-	public void AllowPassableAtSetSides()
-	{
-		passableOnAll = false;
-		Passable = true;
-	}
-
-	bool CheckPassable(Vector3Int sideVector)
-	{
-		// If passable on all, can be passable on any side.
-		if (PassableOnAll) return true;
-		// If not passable, cannot be passed on any side.
-		if (!Passable) return false;
-
-		Vector2Int sideToCross = (sideVector - LocalPosition).To2Int();
-		bool result = IsPassableAtSide(sideToCross);
-		return result;
-	}
-
-	bool IsPassableAtSide(Vector2Int sideToCross)
-	{
-		// TODO Consider using some data structure
-		switch (Directional.CurrentDirection.AsEnum())
+		protected override void Awake()
 		{
-			case OrientationEnum.Up:
-				if (sideToCross == Vector2Int.up) return PassableDown;
-				else if (sideToCross == Vector2Int.down) return PassableUp;
-				else if (sideToCross == Vector2Int.left) return PassableRight;
-				else if (sideToCross == Vector2Int.right) return PassableLeft;
-				break;
-			case OrientationEnum.Down:
-				if (sideToCross == Vector2Int.up) return PassableUp;
-				else if (sideToCross == Vector2Int.down) return PassableDown;
-				else if (sideToCross == Vector2Int.left) return PassableLeft;
-				else if (sideToCross == Vector2Int.right) return PassableRight;
-				break;
-			case OrientationEnum.Left:
-				if (sideToCross == Vector2Int.up) return PassableLeft;
-				else if (sideToCross == Vector2Int.down) return PassableRight;
-				else if (sideToCross == Vector2Int.left) return PassableDown;
-				else if (sideToCross == Vector2Int.right) return PassableUp;
-				break;
-			case OrientationEnum.Right:
-				if (sideToCross == Vector2Int.up) return PassableRight;
-				else if (sideToCross == Vector2Int.down) return PassableLeft;
-				else if (sideToCross == Vector2Int.left) return PassableUp;
-				else if (sideToCross == Vector2Int.right) return PassableDown;
-				break;
+			base.Awake();
+			Directional = GetComponent<Directional>();
 		}
 
-		return false;
+		public override bool IsPassable(bool isServer, GameObject context = null)
+		{
+			if (!Passable) return false;
+			if (context == gameObject || context == null) return true;
+
+			return Passable;
+		}
+
+		public override bool IsPassable(Vector3Int enteringFrom, bool isServer, GameObject context = null)
+		{
+			if (!Passable) return false;
+			if (IsEnterableOnAll) return true;
+			if (context == gameObject || context == null) return true;
+
+			return IsPassableAtSide(GetSideFromVector(enteringFrom), enterableSides);
+		}
+
+		public override bool IsPassableTo(Vector3Int leavingTo, bool isServer, GameObject context = null)
+		{
+			if (!Passable) return false;
+			if (IsLeavableOnAll) return true;
+			if (context == gameObject || context == null) return true;
+
+			return IsPassableAtSide(GetSideFromVector(leavingTo), leavableSides);
+		}
+
+		public override bool IsAtmosPassable(Vector3Int enteringFrom, bool isServer)
+		{
+			if (!AtmosPassable) return false;
+			if (IsAtmosPassableOnAll) return true;
+
+			return IsPassableAtSide(GetSideFromVector(enteringFrom), atmosphericPassableSides);
+		}
+
+		#endregion RegisterObject Overrides
+
+		/// <summary>
+		/// Sets all sides for this object as passable for the given pass type.
+		/// </summary>
+		public void AllowPassableOnAllSides(PassType passType)
+		{
+			switch (passType)
+			{
+				case PassType.Entering:
+					isEnterableOnAll = true;
+					Passable = true;
+					break;
+				case PassType.Leaving:
+					isLeavableOnAll = true;
+					Passable = true;
+					break;
+				case PassType.Atmospheric:
+					isAtmosPassableOnAll = true;
+					AtmosPassable = true;
+					break;
+				default:
+					Logger.LogWarning("Unknown DirectionalPassable PassType. Doing nothing.", Category.Direction);
+					break;
+			}
+		}
+
+		/// <summary>
+		/// Sets all sides for this object as impassable for the given pass type.
+		/// </summary>
+		public void DenyPassableOnAllSides(PassType passType)
+		{
+			switch (passType)
+			{
+				case PassType.Entering:
+					isEnterableOnAll = false;
+					Passable = false;
+					break;
+				case PassType.Leaving:
+					isLeavableOnAll = false;
+					Passable = false;
+					break;
+				case PassType.Atmospheric:
+					isAtmosPassableOnAll = false;
+					AtmosPassable = false;
+					break;
+				default:
+					Logger.LogWarning("Unknown DirectionalPassable PassType. Doing nothing.", Category.Direction);
+					break;
+			}
+		}
+
+		/// <summary>
+		/// Sets only the sides defined as passable for the given pass type.
+		/// </summary>
+		public void AllowPassableAtSetSides(PassType passType)
+		{
+			switch (passType)
+			{
+				case PassType.Entering:
+					isEnterableOnAll = false;
+					Passable = true;
+					break;
+				case PassType.Leaving:
+					isLeavableOnAll = false;
+					Passable = true;
+					break;
+				case PassType.Atmospheric:
+					isAtmosPassableOnAll = false;
+					AtmosPassable = true;
+					break;
+				default:
+					Logger.LogWarning("Unknown DirectionalPassable PassType. Doing nothing.", Category.Direction);
+					break;
+			}
+		}
+
+		private Vector2Int GetSideFromVector(Vector3Int vector)
+		{
+			return (vector - LocalPosition).To2Int();
+		}
+
+		private bool IsPassableAtSide(Vector2Int sideToCross, PassableSides sides)
+		{
+			if (sideToCross == Vector2Int.zero) return true;
+
+			// TODO: figure out a better way or at least use some data structure.
+			switch (Directional.CurrentDirection.AsEnum())
+			{
+				case OrientationEnum.Up:
+					if (sideToCross == Vector2Int.up) return sides.Down;
+					else if (sideToCross == Vector2Int.down) return sides.Up;
+					else if (sideToCross == Vector2Int.left) return sides.Right;
+					else if (sideToCross == Vector2Int.right) return sides.Left;
+					break;
+				case OrientationEnum.Down:
+					if (sideToCross == Vector2Int.up) return sides.Up;
+					else if (sideToCross == Vector2Int.down) return sides.Down;
+					else if (sideToCross == Vector2Int.left) return sides.Left;
+					else if (sideToCross == Vector2Int.right) return sides.Right;
+					break;
+				case OrientationEnum.Left:
+					if (sideToCross == Vector2Int.up) return sides.Left;
+					else if (sideToCross == Vector2Int.down) return sides.Right;
+					else if (sideToCross == Vector2Int.left) return sides.Down;
+					else if (sideToCross == Vector2Int.right) return sides.Up;
+					break;
+				case OrientationEnum.Right:
+					if (sideToCross == Vector2Int.up) return sides.Right;
+					else if (sideToCross == Vector2Int.down) return sides.Left;
+					else if (sideToCross == Vector2Int.left) return sides.Up;
+					else if (sideToCross == Vector2Int.right) return sides.Down;
+					break;
+				default:
+					Logger.LogWarning("Unknown orientation. Returning false.", Category.Direction);
+					break;
+			}
+
+			return false;
+		}
+
+		[Serializable]
+		public struct PassableSides
+		{
+			public bool Up;
+			public bool Down;
+			public bool Left;
+			public bool Right;
+		}
+	}
+
+	public enum PassType
+	{
+		Entering,
+		Leaving,
+		Atmospheric,
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalBin.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalBin.cs
@@ -272,21 +272,22 @@ namespace Objects.Disposals
 		// TODO This was copied from somewhere. Where?
 		void StartStoringPlayer(MouseDrop interaction)
 		{
-			List<LayerType> excludeObjects = new List<LayerType>() { LayerType.Objects };
 			Vector3Int targetObjectLocalPosition = interaction.TargetObject.RegisterTile().LocalPosition;
 			Vector3Int targetObjectWorldPos = interaction.TargetObject.WorldPosServer().CutToInt();
 
-			if (!interaction.UsedObject.RegisterTile().Matrix.IsPassableAt(targetObjectLocalPosition, true, excludeLayers: excludeObjects))
+			// We check if there's nothing in the way, like another player or a directional window.
+			if (interaction.UsedObject.RegisterTile().Matrix.IsPassableAt(targetObjectLocalPosition, true, context: gameObject) == false)
 			{
 				return;
 			}
 
+			// Runs when the progress action is complete.
 			void StoringPlayer()
 			{
 				PlayerScript playerScript;
 				if (interaction.UsedObject.TryGetComponent(out playerScript))
 				{
-					if (playerScript.registerTile.Matrix.IsPassableAt(targetObjectLocalPosition, true, excludeLayers: excludeObjects))
+					if (playerScript.registerTile.Matrix.IsPassableAt(targetObjectLocalPosition, true, context: gameObject))
 					{
 						playerScript.PlayerSync.SetPosition(targetObjectWorldPos);
 					}

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalIntake.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalIntake.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using Core.Directionals;
 using Systems.Disposals;
 
 namespace Objects.Disposals
@@ -112,7 +113,7 @@ namespace Objects.Disposals
 			if (FloorPlatingExposed()) baseString = base.Examine().TrimEnd('.') + " and";
 
 			if (IsOperating) return $"{baseString} is currently flushing its contents.";
-			else return $"{baseString} is ready for use.";
+			else return $"{baseString} is {(MachineSecured ? "ready" : "not ready")} for use.";
 		}
 
 		#endregion Interactions
@@ -184,14 +185,12 @@ namespace Objects.Disposals
 
 		void DenyEntry()
 		{
-			// TODO: Figure out a way to exclude this object from directional passable checks
-			// before we can re-enable this line, else we cannot move the object.
-			//directionalPassable.DenyPassableOnAllSides();
+			directionalPassable.DenyPassableOnAllSides(PassType.Entering);
 		}
 
 		void AllowEntry()
 		{
-			directionalPassable.AllowPassableAtSetSides();
+			directionalPassable.AllowPassableAtSetSides(PassType.Entering);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Objects/Disposals/DisposalOutlet.cs
+++ b/UnityProject/Assets/Scripts/Objects/Disposals/DisposalOutlet.cs
@@ -102,7 +102,7 @@ namespace Objects.Disposals
 			if (FloorPlatingExposed()) baseString = base.Examine().TrimEnd('.') + " and";
 
 			if (IsOperating) return $"{baseString} is currently ejecting its contents.";
-			else return $"{baseString} is ready for use.";
+			else return $"{baseString} is {(MachineSecured ? "ready" : "not ready")} for use.";
 		}
 
 		#endregion Interactions

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -239,7 +239,7 @@ public partial class PlayerSync
 		for (int i = 0; i < pushPulls.Count; i++)
 		{
 			var pushPull = pushPulls[i];
-			if (pushPull && pushPull.gameObject != gameObject && pushPull.IsSolidClient)
+			if (pushPull && pushPull.gameObject != gameObject && pushPull.CanPushClient(worldTile, direction))
 			{
 				//					Logger.LogTraceFormat( "Predictive pushing {0} from {1} to {2}", Category.PushPull, pushPulls[i].gameObject, worldTile, (Vector2)(Vector3)worldTile+(Vector2)direction );
 				if (pushPull.TryPredictivePush(worldTile, direction))

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -145,10 +145,10 @@ public class Matrix : MonoBehaviour
 	}
 
 	public bool IsPassableAt(Vector3Int position, bool isServer, bool includingPlayers = true,
-		List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null, GameObject context = null)
+		List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null, GameObject context = null, bool ignoreObjects = false)
 	{
-		return IsPassableAt(position, position, isServer, context: context,includingPlayers: includingPlayers,
-			excludeLayers: excludeLayers, excludeTiles: excludeTiles);
+		return IsPassableAt(position, position, isServer, context: context, includingPlayers: includingPlayers,
+			excludeLayers: excludeLayers, excludeTiles: excludeTiles, ignoreObjects: ignoreObjects);
 	}
 
 	/// <summary>
@@ -168,11 +168,11 @@ public class Matrix : MonoBehaviour
 	/// <param name="context">Is excluded from passable check</param>
 	/// <returns></returns>
 	public bool IsPassableAt(Vector3Int origin, Vector3Int position, bool isServer,
-		CollisionType collisionType = CollisionType.Player, bool includingPlayers = true, GameObject context = null,
-		List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null)
+			CollisionType collisionType = CollisionType.Player, bool includingPlayers = true, GameObject context = null,
+			List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null, bool ignoreObjects = false)
 	{
 		return MetaTileMap.IsPassableAt(origin, position, isServer, collisionType: collisionType,
-			inclPlayers: includingPlayers, context: context, excludeLayers: excludeLayers, excludeTiles: excludeTiles);
+			inclPlayers: includingPlayers, context: context, excludeLayers: excludeLayers, excludeTiles: excludeTiles, ignoreObjects: ignoreObjects);
 	}
 
 	public bool IsAtmosPassableAt(Vector3Int position, bool isServer)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -245,27 +245,26 @@ namespace TileManagement
 		}
 
 		public bool IsPassableAt(Vector3Int origin, Vector3Int to, bool isServer,
-			CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null,
-			List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null)
+				CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null,
+				List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null, bool ignoreObjects = false)
 		{
 			Vector3Int toX = new Vector3Int(to.x, origin.y, origin.z);
 			Vector3Int toY = new Vector3Int(origin.x, to.y, origin.z);
 
 			return _IsPassableAt(origin, toX, isServer, collisionType, inclPlayers, context, excludeLayers,
-				       excludeTiles) &&
-			       _IsPassableAt(toX, to, isServer, collisionType, inclPlayers, context, excludeLayers, excludeTiles) ||
+				       excludeTiles, ignoreObjects) &&
+			       _IsPassableAt(toX, to, isServer, collisionType, inclPlayers, context, excludeLayers, excludeTiles, ignoreObjects) ||
 			       _IsPassableAt(origin, toY, isServer, collisionType, inclPlayers, context, excludeLayers,
-				       excludeTiles) &&
-			       _IsPassableAt(toY, to, isServer, collisionType, inclPlayers, context, excludeLayers, excludeTiles);
+				       excludeTiles, ignoreObjects) &&
+			       _IsPassableAt(toY, to, isServer, collisionType, inclPlayers, context, excludeLayers, excludeTiles, ignoreObjects);
 		}
-
 
 		private bool _IsPassableAt(Vector3Int origin, Vector3Int to, bool isServer,
 			CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null,
-			List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null)
+			List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null, bool ignoreObjects = false)
 		{
-			if (ObjectLayer.IsPassableAt(origin, to, isServer, collisionType, inclPlayers, context, excludeTiles) ==
-			    false)
+			if (ignoreObjects == false &&
+					ObjectLayer.IsPassableAt(origin, to, isServer, collisionType, inclPlayers, context, excludeTiles) == false)
 			{
 				return false;
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/ObjectLayer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -50,13 +50,13 @@ public class ObjectLayer : Layer
 		return resistance;
 	}
 
-	public bool IsPassableAt(Vector3Int origin, Vector3Int to, bool isServer,
-									  CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null, List<TileType> excludeTiles = null)
+	public bool IsPassableAt(Vector3Int origin, Vector3Int to, bool isServer, CollisionType collisionType = CollisionType.Player,
+			bool inclPlayers = true, GameObject context = null, List<TileType> excludeTiles = null)
 	{
 		//Targeting windoors here
 		foreach ( RegisterTile t in isServer ? ServerObjects.Get(origin) : ClientObjects.Get(origin) )
 		{
-			if (!t.IsPassableTo(to, isServer) && (!context || t.gameObject != context))
+			if (!t.IsPassableTo(to, isServer, context) && (!context || t.gameObject != context))
 			{
 				//Can't get outside the tile because windoor doesn't allow us
 				return false;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterDoor.cs
@@ -61,7 +61,7 @@
 		}
 
 
-		public override bool IsPassableTo( Vector3Int to, bool isServer )
+		public override bool IsPassableTo(Vector3Int leavingTo, bool isServer, GameObject context = null)
 		{
 			if (isClosed && OneDirectionRestricted)
 			{
@@ -71,7 +71,7 @@
 
 				// Returns false if player is bumping door from the restricted direction
 				var position = isServer? LocalPositionServer : LocalPositionClient;
-				var direction = to - position;
+				var direction = leavingTo - position;
 
 				//Use Directional component if it exists
 				var tryGetDir = GetComponent<Directional>();

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterObject.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterObject.cs
@@ -45,21 +45,23 @@ public class RegisterObject : RegisterTile
 		Passable = initialPassable;
 	}
 
-	public override bool IsPassable(Vector3Int from, bool isServer, GameObject context = null)
+	public override bool IsPassable(Vector3Int enteringFrom, bool isServer, GameObject context = null)
 	{
+		if (context == gameObject) return true; // Object can pass through its own RegisterTile.
 		if (CheckPassableExclusions(context)) return true;
 
-		return Passable || (isServer ? LocalPositionServer == TransformState.HiddenPos : LocalPositionClient == TransformState.HiddenPos );
+		return Passable || (isServer ? LocalPositionServer == TransformState.HiddenPos : LocalPositionClient == TransformState.HiddenPos);
 	}
 
 	public override bool IsPassable(bool isServer, GameObject context = null)
 	{
+		if (context == gameObject) return true; // Object can pass through its own RegisterTile.
 		if (CheckPassableExclusions(context)) return true;
 
 		return Passable || (isServer ? LocalPositionServer == TransformState.HiddenPos : LocalPositionClient == TransformState.HiddenPos );
 	}
 
-	public override bool IsAtmosPassable(Vector3Int from, bool isServer)
+	public override bool IsAtmosPassable(Vector3Int enteringFrom, bool isServer)
 	{
 		return AtmosPassable || (isServer ? LocalPositionServer == TransformState.HiddenPos : LocalPositionClient == TransformState.HiddenPos );
 	}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterTile.cs
@@ -749,19 +749,20 @@ public class RegisterTile : NetworkBehaviour, IServerDespawn
 		return true;
 	}
 
-	/// Is it passable when approaching from outside?
-	public virtual bool IsPassable(Vector3Int from, bool isServer, GameObject context = null)
+	///<summary> Is it passable when approaching from outside? </summary>
+	public virtual bool IsPassable(Vector3Int enteringFrom, bool isServer, GameObject context = null)
 	{
 		return true;
 	}
 
-	/// Is it passable when trying to leave it?
-	public virtual bool IsPassableTo(Vector3Int to, bool isServer)
+	/// <summary> Is it passable when trying to leave it? </summary>
+	public virtual bool IsPassableTo(Vector3Int leavingTo, bool isServer, GameObject context = null)
 	{
 		return true;
 	}
 
-	public virtual bool IsAtmosPassable(Vector3Int from, bool isServer)
+	///<summary> Is it passable when approaching from outside? </summary>
+	public virtual bool IsAtmosPassable(Vector3Int enteringFrom, bool isServer)
 	{
 		return true;
 	}


### PR DESCRIPTION
- Fixes being unable to drag things into the disposal bin.
- Fixes `DirectionalPassable` component.
    - Fixes disposal intakes unable to be dragged from any direction other than its opening. Fixes part 21. of issue #4654.
- Swaps directional windows to use `DirectionalPassable` instead of `RegisterDoor`.
- Fixes pushing while playing in editor being buggy.

> Note: it is now possible to convert directional doors to use `DirectionalPassable`, too.

CL:Fixes being unable to dispose of yourself, and unable to drag disposal intakes.