### PR TITLE
Toy gun tweaks.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftLMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftLMG.prefab
@@ -47,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -216,6 +217,11 @@ PrefabInstance:
         type: 3}
       propertyPath: initialName
       value: donksoft LMG
+      objectReference: {fileID: 0}
+    - target: {fileID: 8979097940314571549, guid: 24274bda3be42c049b4bbb150f6e1220,
+        type: 3}
+      propertyPath: allowClumsy
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 24274bda3be42c049b4bbb150f6e1220, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftLMGUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftLMGUnrestricted.prefab
@@ -65,7 +65,17 @@ PrefabInstance:
     - target: {fileID: 3375427805864737318, guid: fa30aa9352ebf92499cf7e500e5ce0d9,
         type: 3}
       propertyPath: m_Name
-      value: DonksoftLMG
+      value: DonksoftLMGUnrestricted
+      objectReference: {fileID: 0}
+    - target: {fileID: 3405803429765121938, guid: fa30aa9352ebf92499cf7e500e5ce0d9,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8161372715543558980, guid: fa30aa9352ebf92499cf7e500e5ce0d9,
+        type: 3}
+      propertyPath: setRestriction
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fa30aa9352ebf92499cf7e500e5ce0d9, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftSMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftSMG.prefab
@@ -47,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -221,6 +222,11 @@ PrefabInstance:
         type: 3}
       propertyPath: initialName
       value: donksoft SMG
+      objectReference: {fileID: 0}
+    - target: {fileID: 8389838223081530612, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
+        type: 3}
+      propertyPath: allowClumsy
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0a7ba29086818cf4a8010f3b2743a7ac, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftSMGUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftSMGUnrestricted.prefab
@@ -7,10 +7,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3456283829597045344, guid: 688c2d387255bf24d808b12edcd11c46,
+        type: 3}
+      propertyPath: setRestriction
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8098535763128206082, guid: 688c2d387255bf24d808b12edcd11c46,
         type: 3}
       propertyPath: m_Name
-      value: DonksoftSMG
+      value: DonksoftSMGUnrestricted
       objectReference: {fileID: 0}
     - target: {fileID: 8102052139190828662, guid: 688c2d387255bf24d808b12edcd11c46,
         type: 3}
@@ -66,6 +71,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8212299379671039670, guid: 688c2d387255bf24d808b12edcd11c46,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 688c2d387255bf24d808b12edcd11c46, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceSMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceSMG.prefab
@@ -47,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -148,6 +149,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -249,6 +251,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -350,6 +353,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -417,6 +421,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 0a9e2427149770148b3e6986156d3671,
         type: 2}
+    - target: {fileID: 3383358116270698800, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: allowClumsy
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: ammoPrefab

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceShotgun.prefab
@@ -47,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -220,6 +221,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8121578692497752265, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: allowClumsy
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3da1d244806a96340a48e959ecc816e4, type: 3}


### PR DESCRIPTION
### Purpose
- Some toy gun variants no longer have syndicate restrictions.
- Toy guns no longer check for clumsiness when you fire them.