### PR TITLE
Makes non-objects block diagonal interaction

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Validations.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Validations.cs
@@ -416,7 +416,8 @@ public static class Validations
 
 		bool result = MatrixManager.IsPassableAt(worldPosAInt, worldPosBInt, isServer: isServer, collisionType: CollisionType.Airborne,
 			context: context, includingPlayers: false, isReach: true,
-			excludeLayers: new List<LayerType> { LayerType.Walls, LayerType.Windows, LayerType.Grills });
+			excludeLayers: new List<LayerType> { LayerType.Walls, LayerType.Windows, LayerType.Grills },
+			onlyExcludeLayerOnDestination: true);
 
 		return result;
 	}

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -481,7 +481,7 @@ public partial class MatrixManager : MonoBehaviour
 	///<inheritdoc cref="Matrix.IsPassableAt(UnityEngine.Vector3Int,UnityEngine.Vector3Int,bool,GameObject)"/>
 	public static bool IsPassableAt(Vector3Int worldOrigin, Vector3Int worldTarget, bool isServer,
 		CollisionType collisionType = CollisionType.Player, bool includingPlayers = true, GameObject context = null,
-		int[] excludeList = null, List<LayerType> excludeLayers = null, bool isReach = false)
+		int[] excludeList = null, List<LayerType> excludeLayers = null, bool isReach = false, bool onlyExcludeLayerOnDestination = false)
 	{
 		// Gets the list of Matrixes to actually check
 		MatrixInfo[] includeList = excludeList != null
@@ -491,7 +491,7 @@ public partial class MatrixManager : MonoBehaviour
 		return AllMatchInternal(mat =>
 			mat.Matrix.IsPassableAt(WorldToLocalInt(worldOrigin, mat), WorldToLocalInt(worldTarget, mat), isServer,
 				collisionType: collisionType, includingPlayers: includingPlayers, context: context,
-				excludeLayers: excludeLayers, isReach: isReach),
+				excludeLayers: excludeLayers, isReach: isReach, onlyExcludeLayerOnDestination: onlyExcludeLayerOnDestination),
 				includeList);
 	}
 
@@ -695,8 +695,41 @@ public partial class MatrixManager : MonoBehaviour
 		}
 	}
 
+	/// Gets pushables residing on one tile
+	/// <see cref="MatrixManager.GetPushableAt(Vector3Int, Vector2Int, GameObject, bool)"/>
+	private static void GetPushablesOneTile(ref List<PushPull> pushableList, Vector3Int pushableLocation, Vector2Int dir, GameObject pusher, bool isServer)
+	{
+		foreach (PushPull pushPull in GetAt<PushPull>(pushableLocation, isServer))
+		{
+			if (pushPull == null || pushPull.gameObject == pusher) continue;
+
+			PushPull pushable = pushPull;
+			if (isServer ? pushPull.CanPushServer(pushableLocation, dir) : pushPull.CanPushClient(pushableLocation, dir))
+			{
+				// If the object being Push/Pulled is a player, and that player is buckled, we should use the pushPull object that the player is buckled to.
+				// By design, chairs are not "solid" so, the condition above will filter chairs but won't filter players
+				PlayerMove playerMove = pushPull.GetComponent<PlayerMove>();
+				if (playerMove && playerMove.IsBuckled)
+				{
+					PushPull buckledPushPull = playerMove.BuckledObject.GetComponent<PushPull>();
+
+					if (buckledPushPull)
+						pushable = buckledPushPull;
+				}
+
+				if (isServer
+					? pushable.CanPushServer(pushableLocation, Vector2Int.RoundToInt(dir))
+					: pushable.CanPushClient(pushableLocation, Vector2Int.RoundToInt(dir))
+				)
+				{
+					pushableList.Add(pushable);
+				}
+			}
+		}
+	}
+
 	/// <summary>
-	/// Checks if there are any pushables at the specified target which can be pushed from the current position.
+	/// Checks if there are any pushables int the specified direction which can be pushed from the current position.
 	/// </summary>
 	/// <param name="worldOrigin">position pushing from</param>
 	/// <param name="dir">direction to push</param>
@@ -708,65 +741,12 @@ public partial class MatrixManager : MonoBehaviour
 	{
 		List<PushPull> result = new List<PushPull>();
 
-		// Get pushables the player is pushing "inside" from
-		foreach (PushPull pushPull in GetAt<PushPull>(worldOrigin, isServer))
-		{
-			if (pushPull == null || pushPull.gameObject == pusher) continue;
+		// Get pushables the pusher is pushing "inside" from
+		GetPushablesOneTile(ref result, worldOrigin, dir, pusher, isServer);
 
-			PushPull pushable = pushPull;
-			if (isServer ? pushPull.CanPushServer(worldOrigin, dir) : pushPull.CanPushClient(worldOrigin, dir))
-			{
-				// If the object being Push/Pulled is a player, and that player is buckled, we should use the pushPull object that the player is buckled to.
-				// By design, chairs are not "solid" so, the condition above will filter chairs but won't filter players
-				PlayerMove playerMove = pushPull.GetComponent<PlayerMove>();
-				if (playerMove && playerMove.IsBuckled)
-				{
-					PushPull buckledPushPull = playerMove.BuckledObject.GetComponent<PushPull>();
-
-					if (buckledPushPull)
-						pushable = buckledPushPull;
-				}
-
-				if (isServer
-					? pushable.CanPushServer(worldOrigin, Vector2Int.RoundToInt(dir))
-					: pushable.CanPushClient(worldOrigin, Vector2Int.RoundToInt(dir))
-				)
-				{
-					result.Add(pushable);
-				}
-			}
-		}
-
-
+		// Get pushables the pusher is pushing into in the destination space
 		Vector3Int worldTarget = worldOrigin + dir.To3Int();
-
-		foreach (PushPull pushPull in GetAt<PushPull>(worldTarget, isServer))
-		{
-			if (pushPull == null || pushPull.gameObject == pusher) continue;
-
-			PushPull pushable = pushPull;
-			if (isServer ? pushPull.CanPushServer(worldTarget, dir) : pushPull.CanPushClient(worldTarget, dir))
-			{
-				// If the object being Push/Pulled is a player, and that player is buckled, we should use the pushPull object that the player is buckled to.
-				// By design, chairs are not "solid" so, the condition above will filter chairs but won't filter players
-				PlayerMove playerMove = pushPull.GetComponent<PlayerMove>();
-				if (playerMove && playerMove.IsBuckled)
-				{
-					PushPull buckledPushPull = playerMove.BuckledObject.GetComponent<PushPull>();
-
-					if (buckledPushPull)
-						pushable = buckledPushPull;
-				}
-
-				if (isServer
-					? pushable.CanPushServer(worldTarget, Vector2Int.RoundToInt(dir))
-					: pushable.CanPushClient(worldTarget, Vector2Int.RoundToInt(dir))
-				)
-				{
-					result.Add(pushable);
-				}
-			}
-		}
+		GetPushablesOneTile(ref result, worldTarget, dir, pusher, isServer);
 
 		return result;
 	}
@@ -796,8 +776,8 @@ public partial class MatrixManager : MonoBehaviour
 		return !IsPassableAt(worldTarget, isServer) && !IsAtmosPassableAt(worldTarget, isServer);
 	}
 
-	///Cross-matrix edition of <see cref="Matrix.IsPassableAt(UnityEngine.Vector3Int,bool)"/>
-	///<inheritdoc cref="Matrix.IsPassableAt(UnityEngine.Vector3Int,bool)"/>
+	///Cross-matrix edition of <see crIsPassableAtef="Matrix.IsPassableAt(UnityEngine.Vector3Int,bool)"/>
+	///<inheritdoc cref="Matrix.(UnityEngine.Vector3Int,bool)"/>
 	public static bool IsPassableAt(Vector3Int worldTarget, bool isServer, bool includingPlayers = true)
 	{
 		return AllMatchInternal(mat =>

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -776,7 +776,7 @@ public partial class MatrixManager : MonoBehaviour
 		return !IsPassableAt(worldTarget, isServer) && !IsAtmosPassableAt(worldTarget, isServer);
 	}
 
-	///Cross-matrix edition of <see crIsPassableAtef="Matrix.IsPassableAt(UnityEngine.Vector3Int,bool)"/>
+	///Cross-matrix edition of <see cref="Matrix.IsPassableAt(UnityEngine.Vector3Int,bool)"/>
 	///<inheritdoc cref="Matrix.(UnityEngine.Vector3Int,bool)"/>
 	public static bool IsPassableAt(Vector3Int worldTarget, bool isServer, bool includingPlayers = true)
 	{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -169,6 +169,7 @@ public class Matrix : MonoBehaviour
 	/// <param name="includingPlayers">Set this to false to ignore players from check</param>
 	/// <param name="context">Is excluded from passable check</param>
 	/// <param name="isReach">True if we're seeing if an object can be reached through</param>
+	/// <param name="onlyExcludeLayerOnDestination">false if every involved tile should have the layers excluded, true if only the destination tile</param>
 	/// <returns></returns>
 	public bool IsPassableAt(Vector3Int origin, Vector3Int position, bool isServer,
 			CollisionType collisionType = CollisionType.Player, bool includingPlayers = true, GameObject context = null,

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/Matrix.cs
@@ -145,7 +145,9 @@ public class Matrix : MonoBehaviour
 	}
 
 	public bool IsPassableAt(Vector3Int position, bool isServer, bool includingPlayers = true,
-		List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null, GameObject context = null, bool ignoreObjects = false)
+		List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null, GameObject context = null, bool ignoreObjects = false,
+		bool onlyExcludeLayerOnDestination = false
+		)
 	{
 		return IsPassableAt(position, position, isServer, context: context, includingPlayers: includingPlayers,
 			excludeLayers: excludeLayers, excludeTiles: excludeTiles, ignoreObjects: ignoreObjects);
@@ -171,11 +173,12 @@ public class Matrix : MonoBehaviour
 	public bool IsPassableAt(Vector3Int origin, Vector3Int position, bool isServer,
 			CollisionType collisionType = CollisionType.Player, bool includingPlayers = true, GameObject context = null,
 			List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null, bool ignoreObjects = false,
-			bool isReach = false)
+			bool isReach = false, bool onlyExcludeLayerOnDestination = false)
 	{
 		return MetaTileMap.IsPassableAt(origin, position, isServer, collisionType: collisionType,
 			inclPlayers: includingPlayers, context: context, excludeLayers: excludeLayers,
-			excludeTiles: excludeTiles, ignoreObjects: ignoreObjects, isReach: isReach);
+			excludeTiles: excludeTiles, ignoreObjects: ignoreObjects, isReach: isReach,
+			onlyExcludeLayerOnDestination: onlyExcludeLayerOnDestination);
 	}
 
 	public bool IsAtmosPassableAt(Vector3Int position, bool isServer)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -247,17 +247,28 @@ namespace TileManagement
 		public bool IsPassableAt(Vector3Int origin, Vector3Int to, bool isServer,
 				CollisionType collisionType = CollisionType.Player, bool inclPlayers = true, GameObject context = null,
 				List<LayerType> excludeLayers = null, List<TileType> excludeTiles = null, bool ignoreObjects = false,
-				bool isReach = false)
+				bool isReach = false, bool onlyExcludeLayerOnDestination = false)
 		{
-			Vector3Int toX = new Vector3Int(to.x, origin.y, origin.z);
-			Vector3Int toY = new Vector3Int(origin.x, to.y, origin.z);
+			if (origin.x == to.x || origin.y == to.y)
+			{
+				return _IsPassableAt(origin, to, isServer, collisionType, inclPlayers, context, excludeLayers,
+					   excludeTiles, ignoreObjects, isReach: isReach);
+			}
+			else
+			{
+				Vector3Int toX = new Vector3Int(to.x, origin.y, origin.z);
+				Vector3Int toY = new Vector3Int(origin.x, to.y, origin.z);
 
-			return _IsPassableAt(origin, toX, isServer, collisionType, inclPlayers, context, excludeLayers,
-				       excludeTiles, ignoreObjects, isReach: isReach) &&
-			       _IsPassableAt(toX, to, isServer, collisionType, inclPlayers, context, excludeLayers, excludeTiles, ignoreObjects, isReach: isReach) ||
-			       _IsPassableAt(origin, toY, isServer, collisionType, inclPlayers, context, excludeLayers,
-				       excludeTiles, ignoreObjects, isReach: isReach) &&
-			       _IsPassableAt(toY, to, isServer, collisionType, inclPlayers, context, excludeLayers, excludeTiles, ignoreObjects, isReach: isReach);
+				List<LayerType> diagonalExcludes = onlyExcludeLayerOnDestination ? null : excludeLayers;
+
+				return _IsPassableAt(origin, toX, isServer, collisionType, inclPlayers, context, diagonalExcludes,
+						   excludeTiles, ignoreObjects, isReach: isReach) &&
+					   _IsPassableAt(toX, to, isServer, collisionType, inclPlayers, context, excludeLayers, excludeTiles, ignoreObjects, isReach: isReach) ||
+					   _IsPassableAt(origin, toY, isServer, collisionType, inclPlayers, context, diagonalExcludes,
+						   excludeTiles, ignoreObjects, isReach: isReach) &&
+					   _IsPassableAt(toY, to, isServer, collisionType, inclPlayers, context, excludeLayers, excludeTiles, ignoreObjects, isReach: isReach);
+			}
+
 		}
 
 		private bool _IsPassableAt(Vector3Int origin, Vector3Int to, bool isServer,


### PR DESCRIPTION
Fixes edge case of #4282 mentioned in #5434:

> It's possible that diagonal tilemap walls/windows/grates might not block. 
