### PR TITLE
Revert removal of ProjectVersion.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,6 @@ UnityProject/ProjectSettings/UnityAdsSettings.asset
 .vs/
 .idea/
 workspace.xml
-UnityProject/ProjectSettings/ProjectVersion.txt
 UnityProject/Assets/Plugins/Editor/Jetbrains*
 UnityProject/.vscode/settings.json
 

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminPromotion.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestAdminPromotion.cs
@@ -24,7 +24,7 @@ public class RequestAdminPromotion : ClientMessage
 			PlayerList.Instance.ProcessAdminEnableRequest(Userid, UserToPromote);
 			var user = PlayerList.Instance.GetByUserID(UserToPromote);
 			UIManager.Instance.adminChatWindows.adminToAdminChat.ServerAddChatRecord(
-				$"{player.ExpensiveName()} made {user.Name} an admin. Users ID is: {UserToPromote}", Userid);
+				$"{player.Player().Username} made {user.Name} an admin. Users ID is: {UserToPromote}", Userid);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestGameModeUpdate.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Admin/RequestGameModeUpdate.cs
@@ -21,13 +21,13 @@ public class RequestGameModeUpdate : ClientMessage
 		{
 			if (GameManager.Instance.NextGameMode != NextGameMode)
 			{
-				Logger.Log(admin.ExpensiveName() + $" with uid: {Userid}, has updated the next game mode with {NextGameMode}", Category.Admin);
+				Logger.Log(admin.Player().Username + $" with uid: {Userid}, has updated the next game mode with {NextGameMode}", Category.Admin);
 				GameManager.Instance.NextGameMode = NextGameMode;
 			}
 
 			if (GameManager.Instance.SecretGameMode != IsSecret)
 			{
-				Logger.Log(admin.ExpensiveName() + $" with uid: {Userid}, has set the IsSecret GameMode flag to {IsSecret}", Category.Admin);
+				Logger.Log(admin.Player().Username + $" with uid: {Userid}, has set the IsSecret GameMode flag to {IsSecret}", Category.Admin);
 				GameManager.Instance.SecretGameMode = IsSecret;
 			}
 		}

--- a/UnityProject/Assets/Scripts/Messages/Client/DevSpawner/DevCloneMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/DevSpawner/DevCloneMessage.cs
@@ -37,7 +37,7 @@ public class DevCloneMessage : ClientMessage
 			{
 				Spawn.ServerClone(NetworkObject, WorldPosition);
 				UIManager.Instance.adminChatWindows.adminToAdminChat.ServerAddChatRecord(
-					$"{admin.ExpensiveName()} spawned a clone of {NetworkObject} at {WorldPosition}", AdminId);
+					$"{admin.Player().Username} spawned a clone of {NetworkObject} at {WorldPosition}", AdminId);
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Messages/Client/DevSpawner/DevDestroyMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/DevSpawner/DevDestroyMessage.cs
@@ -36,7 +36,7 @@ public class DevDestroyMessage : ClientMessage
 
 			Vector2Int worldPos = NetworkObject.transform.position.To2Int();
 			UIManager.Instance.adminChatWindows.adminToAdminChat.ServerAddChatRecord(
-				$"{admin.ExpensiveName()} destroyed a {NetworkObject} at {worldPos}", AdminId);
+				$"{admin.Player().Username} destroyed a {NetworkObject} at {worldPos}", AdminId);
 			Despawn.ServerSingle(NetworkObject);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Messages/Client/DevSpawner/DevSpawnMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/DevSpawner/DevSpawnMessage.cs
@@ -31,7 +31,7 @@ public class DevSpawnMessage : ClientMessage
 		{
 			Spawn.ServerPrefab(prefab, WorldPosition);
 			UIManager.Instance.adminChatWindows.adminToAdminChat.ServerAddChatRecord(
-				$"{admin.ExpensiveName()} spawned a {prefab.name} at {WorldPosition}", AdminId);
+				$"{admin.Player().Username} spawned a {prefab.name} at {WorldPosition}", AdminId);
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -40,7 +40,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 		set {
 			if (this == null) // is possible, Unity
 			{
-				Logger.LogWarning($"{gameObject} is null, and yet it tried to set a {nameof(parentContainer)}.", Category.Transform);
+				Logger.LogWarning("GameObject is null, and yet it tried to set a parentContainer.", Category.Transform);
 			}
 			else if (value == this)
 			{

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Fugitive.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Fugitive.cs
@@ -53,7 +53,7 @@ namespace Antagonists
 				" I need to move in the shadows and keep out of sight," +
 				" I'm not going back.");
 
-			_ = StationWarning(newPlayer.ExpensiveName());
+			_ = StationWarning(newPlayer.Player().Name);
 
 			return newPlayer;
 		}

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/DevSpawnerListItemController.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/DevSpawnerListItemController.cs
@@ -183,7 +183,7 @@ public class DevSpawnerListItemController : MonoBehaviour
 		{
 			Spawn.ServerPrefab(prefab, position);
 			UIManager.Instance.adminChatWindows.adminToAdminChat.ServerAddChatRecord(
-				$"{PlayerManager.LocalPlayer.ExpensiveName()} spawned a {prefab.name} at {position}", ServerData.UserID);
+				$"{PlayerManager.LocalPlayer.Player().Username} spawned a {prefab.name} at {position}", ServerData.UserID);
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/PlayerAlerts.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/PlayerAlerts.cs
@@ -167,10 +167,10 @@ namespace AdminTools
 
 			var playerScript = perp.GetComponent<PlayerScript>();
 			if (playerScript == null || playerScript.IsGhost || playerScript.playerHealth == null) return;
-
-			UIManager.Instance.adminChatWindows.adminToAdminChat.ServerAddChatRecord($"{admin.ExpensiveName()} BRUTALLY GIBBED player {perp.ExpensiveName()} for a " +
-			                                                                         $"{alertEntry.playerAlertType.ToString()} incident that happened at roundtime: " +
-			                                                                         $"{alertEntry.roundTime}", adminId);
+			ConnectedPlayer perpPlayer = perp.Player();
+			UIManager.Instance.adminChatWindows.adminToAdminChat.ServerAddChatRecord(
+					$"{admin.Player().Username} BRUTALLY GIBBED player {perpPlayer.Name} ({perpPlayer.Username}) for a " +
+			        $"{alertEntry.playerAlertType.ToString()} incident that happened at roundtime: {alertEntry.roundTime}", adminId);
 
 			playerScript.playerHealth.ServerGibPlayer();
 
@@ -186,10 +186,10 @@ namespace AdminTools
 
 			var playerScript = perp.GetComponent<PlayerScript>();
 			if (playerScript == null || playerScript.IsGhost || playerScript.playerHealth == null) return;
-
-			UIManager.Instance.adminChatWindows.adminToAdminChat.ServerAddChatRecord($"{admin.ExpensiveName()} is talking to or monitoring player {perp.ExpensiveName()} for a " +
-			                                                                         $"{alertEntry.playerAlertType.ToString()} incident that happened at roundtime: " +
-			                                                                         $"{alertEntry.roundTime}", adminId);
+			ConnectedPlayer perpPlayer = perp.Player();
+			UIManager.Instance.adminChatWindows.adminToAdminChat.ServerAddChatRecord(
+					$"{admin.Player().Username} is talking to or monitoring player {perpPlayer.Name} ({perpPlayer.Username}) for a " +
+			        $"{alertEntry.playerAlertType.ToString()} incident that happened at roundtime: {alertEntry.roundTime}", adminId);
 
 			alertEntry.takenCareOf = true;
 			ServerSendEntryToAllAdmins(alertEntry);

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -61,9 +61,9 @@ public static class SweetExtensions
 		}
 
 		var player = go.Player();
-		if (player != null && !String.IsNullOrWhiteSpace(player.Name))
+		if (player != null && !String.IsNullOrWhiteSpace(player.Script.visibleName))
 		{
-			return player.Name;
+			return player.Script.visibleName;
 		}
 
 		return go.name.Replace("NPC_", "").Replace("_", " ").Replace("(Clone)","");

--- a/UnityProject/ProjectSettings/ProjectVersion.txt
+++ b/UnityProject/ProjectSettings/ProjectVersion.txt
@@ -1,0 +1,2 @@
+m_EditorVersion: 2020.1.6f1
+m_EditorVersionWithRevision: 2020.1.6f1 (fc477ca6df10)


### PR DESCRIPTION
- Reverts the removal of ProjectVersion.txt.
- Fixes NRE on PushPull parentContainer setting when PushPull is null.
- Changes the `ExpensiveName()` extension for player GameObjects, favouring the visible name instead. Fixes #5471.
    - If this has not fixed every instance, please create a new issue with a list of the instances.
    - Converts several instances where this is not desirable into more explicit name calls.