### PR TITLE
Removes pushing of nonblocking objects and fixes pulling of blocking objects

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -92,7 +92,7 @@ public partial class MatrixManager : MonoBehaviour
 	void OnSceneChange(Scene oldScene, Scene newScene)
 	{
 		ResetMatrixManager();
-		if (!newScene.name.Equals("Lobby"))
+		if (newScene.name.Equals("Lobby") == false)
 		{
 			IsInitialized = false;
 			StartCoroutine(WaitForLoad());
@@ -121,12 +121,12 @@ public partial class MatrixManager : MonoBehaviour
 
 		var matrixInfo = CreateMatrixInfoFromMatrix(matrixToRegister, Instance.ActiveMatrices.Count);
 
-		if (!Instance.ActiveMatrices.Contains(matrixInfo))
+		if (Instance.ActiveMatrices.Contains(matrixInfo) == false)
 		{
 			Instance.ActiveMatrices.Add(matrixInfo);
 		}
 
-		if (!Instance.MovableMatrices.Contains(matrixInfo) && matrixInfo.MatrixMove != null)
+		if (Instance.MovableMatrices.Contains(matrixInfo) == false && matrixInfo.MatrixMove != null)
 		{
 			Instance.MovableMatrices.Add(matrixInfo);
 		}
@@ -199,7 +199,7 @@ public partial class MatrixManager : MonoBehaviour
 		{
 			MatrixInfo mat = Instance.ActiveMatrices[i];
 			if (mat.Matrix == Instance.spaceMatrix) continue;
-			if (!mat.Matrix.IsEmptyAt(WorldToLocalInt(worldPos, mat), isServer))
+			if (mat.Matrix.IsEmptyAt(WorldToLocalInt(worldPos, mat), isServer) == false)
 			{
 				return mat;
 			}
@@ -453,7 +453,7 @@ public partial class MatrixManager : MonoBehaviour
 	{
 		foreach (MatrixInfo mat in Instance.ActiveMatrices)
 		{
-			if (!mat.Matrix.IsSpaceAt(WorldToLocalInt(worldPos, mat), isServer))
+			if (mat.Matrix.IsSpaceAt(WorldToLocalInt(worldPos, mat), isServer) == false)
 			{
 				return false;
 			}
@@ -468,7 +468,7 @@ public partial class MatrixManager : MonoBehaviour
 	{
 		foreach (MatrixInfo mat in Instance.ActiveMatrices)
 		{
-			if (!mat.Matrix.IsEmptyAt(WorldToLocalInt(worldPos, mat), isServer))
+			if (mat.Matrix.IsEmptyAt(WorldToLocalInt(worldPos, mat), isServer) == false)
 			{
 				return false;
 			}
@@ -521,7 +521,7 @@ public partial class MatrixManager : MonoBehaviour
 
 
 		bool hasHelpIntent = false;
-		if (bumper.gameObject == PlayerManager.LocalPlayer && !isServer)
+		if (bumper.gameObject == PlayerManager.LocalPlayer && isServer == false)
 		{
 			//locally predict based on our set intent.
 			hasHelpIntent = UIManager.CurrentIntent == Intent.Help;
@@ -545,7 +545,7 @@ public partial class MatrixManager : MonoBehaviour
 				{
 					return BumpType.Swappable;
 				}
-				else if (!bumper.PlayerScript.pushPull.IsPullingSomething)
+				else if (bumper.PlayerScript.pushPull.IsPullingSomething == false)
 				{
 					return BumpType.Swappable;
 				}
@@ -554,7 +554,7 @@ public partial class MatrixManager : MonoBehaviour
 
 		bool isPassable = IsPassableAt(worldOrigin, targetPos, isServer, includingPlayers: true, context: bumper.gameObject);
 		// Only push if not passable, e.g. for directional windows being pushed from parallel
-		if (!isPassable && GetPushableAt(worldOrigin, dir, bumper.gameObject, isServer).Count > 0)
+		if (isPassable == false && GetPushableAt(worldOrigin, dir, bumper.gameObject, isServer).Count > 0)
 		{
 			return BumpType.Push;
 		}
@@ -564,7 +564,7 @@ public partial class MatrixManager : MonoBehaviour
 			return BumpType.ClosedDoor;
 		}
 
-		if (!isPassable)
+		if (isPassable == false)
 		{
 			return BumpType.Blocked;
 		}
@@ -601,7 +601,7 @@ public partial class MatrixManager : MonoBehaviour
 		var originDoorList = GetAt<InteractableDoor>(worldOrigin, isServer);
 		foreach (InteractableDoor originDoor in originDoorList)
 		{
-			if (originDoor && !originDoor.GetComponent<RegisterDoor>().IsPassableTo(localTarget, isServer))
+			if (originDoor && originDoor.GetComponent<RegisterDoor>().IsPassableTo(localTarget, isServer) == false)
 				return originDoor;
 		}
 
@@ -610,7 +610,7 @@ public partial class MatrixManager : MonoBehaviour
 		var targetDoorList = GetAt<InteractableDoor>(targetPos, isServer);
 		foreach (InteractableDoor targetDoor in targetDoorList)
 		{
-			if (targetDoor && !targetDoor.GetComponent<RegisterDoor>().IsPassable(localOrigin, isServer))
+			if (targetDoor && targetDoor.GetComponent<RegisterDoor>().IsPassable(localOrigin, isServer) == false)
 				return targetDoor;
 		}
 
@@ -626,7 +626,7 @@ public partial class MatrixManager : MonoBehaviour
 		var originDoorList = GetAt<DoorMasterController>(worldOrigin, isServer);
 		foreach (DoorMasterController originDoor in originDoorList)
 		{
-			if (originDoor && !originDoor.GetComponent<RegisterDoor>().IsPassableTo(localTarget, isServer))
+			if (originDoor && originDoor.GetComponent<RegisterDoor>().IsPassableTo(localTarget, isServer) == false)
 				return originDoor;
 		}
 
@@ -635,7 +635,7 @@ public partial class MatrixManager : MonoBehaviour
 		var targetDoorList = GetAt<DoorMasterController>(targetPos, isServer);
 		foreach (DoorMasterController targetDoor in targetDoorList)
 		{
-			if (targetDoor && !targetDoor.GetComponent<RegisterDoor>().IsPassable(localOrigin, isServer))
+			if (targetDoor && targetDoor.GetComponent<RegisterDoor>().IsPassable(localOrigin, isServer) == false)
 				return targetDoor;
 		}
 
@@ -655,7 +655,7 @@ public partial class MatrixManager : MonoBehaviour
 			Vector3Int position = WorldToLocalInt(worldPosition, mat);
 			MetaDataNode node = mat.MetaDataLayer.Get(position, false);
 
-			if (node.Exists && !node.IsSpace)
+			if (node.Exists && node.IsSpace == false)
 			{
 				return node;
 			}
@@ -671,7 +671,10 @@ public partial class MatrixManager : MonoBehaviour
 	/// </summary>
 	public static void ReagentReact(ReagentMix reagents, Vector3Int worldPos)
 	{
-		if (!CustomNetworkManager.IsServer) return;
+		if (CustomNetworkManager.IsServer == false) 
+		{
+			return;
+		}
 
 		var matrixInfo = AtPoint(worldPos, true);
 		Vector3Int localPos = WorldToLocalInt(worldPos, matrixInfo);
@@ -773,7 +776,7 @@ public partial class MatrixManager : MonoBehaviour
 
 	public static bool IsTotallyImpassable(Vector3Int worldTarget, bool isServer)
 	{
-		return !IsPassableAt(worldTarget, isServer) && !IsAtmosPassableAt(worldTarget, isServer);
+		return IsPassableAt(worldTarget, isServer) == false && IsAtmosPassableAt(worldTarget, isServer) == false;
 	}
 
 	///Cross-matrix edition of <see cref="Matrix.IsPassableAt(UnityEngine.Vector3Int,bool)"/>
@@ -845,7 +848,7 @@ public partial class MatrixManager : MonoBehaviour
 	{
 		for (var i = 0; i < matrixInfos.Length; i++)
 		{
-			if (!condition(matrixInfos[i]))
+			if (condition(matrixInfos[i]) == false)
 			{
 				return false;
 			}
@@ -1063,7 +1066,7 @@ public partial class MatrixManager : MonoBehaviour
 
 //		return matrix.MetaTileMap.LocalToWorld( localPos );
 
-		if (!matrix.MatrixMove)
+		if (matrix.MatrixMove == null)
 		{
 			return localPos + matrix.Offset;
 		}
@@ -1093,7 +1096,7 @@ public partial class MatrixManager : MonoBehaviour
 		}
 
 
-		if (!matrix.MatrixMove)
+		if (matrix.MatrixMove == null)
 		{
 			return worldPos - matrix.Offset;
 		}
@@ -1168,7 +1171,7 @@ public partial class MatrixManager : MonoBehaviour
 			floorDecals[i].TryClean();
 		}
 
-		if (!IsSpaceAt(worldPosInt, true) && makeSlippery)
+		if (IsSpaceAt(worldPosInt, true) == false && makeSlippery)
 		{
 			// Create a WaterSplat Decal (visible slippery tile)
 			EffectsFactory.WaterSplat(worldPosInt);
@@ -1180,7 +1183,7 @@ public partial class MatrixManager : MonoBehaviour
 
 	public static Transform GetDefaultParent( Vector3? position, bool isServer )
 	{
-		if (!position.HasValue)
+		if (position.HasValue == false)
 		{
 			return MainStationMatrix.ObjectParent;
 		}

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -924,6 +924,10 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 			return false;
 		}
 
+		// TODO: check if there is anything in the pushable's location that can't leave in the opposite direction due to the pushable.
+		// If there is, then pushable can not be pushed.
+		// This prevents e.g., unsecured directional windows in the same square as a canister from being pushed through the canister.
+
 		return true;
 	}
 

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -58,7 +58,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 				return parentContainer.parentContainer;
 			}
 
-			if (!VisibleState)
+			if (VisibleState == false)
 			{
 				var pu = GetComponent<Pickupable>();
 				if (pu != null && pu.ItemSlot != null)
@@ -142,7 +142,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	/// Checks if there is anything preventing this from being pushed regardless of direction
 	/// (basically if it's anchored)
 	/// </summary>
-	public bool IsPushable => !isNotPushable;
+	public bool IsPushable => isNotPushable == false;
 	/// <summary>
 	/// Opposite of IsPushable
 	/// </summary>
@@ -155,7 +155,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	[Server]
 	public void ServerSetPushable(bool isPushable)
 	{
-		SyncIsNotPushable(isNotPushable, !isPushable);
+		SyncIsNotPushable(isNotPushable, isPushable == false);
 	}
 
 	[Tooltip("The sound to play when pushed/pulled")]
@@ -276,8 +276,8 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 		Pushable?.OnClientStopFollowing();
 	}
 
-	public bool IsSolidServer => !registerTile.IsPassable(true);
-	public bool IsSolidClient => !registerTile.IsPassable(false);
+	public bool IsSolidServer => registerTile.IsPassable(true) == false;
+	public bool IsSolidClient => registerTile.IsPassable(false) == false;
 
 
 	#region Pull Master
@@ -328,7 +328,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 
 	private void ReleaseControl()
 	{
-		if (!IsPullingSomethingServer)
+		if (IsPullingSomethingServer == false)
 		{
 			return;
 		}
@@ -346,7 +346,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	{
 		if (pullableObject == null) return;
 		PushPull pullable = pullableObject.GetComponent<PushPull>();
-		if (!pullable)
+		if (pullable == false)
 		{
 			return;
 		}
@@ -366,13 +366,13 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 			}
 		}
 		ConnectedPlayer clientWhoAsked = PlayerList.Instance.Get(gameObject);
-		if (!Validations.CanApply(clientWhoAsked.Script, gameObject, NetworkSide.Server))
+		if (Validations.CanApply(clientWhoAsked.Script, gameObject, NetworkSide.Server) == false)
 		{
 			return;
 		}
 
-		if (Validations.IsInReach(pullable.registerTile, this.registerTile, true)
-				&& !pullable.isNotPushable && pullable != this && !IsBeingPulled)
+		if (Validations.IsInReach(pullable.registerTile, this.registerTile, true, context: pullableObject)
+				&& pullable.isNotPushable == false && pullable != this && IsBeingPulled == false)
 		{
 
 			if (pullable.StartFollowing(this))
@@ -418,7 +418,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	{
 		yield return WaitFor.Seconds(2);
 
-		if (!Pushable.IsMovingClient
+		if (Pushable.IsMovingClient == false
 				&& Pushable.ClientPosition != Pushable.TrustedPosition
 			)
 		{
@@ -460,7 +460,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 		else
 		{
 			// Check if in range for pulling, not trying to pull itself and it can be pulled.
-			if (Validations.IsInReach(registerTile, initiator.registerTile, false) &&
+			if (Validations.IsInReach(initiator.registerTile, registerTile, false, context: gameObject) &&
 				IsPushable && initiator != this)
 			{
 				return RightClickableResult.Create()
@@ -489,7 +489,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 			{
 				return;
 			}
-			if (!TryFollow(currentPos, followDir, GetHeadSpeedServer()))
+			if (TryFollow(currentPos, followDir, GetHeadSpeedServer()) == false)
 			{
 				StopFollowing();
 			}
@@ -514,7 +514,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 			{
 				return;
 			}
-			if (!TryPredictiveFollow(currentPos, oldPos, GetHeadSpeedClient()))
+			if (TryPredictiveFollow(currentPos, oldPos, GetHeadSpeedClient()) == false)
 			{
 				Logger.LogError($"{gameObject.name}: oops, predictive following {PulledByClient.gameObject.name} failed", Category.PushPull);
 			}
@@ -533,7 +533,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	/// </summary>
 	public bool CausesGravity()
 	{
-		if (!isNotPushable || floorDecal != null)
+		if (isNotPushable == false|| floorDecal != null)
 			return false;
 
 		return true;
@@ -642,7 +642,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	/// (Eventually)
 	public bool IsPulledByClient(PushPull pushPull)
 	{
-		if (!IsBeingPulledClient)
+		if (IsBeingPulledClient == false)
 		{
 			return false;
 		}
@@ -667,8 +667,8 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 		bool chooChooTrain = attachTo.IsBeingPulled && attachTo.PulledBy != this;
 
 		//if puller can reach this + not trying to pull himself + not being pulled
-		if (Validations.IsInReach(attachTo.registerTile, this.registerTile, true)
-				&& attachTo != this && (!attachTo.IsBeingPulled || chooChooTrain))
+		if (Validations.IsInReach(attachTo.registerTile, this.registerTile, true, context: gameObject)
+				&& attachTo != this && (attachTo.IsBeingPulled == false || chooChooTrain))
 		{
 			Logger.LogTraceFormat("{0} started following {1}", Category.PushPull, this.gameObject.name, attachTo.gameObject.name);
 			PulledBy = attachTo;
@@ -681,7 +681,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	[Command]
 	public void CmdStopFollowing()
 	{
-		if (!IsBeingPulled)
+		if (IsBeingPulled == false)
 		{
 			return;
 		}
@@ -695,7 +695,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	[Server]
 	public void StopFollowing()
 	{
-		if (!IsBeingPulled)
+		if (IsBeingPulled == false)
 		{
 			return;
 		}
@@ -714,7 +714,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	{
 		var initiator = PlayerManager.LocalPlayerScript.pushPull;
 		//client pre-validation
-		if (Validations.IsInReach(this.registerTile, initiator.registerTile, false) && initiator != this)
+		if (Validations.IsInReach(initiator.registerTile, this.registerTile, false, context: gameObject) && initiator != this)
 		{
 			//client request: start/stop pulling
 			initiator.CmdPullObject(gameObject);
@@ -730,7 +730,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	[Server]
 	private bool TryFollow(Vector3Int from, Vector2Int dir, float speed = Single.NaN)
 	{
-		if (!IsBeingPulled || isNotPushable || isBeingPushed || Pushable == null)
+		if (IsBeingPulled == false || isNotPushable || isBeingPushed || Pushable == null)
 		{
 			return false;
 		}
@@ -742,7 +742,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 		}
 
 		Vector3Int target = from + Vector3Int.RoundToInt((Vector2)dir);
-		if (!MatrixManager.IsPassableAt(from, target, isServer: true, includingPlayers: false, context: gameObject)) //non-solid things can be pushed to player tile
+		if (MatrixManager.IsPassableAt(from, target, isServer: true, includingPlayers: false, context: gameObject) == false) //non-solid things can be pushed to player tile
 		{
 			return false;
 		}
@@ -758,7 +758,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 			}
 
 			// If there is a sound to be played
-			if (!string.IsNullOrWhiteSpace(pushPullSound) && (Time.time * 1000 > lastPlayedSoundTime + soundDelayTime))
+			if (string.IsNullOrWhiteSpace(pushPullSound) == false && (Time.time * 1000 > lastPlayedSoundTime + soundDelayTime))
 			{
 				SoundManager.PlayNetworkedAtPos(pushPullSound, target, Random.Range(soundMinimumPitchVariance, soundMaximumPitchVariance), sourceObj: gameObject);
 				lastPlayedSoundTime = Time.time * 1000;
@@ -772,7 +772,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	}
 	private bool TryPredictiveFollow(Vector3Int from, Vector3Int target, float speed = Single.NaN)
 	{
-		if (!IsBeingPulledClient || isNotPushable || Pushable == null)
+		if (IsBeingPulledClient == false || isNotPushable || Pushable == null)
 		{
 			return false;
 		}
@@ -815,10 +815,10 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 
 	private void CheckQueue()
 	{
-		if (pushRequestQueue.Count > 0 && !isBeingPushed)
+		if (pushRequestQueue.Count > 0 && isBeingPushed == false)
 		{
 			var tuple = pushRequestQueue.Dequeue();
-			if (!TryPush(tuple.Item1, tuple.Item2))
+			if (TryPush(tuple.Item1, tuple.Item2) == false)
 			{
 				pushRequestQueue.Clear();
 			}
@@ -837,7 +837,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	public bool TryPush(Vector2Int dir, float speed = Single.NaN)
 	{
 		Vector3Int from = Pushable.ServerPosition;
-		if (!CanPushServer(from, dir, speed))
+		if (CanPushServer(from, dir, speed) == false)
 		{
 			return false;
 		}
@@ -847,12 +847,12 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 		if (success)
 		{
 			if (IsBeingPulled && //Break pull only if pushable will end up far enough
-					(pushRequestQueue.Count > 0 || !Validations.IsInReach(PulledBy.registerTile.WorldPositionServer, target, true, context: gameObject)))
+					(pushRequestQueue.Count > 0 || Validations.IsInReach(PulledBy.registerTile.WorldPositionServer, target, true, context: gameObject) == false))
 			{
 				StopFollowing();
 			}
 			if (IsPullingSomethingServer && //Break pull only if pushable will end up far enough
-					(pushRequestQueue.Count > 0 || !Validations.IsInReach(PulledObjectServer.registerTile.WorldPositionServer, target, true, context: gameObject)))
+					(pushRequestQueue.Count > 0 || Validations.IsInReach(PulledObjectServer.registerTile.WorldPositionServer, target, true, context: gameObject) == false))
 			{
 				ReleaseControl();
 			}
@@ -900,7 +900,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	/// cause the object to move.</returns>
 	private bool CanPush(Vector3Int pusherPos, Vector2Int dir, float speed = Single.NaN, bool serverSide = true)
 	{
-		if (isNotPushable || isBeingPushed || Pushable == null || !isAllowedDir(dir))
+		if (isNotPushable || isBeingPushed || Pushable == null || isAllowedDir(dir) == false)
 		{
 			return false;
 		}
@@ -919,7 +919,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 
 		// If the pushable's movement in that direction is obstructed, then it can't be pushed.
 		Vector3Int target = pusherPos + Vector3Int.RoundToInt((Vector2)dir);
-		if (!MatrixManager.IsPassableAt(pusherPos, target, isServer: serverSide, includingPlayers: IsSolidClient, context: gameObject)) //non-solid things can be pushed to player tile
+		if (MatrixManager.IsPassableAt(pusherPos, target, isServer: serverSide, includingPlayers: IsSolidClient, context: gameObject) == false) //non-solid things can be pushed to player tile
 		{
 			return false;
 		}
@@ -929,7 +929,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 
 	public bool TryPredictivePush(Vector3Int from, Vector2Int dir, float speed = Single.NaN)
 	{
-		if (isNotPushable || !CanPredictPush || Pushable == null || !isAllowedDir(dir))
+		if (isNotPushable || CanPredictPush == false || Pushable == null || isAllowedDir(dir) == false)
 		{
 			return false;
 		}
@@ -939,7 +939,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 			return false;
 		}
 		Vector3Int target = from + Vector3Int.RoundToInt((Vector2)dir);
-		if (!MatrixManager.IsPassableAt(from, target, isServer: false, context: gameObject) ||
+		if (MatrixManager.IsPassableAt(from, target, isServer: false, context: gameObject) == false ||
 				MatrixManager.IsNoGravityAt(target, isServer: false))
 		{ //not allowing predictive push into space
 			return false;
@@ -988,7 +988,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 
 	private void OnServerTileReached(Vector3Int newPos)
 	{
-		if (!isBeingPushed && pushRequestQueue.Count == 0)
+		if (isBeingPushed == false && pushRequestQueue.Count == 0)
 		{
 			return;
 		}
@@ -998,7 +998,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 
 		if (pushTarget != TransformState.HiddenPos &&
 				pushTarget != newPos &&
-				!MatrixManager.IsFloatingAt(gameObject, newPos, true))
+				MatrixManager.IsFloatingAt(gameObject, newPos, true) == false)
 		{
 			//unexpected pos reported by server tile (common in space, space )
 			pushRequestQueue.Clear();

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -230,6 +230,9 @@ public partial class PlayerSync
 	/// <param name="direction">Direction you're pushing</param>
 	private void PredictiveBumpInteract(Vector3Int worldTile, Vector2Int direction)
 	{
+		Vector3Int worldOrigin = worldTile - (Vector3Int)direction;
+		Vector3Int localOrigin = MatrixManager.Instance.WorldToLocalInt(worldTile, MatrixManager.AtPoint(worldTile, isServer).Matrix);
+
 		if (!Validations.CanInteract(playerScript, NetworkSide.Client, allowCuffed: true))
 		{
 			return;
@@ -239,6 +242,13 @@ public partial class PlayerSync
 		for (int i = 0; i < pushPulls.Count; i++)
 		{
 			var pushPull = pushPulls[i];
+
+			// ignore pushables we can just walk over
+			if (pushPull.registerTile.IsPassable(localOrigin, false))
+			{
+				continue;
+			}
+
 			if (pushPull && pushPull.gameObject != gameObject && pushPull.CanPushClient(worldTile, direction))
 			{
 				//					Logger.LogTraceFormat( "Predictive pushing {0} from {1} to {2}", Category.PushPull, pushPulls[i].gameObject, worldTile, (Vector2)(Vector3)worldTile+(Vector2)direction );

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -230,7 +230,6 @@ public partial class PlayerSync
 	/// <param name="direction">Direction you're pushing</param>
 	private void PredictiveBumpInteract(Vector3Int worldTile, Vector2Int direction)
 	{
-		Vector3Int worldOrigin = worldTile - (Vector3Int)direction;
 		Vector3Int localOrigin = MatrixManager.Instance.WorldToLocalInt(worldTile, MatrixManager.AtPoint(worldTile, isServer).Matrix);
 
 		if (!Validations.CanInteract(playerScript, NetworkSide.Client, allowCuffed: true))

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Client.cs
@@ -230,24 +230,17 @@ public partial class PlayerSync
 	/// <param name="direction">Direction you're pushing</param>
 	private void PredictiveBumpInteract(Vector3Int worldTile, Vector2Int direction)
 	{
-		Vector3Int localOrigin = MatrixManager.Instance.WorldToLocalInt(worldTile, MatrixManager.AtPoint(worldTile, isServer).Matrix);
+		Vector3Int worldOrigin = worldTile - (Vector3Int)direction;
 
 		if (!Validations.CanInteract(playerScript, NetworkSide.Client, allowCuffed: true))
 		{
 			return;
 		}
 		// Is the object pushable (iterate through all of the objects at the position):
-		var pushPulls = MatrixManager.GetAt<PushPull>(worldTile, false);
+		List<PushPull> pushPulls = MatrixManager.GetPushableAt(worldOrigin, direction, gameObject, false, true);
 		for (int i = 0; i < pushPulls.Count; i++)
 		{
 			var pushPull = pushPulls[i];
-
-			// ignore pushables we can just walk over
-			if (pushPull.registerTile.IsPassable(localOrigin, false))
-			{
-				continue;
-			}
-
 			if (pushPull && pushPull.gameObject != gameObject && pushPull.CanPushClient(worldTile, direction))
 			{
 				//					Logger.LogTraceFormat( "Predictive pushing {0} from {1} to {2}", Category.PushPull, pushPulls[i].gameObject, worldTile, (Vector2)(Vector3)worldTile+(Vector2)direction );

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -721,15 +721,17 @@ public partial class PlayerSync
 		{
 			return;
 		}
-		List<PushPull> pushables = MatrixManager.GetPushableAt(worldOrigin, direction.To2Int(), gameObject, true);
+
+		Vector2Int twoIntDirection = direction.To2Int();
+
+		List<PushPull> pushables = MatrixManager.GetPushableAt(worldOrigin, twoIntDirection, gameObject, true, true);
 		if (pushables.Count > 0)
 		{
-			Vector3Int localOrigin = MatrixManager.Instance.WorldToLocalInt(worldOrigin, MatrixManager.AtPoint(worldOrigin, isServer).Matrix);
-			PushPull firstPushable = pushables.Find(p => p.registerTile.IsPassable(localOrigin, isServer: true) == false);
-
-			if (firstPushable != null)
+			foreach ( PushPull pushable in pushables)
 			{
-				firstPushable.TryPush(direction.To2Int());
+
+				pushable.TryPush(twoIntDirection);
+				break;
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -721,10 +721,16 @@ public partial class PlayerSync
 		{
 			return;
 		}
-		List<PushPull> pushables = MatrixManager.GetPushableAt(worldOrigin, direction.To2Int(), gameObject, isServer: true);
+		List<PushPull> pushables = MatrixManager.GetPushableAt(worldOrigin, direction.To2Int(), gameObject, true);
 		if (pushables.Count > 0)
 		{
-			pushables[0].TryPush(direction.To2Int());
+			Vector3Int localOrigin = MatrixManager.Instance.WorldToLocalInt(worldOrigin, MatrixManager.AtPoint(worldOrigin, isServer).Matrix);
+			PushPull firstPushable = pushables.Find(p => p.registerTile.IsPassable(localOrigin, isServer: true) == false);
+
+			if (firstPushable != null)
+			{
+				firstPushable.TryPush(direction.To2Int());
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #5385
Allows pulling of blocking pullable objects (e.g., canisters)
Some code styling