### PR TITLE
per firemode watt usage for energy weapons

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/_GunEnergyBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Energy/_GunEnergyBase.prefab
@@ -258,6 +258,7 @@ MonoBehaviour:
   - ShootLaser
   firemodeName:
   - Kill
+  firemodeUsage: 53000000
 --- !u!1 &6227234703256324225
 GameObject:
   m_ObjectHideFlags: 0
@@ -609,18 +610,6 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 4644871529314044369, guid: da85b7a590e7c8444af73629fcb5dd22, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: da85b7a590e7c8444af73629fcb5dd22, type: 3}
---- !u!1 &4454405483554457966 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8150840225578731674, guid: da85b7a590e7c8444af73629fcb5dd22,
-    type: 3}
-  m_PrefabInstance: {fileID: 5533974169584468468}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &4450321759764526106 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8146475302025016814, guid: da85b7a590e7c8444af73629fcb5dd22,
-    type: 3}
-  m_PrefabInstance: {fileID: 5533974169584468468}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &942046851822298982 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: -4477014874976573806, guid: da85b7a590e7c8444af73629fcb5dd22,
@@ -633,3 +622,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdce8a163088453ca593c0e98f2c5f07, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &4450321759764526106 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8146475302025016814, guid: da85b7a590e7c8444af73629fcb5dd22,
+    type: 3}
+  m_PrefabInstance: {fileID: 5533974169584468468}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4454405483554457966 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8150840225578731674, guid: da85b7a590e7c8444af73629fcb5dd22,
+    type: 3}
+  m_PrefabInstance: {fileID: 5533974169584468468}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Items/Weapons/ElectricalMagazine.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/ElectricalMagazine.cs
@@ -3,22 +3,28 @@
 /// <summary>
 /// Gun scripts are strange, This is to make it easy to have a charging Ammo clip
 /// </summary>
+[RequireComponent(typeof(Battery))]
 public class ElectricalMagazine : MagazineBehaviour
 {
+
 	public Battery battery;
+
+	public int toRemove;
+
+	public void Awake()
+	{
+		battery = GetComponent<Battery>();
+	}
 
 	public override void ExpendAmmo(int amount = 1)
 	{
+		if (toRemove > battery.Watts) 
+		{
+			return;
+		}
 		base.ExpendAmmo(amount);
 		if (CustomNetworkManager.Instance._isServer == false) return;
-		if (ServerAmmoRemains == 0)
-		{
-			battery.Watts = 0;
-		}
-		else
-		{
-			battery.Watts = Mathf.RoundToInt( battery.MaxWatts * ((float)ServerAmmoRemains /  (float) magazineSize));
-		}
+		battery.Watts -= toRemove;
 	}
 
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -762,7 +762,7 @@ namespace Weapons
 			SoundManager.PlayNetworkedAtPos("OutOfAmmoAlarm", transform.position, sourceObj: serverHolder);
 		}
 
-		private void PlayEmptySFX()
+		public void PlayEmptySFX()
 		{
 			SoundManager.PlayNetworkedAtPos("EmptyGunClick", transform.position, sourceObj: serverHolder);
 		}

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -160,7 +160,7 @@ namespace Weapons
 
 		private RegisterTile registerTile;
 		private ItemStorage itemStorage;
-		private ItemSlot magSlot;
+		public ItemSlot magSlot;
 
 		private GunTrigger gunTrigger;
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/GunElectrical.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/GunElectrical.cs
@@ -33,6 +33,7 @@ public class GunElectrical : Gun, ICheckedInteractable<HandActivate>
 	{
 		if (firemodeUsage[currentFiremode] > battery.Watts) 
 		{
+			base.PlayEmptySFX();
 			return false;
 		}
 		CurrentMagazine.containedBullets[0] = firemodeProjectiles[currentFiremode];

--- a/UnityProject/Assets/Scripts/Items/Weapons/GunElectrical.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/GunElectrical.cs
@@ -4,16 +4,25 @@ using System.Collections.Generic;
 using UnityEngine;
 using Weapons;
 using Mirror;
-
+using Weapons.Projectiles;
 
 public class GunElectrical : Gun, ICheckedInteractable<HandActivate>
 {
 	public List<GameObject> firemodeProjectiles = new List<GameObject>();
 	public List<string> firemodeFiringSound = new List<string>();
 	public List<string> firemodeName = new List<string>();
+	public List<int> firemodeUsage = new List<int>();
 
 	[SyncVar(hook = nameof(UpdateFiremode))]
 	private int currentFiremode = 0;
+
+	public int CurrentFiremode => currentFiremode;
+
+	public Battery battery =>
+			magSlot.Item != null ? magSlot.Item.GetComponent<Battery>() : null;
+
+	public ElectricalMagazine currentelmag =>
+			magSlot.Item != null ? magSlot.Item.GetComponent<ElectricalMagazine>() : null;
 
 	public bool WillInteract(HandActivate interaction, NetworkSide side)
 	{
@@ -22,7 +31,12 @@ public class GunElectrical : Gun, ICheckedInteractable<HandActivate>
 
 	public override bool WillInteract(AimApply interaction, NetworkSide side)
 	{
+		if (firemodeUsage[currentFiremode] > battery.Watts) 
+		{
+			return false;
+		}
 		CurrentMagazine.containedBullets[0] = firemodeProjectiles[currentFiremode];
+		currentelmag.toRemove = firemodeUsage[currentFiremode];
 		return base.WillInteract(interaction, side);
 	}
 
@@ -39,6 +53,12 @@ public class GunElectrical : Gun, ICheckedInteractable<HandActivate>
 		Chat.AddExamineMsgToClient($"You switch your {gameObject.ExpensiveName()} into {firemodeName[currentFiremode]} mode");
 	}
 
+	public override void ServerPerformInteraction(AimApply interaction)
+	{
+		if (firemodeUsage[currentFiremode] > battery.Watts) return;
+		base.ServerPerformInteraction(interaction);		
+	}
+
 	public void UpdateFiremode(int oldValue, int newState)
 	{
 		currentFiremode = newState;
@@ -48,7 +68,7 @@ public class GunElectrical : Gun, ICheckedInteractable<HandActivate>
 
 	public override String Examine(Vector3 pos)
 	{
-		string returnstring = WeaponType + " - Fires " + ammoType + " ammunition (" + (CurrentMagazine != null ? (CurrentMagazine.ServerAmmoRemains.ToString() + " rounds loaded in magazine") : "It's empty!") + ")";
+		string returnstring = WeaponType + " - Fires " + ammoType + " ammunition (" + (CurrentMagazine != null ? (Mathf.Floor(battery.Watts / firemodeUsage[currentFiremode]) + " rounds loaded in magazine") : "It's empty!") + ")";
 
 		if (firemodeProjectiles.Count > 1) {
 			returnstring += "\nIt is set to " + firemodeName[currentFiremode] + " mode.";

--- a/UnityProject/Assets/Scripts/Objects/Charger.cs
+++ b/UnityProject/Assets/Scripts/Objects/Charger.cs
@@ -122,6 +122,11 @@ namespace Objects
 		private void AddCharge()
 		{
 			battery.Watts += ChargingWatts;
+			
+			if (battery.Watts > battery.MaxWatts)
+			{
+				battery.Watts = battery.MaxWatts;
+			}
 
 			if (electricalMagazine != null)
 			{


### PR DESCRIPTION
changes inspect ammocount to use a different calculation that depends on the wattage contained within the battery
adds a system to allow for firemodes to have a seperate watt usage, allowing for different ammo counts (say 6 shots laser 12 shots disabler, etc)
fixes a small issue with chargers charging a cell more then it can hold
these changes will require all extra firemodes to have their watt usage added, a default value has been provided for the first firemode