### PR TITLE
Re-add emag to uplink.

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjects/PDA/UplinkCategoryList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/PDA/UplinkCategoryList.asset
@@ -76,6 +76,10 @@ MonoBehaviour:
       item: {fileID: 3668676918291703395, guid: 00019cd41de95b244ac165825679fd64,
         type: 3}
       name: Chest Rig
+    - cost: 6
+      item: {fileID: 3086828684011793880, guid: 92d97624df4de9c44b21713ad3a016cc,
+        type: 3}
+      name: Cryptographic Sequencer
     - cost: 1
       item: {fileID: 2636666438991721797, guid: da5c775edced9c242be7c64d8f159b8f,
         type: 3}


### PR DESCRIPTION
### Purpose
- Title, readds the emag to the uplink after #5376.
   - Emag now costs 6 TC instead of 4, to be in line with its old /tg/ value pre-doorjack.