### PR TITLE
Some canister code cleanup

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Canisters/Canister.cs
+++ b/UnityProject/Assets/Scripts/Objects/Canisters/Canister.cs
@@ -2,6 +2,7 @@ using System;
 using UnityEngine;
 using Mirror;
 using Pipes;
+using Systems.Atmospherics;
 
 namespace Objects.Atmospherics
 {
@@ -50,6 +51,7 @@ namespace Objects.Atmospherics
 		private ShuttleFuelConnector connectorFuel;
 
 		public bool ValveIsOpen { get; private set; }
+		public bool tankValveOpen;
 		public GameObject InsertedContainer { get; private set; }
 		public bool HasContainerInserted => InsertedContainer != null;
 		public bool IsConnected => connector != null || connectorFuel != null;
@@ -140,7 +142,7 @@ namespace Objects.Atmospherics
 
 		private void OnDisable()
 		{
-			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, RefreshPressureIndicator);
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateMe);
 		}
 
 		//this is just here so anyone trying to change the armor value in inspector sees it being
@@ -191,20 +193,14 @@ namespace Objects.Atmospherics
 		public void SetValve(bool isOpen)
 		{
 			ValveIsOpen = isOpen;
-			if (!IsConnected)
-			{
-				GasContainer.SetVent(isOpen);
-			}
-
 			RefreshOverlays();
-
 			if (isOpen)
 			{
-				UpdateManager.Add(RefreshPressureIndicator, 1);
+				UpdateManager.Add(UpdateMe, 1);
 			}
 			else
 			{
-				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, RefreshPressureIndicator);
+				UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateMe);
 			}
 		}
 
@@ -355,13 +351,6 @@ namespace Objects.Atmospherics
 			RefreshOverlays();
 			objectBehaviour.ServerSetPushable(!IsConnected);
 			ServerOnConnectionStatusChange.Invoke(IsConnected);
-
-			// Will release gas if canister valve was not turned off before disconnecting from a connector,
-			// or stop the release of gas if canister valve is open and is now connected.
-			if (ValveIsOpen)
-			{
-				GasContainer.SetVent(!IsConnected);
-			}
 		}
 
 		#endregion Interaction
@@ -373,6 +362,25 @@ namespace Objects.Atmospherics
 				GasContainer.GasMix *= Mathf.Pow(10, canisterTier);
 				canisterTierOverlay.ChangeSprite(canisterTier - 1); // Tier 0 has no overlay.
 			}
+		}
+
+		public void UpdateMe()
+		{
+			if(!IsConnected)
+				GasContainer.VentContents();
+			if (tankValveOpen)
+				MergeCanisterAndTank();
+			RefreshPressureIndicator();
+		}
+
+		public void MergeCanisterAndTank()
+		{
+			GasContainer canisterTank = GetComponent<GasContainer>();
+			GasContainer externalTank = InsertedContainer.GetComponent<GasContainer>();
+			GasMix canisterGas = canisterTank.GasMix;
+			GasMix tankGas = externalTank.GasMix;
+			canisterTank.GasMix = tankGas.MergeGasMix(canisterGas);
+			externalTank.GasMix = tankGas;
 		}
 
 		public void RefreshPressureIndicator()

--- a/UnityProject/Assets/Scripts/Objects/GasContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/GasContainer.cs
@@ -57,7 +57,6 @@ namespace Objects.Atmospherics
 
 		private void OnDisable()
 		{
-			SetVentClosed();
 			integrity.OnApplyDamage.RemoveListener(OnServerDamage);
 		}
 
@@ -65,7 +64,6 @@ namespace Objects.Atmospherics
 		{
 			if (integrity.integrity - info.Damage <= 0)
 			{
-				SetVentClosed();
 				ExplodeContainer();
 				integrity.RestoreIntegrity(integrity.initialIntegrity);
 			}
@@ -95,42 +93,13 @@ namespace Objects.Atmospherics
 		{
 			MetaDataLayer metaDataLayer = MatrixManager.AtPoint(WorldPosition, true).MetaDataLayer;
 			MetaDataNode node = metaDataLayer.Get(LocalPosition, false);
-			
+
 			node.GasMix += GasMix;
 			metaDataLayer.UpdateSystemsAt(LocalPosition, SystemType.AtmosSystem);
 		}
 
-		public void SetVent(bool isOpen)
-		{
-			if (isOpen)
-			{
-				SetVentOpen();
-			}
-			else
-			{
-				SetVentClosed();
-			}
-		}
-
-		private void SetVentOpen()
-		{
-			IsVenting = true;
-			UpdateManager.Add(CallbackType.UPDATE, UpdateVenting);
-		}
-
-		private void SetVentClosed()
-		{
-			IsVenting = false;
-			UpdateManager.Remove(CallbackType.UPDATE, UpdateVenting);
-		}
-
-		private void UpdateVenting()
-		{
-			VentContents();
-		}
-
 		[Server]
-		private void VentContents()
+		public void VentContents()
 		{
 			var metaDataLayer = MatrixManager.AtPoint(Vector3Int.RoundToInt(transform.position), true).MetaDataLayer;
 

--- a/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/Canister/GUI_Canister.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/Canister/GUI_Canister.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using AdminTools;
 using UnityEngine;
 using UnityEngine.UI;
-using Systems.Atmospherics;
 using Objects.Atmospherics;
 
 namespace UI.Objects.Atmospherics
@@ -68,9 +67,6 @@ namespace UI.Objects.Atmospherics
 		private float timeSincePressureChange;
 		private float prevInternalPressure;
 		private bool muteSounds = false;
-		private bool valveOpen;
-		//keep track of the tank lever for ejection
-		private bool tankValveOpen = false;
 		/// <summary>
 		/// Whether sounds should be muted on this instance of the UI.
 		/// </summary>
@@ -110,8 +106,8 @@ namespace UI.Objects.Atmospherics
 			{
 				yield return WaitFor.EndOfFrame;
 			}
-
 			canister = Provider.GetComponent<Canister>();
+
 			//init pressure dials
 			InternalPressureDial.ServerSpinTo(Mathf.RoundToInt(gasContainer.ServerInternalPressure));
 			ReleasePressureDial.ServerSpinTo(Mathf.RoundToInt(gasContainer.ReleasePressure));
@@ -144,7 +140,6 @@ namespace UI.Objects.Atmospherics
 				yield return WaitFor.EndOfFrame;
 			}
 			//set the tab color and label based on the provider
-			Canister canister = Provider.GetComponent<Canister>();
 			BG.color = canister.UIBGTint;
 			InnerPanelBG.color = canister.UIInnerPanelTint;
 			LabelText.text = "Contains " + canister.ContentsName;
@@ -172,7 +167,6 @@ namespace UI.Objects.Atmospherics
 		/// </summary>
 		private void ServerUpdateExternalTank(bool externalExists)
 		{
-			Canister canister = Provider.GetComponent<Canister>();
 			GameObject insertedContainer = canister.InsertedContainer;
 
 			if (externalExists)
@@ -338,6 +332,11 @@ namespace UI.Objects.Atmospherics
 			if (InternalPressureDial.SyncedValue != currentValue)
 			{
 				InternalPressureDial.ServerSpinTo(currentValue);
+				if (canister.InsertedContainer != null && canister.tankValveOpen)
+				{
+					GasContainer externalTank = canister.InsertedContainer.GetComponent<GasContainer>();
+					ExternalPressureDial.ServerSpinTo(Mathf.RoundToInt(externalTank.ServerInternalPressure));
+				}
 			}
 
 			yield return WaitFor.Seconds(PRESSURE_UPDATE_RATE);
@@ -391,84 +390,28 @@ namespace UI.Objects.Atmospherics
 		/// <param name="usingTank">Is the valve set to tank.</param>
 		public void ServerToggleSecondary(bool usingTank)
 		{
-			tankValveOpen = usingTank;
-			Canister canister = Provider.GetComponent<Canister>();
-			GasContainer canisterTank = canister.GetComponent<GasContainer>();
-			GasContainer externalTank = canister.InsertedContainer?.GetComponent<GasContainer>();
+			canister.tankValveOpen = usingTank;
 
-			if (usingTank && externalTank != null)
+			if (usingTank)
 			{
-				GasMix canisterGas = canisterTank.GasMix;
-				GasMix tankGas = externalTank.GasMix;
-				float[] updatedCanisterGases = { 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f };
-				float[] updatedTankGases = { 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f, 0f };
-				float updatedTankMoles = 0f;
-
-				GasMix totalGas = canisterGas + tankGas;
-				float[] totalGases = totalGas.Gases;
-
-				bool emptyTotal = true;
-				//while: canister has greater pressure than external tank AND tank isn't full
-				while (canisterTank.ServerInternalPressure >= externalTank.ServerInternalPressure &&
-					   updatedTankMoles <= externalTank.MaximumMoles && emptyTotal)
+				if (canister.InsertedContainer != null)
 				{
-					emptyTotal = true;
-					//iterate through gases and distribute between the canister and external tank
-					for (int i = 0; i < totalGases.Length; i++)
-					{
-						if (totalGases[i] > 0f && updatedTankMoles <= externalTank.MaximumMoles)
-						{
-							emptyTotal = false;
-							totalGases[i] -= 0.02f;
-							updatedCanisterGases[i] += 0.01f;
-							updatedTankGases[i] += 0.01f;
-							updatedTankMoles += 0.01f;
-						}
-					}
+					canister.MergeCanisterAndTank();
+					GasContainer externalTank = canister.InsertedContainer.GetComponent<GasContainer>();
+					ExternalPressureDial.ServerSpinTo(Mathf.RoundToInt(externalTank.ServerInternalPressure));
 				}
-				//add remaining gases to the canister values
-				for (int i = 0; i < totalGases.Length; i++)
+				else
 				{
-					if (totalGases[i] > 0f)
-					{
-						updatedCanisterGases[i] += totalGases[i];
-						totalGases[i] = 0f;
-						//compensate for valve blowoff
-						updatedCanisterGases[i] -= 0.02052f;
-					}
-
+					StartCoroutine(DisplayFlashingText("Insert a tank before opening the valve!", 1F));
 				}
-
-				//make sure we're not marginally increasing gas in the tank
-				//due to float falloff
-				bool accuracyCheck = true;
-				for (int i = 0; i < canisterTank.Gases.Length; i++)
-				{
-					if (canisterTank.Gases[i] < updatedCanisterGases[i])
-						accuracyCheck = false;
-				}
-				if (accuracyCheck)
-				{
-					canisterTank.Gases = updatedCanisterGases;
-					canisterTank.UpdateGasMix();
-				}
-				externalTank.Gases = updatedTankGases;
-				externalTank.UpdateGasMix();
-				ExternalPressureDial.ServerSpinTo(Mathf.RoundToInt(externalTank.ServerInternalPressure));
-			}
-			else if (usingTank && externalTank == null)
-			{
-				StartCoroutine(DisplayFlashingText("Insert a tank before opening the valve!", 1F));
 			}
 		}
 
 		public void EjectExternalTank()
 		{
-			Canister canister = Provider.GetComponent<Canister>();
-
 			if (canister.InsertedContainer != null)
 			{
-				if (tankValveOpen)
+				if (canister.tankValveOpen)
 				{
 					StartCoroutine(DisplayFlashingText("Close the valve first!"));
 				}
@@ -516,8 +459,6 @@ namespace UI.Objects.Atmospherics
 			yield return WaitFor.Seconds(speed);
 			externalTankStatus.SetValueServer("");
 			yield return WaitFor.Seconds(speed / 2);
-
-			Canister canister = Provider.GetComponent<Canister>();
 
 			if (canister.InsertedContainer != null)
 			{


### PR DESCRIPTION
### Purpose
Replaces the custom gas merge code in GUI_Canister with a gasmix call.
Cleans up a bit canister code.
The connected tanks will now merge and update the pressure level in the UI at the same time than the canister air change. See gif
![canister tank sync](https://user-images.githubusercontent.com/701959/98151543-1841af00-1eaf-11eb-8c5e-3aff712d2119.gif)

