### PR TITLE
Cloning fixes

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Medical/CloningConsole.cs
+++ b/UnityProject/Assets/Scripts/Objects/Medical/CloningConsole.cs
@@ -62,21 +62,30 @@ namespace Objects.Medical
 		/// </summary>
 		public void ServerToggleLock()
 		{
-			if (!Inoperable() && scanner.IsClosed)
+			if (Inoperable())
+			{
+				UpdateInoperableStatus();
+				return;
+			}
+			if (scanner.IsClosed)
 			{
 				scanner.ServerToggleLocked();
 				scanner.statusString = scanner.IsLocked ? "Scanner locked." : "Scanner unlocked.";
 			}
-			else 
+			else
 			{
-				if(Inoperable()) UpdateInoperableStatus();
-				else if(!scanner.IsClosed) scanner.statusString = "Scanner is not closed.";
+				scanner.statusString = "Scanner is not closed.";
 			}
 		}
 
 		public void Scan()
 		{
-			if (!Inoperable() && scanner.occupant)
+			if (Inoperable())
+			{
+				UpdateInoperableStatus();
+				return;
+			}
+			if (scanner.occupant)
 			{
 				var mob = scanner.occupant;
 				var mobID = scanner.occupant.mobID;
@@ -99,23 +108,23 @@ namespace Objects.Medical
 				CreateRecord(mob, playerScript);
 				scanner.statusString = "Subject successfully scanned.";
 			}
-			else 
+			else
 			{
-				if (Inoperable()) UpdateInoperableStatus();
-				else if (!scanner.occupant) scanner.statusString = "Scanner is empty.";
+				scanner.statusString = "Scanner is empty.";
 			}
 		}
 
-		private bool Inoperable() 
+		private bool Inoperable()
 		{
 			return !(scanner && scanner.RelatedAPC && scanner.Powered);
 		}
 
 		private void UpdateInoperableStatus()
 		{
-			if (!scanner) scanner.statusString = "Scanner not found.";
-			else if (!scanner.RelatedAPC) scanner.statusString = "Scanner not connected to APC.";
-			else if (!scanner.Powered) scanner.statusString = "Voltage too low.";
+			if (!scanner.RelatedAPC)
+				scanner.statusString = "Scanner not connected to APC.";
+			else if (!scanner.Powered)
+				scanner.statusString = "Voltage too low.";
 		}
 
 		public void ServerTryClone(CloningRecord record)

--- a/UnityProject/Assets/Scripts/UI/Objects/Medical/Cloning/GUI_Cloning.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Medical/Cloning/GUI_Cloning.cs
@@ -29,16 +29,21 @@ namespace UI.Objects.Medical
 		public NetLabel recordBrute;
 		public NetLabel recordUniqueID;
 
-		void Start()
+		protected override void InitServer()
 		{
-			if (Provider != null)
+			StartCoroutine(WaitForProvider());
+		}
+
+		private IEnumerator WaitForProvider()
+		{
+			while (Provider == null)
 			{
-				//Makes sure it connects with the dispenser properly
-				CloningConsole = Provider.GetComponentInChildren<CloningConsole>();
-				CloningConsole.RegisterConsoleGUI(this);
-				//Subscribe to change event from CloningConsole.cs
-				UpdateDisplay();
+				yield return WaitFor.EndOfFrame;
 			}
+			CloningConsole = Provider.GetComponentInChildren<CloningConsole>();
+			CloningConsole.RegisterConsoleGUI(this);
+			//Subscribe to change event from CloningConsole.cs
+			UpdateDisplay();
 		}
 
 		public void UpdateDisplay()


### PR DESCRIPTION
### Purpose
Clients will no longer have an error message when opening the cloning console for the first time.
Fixes a runtime pop when the scanner was missing.
Makes the cloning console code a bit easier to read.
Fixes #5515
