### PR TITLE
Revert (most) changes to PlayerSpawn

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowFullTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowFullTile.prefab
@@ -45,6 +45,7 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  passableExclusionsToThis: []
 --- !u!1001 &1256876796715916942
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -52,6 +53,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -7987623581128504728, guid: 157fcff274a3644448d1ff3bdc019619,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1716766423784078090, guid: 157fcff274a3644448d1ff3bdc019619,
         type: 3}
       propertyPath: isInitiallyNotPushable
@@ -166,6 +172,7 @@ PrefabInstance:
     - {fileID: -5694877607498037915, guid: 157fcff274a3644448d1ff3bdc019619, type: 3}
     - {fileID: 9012874896178120669, guid: 157fcff274a3644448d1ff3bdc019619, type: 3}
     - {fileID: 992935627982901909, guid: 157fcff274a3644448d1ff3bdc019619, type: 3}
+    - {fileID: -7987623581128504728, guid: 157fcff274a3644448d1ff3bdc019619, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 157fcff274a3644448d1ff3bdc019619, type: 3}
 --- !u!1 &5198140336175476872 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowPlasmaFullTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowPlasmaFullTile.prefab
@@ -18,6 +18,7 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  passableExclusionsToThis: []
 --- !u!114 &-3839959352144189932
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -58,6 +59,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 507117d4efde46d468359d7d31e778c2,
         type: 2}
+    - target: {fileID: 1995729699552988781, guid: 7020b235ecf8ece4ca00af70a60258f8,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2109706411221417743, guid: 7020b235ecf8ece4ca00af70a60258f8,
         type: 3}
       propertyPath: isInitiallyNotPushable
@@ -171,6 +177,7 @@ PrefabInstance:
     - {fileID: 4207410744649580896, guid: 7020b235ecf8ece4ca00af70a60258f8, type: 3}
     - {fileID: 8610929551406220248, guid: 7020b235ecf8ece4ca00af70a60258f8, type: 3}
     - {fileID: 527939903451879056, guid: 7020b235ecf8ece4ca00af70a60258f8, type: 3}
+    - {fileID: 1995729699552988781, guid: 7020b235ecf8ece4ca00af70a60258f8, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 7020b235ecf8ece4ca00af70a60258f8, type: 3}
 --- !u!1 &1467727991537208861 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowPlastitaniumFullTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowPlastitaniumFullTile.prefab
@@ -18,6 +18,7 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  passableExclusionsToThis: []
 --- !u!114 &7431892531360401419
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -133,6 +134,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: WindowPlastitaniumFullTile
       objectReference: {fileID: 0}
+    - target: {fileID: 4811040299159149250, guid: 422afccc119081a4fa895bc72e8ecd78,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4913797670289714080, guid: 422afccc119081a4fa895bc72e8ecd78,
         type: 3}
       propertyPath: isInitiallyNotPushable
@@ -161,6 +167,7 @@ PrefabInstance:
     - {fileID: 7139832653136909775, guid: 422afccc119081a4fa895bc72e8ecd78, type: 3}
     - {fileID: 3383985568769546103, guid: 422afccc119081a4fa895bc72e8ecd78, type: 3}
     - {fileID: 6784075479398023743, guid: 422afccc119081a4fa895bc72e8ecd78, type: 3}
+    - {fileID: 4811040299159149250, guid: 422afccc119081a4fa895bc72e8ecd78, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 422afccc119081a4fa895bc72e8ecd78, type: 3}
 --- !u!1 &6397275954408119094 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowPodFullTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowPodFullTile.prefab
@@ -45,6 +45,7 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  passableExclusionsToThis: []
 --- !u!1001 &9088965797356890092
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -143,6 +144,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 6966500773567203384, guid: 2687df960de8f3f4aa407993936cf69a,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7374808011888392538, guid: 2687df960de8f3f4aa407993936cf69a,
         type: 3}
       propertyPath: isInitiallyNotPushable
@@ -161,6 +167,7 @@ PrefabInstance:
     - {fileID: 4718650745849153333, guid: 2687df960de8f3f4aa407993936cf69a, type: 3}
     - {fileID: 909604874776462733, guid: 2687df960de8f3f4aa407993936cf69a, type: 3}
     - {fileID: 8956573985973752005, guid: 2687df960de8f3f4aa407993936cf69a, type: 3}
+    - {fileID: 6966500773567203384, guid: 2687df960de8f3f4aa407993936cf69a, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 2687df960de8f3f4aa407993936cf69a, type: 3}
 --- !u!1 &6267626164826213306 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowReinforcedFullTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowReinforcedFullTile.prefab
@@ -46,6 +46,7 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  passableExclusionsToThis: []
 --- !u!1001 &3475978088997710883
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -56,6 +57,11 @@ PrefabInstance:
     - target: {fileID: 1223838958160137227, guid: c80393b4412660b41937e05425ceb921,
         type: 3}
       propertyPath: isInitiallyNotPushable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1589379618128903529, guid: c80393b4412660b41937e05425ceb921,
+        type: 3}
+      propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2029713811664008157, guid: c80393b4412660b41937e05425ceb921,
@@ -162,6 +168,7 @@ PrefabInstance:
     - {fileID: 4026046569720328804, guid: c80393b4412660b41937e05425ceb921, type: 3}
     - {fileID: 8808186602529976540, guid: c80393b4412660b41937e05425ceb921, type: 3}
     - {fileID: 787922446905566612, guid: c80393b4412660b41937e05425ceb921, type: 3}
+    - {fileID: 1589379618128903529, guid: c80393b4412660b41937e05425ceb921, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: c80393b4412660b41937e05425ceb921, type: 3}
 --- !u!1 &7946366853500351780 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowReinforcedPlasmaFullTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowReinforcedPlasmaFullTile.prefab
@@ -18,6 +18,7 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  passableExclusionsToThis: []
 --- !u!114 &8553434195301175642
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -62,6 +63,11 @@ PrefabInstance:
     - target: {fileID: 1743697883923330276, guid: 9028811e852742d40ac5ae72a716a679,
         type: 3}
       propertyPath: isInitiallyNotPushable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2217939973043340678, guid: 9028811e852742d40ac5ae72a716a679,
+        type: 3}
+      propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2553246389459621002, guid: 9028811e852742d40ac5ae72a716a679,
@@ -172,6 +178,7 @@ PrefabInstance:
     - {fileID: 4545905496693852811, guid: 9028811e852742d40ac5ae72a716a679, type: 3}
     - {fileID: 8283773366978316339, guid: 9028811e852742d40ac5ae72a716a679, type: 3}
     - {fileID: 154929686146588027, guid: 9028811e852742d40ac5ae72a716a679, type: 3}
+    - {fileID: 2217939973043340678, guid: 9028811e852742d40ac5ae72a716a679, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 9028811e852742d40ac5ae72a716a679, type: 3}
 --- !u!1 &8209036267351138478 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowShuttleFullTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowShuttleFullTile.prefab
@@ -18,6 +18,7 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  passableExclusionsToThis: []
 --- !u!114 &4160705628322839618
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -52,6 +53,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1266267677436706526, guid: 044c5be8ebc308b4b9e450ab85fec306,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1686528676404301756, guid: 044c5be8ebc308b4b9e450ab85fec306,
         type: 3}
       propertyPath: isInitiallyNotPushable
@@ -161,6 +167,7 @@ PrefabInstance:
     - {fileID: 3477720021984211411, guid: 044c5be8ebc308b4b9e450ab85fec306, type: 3}
     - {fileID: 9052451738989802347, guid: 044c5be8ebc308b4b9e450ab85fec306, type: 3}
     - {fileID: 969242191968937507, guid: 044c5be8ebc308b4b9e450ab85fec306, type: 3}
+    - {fileID: 1266267677436706526, guid: 044c5be8ebc308b4b9e450ab85fec306, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 044c5be8ebc308b4b9e450ab85fec306, type: 3}
 --- !u!1 &1695682973792995729 stripped
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowTintedFullTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Construction/Windows/WindowFullTiles/WindowTintedFullTile.prefab
@@ -18,6 +18,7 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  passableExclusionsToThis: []
 --- !u!114 &5835473227500181835
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -62,6 +63,11 @@ PrefabInstance:
     - target: {fileID: 2012595775094159134, guid: f2a16f12167ad5442a606bc9c87fd9fe,
         type: 3}
       propertyPath: isInitiallyNotPushable
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2097343077160748668, guid: f2a16f12167ad5442a606bc9c87fd9fe,
+        type: 3}
+      propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2355948704887986032, guid: f2a16f12167ad5442a606bc9c87fd9fe,
@@ -177,6 +183,7 @@ PrefabInstance:
     - {fileID: 4380518353706879345, guid: f2a16f12167ad5442a606bc9c87fd9fe, type: 3}
     - {fileID: 8154093894900665289, guid: f2a16f12167ad5442a606bc9c87fd9fe, type: 3}
     - {fileID: 142599475188719233, guid: f2a16f12167ad5442a606bc9c87fd9fe, type: 3}
+    - {fileID: 2097343077160748668, guid: f2a16f12167ad5442a606bc9c87fd9fe, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: f2a16f12167ad5442a606bc9c87fd9fe, type: 3}
 --- !u!1 &2861107897139715475 stripped
 GameObject:

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
@@ -67,12 +67,16 @@ public static class PlayerSpawn
 	public static void ServerRespawnPlayer(Mind forMind)
 	{
 		//get the settings from the mind
+		var occupation = forMind.occupation;
 		var oldBody = forMind.GetCurrentMob();
+		var connection = oldBody.GetComponent<NetworkIdentity>().connectionToClient;
+		var settings = oldBody.GetComponent<PlayerScript>().characterSettings;
+
 		var player = oldBody.Player();
 		var oldGhost = forMind.ghost;
 		forMind.stepType = GetStepType(player.Script);
 
-		ServerSpawnInternal(player.Connection, forMind.occupation, player.CharacterSettings, forMind, willDestroyOldBody: oldGhost != null);
+		ServerSpawnInternal(connection, occupation, settings, forMind, willDestroyOldBody: oldGhost != null);
 
 		if (oldGhost)
 		{


### PR DESCRIPTION
- Reverts changes to PlayerSpawn, save the check preventing spectators from being admin-spawned.
- Removes `DirectionalPassable` from full window tiles (lol).

> Was unable to reproduce the spawning bug locally, and so have reverted changes just in case.