### PR TITLE
Fixes the syndicate shuttle having their lockers empty.

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.GameMode.cs
@@ -44,7 +44,7 @@ public partial class GameManager
 	public RoundState CurrentRoundState
 	{
 		get => currentRoundState;
-		private set
+		set
 		{
 			currentRoundState = value;
 			Logger.LogFormat("CurrentRoundState is now {0}!", Category.Round, value);

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -417,8 +417,6 @@ public partial class GameManager : MonoBehaviour, IInitialise
 			// Tell all clients that the countdown has finished
 			UpdateCountdownMessage.Send(true, 0);
 
-			CurrentRoundState = RoundState.Started;
-			EventManager.Broadcast(EVENT.RoundStarted);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
+++ b/UnityProject/Assets/Scripts/Systems/GameModes/GameMode.cs
@@ -357,6 +357,8 @@ namespace GameModes
 			{
 				SpawnAntag(spawnReq);
 			}
+			GameManager.Instance.CurrentRoundState = RoundState.Started;
+			EventManager.Broadcast(EVENT.RoundStarted);
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Purpose
Fixes the syndicate shuttle having their lockers empty.
The RoundStarted event will now be broadcasted after the gamemode subscenes load, making OnSpawnServer() being called on their objects.
Fixes #5514


