### PR TITLE
Fixes blacked out action icons, fixes regressions in paletteable objects in dev spawner & cloner

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,3 @@
 ---
 exclude_paths:
-  - 'UnityProject/Assets/Plugins/YamlDotNet/**'
+  - 'UnityProject/Assets/Plugins/YamlDotNet'

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,0 @@
----
-exclude_paths:
-  - 'UnityProject/Assets/Plugins/YamlDotNet/**'

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+  - 'UnityProject/Assets/Plugins/YamlDotNet/**'

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,3 @@
 ---
 exclude_paths:
-  - 'UnityProject/Assets/Plugins/YamlDotNet'
+  - 'UnityProject/Assets/Plugins/YamlDotNet/**'

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/BlueShoes.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/BlueShoes.prefab
@@ -103,6 +103,86 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A pair of blue shoes.
       objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].g
+      value: 0.5372549
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].b
+      value: 0.9372549
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].r
+      value: 0.6313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].g
+      value: 0.6313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].b
+      value: 0.6313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.IsPaletted
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4728094771363396249, guid: 502f496beb9034b9b9c97868e845ed7e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/BrownShoes.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/BrownShoes.prefab
@@ -98,6 +98,86 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A pair of brown shoes.
       objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.IsPaletted
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].r
+      value: 0.49019608
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].g
+      value: 0.24705882
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].b
+      value: 0.003921569
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].r
+      value: 0.6313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].g
+      value: 0.6313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].b
+      value: 0.6313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].b
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4728094771363396249, guid: 502f496beb9034b9b9c97868e845ed7e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/OrangeShoes.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/OrangeShoes.prefab
@@ -118,6 +118,101 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A pair of orange shoes.
       objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].r
+      value: 0.9372549
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].g
+      value: 0.5058824
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.IsPaletted
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[3].r
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[3].g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[3].b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[3].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].r
+      value: 0.6313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].g
+      value: 0.6313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].b
+      value: 0.6313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].b
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4728094771363396249, guid: 502f496beb9034b9b9c97868e845ed7e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/WhiteShoes.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Feetwear/WhiteShoes.prefab
@@ -98,6 +98,86 @@ PrefabInstance:
       propertyPath: initialDescription
       value: A pair of white shoes.
       objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].r
+      value: 0.81960785
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].g
+      value: 0.81960785
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].b
+      value: 0.81960785
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[0].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.IsPaletted
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[1].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].r
+      value: 0.6313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].g
+      value: 0.6313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].b
+      value: 0.6313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[2].a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2237498582025012862, guid: 502f496beb9034b9b9c97868e845ed7e,
+        type: 3}
+      propertyPath: itemSprites.Palette.Array.data[4].b
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4728094771363396249, guid: 502f496beb9034b9b9c97868e845ed7e,
         type: 3}
       propertyPath: clothData

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/AdminTools/DevSpawnCursor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/UIManager/AdminTools/DevSpawnCursor.prefab
@@ -45,10 +45,12 @@ SpriteRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 15f015b12f2615240bab192aeaa9c18d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -67,7 +69,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 1702942933
-  m_SortingLayer: 23
+  m_SortingLayer: 25
   m_SortingOrder: 0
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.48235294}

--- a/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
+++ b/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
@@ -25,7 +25,6 @@ namespace Clothing
 		private GameObject larvae = null;
 
 		private bool isAlive = true;
-		private RegisterPlayer registerPlayer;
 		private ClothingV2 clothingV2;
 		private ItemAttributesV2 itemAttributesV2;
 
@@ -90,7 +89,7 @@ namespace Clothing
 			yield return WaitFor.EndOfFrame;
 		}
 
-		private async Task Pregnancy(PlayerHealth player)
+		private async void Pregnancy(PlayerHealth player)
 		{
 			KillHugger();
 			await Task.Delay(TimeSpan.FromSeconds(pregnancyTime));
@@ -116,7 +115,9 @@ namespace Clothing
 
 		public void OnInventoryMoveServer(InventoryMove info)
 		{
-			if (info.ToSlot != null & info.ToSlot?.NamedSlot != null)
+			RegisterPlayer registerPlayer;
+
+			if (info.ToSlot != null && info.ToSlot?.NamedSlot != null)
 			{
 				registerPlayer = info.ToRootPlayer;
 
@@ -126,7 +127,7 @@ namespace Clothing
 				}
 			}
 
-			if (info.FromSlot != null & info.FromSlot?.NamedSlot != null & info.ToSlot != null)
+			if (info.FromSlot != null && info.FromSlot?.NamedSlot != null && info.ToSlot != null)
 			{
 				registerPlayer = info.FromRootPlayer;
 
@@ -135,7 +136,7 @@ namespace Clothing
 					OnTakingOff();
 				}
 			}
-			else if (info.FromSlot != null & info.ToSlot == null)
+			else if (info.FromSlot != null && info.ToSlot == null)
 			{
 				OnReleasing();
 			}
@@ -152,18 +153,15 @@ namespace Clothing
 				return;
 			}
 
-			switch (info.ClientInventoryMoveType)
+			if (info.ClientInventoryMoveType == ClientInventoryMoveType.Added
+				&& gameObject == playerScript.playerNetworkActions.GetActiveItemInSlot(NamedSlot.mask)?.gameObject)
 			{
-				case ClientInventoryMoveType.Added
-					when playerScript.playerNetworkActions.GetActiveItemInSlot(NamedSlot.mask)?.gameObject ==
-					     gameObject:
-					UIManager.PlayerHealthUI.heartMonitor.overlayCrits.SetState(OverlayState.crit);
-					break;
-				case ClientInventoryMoveType.Removed
-					when playerScript.playerNetworkActions.GetActiveItemInSlot(NamedSlot.mask)?.gameObject !=
-					     gameObject:
-					UIManager.PlayerHealthUI.heartMonitor.overlayCrits.SetState(OverlayState.normal);
-					break;
+				UIManager.PlayerHealthUI.heartMonitor.overlayCrits.SetState(OverlayState.crit);
+			}
+			else if (info.ClientInventoryMoveType == ClientInventoryMoveType.Removed
+				&& gameObject != playerScript.playerNetworkActions.GetActiveItemInSlot(NamedSlot.mask)?.gameObject)
+			{
+				UIManager.PlayerHealthUI.heartMonitor.overlayCrits.SetState(OverlayState.normal);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
@@ -509,17 +509,18 @@ public partial class Chat : MonoBehaviour
 	/// <param name="side">side this is being called from</param>
 	public static void AddExamineMsg(GameObject recipient, string message, NetworkSide side)
 	{
-		if (side == NetworkSide.Client)
+		switch(side)
 		{
-			AddExamineMsgToClient(message);
-		}
-		else if (side == NetworkSide.Server)
-		{
-			AddExamineMsgFromServer(recipient, message);
-		}
-		else
-		{
-			Debug.Assert(false, "Unknown Network Side");
+			case NetworkSide.Client:
+				AddExamineMsgToClient(message);
+				break;
+
+			case NetworkSide.Server:
+				AddExamineMsgFromServer(recipient, message);
+				break;
+			default:
+				Debug.Assert(false, "Unknown Network Side");
+				break;
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
@@ -5,6 +5,7 @@ using Tilemaps.Behaviours.Meta;
 using DiscordWebhook;
 using DatabaseAPI;
 using Systems.MobAIs;
+using System.Text;
 
 /// <summary>
 /// The Chat API
@@ -36,7 +37,7 @@ public partial class Chat : MonoBehaviour
 	//Does the ghost hear everyone or just local
 	public bool GhostHearAll { get; set; } = true;
 
-	public static bool OOCMute = false;
+	public bool OOCMute = false;
 
 	/// <summary>
 	/// Set the scene based chat relay at the start of every round
@@ -53,7 +54,7 @@ public partial class Chat : MonoBehaviour
 	public static void InvokeChatEvent(ChatEvent chatEvent)
 	{
 		var channels = chatEvent.channels;
-		string discordMessage = "";
+		StringBuilder discordMessageBuilder = new StringBuilder();
 
 		// There could be multiple channels we need to send a message for each.
 		// We do this on the server side so that local chans can be validated correctly
@@ -66,11 +67,12 @@ public partial class Chat : MonoBehaviour
 
 			chatEvent.channels = channel;
 			Instance.addChatLogServer.Invoke(chatEvent);
-			discordMessage += $"[{channel}] ";
+			discordMessageBuilder.Append($"[{channel}] ");
 		}
 
-		discordMessage += $"\n```css\n{chatEvent.speaker}: {chatEvent.message}\n```\n";
+		discordMessageBuilder.Append($"\n```css\n{chatEvent.speaker}: {chatEvent.message}\n```\n");
 
+		string discordMessage = discordMessageBuilder.ToString();
 		//Sends All Chat messages to a discord webhook
 		DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookAllChatURL, discordMessage, "");
 	}
@@ -116,7 +118,7 @@ public partial class Chat : MonoBehaviour
 				chatEvent.speaker = "[Admin] " + chatEvent.speaker;
 			}
 
-			if (OOCMute && !isAdmin) return;
+			if (Instance.OOCMute && !isAdmin) return;
 
 			Instance.addChatLogServer.Invoke(chatEvent);
 
@@ -399,14 +401,16 @@ public partial class Chat : MonoBehaviour
 	{
 		if (!IsServer()) return;
 
+		BodyPartType effectiveHitZone = hitZone;
+
 		var player = victim.Player();
 		if (player == null)
 		{
-			hitZone = BodyPartType.None;
+			effectiveHitZone = BodyPartType.None;
 		}
 
 		var message =
-			$"{victim.ExpensiveName()} has been hit by {item.Item()?.ArticleName ?? item.name}{InTheZone(hitZone)}";
+			$"{victim.ExpensiveName()} has been hit by {item.Item()?.ArticleName ?? item.name}{InTheZone(effectiveHitZone)}";
 		Instance.addChatLogServer.Invoke(new ChatEvent
 		{
 			channels = ChatChannel.Combat,
@@ -505,14 +509,17 @@ public partial class Chat : MonoBehaviour
 	/// <param name="side">side this is being called from</param>
 	public static void AddExamineMsg(GameObject recipient, string message, NetworkSide side)
 	{
-		switch (side)
+		if (side == NetworkSide.Client)
 		{
-			case NetworkSide.Client:
-				AddExamineMsgToClient(message);
-				break;
-			case NetworkSide.Server:
-				AddExamineMsgFromServer(recipient, message);
-				break;
+			AddExamineMsgToClient(message);
+		}
+		else if (side == NetworkSide.Server)
+		{
+			AddExamineMsgFromServer(recipient, message);
+		}
+		else
+		{
+			Debug.Assert(false, "Unknown Network Side");
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
@@ -144,7 +144,7 @@ public class SpriteHandler : MonoBehaviour
 		cataloguePage = SubCataloguePage;
 		if (isSubCatalogueChanged)
 		{
-			SetSpriteSO(SubCatalogue[SubCataloguePage], Network: true);
+			SetSpriteSO(SubCatalogue[SubCataloguePage]);
 		}
 		else
 		{
@@ -404,7 +404,7 @@ public class SpriteHandler : MonoBehaviour
 				Logger.LogError("Was unable to find A NetworkBehaviour for ",
 					Category.SpriteHandler);
 				return;
-			};
+			}
 
 			NetworkIdentity = NetID.netIdentity;
 			if (NetworkIdentity == null)
@@ -554,16 +554,17 @@ public class SpriteHandler : MonoBehaviour
 
 	private void SetImageSprite(Sprite value)
 	{
+		List<Color> paletteOrNull;
 		if (spriteRenderer != null)
 		{
 			spriteRenderer.enabled = true;
 			spriteRenderer.sprite = value;
 			MaterialPropertyBlock block = new MaterialPropertyBlock();
 			spriteRenderer.GetPropertyBlock(block);
-			var palette = getPaletteOrNull();
-			if (palette != null && palette.Count == 8)
+			paletteOrNull = getPaletteOrNull();
+			if (paletteOrNull != null && paletteOrNull.Count == 8)
 			{
-				List<Vector4> pal = palette.ConvertAll((c) => new Vector4(c.r, c.g, c.b, c.a));
+				List<Vector4> pal = paletteOrNull.ConvertAll((c) => new Vector4(c.r, c.g, c.b, c.a));
 				block.SetVectorArray("_ColorPalette", pal);
 				block.SetInt("_IsPaletted", 1);
 			}
@@ -577,10 +578,11 @@ public class SpriteHandler : MonoBehaviour
 		else if (image != null)
 		{
 			image.sprite = value;
+			paletteOrNull = getPaletteOrNull();
 
-			if (palette != null && palette.Count == 8)
+			if (paletteOrNull != null && paletteOrNull.Count == 8)
 			{
-				List<Vector4> pal = palette.ConvertAll((c) => new Vector4(c.r, c.g, c.b, c.a));
+				List<Vector4> pal = paletteOrNull.ConvertAll((c) => new Vector4(c.r, c.g, c.b, c.a));
 				image.material.SetVectorArray("_ColorPalette", pal);
 				image.material.SetInt("_IsPaletted", 1);
 			}

--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
@@ -311,6 +311,15 @@ public class SpriteHandler : MonoBehaviour
 
 	public void SetPaletteOfCurrentSprite(List<Color> newPalette, bool Network = true)
 	{
+		bool paletted = isPaletted();
+
+		Debug.Assert(!(paletted && newPalette == null), "Paletted sprites should never have palette set to null");
+
+		if (!paletted)
+		{
+			newPalette = null;
+		}
+
 		palette = newPalette;
 		PushTexture(false);
 		if (Network)
@@ -575,6 +584,11 @@ public class SpriteHandler : MonoBehaviour
 				image.material.SetVectorArray("_ColorPalette", pal);
 				image.material.SetInt("_IsPaletted", 1);
 			}
+			else
+			{
+				image.material.SetInt("_IsPaletted", 0);
+			}
+
 			if (value == null)
 			{
 				image.enabled = false;

--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
@@ -563,7 +563,7 @@ public class SpriteHandler : MonoBehaviour
 			var palette = getPaletteOrNull();
 			if (palette != null && palette.Count == 8)
 			{
-				List<Vector4> pal = palette.ConvertAll<Vector4>((Color c) => new Vector4(c.r, c.g, c.b, c.a));
+				List<Vector4> pal = palette.ConvertAll((c) => new Vector4(c.r, c.g, c.b, c.a));
 				block.SetVectorArray("_ColorPalette", pal);
 				block.SetInt("_IsPaletted", 1);
 			}
@@ -580,7 +580,7 @@ public class SpriteHandler : MonoBehaviour
 
 			if (palette != null && palette.Count == 8)
 			{
-				List<Vector4> pal = palette.ConvertAll<Vector4>((Color c) => new Vector4(c.r, c.g, c.b, c.a));
+				List<Vector4> pal = palette.ConvertAll((c) => new Vector4(c.r, c.g, c.b, c.a));
 				image.material.SetVectorArray("_ColorPalette", pal);
 				image.material.SetInt("_IsPaletted", 1);
 			}

--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -62,14 +62,14 @@ namespace AdminCommands
 
 			string msg;
 
-			if (Chat.OOCMute)
+			if (Chat.Instance.OOCMute)
 			{
-				Chat.OOCMute = false;
+				Chat.Instance.OOCMute = false;
 				msg = "OOC has been unmuted";
 			}
 			else
 			{
-				Chat.OOCMute = true;
+				Chat.Instance.OOCMute = true;
 				msg = "OOC has been muted";
 			}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosDefines.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosDefines.cs
@@ -7,63 +7,63 @@ namespace Systems.Atmospherics
 	public static class AtmosDefines
 	{
 		//Plasma fire properties
-		public static float OXYGEN_BURN_RATE_BASE = 1.4f;
-		public static float PLASMA_BURN_RATE_DELTA = 9f;
-		public static float PLASMA_MINIMUM_OXYGEN_NEEDED = 2f;
-		public static float PLASMA_MINIMUM_OXYGEN_PLASMA_RATIO = 30f;
-		public static float FIRE_CARBON_ENERGY_RELEASED = 100000f;	//Amount of heat released per mole of burnt carbon into the tile
-		public static float FIRE_HYDROGEN_ENERGY_RELEASED = 280000f;  //Amount of heat released per mole of burnt hydrogen and/or tritium(hydrogen isotope)
+		public static readonly float OXYGEN_BURN_RATE_BASE = 1.4f;
+		public static readonly float PLASMA_BURN_RATE_DELTA = 9f;
+		public static readonly float PLASMA_MINIMUM_OXYGEN_NEEDED = 2f;
+		public static readonly float PLASMA_MINIMUM_OXYGEN_PLASMA_RATIO = 30f;
+		public static readonly float FIRE_CARBON_ENERGY_RELEASED = 100000f;	//Amount of heat released per mole of burnt carbon into the tile
+		public static readonly float FIRE_HYDROGEN_ENERGY_RELEASED = 280000f;  //Amount of heat released per mole of burnt hydrogen and/or tritium(hydrogen isotope)
 
-		public static float FIRE_PLASMA_ENERGY_RELEASED = 3000000f;	//Amount of heat released per mole of burnt plasma into the tile
+		public static readonly float FIRE_PLASMA_ENERGY_RELEASED = 3000000f;	//Amount of heat released per mole of burnt plasma into the tile
 //General assmos defines.
-		public static float WATER_VAPOR_FREEZE = 200f;
+		public static readonly float WATER_VAPOR_FREEZE = 200f;
 //freon reaction
-		public static float FREON_BURN_RATE_DELTA = 4f;
-		public static float FIRE_FREON_ENERGY_RELEASED = -300000f; //amount of heat absorbed per mole of burnt freon in the tile
+		public static readonly float FREON_BURN_RATE_DELTA = 4f;
+		public static readonly float FIRE_FREON_ENERGY_RELEASED = -300000f; //amount of heat absorbed per mole of burnt freon in the tile
 
-		public static float FREON_MAXIMUM_BURN_TEMPERATURE = 293f;
-		public static float FREON_LOWER_TEMPERATURE = 60f; //minimum temperature allowed for the burn to go, we would have negative pressure otherwise
-		public static float FREON_OXYGEN_FULLBURN = 10f;
+		public static readonly float FREON_MAXIMUM_BURN_TEMPERATURE = 293f;
+		public static readonly float FREON_LOWER_TEMPERATURE = 60f; //minimum temperature allowed for the burn to go, we would have negative pressure otherwise
+		public static readonly float FREON_OXYGEN_FULLBURN = 10f;
 
-		public static float N2O_DECOMPOSITION_MIN_ENERGY = 1400f;
-		public static float N2O_DECOMPOSITION_ENERGY_RELEASED = 200000f;
+		public static readonly float N2O_DECOMPOSITION_MIN_ENERGY = 1400f;
+		public static readonly float N2O_DECOMPOSITION_ENERGY_RELEASED = 200000f;
 
-		public static float NITRYL_FORMATION_ENERGY = 100000f;
-		public static float NITROUS_FORMATION_ENERGY = 10000f;
-		public static float TRITIUM_BURN_OXY_FACTOR = 100f;
-		public static float TRITIUM_BURN_TRIT_FACTOR = 10f;
-		public static float TRITIUM_BURN_RADIOACTIVITY_FACTOR = 50000f; 	//The neutrons gotta go somewhere. Completely arbitrary number.
-		public static float TRITIUM_MINIMUM_RADIATION_ENERGY = 0.1f;  	//minimum 0.01 moles trit or 10 moles oxygen to start producing rads
-		public static float MINIMUM_TRIT_OXYBURN_ENERGY = 2000000f;	//This is calculated to help prevent singlecap bombs(Overpowered tritium/oxygen single tank bombs)
-		public static float SUPER_SATURATION_THRESHOLD = 96f;
-		public static float STIMULUM_HEAT_SCALE = 100000f;
-		public static float STIMULUM_FIRST_RISE = 0.65f;
-		public static float STIMULUM_FIRST_DROP = 0.065f;
-		public static float STIMULUM_SECOND_RISE = 0.0009f;
-		public static float STIMULUM_ABSOLUTE_DROP = 0.00000335f;
-		public static float REACTION_OPPRESSION_THRESHOLD = 5f;
-		public static float NOBLIUM_FORMATION_ENERGY = 2e9f; 	//1 Mole of Noblium takes the planck energy to condense.
+		public static readonly float NITRYL_FORMATION_ENERGY = 100000f;
+		public static readonly float NITROUS_FORMATION_ENERGY = 10000f;
+		public static readonly float TRITIUM_BURN_OXY_FACTOR = 100f;
+		public static readonly float TRITIUM_BURN_TRIT_FACTOR = 10f;
+		public static readonly float TRITIUM_BURN_RADIOACTIVITY_FACTOR = 50000f; 	//The neutrons gotta go somewhere. Completely arbitrary number.
+		public static readonly float TRITIUM_MINIMUM_RADIATION_ENERGY = 0.1f;  	//minimum 0.01 moles trit or 10 moles oxygen to start producing rads
+		public static readonly float MINIMUM_TRIT_OXYBURN_ENERGY = 2000000f;	//This is calculated to help prevent singlecap bombs(Overpowered tritium/oxygen single tank bombs)
+		public static readonly float SUPER_SATURATION_THRESHOLD = 96f;
+		public static readonly float STIMULUM_HEAT_SCALE = 100000f;
+		public static readonly float STIMULUM_FIRST_RISE = 0.65f;
+		public static readonly float STIMULUM_FIRST_DROP = 0.065f;
+		public static readonly float STIMULUM_SECOND_RISE = 0.0009f;
+		public static readonly float STIMULUM_ABSOLUTE_DROP = 0.00000335f;
+		public static readonly float REACTION_OPPRESSION_THRESHOLD = 5f;
+		public static readonly float NOBLIUM_FORMATION_ENERGY = 2e9f; 	//1 Mole of Noblium takes the planck energy to condense.
 
-		public static float STIM_BALL_GAS_AMOUNT = 5f;
+		public static readonly float STIM_BALL_GAS_AMOUNT = 5f;
 //Research point amounts
-		public static float NOBLIUM_RESEARCH_AMOUNT = 1000f;
-		public static float BZ_RESEARCH_SCALE = 4f;
-		public static float BZ_RESEARCH_MAX_AMOUNT = 400f;
+		public static readonly float NOBLIUM_RESEARCH_AMOUNT = 1000f;
+		public static readonly float BZ_RESEARCH_SCALE = 4f;
+		public static readonly float BZ_RESEARCH_MAX_AMOUNT = 400f;
 
-		public static float STIMULUM_RESEARCH_AMOUNT = 50f;
+		public static readonly float STIMULUM_RESEARCH_AMOUNT = 50f;
 //Plasma fusion properties
-		public static float FUSION_ENERGY_THRESHOLD = 3e9f;	//Amount of energy it takes to start a fusion reaction
-		public static float FUSION_MOLE_THRESHOLD = 250f;	//Mole count required (tritium/plasma) to start a fusion reaction
-		public static float FUSION_TRITIUM_CONVERSION_COEFFICIENT = 1e-10f;
-		public static float INSTABILITY_GAS_POWER_FACTOR = 0.003f;
-		public static float FUSION_TRITIUM_MOLES_USED = 1f;
-		public static float PLASMA_BINDING_ENERGY = 20000000f;
-		public static float TOROID_VOLUME_BREAKEVEN = 1000f;
-		public static float FUSION_TEMPERATURE_THRESHOLD = 10000f;
-		public static float PARTICLE_CHANCE_CONSTANT = -20000000f;
-		public static float FUSION_RAD_MAX = 2000f;
-		public static float FUSION_RAD_COEFFICIENT = -1000f;
-		public static float FUSION_INSTABILITY_ENDOTHERMALITY = 2f;
-		public static float FUSION_MAXIMUM_TEMPERATURE = 1e8f;
+		public static readonly float FUSION_ENERGY_THRESHOLD = 3e9f;	//Amount of energy it takes to start a fusion reaction
+		public static readonly float FUSION_MOLE_THRESHOLD = 250f;	//Mole count required (tritium/plasma) to start a fusion reaction
+		public static readonly float FUSION_TRITIUM_CONVERSION_COEFFICIENT = 1e-10f;
+		public static readonly float INSTABILITY_GAS_POWER_FACTOR = 0.003f;
+		public static readonly float FUSION_TRITIUM_MOLES_USED = 1f;
+		public static readonly float PLASMA_BINDING_ENERGY = 20000000f;
+		public static readonly float TOROID_VOLUME_BREAKEVEN = 1000f;
+		public static readonly float FUSION_TEMPERATURE_THRESHOLD = 10000f;
+		public static readonly float PARTICLE_CHANCE_CONSTANT = -20000000f;
+		public static readonly float FUSION_RAD_MAX = 2000f;
+		public static readonly float FUSION_RAD_COEFFICIENT = -1000f;
+		public static readonly float FUSION_INSTABILITY_ENDOTHERMALITY = 2f;
+		public static readonly float FUSION_MAXIMUM_TEMPERATURE = 1e8f;
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Core/Action/UIActionManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Action/UIActionManager.cs
@@ -104,15 +104,13 @@ public class UIActionManager : MonoBehaviour
 	/// </summary>
 	public static void SetSpriteSO(IActionGUI iActionGUI, SpriteDataSO sprite, bool networked = true, List<Color> palette = null)
 	{
+		Debug.Assert(!(sprite.IsPalette && palette == null), "Paletted sprites should never be set without a palette");
+
 		if (Instance.DicIActionGUI.ContainsKey(iActionGUI))
 		{
 			var _UIAction = Instance.DicIActionGUI[iActionGUI];
-			_UIAction.IconFront.SetSpriteSO(sprite, Network: networked);
-
-			if (sprite.IsPalette && palette != null)
-			{
-				_UIAction.IconFront.SetPaletteOfCurrentSprite(palette);
-			}
+			_UIAction.IconFront.SetSpriteSO(sprite, Network: networked);		
+			_UIAction.IconFront.SetPaletteOfCurrentSprite(palette);
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/UI/Objects/Commons/Vending/GUI_Spawner.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Commons/Vending/GUI_Spawner.cs
@@ -31,13 +31,16 @@ public class GUI_Spawner : NetTab
 		SpawnedObjectList.OnObjectChange.AddListener( ( newObject, elementName, element ) =>
 		{
 			var netElement = (NetUIElement<string>) element;
-			if (elementName == "MobName")
-			{
-				netElement.Value = newObject.ExpensiveName();
-			}
-			else if (elementName == "MobIcon")
-			{
-				netElement.Value = newObject.NetId().ToString();
+			switch(elementName){
+				case "MobName":
+					netElement.Value = newObject.ExpensiveName();
+					break;
+				case "MobIcon":
+					netElement.Value = newObject.NetId().ToString();
+					break;
+				default:
+					//Don't need to change netElement.Value for other elements
+					break;
 			}
 		} );
 

--- a/UnityProject/Assets/Scripts/UI/Objects/Commons/Vending/GUI_Spawner.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Commons/Vending/GUI_Spawner.cs
@@ -31,14 +31,13 @@ public class GUI_Spawner : NetTab
 		SpawnedObjectList.OnObjectChange.AddListener( ( newObject, elementName, element ) =>
 		{
 			var netElement = (NetUIElement<string>) element;
-			switch ( elementName )
+			if (elementName == "MobName")
 			{
-				case "MobName":
-					netElement.Value = newObject.ExpensiveName();
-					break;
-				case "MobIcon":
-					netElement.Value = newObject.NetId().ToString();
-					break;
+				netElement.Value = newObject.ExpensiveName();
+			}
+			else if (elementName == "MobIcon")
+			{
+				netElement.Value = newObject.NetId().ToString();
 			}
 		} );
 

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/DevSpawnerListItemController.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/DevSpawnerListItemController.cs
@@ -34,7 +34,7 @@ public class DevSpawnerListItemController : MonoBehaviour
 	void Awake()
 	{
 		// unity doesn't support property blocks on ui renderers, so this is a workaround
-		//image.material = Instantiate(image.material);
+		image.material = Instantiate(image.material);
 	}
 
 	private void OnEnable()

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/DevSpawnerListItemController.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/DevSpawnerListItemController.cs
@@ -34,7 +34,7 @@ public class DevSpawnerListItemController : MonoBehaviour
 	void Awake()
 	{
 		// unity doesn't support property blocks on ui renderers, so this is a workaround
-		image.material = Instantiate(image.material);
+		//image.material = Instantiate(image.material);
 	}
 
 	private void OnEnable()
@@ -115,16 +115,21 @@ public class DevSpawnerListItemController : MonoBehaviour
 			SpriteRenderer curRend = cursorObject.GetComponent<SpriteRenderer>();
 			curRend.sprite = image.sprite;
 
+			curRend.material = prefab.GetComponentInChildren<SpriteRenderer>().sharedMaterial;
+			MaterialPropertyBlock block = new MaterialPropertyBlock();
+			curRend.GetPropertyBlock(block);
 			if (isPaletted)
 			{
-				curRend.material = prefab.GetComponentInChildren<SpriteRenderer>().sharedMaterial;
-				MaterialPropertyBlock block = new MaterialPropertyBlock();
-				curRend.GetPropertyBlock(block);
+				Debug.Assert(palette != null, "Palette must not be null on paletteable objects.");
 				List<Vector4> pal = palette.ConvertAll((Color c) => new Vector4(c.r, c.g, c.b, c.a));
 				block.SetVectorArray("_ColorPalette", pal);
 				block.SetInt("_IsPaletted", 1);
-				curRend.SetPropertyBlock(block);
 			}
+			else
+			{
+				block.SetInt("_IsPaletted", 0);
+			}
+			curRend.SetPropertyBlock(block);
 
 			UIManager.IsMouseInteractionDisabled = true;
 			escapeKeyTarget.enabled = true;
@@ -139,16 +144,22 @@ public class DevSpawnerListItemController : MonoBehaviour
 		isPaletted = false;
 		//image.material.SetInt("_IsPaletted", 0);
 
-		ClothingV2 prefabClothing = prefab.GetComponent<ClothingV2>();
-		if (prefabClothing != null)
+		if (prefab.TryGetComponent<ItemAttributesV2>(out ItemAttributesV2 prefabAttributes))
 		{
-			palette = prefabClothing.GetPaletteOrNull();
-			if (palette != null)
+			ItemsSprites sprites = prefabAttributes.ItemSprites;
+			if (sprites.IsPaletted)
 			{
+				palette = sprites.Palette;
+				Debug.Assert(palette != null, "Palette must not be null on paletteable objects.");
+
 				isPaletted = true;
 				image.material.SetInt("_IsPaletted", 1);
 				image.material.SetColorArray("_ColorPalette", palette.ToArray());
 				palette = new List<Color>(image.material.GetColorArray("_ColorPalette"));
+			}
+			else
+			{
+				palette = null;
 			}
 		}
 
@@ -156,8 +167,6 @@ public class DevSpawnerListItemController : MonoBehaviour
 		{
 			image.material.SetInt("_IsPaletted", 0);
 		}
-
-
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/DevSpawnerListItemController.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/DevSpawnerListItemController.cs
@@ -121,7 +121,7 @@ public class DevSpawnerListItemController : MonoBehaviour
 			if (isPaletted)
 			{
 				Debug.Assert(palette != null, "Palette must not be null on paletteable objects.");
-				List<Vector4> pal = palette.ConvertAll((Color c) => new Vector4(c.r, c.g, c.b, c.a));
+				List<Vector4> pal = palette.ConvertAll((c) => new Vector4(c.r, c.g, c.b, c.a));
 				block.SetVectorArray("_ColorPalette", pal);
 				block.SetInt("_IsPaletted", 1);
 			}

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevCloner.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevCloner.cs
@@ -49,6 +49,34 @@ public class GUI_DevCloner : MonoBehaviour
 		ToState(State.SELECTING);
 	}
 
+	private void CheckAndApplyPalette(ref SpriteRenderer renderer)
+	{
+		bool isPaletted = false;
+
+		if (toClone.TryGetComponent(out ItemAttributesV2 prefabAttributes))
+		{
+			ItemsSprites sprites = prefabAttributes.ItemSprites;
+			if (sprites.IsPaletted)
+			{
+				List<Color> palette = sprites.Palette;
+				Debug.Assert(palette != null, "Palette must not be null on paletteable objects.");
+				MaterialPropertyBlock block = new MaterialPropertyBlock();
+				renderer.GetPropertyBlock(block);
+				List<Vector4> pal = palette.ConvertAll((Color c) => new Vector4(c.r, c.g, c.b, c.a));
+				block.SetVectorArray("_ColorPalette", pal);
+				block.SetInt("_IsPaletted", 1);
+				renderer.SetPropertyBlock(block);
+
+				isPaletted = true;
+			}
+		}
+
+		if (!isPaletted)
+		{
+			renderer.material.SetInt("_IsPaletted", 0);
+		}
+	}
+
 	private void ToState(State newState)
 	{
 		if (newState == state)
@@ -74,7 +102,9 @@ public class GUI_DevCloner : MonoBehaviour
 			UIManager.IsMouseInteractionDisabled = true;
 			//just chosen to be spawned on the map. Put our object under the mouse cursor
 			cursorObject = Instantiate(cursorPrefab, transform.root);
-			cursorObject.GetComponent<SpriteRenderer>().sprite = toClone.GetComponentInChildren<SpriteRenderer>().sprite;
+			SpriteRenderer cursorRenderer = cursorObject.GetComponent<SpriteRenderer>();
+			cursorRenderer.sprite = toClone.GetComponentInChildren<SpriteRenderer>().sprite;
+			CheckAndApplyPalette(ref cursorRenderer);
 			lightingSystem.enabled = false;
 		}
 		else if (newState == State.INACTIVE)

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevCloner.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevCloner.cs
@@ -62,7 +62,7 @@ public class GUI_DevCloner : MonoBehaviour
 				Debug.Assert(palette != null, "Palette must not be null on paletteable objects.");
 				MaterialPropertyBlock block = new MaterialPropertyBlock();
 				renderer.GetPropertyBlock(block);
-				List<Vector4> pal = palette.ConvertAll((Color c) => new Vector4(c.r, c.g, c.b, c.a));
+				List<Vector4> pal = palette.ConvertAll((c) => new Vector4(c.r, c.g, c.b, c.a));
 				block.SetVectorArray("_ColorPalette", pal);
 				block.SetInt("_IsPaletted", 1);
 				renderer.SetPropertyBlock(block);

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemImage.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemImage.cs
@@ -90,8 +90,7 @@ public class UI_ItemImage
 			var color = handler.CurrentColor;
 			image.color = color;
 
-			// I don't have any idea what is happening here or how to test it
-			// set palleted and color palette
+			// Configure the shader to use palette if item uses it
 			var itemAttrs = item.GetComponent<ItemAttributesV2>();
 			if (itemAttrs.ItemSprites.IsPaletted)
 			{


### PR DESCRIPTION
Makes action icons appear as they should (not all blacked out). (Regression caused by #5379)

Makes paletteable objects appear as intended in dev spawner and cloner. 