### PR TITLE
Fix CE tools

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Snake/NPC_Snake.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Snake/NPC_Snake.prefab
@@ -10,8 +10,9 @@ GameObject:
   m_Component:
   - component: {fileID: 8891796486152224138}
   - component: {fileID: 83192708151968013}
+  - component: {fileID: 174510093161172441}
   m_Layer: 12
-  m_Name: sprite
+  m_Name: Sprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -71,7 +72,7 @@ SpriteRenderer:
   m_SortingLayerID: -229502157
   m_SortingLayer: 16
   m_SortingOrder: 11
-  m_Sprite: {fileID: 21300004, guid: 2ea74600231aed749abb753a4e510f48, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 2ea74600231aed749abb753a4e510f48, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -82,6 +83,27 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &174510093161172441
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3392343644113499114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetworkThis: 1
+  SubCatalogue:
+  - {fileID: 11400000, guid: f608b3f76f1d5554dbce1ae349227ca2, type: 2}
+  - {fileID: 11400000, guid: 400afa54cac54ae4dadf3b79f41b26bd, type: 2}
+  PresentSpriteSet: {fileID: 11400000, guid: f608b3f76f1d5554dbce1ae349227ca2, type: 2}
+  pushTextureOnStartUp: 1
+  variantIndex: 0
+  palette: []
+  Sprites: []
 --- !u!1 &4826224059160213873
 GameObject:
   m_ObjectHideFlags: 0
@@ -393,6 +415,7 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  passableExclusionsToThis: []
 --- !u!114 &4859363408336224435
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/Objects/Furniture/InteractableFurniture.cs
+++ b/UnityProject/Assets/Scripts/Objects/Furniture/InteractableFurniture.cs
@@ -32,26 +32,26 @@ namespace Objects
 		{
 			//start with the default HandApply WillInteract logic.
 			if (!DefaultWillInteract.Default(interaction, side)) return false;
-			if (MatrixManager.GetAt<PlayerMove>(interaction.TargetObject, side)
-				.Any(pm => pm.IsBuckled))
-			{
-				return false;
-			}
+			
 			//only care about interactions targeting us
 			if (interaction.TargetObject != gameObject) return false;
 			//only try to interact if the user has a wrench, screwdriver in their hand
-			if (!Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench)) { return false; }
+			if (!Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench)) return false;
+
 			return true;
 		}
 
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-			if (interaction.TargetObject != gameObject) return;
-			else if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Wrench))
+			if (MatrixManager.GetAt<PlayerMove>(interaction.TargetObject, NetworkSide.Server)
+					.Any(pm => pm.IsBuckled))
 			{
-				ToolUtils.ServerPlayToolSound(interaction);
-				Disassemble(interaction);
+				Chat.AddExamineMsgFromServer(interaction.Performer, $"You cannot deconstruct this while it is occupied!");
+				return;
 			}
+
+			ToolUtils.ServerPlayToolSound(interaction);
+			Disassemble(interaction);
 		}
 
 		[Server]

--- a/UnityProject/Assets/Scripts/Objects/PlayerRotatable.cs
+++ b/UnityProject/Assets/Scripts/Objects/PlayerRotatable.cs
@@ -70,7 +70,6 @@ namespace Objects
 			}
 			else
 			{
-				Debug.Log($"{this} is rotating transform...");
 				transform.Rotate(0, 0, -90);
 				SyncRotation(zRotation, transform.eulerAngles.z);
 			}


### PR DESCRIPTION
- Syncs traits on `ToolSwapComponent`, likely fixing the jankiness with CE tools. Seems fine testing on local headless.
- Players are now notified that they cannot deconstruct furniture while someone is occupying it, instead of attacking the chair.

CL:Fixed CE tool jankiness, improved occupiable furniture deconstruction