### PR TITLE
Fix DirectionalPassable NRE, more logging

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Directionals/DirectionalPassable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Directionals/DirectionalPassable.cs
@@ -39,6 +39,13 @@ namespace Core.Directionals
 		protected override void Awake()
 		{
 			base.Awake();
+			EnsureInit();
+		}
+
+		private void EnsureInit()
+		{
+			if (Directional != null) return;
+
 			Directional = GetComponent<Directional>();
 		}
 
@@ -160,6 +167,13 @@ namespace Core.Directionals
 
 		private bool IsPassableAtSide(Vector2Int sideToCross, PassableSides sides)
 		{
+			EnsureInit();
+			if (Directional == null)
+			{
+				Logger.LogError($"No {nameof(Directional)} component found on {this}?");
+				return false;
+			}
+
 			if (sideToCross == Vector2Int.zero) return true;
 
 			// TODO: figure out a better way or at least use some data structure.


### PR DESCRIPTION
- Prevents `DirectionalPassable` NRE when no `Directional` component is found or if the component was checked before `Awake()` had initialised.
- Adds logging in case no `Directional` component was found on the object.