### PR TITLE
Fix reachableInto on BVOld prefabs

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Furniture/Chairs/BVOld_ToiletChair.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Items/Furniture/Chairs/BVOld_ToiletChair.prefab
@@ -119,7 +119,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114055517453558958
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Chick.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Chick.prefab
@@ -317,7 +317,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114386898746361270
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Chicken_Black.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Chicken_Black.prefab
@@ -317,7 +317,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114386898746361270
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Chicken_Brown.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Chicken_Brown.prefab
@@ -317,7 +317,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114386898746361270
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Chicken_White.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Chicken_White.prefab
@@ -317,7 +317,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114386898746361270
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Coffee.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Coffee.prefab
@@ -314,7 +314,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114386898746361270
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Ian.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Ian.prefab
@@ -317,7 +317,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114386898746361270
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Jerry.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Jerry.prefab
@@ -317,7 +317,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114386898746361270
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Paperwork.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Paperwork.prefab
@@ -316,7 +316,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114386898746361270
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Pete.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Pete.prefab
@@ -245,7 +245,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114544550771380326
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Poly.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Poly.prefab
@@ -317,7 +317,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114386898746361270
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Runtime.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Runtime.prefab
@@ -153,7 +153,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114582363912736342
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Sergeant_Araneus.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Friendly/BVOld_NPC_Sergeant_Araneus.prefab
@@ -322,7 +322,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114386898746361270
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Hostile/Blood Cult/BVOld_NPC_Bloodcult_Artificer.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Hostile/Blood Cult/BVOld_NPC_Bloodcult_Artificer.prefab
@@ -394,7 +394,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &4859363408336224435
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Hostile/Blood Cult/BVOld_NPC_Bloodcult_Behemoth.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Hostile/Blood Cult/BVOld_NPC_Bloodcult_Behemoth.prefab
@@ -394,7 +394,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &4859363408336224435
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Hostile/Blood Cult/BVOld_NPC_Bloodcult_Chosen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Hostile/Blood Cult/BVOld_NPC_Bloodcult_Chosen.prefab
@@ -394,7 +394,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &4859363408336224435
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Hostile/Blood Cult/BVOld_NPC_Bloodcult_Cultist.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Hostile/Blood Cult/BVOld_NPC_Bloodcult_Cultist.prefab
@@ -394,7 +394,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &4859363408336224435
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Hostile/Blood Cult/BVOld_NPC_Bloodcult_Floating.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Hostile/Blood Cult/BVOld_NPC_Bloodcult_Floating.prefab
@@ -394,7 +394,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &4859363408336224435
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Hostile/Blood Cult/BVOld_NPC_Bloodcult_Harvester.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Mobs/NPCs/Hostile/Blood Cult/BVOld_NPC_Bloodcult_Harvester.prefab
@@ -394,7 +394,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &4859363408336224435
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Atmos/BVOld_atmos_22.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Atmos/BVOld_atmos_22.prefab
@@ -207,7 +207,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114607671326150752
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Atmos/BVOld_atmos_25.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Atmos/BVOld_atmos_25.prefab
@@ -125,7 +125,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114179000841655036
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Atmos/BVOld_atmos_35.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Atmos/BVOld_atmos_35.prefab
@@ -181,7 +181,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114807368382752792
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114545571075304212

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_BioHazard_General.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_BioHazard_General.prefab
@@ -241,7 +241,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114856365489096404

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_BioHazard_Janitor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_BioHazard_Janitor.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114511804586140830

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_BioHazard_Science.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_BioHazard_Science.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114519977436863984

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_BioHazard_Security.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_BioHazard_Security.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114884582897557178

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_BioHazard_Virology.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_BioHazard_Virology.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114519977436863984

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Black.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Black.prefab
@@ -173,7 +173,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114485981991692948

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Blue.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114216219414848042

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Bomb.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Bomb.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114962883098702228

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Brown.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Brown.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114322818485990734

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Electricity.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Electricity.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114658243340217052

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Enginering.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Enginering.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114053857859740838

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Fire_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Fire_Red.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114994280551353884

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Fire_Yellow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Fire_Yellow.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114592498458485390

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Green.prefab
@@ -369,7 +369,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114237451671875158

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Grey.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Grey.prefab
@@ -286,7 +286,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114233137969556542

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Janitor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Janitor.prefab
@@ -369,7 +369,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114301095212362376

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Atmos.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Atmos.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114204684251905994

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_CE.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_CE.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114580957745180896

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_CMO.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_CMO.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114679315888303910

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Captain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Captain.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114231714007873568

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Cargo.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Cargo.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114688112107947502

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Green.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Green.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114718002685166136

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_HOP.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_HOP.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114281493637463554

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_HOS.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_HOS.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114563700993001040

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_HOS2.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_HOS2.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114418841570268954

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Medical_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Medical_Blue.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114971026841769662

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Medical_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Medical_Red.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114915998634745900

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Plain.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114097080808669552

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_QM.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_QM.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114676575423395924

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_RD.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_RD.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114814996517245894

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Science.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Science.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114570445175126256

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Security.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Security.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114113182609010320

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Warden.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_Warden.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114142356391403884

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_White_Blue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_White_Blue.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114854720885297536

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_mining.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Locker_mining.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114404811438738350

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Nuclear.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Nuclear.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114255594270957750

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Oxygen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Oxygen.prefab
@@ -174,7 +174,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114202447134840306

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Pink_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Pink_Plain.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114975304268083358

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Red.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Red.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114652153136408314

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Red_Plain.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_Red_Plain.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114890316843556772

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_YellowBlue.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Closet_YellowBlue.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114258542002609098

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Generic Closet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Generic Closet.prefab
@@ -274,7 +274,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &5289412143706698953

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Refrigerator.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Closets/BVOld_Refrigerator.prefab
@@ -217,7 +217,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 0
 --- !u!114 &114644010719156962

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_Cargo_Console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_Cargo_Console.prefab
@@ -193,7 +193,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &3397741670811314997
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_Cloning_Console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_Cloning_Console.prefab
@@ -276,7 +276,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114784912755194898
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_Communications_Console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_Communications_Console.prefab
@@ -277,7 +277,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114310873128946770
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_HealthRecords_Console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_HealthRecords_Console.prefab
@@ -189,7 +189,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114431237792223494
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_Id_Console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_Id_Console.prefab
@@ -193,7 +193,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &5554068536061526188
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_SecurityRecords_Console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_SecurityRecords_Console.prefab
@@ -295,7 +295,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &523872058597329049
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_shuttle_console.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Consoles/BVOld_shuttle_console.prefab
@@ -191,7 +191,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114489178862107254
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Construction/BVOld_Girder.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Construction/BVOld_Girder.prefab
@@ -168,7 +168,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &7478891196200289026
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Construction/BVOld_Rack.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Construction/BVOld_Rack.prefab
@@ -209,7 +209,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &4216241947996897747
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Crates/BVOld_Crates_wooden.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Crates/BVOld_Crates_wooden.prefab
@@ -191,7 +191,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 1
 --- !u!114 &5934102971753303936

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Crates/BVOld_crate.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Crates/BVOld_crate.prefab
@@ -191,7 +191,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 1
 --- !u!114 &5934102971753303936

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Crates/BVOld_crates_58.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Crates/BVOld_crates_58.prefab
@@ -84,7 +84,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114108603661580648
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Crates/BVOld_crates_59.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Crates/BVOld_crates_59.prefab
@@ -368,7 +368,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 1
 --- !u!114 &114829380719981106

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Electricity/BVOld_APC.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Electricity/BVOld_APC.prefab
@@ -161,7 +161,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114809207030236184
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_ArcadeMachine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_ArcadeMachine.prefab
@@ -168,7 +168,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &7478891196200289026
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_Stool.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_Stool.prefab
@@ -170,7 +170,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114377328424748032
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_bed.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_bed.prefab
@@ -198,7 +198,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114638872430197162
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_chairs_bar.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_chairs_bar.prefab
@@ -286,7 +286,6 @@ MonoBehaviour:
   objectType: 0
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &909463862082034201
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_comfy_chair.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_comfy_chair.prefab
@@ -90,7 +90,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114677636749695840
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_metal_chair.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_metal_chair.prefab
@@ -121,7 +121,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114055517453558958
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_mime_chair.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_mime_chair.prefab
@@ -118,7 +118,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114055517453558958
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_office_chair.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_office_chair.prefab
@@ -92,7 +92,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114376184931329912
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_pewend_left_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_pewend_left_0.prefab
@@ -120,7 +120,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &3627631272076510735
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_pewend_right_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_pewend_right_0.prefab
@@ -202,7 +202,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &3342342776282640571
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_pewmiddle_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_pewmiddle_0.prefab
@@ -202,7 +202,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &-3285347575489872077
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_shuttle_chair_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_shuttle_chair_0.prefab
@@ -286,7 +286,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &-7596303361927942555
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_sofacorner_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_sofacorner_0.prefab
@@ -120,7 +120,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &8039311948146211082
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_sofaend_left_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_sofaend_left_0.prefab
@@ -284,7 +284,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &7615799771618278032
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_sofaend_right_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_sofaend_right_0.prefab
@@ -202,7 +202,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &7862356214891882554
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_sofamiddle_0.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_sofamiddle_0.prefab
@@ -284,7 +284,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &-6056491110923657985
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_wooden_chair.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Furniture/BVOld_wooden_chair.prefab
@@ -175,7 +175,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114840956348795048
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Kitchen/BVOld_DinnerWareVendor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Kitchen/BVOld_DinnerWareVendor.prefab
@@ -185,7 +185,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 0
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114418060968581254
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Kitchen/BVOld_Microwave.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Kitchen/BVOld_Microwave.prefab
@@ -239,7 +239,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114348264163667782
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Kitchen/BVOld_SmartFridge.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Kitchen/BVOld_SmartFridge.prefab
@@ -89,7 +89,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 0
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114010932235653022
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Medical/BVOld_BluespaceBodyBag.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Medical/BVOld_BluespaceBodyBag.prefab
@@ -189,7 +189,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 2
 --- !u!114 &2170628449131254784

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Medical/BVOld_BodyBag.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Medical/BVOld_BodyBag.prefab
@@ -189,7 +189,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
   closetType: 2
 --- !u!114 &1469759712343314486

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Misc/BVOld_LampGreen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Misc/BVOld_LampGreen.prefab
@@ -168,7 +168,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114617202130299316
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Misc/BVOld_LampGrey.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Misc/BVOld_LampGrey.prefab
@@ -168,7 +168,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114617202130299316
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Misc/BVOld_LampGreyCigarbutt.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Misc/BVOld_LampGreyCigarbutt.prefab
@@ -167,7 +167,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114617202130299316
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Misc/BVOld_LampGreyLampBanana.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Misc/BVOld_LampGreyLampBanana.prefab
@@ -168,7 +168,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114617202130299316
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Tanks/BVOld_FuelTank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Tanks/BVOld_FuelTank.prefab
@@ -130,7 +130,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114077234577922880
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Tanks/BVOld_HighCapacityWaterTank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Tanks/BVOld_HighCapacityWaterTank.prefab
@@ -127,7 +127,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114160359354158132
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Tanks/BVOld_WaterTank.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Tanks/BVOld_WaterTank.prefab
@@ -210,7 +210,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114178559916765474
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_AtmosDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_AtmosDrobe.prefab
@@ -181,7 +181,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_AutoDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_AutoDrobe.prefab
@@ -1125,7 +1125,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_BODA.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_BODA.prefab
@@ -138,7 +138,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114405417986018830
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_BarDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_BarDrobe.prefab
@@ -259,7 +259,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_Booze-O-Mat.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_Booze-O-Mat.prefab
@@ -240,7 +240,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114764024703624026
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_CargoDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_CargoDrobe.prefab
@@ -175,7 +175,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_ChapDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_ChapDrobe.prefab
@@ -283,7 +283,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_ChefDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_ChefDrobe.prefab
@@ -229,7 +229,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_ChemDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_ChemDrobe.prefab
@@ -190,7 +190,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_CoffeeVending.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_CoffeeVending.prefab
@@ -138,7 +138,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_CuraDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_CuraDrobe.prefab
@@ -241,7 +241,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_DetDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_DetDrobe.prefab
@@ -246,7 +246,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_EngiDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_EngiDrobe.prefab
@@ -205,7 +205,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_GeneDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_GeneDrobe.prefab
@@ -175,7 +175,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_Hydrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_Hydrobe.prefab
@@ -204,7 +204,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_JaniDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_JaniDrobe.prefab
@@ -241,7 +241,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_LawDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_LawDrobe.prefab
@@ -277,7 +277,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_LiquidCooler.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_LiquidCooler.prefab
@@ -104,7 +104,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114496511731903232
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_MediDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_MediDrobe.prefab
@@ -265,7 +265,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_RoboDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_RoboDrobe.prefab
@@ -202,7 +202,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_SciDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_SciDrobe.prefab
@@ -193,7 +193,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_SecDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_SecDrobe.prefab
@@ -229,7 +229,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_ViroDrobe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_ViroDrobe.prefab
@@ -181,7 +181,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114947365864617716
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_YouTool.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_YouTool.prefab
@@ -338,7 +338,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114337553390059262
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_100.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_100.prefab
@@ -125,7 +125,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114410048841761286
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_104.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_104.prefab
@@ -229,7 +229,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114548594117427474
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_110.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_110.prefab
@@ -229,7 +229,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114169739028466732
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_133.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_133.prefab
@@ -125,7 +125,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114943133033173114
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_159.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_159.prefab
@@ -125,7 +125,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114682330233778130
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_16.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_16.prefab
@@ -150,7 +150,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114589214678579180
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_17.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_17.prefab
@@ -150,7 +150,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114589214678579180
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_175.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_175.prefab
@@ -125,7 +125,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114710026204977004
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_185.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_185.prefab
@@ -147,7 +147,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114999616005251050
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_188.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_188.prefab
@@ -144,7 +144,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114414702093615426
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_190.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_190.prefab
@@ -244,7 +244,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114102298114621054
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_192.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_192.prefab
@@ -156,7 +156,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114236633167564510
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_194.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_194.prefab
@@ -244,7 +244,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114066524332886862
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_199.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_199.prefab
@@ -229,7 +229,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114078157158861710
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_24.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_24.prefab
@@ -149,7 +149,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114890971556413904
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_34.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_34.prefab
@@ -246,7 +246,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114382407847818618
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_51.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_51.prefab
@@ -249,7 +249,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114862503678879326
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_69.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_69.prefab
@@ -125,7 +125,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114805206030907492
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_73.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_73.prefab
@@ -125,7 +125,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114243585560028574
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_95.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Vending/BVOld_vending_95.prefab
@@ -229,7 +229,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114035917889724156
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/WallProtrusions/BVOld_Camera.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/WallProtrusions/BVOld_Camera.prefab
@@ -223,7 +223,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114399886108331892
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/WallProtrusions/BVOld_LightBulbMount.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/WallProtrusions/BVOld_LightBulbMount.prefab
@@ -105,7 +105,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114870928894298498
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/WallProtrusions/BVOld_LightTubeMount.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/WallProtrusions/BVOld_LightTubeMount.prefab
@@ -187,7 +187,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114413268325490614
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_DoorSwitch.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_DoorSwitch.prefab
@@ -184,7 +184,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114374503033707882
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_FireAlarm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_FireAlarm.prefab
@@ -230,7 +230,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114789676302844992
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_FireExtinguisherCabinet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_FireExtinguisherCabinet.prefab
@@ -226,7 +226,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114185868468834516
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_GeneralSwitch.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_GeneralSwitch.prefab
@@ -184,7 +184,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114374503033707882
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_LightSwitch.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_LightSwitch.prefab
@@ -185,7 +185,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &4336187224331491966
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_MedbaySign.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_MedbaySign.prefab
@@ -87,7 +87,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &5615649491749768186
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_MonitorAir.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_MonitorAir.prefab
@@ -88,7 +88,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114477462743865550
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_NoSmokingSign.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_NoSmokingSign.prefab
@@ -87,7 +87,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114984355352443168
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_Radio.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_Radio.prefab
@@ -87,7 +87,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114793970435373244
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_StatusDisplay.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_StatusDisplay.prefab
@@ -197,7 +197,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &114081409450008146
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_StatusDisplay_News.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_StatusDisplay_News.prefab
@@ -95,7 +95,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &2168645701838333630
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_bio.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_bio.prefab
@@ -185,7 +185,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &7955275196045668915
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_evac.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_evac.prefab
@@ -103,7 +103,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &-7260004244728150235
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_radiation.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_radiation.prefab
@@ -103,7 +103,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &3370248677873941896
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_restroom.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_restroom.prefab
@@ -185,7 +185,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &-3229497616146771903
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_securearea.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_securearea.prefab
@@ -185,7 +185,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &-6458646416160423208
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_shock.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_shock.prefab
@@ -185,7 +185,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &-4505737777722207231
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_space.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/BadVariants/Objects/Wallmounts/BVOld_decals_space.prefab
@@ -103,7 +103,6 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 1
-  ReachableThrough: 0
   passableExclusionsToThis: []
 --- !u!114 &-3790419710188097415
 MonoBehaviour:


### PR DESCRIPTION
Sets the BVOld prefabs to use the default value of true for reachableinto, except for the BVOld directional window.

Closes #5517
