### PR TITLE
Improve tilemap floodfill

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -105,10 +105,13 @@ public class MetaDataSystem : SubsystemBehaviour
 	{
 		BoundsInt bounds = metaTileMap.GetBounds();
 
+		var watch = new Stopwatch();
+		watch.Start();
 		foreach (Vector3Int position in bounds.allPositionsWithin)
 		{
 			FindRoomAt(position);
 		}
+		Logger.LogFormat("Created rooms in {0}ms", Category.TileMaps, watch.ElapsedMilliseconds);
 	}
 
 	private void FindRoomAt(Vector3Int position)
@@ -133,6 +136,10 @@ public class MetaDataSystem : SubsystemBehaviour
 
 	private void CreateRoom(Vector3Int origin)
 	{
+		if (metaDataLayer.Get(origin).RoomNumber != -1)
+		{
+			return;
+		}
 		var roomPositions = new HashSet<Vector3Int>();
 		var freePositions = new UniqueQueue<Vector3Int>();
 


### PR DESCRIPTION
### Purpose
This reduces startup time by checking if the tile is already assigned a room number before using flood fill to find room boundaries.

Before:
![roomnumbers_before](https://user-images.githubusercontent.com/39059512/97737201-004be300-1add-11eb-9487-5622fefa0f82.png)
After:
![roomnumbers_after](https://user-images.githubusercontent.com/39059512/97737252-0e99ff00-1add-11eb-9981-d0722ef244f9.png)

### Notes:
I tested this and both before and after have correct room numbers and atmos and space wind were both working.