### PR TITLE
Fixes structure blocking clicks on items placed on the same tile

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Object.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Object.prefab
@@ -100,6 +100,8 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  ReachableThrough: 1
+  passableExclusionsToThis: []
 --- !u!114 &1361981371736346955
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -261,6 +263,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:


### PR DESCRIPTION
### Purpose
Fixes most structures blocking clicks, preventing players from picking up objects on their same tile.
Fixes #5517
