### PR TITLE
Fixes invisible grenades

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Explosive/Grenade.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Explosive/Grenade.prefab
@@ -80,11 +80,6 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: serverOnly
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Scripts/Systems/Botany/GrownFood.cs
+++ b/UnityProject/Assets/Scripts/Systems/Botany/GrownFood.cs
@@ -29,12 +29,12 @@ public class GrownFood : NetworkBehaviour
 	private Edible edible = default;
 
 	[SyncVar(hook = nameof(SyncSize))]
-	public float SizeScale;
-
+	public float sizeScale = 1;
+	
 	public void SyncSize(float oldScale, float newScale)
 	{
-		SizeScale = newScale;
-		SpriteSizeAdjustment.transform.localScale = new Vector3((SizeScale), (SizeScale), (SizeScale));
+		sizeScale = newScale;
+		SpriteSizeAdjustment.transform.localScale = new Vector3((sizeScale), (sizeScale), (sizeScale));
 	}
 
 	public PlantData GetPlantData()
@@ -65,10 +65,9 @@ public class GrownFood : NetworkBehaviour
 		Sprite.PushTexture();
 	}*/
 
-	public override void OnStartClient()
+	public void Start()
 	{
-		SyncSize(this.SizeScale, this.SizeScale);
-		base.OnStartClient();
+		SyncSize(sizeScale, sizeScale);
 	}
 
 	/// <summary>
@@ -77,7 +76,7 @@ public class GrownFood : NetworkBehaviour
 	public void SetUpFood(PlantData newPlantData, PlantTrayModification modification)
 	{
 		plantData = PlantData.MutateNewPlant(newPlantData, modification);
-		SyncSize(SizeScale, 0.5f + (newPlantData.Potency / 200f));
+		SyncSize(sizeScale, 0.5f + (newPlantData.Potency / 200f));
 		SetupChemicalContents();
 		if(edible != null)
 		{


### PR DESCRIPTION
### Purpose
Fixes grenades not existing on clients.
Fixes grown foods having a sprite scale of 0,0 making them invisible if they weren't manually harvested.
Fixes #5498
