### PR TITLE
Workflow cleanup

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,7 +3,7 @@
 
 "Scene: SquareStation":
   - UnityProject/Assets/Scenes/MainStations/SquareStation.unity
-  
+
 "Scene: PogStation":
   - UnityProject/Assets/Scenes/MainStations/PogStation.unity
 

--- a/.github/workflows/artifactjanitor.yml
+++ b/.github/workflows/artifactjanitor.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Remove old artifacts
         uses: c-hive/gha-remove-artifacts@v1
         with:
-          age: '1 week'
+          age: "1 week"
           skip-tags: true

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,41 +1,40 @@
 name: pr2changelog
 on:
-    pull_request_target:
-        branches:
-            - develop
-        types: [closed]
+  pull_request_target:
+    branches:
+      - develop
+    types: [closed]
 
 jobs:
-    generate:
-        if: github.event.pull_request.merged == true
+  generate:
+    if: github.event.pull_request.merged == true
 
-        name: changelog generator
-        runs-on: ubuntu-latest
-        steps:
+    name: changelog generator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: develop
 
-            - name: Checkout repository
-              uses: actions/checkout@v2
-              with:
-                  fetch-depth: 0
-                  ref: develop
+      - name: pr2changelog
+        id: pr2changelog
+        uses: corp-0/pr2changelog@master
+        with:
+          repo: ${{ github.repository }}
+          pr_number: ${{ github.event.pull_request.number }}
 
-            - name: pr2changelog
-              id: pr2changelog
-              uses: corp-0/pr2changelog@master
-              with:
-                  repo: ${{ github.repository }}
-                  pr_number: ${{ github.event.pull_request.number }}
-
-            -   name: Commit files
-                if: ${{ steps.pr2changelog.outputs.generated_changelog == 1}}
-                run: |
-                    git config --local user.email "action@github.com"
-                    git config --local user.name "GitHub Action"
-                    git add *
-                    git commit -m "misc: update Changelog" -a
-            -   name: Push changes
-                if: ${{ steps.pr2changelog.outputs.generated_changelog == 1}}
-                uses: ad-m/github-push-action@master
-                with:
-                    branch: develop
-                    github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit files
+        if: ${{ steps.pr2changelog.outputs.generated_changelog == 1}}
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add *
+          git commit -m "misc: update Changelog" -a
+      - name: Push changes
+        if: ${{ steps.pr2changelog.outputs.generated_changelog == 1}}
+        uses: ad-m/github-push-action@0.6.0
+        with:
+          branch: develop
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_helpers.yml
+++ b/.github/workflows/pr_helpers.yml
@@ -1,12 +1,12 @@
-# Automation actions that run on every push and pr. Meant to help us to keep the thing cool because we're cool like that.
+# Runs on every push and pr. Meant to help us to keep the thing cool because we're cool like that.
 
-name: Auto helpers
+name: PR helpers
 on:
   push:
-    branches: [ develop ]
+    branches: [develop]
   pull_request_target:
-    branches: [ develop ]
-    
+    branches: [develop]
+
 jobs:
   autohelpers:
     runs-on: ubuntu-latest
@@ -16,7 +16,7 @@ jobs:
         with:
           CONFLICT_LABEL_NAME: "Status: Merge Conflicts"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
       - name: auto labeler
         if: ${{ github.event_name == 'pull_request_target' }}
         uses: actions/labeler@v3-preview

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,24 +3,21 @@ name: Tests
 on:
   push:
     branches:
-    - develop
-    - master
+      - develop
     paths:
-    - 'Tools/UnityLicense.ulf'
-    - 'UnityProject/**'
-    - '.github/workflows/**'
-    - 'Docker/**'
+      - "Tools/UnityLicense.ulf"
+      - "UnityProject/**"
+      - ".github/workflows/**"
+      - "Docker/**"
   pull_request:
     branches:
-    - develop
-    - master
+      - develop
     paths:
-    - 'Tools/UnityLicense.ulf'
-    - 'UnityProject/**'
-    - '.github/workflows/**'
+      - "Tools/UnityLicense.ulf"
+      - "UnityProject/**"
+      - ".github/workflows/**"
 
 jobs:
-
   ########## HOW TO UPDATE UNITY_LICENSE ##########
   # The job below is only used to request a new activation file
   #
@@ -62,47 +59,42 @@ jobs:
         projectPath:
           - UnityProject
         unityVersion:
-#           - 2019.3.15f1
+          # - 2019.3.15f1
           - 2020.1.6f1
         targetPlatform:
           - StandaloneWindows64
+
     steps:
       # Checkout repository (required to test local actions)
       - name: Checkout repository
         uses: actions/checkout@v2.0.0
 
-      # Cache the library directory to speed up builds
-    #  - name: Cache library directory
-    #    uses: actions/cache@v1.1.0
-    #    with:
-    #      path: ${{ matrix.projectPath }}/Library
-    #      key: Library2-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}
-    #      restore-keys: |
-    #        Library2-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}
-    #        Library2-${{ matrix.projectPath }}-
-    #        Library2-
-    #
-      # Set the UNITY_LICENSE environment variable
+      # # Cache the library directory to speed up builds
+      # - name: Cache library directory
+      #   uses: actions/cache@v1.1.0
+      #   with:
+      #     path: ${{ matrix.projectPath }}/Library
+      #     key: Library2-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}
+      #     restore-keys: |
+      #       Library2-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}
+      #       Library2-${{ matrix.projectPath }}-
+      #       Library2-
+
+      # Set the UNITY_LICENSE environment variable with contents of $LICENSE_FILE_PATH
       - name: Setup license
-        # This step:
-        #   - Grabs the license file contents from the $LICENSE_FILE_PATH
-        #   - Uses substitution to escape newline characters for GitHub Actions set-env.
-        #     (from: https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870)
-        #   - Set the UNITY_LICENSE env var for all future steps using special GitHub Actions syntax
         env:
           LICENSE_FILE_PATH: ./Tools/UnityLicense.ulf
         run: |
-          license=$(<"$LICENSE_FILE_PATH")
-          license="${license//'%'/'%25'}"
-          license="${license//$'\n'/'%0A'}"
-          license="${license//$'\r'/'%0D'}"
-          echo "::set-env name=UNITY_LICENSE::$license"
+          echo 'UNITY_LICENSE<<LICENSE-EOF' >> "$GITHUB_ENV"
+          cat "$LICENSE_FILE_PATH" >> "$GITHUB_ENV"
+          printf "\nLICENSE-EOF" >> "$GITHUB_ENV"
 
       # Run tests - only edit mode supported
+      # Note: exits with non-zero on legitimate test fails, "if: always()" is needed for reporting
       - name: Run tests
         uses: webbertakken/unity-test-runner@v1.6
         with:
-          customParameters: '-nographics'
+          customParameters: "-nographics"
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           artifactsPath: ./testReports/${{ matrix.targetPlatform }}
@@ -113,12 +105,12 @@ jobs:
         if: always()
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '2.1.202'
+          dotnet-version: "2.1.202"
 
       # Do the report magic
       - name: Generate .html report
-        run: sudo dotnet ./Tools/ExtentReports/ExtentReportsDotNetCLI.dll -i=testReports/${{ matrix.targetPlatform }}/editmode-results.xml -o testReports/${{ matrix.targetPlatform }}/
         if: always()
+        run: sudo dotnet ./Tools/ExtentReports/ExtentReportsDotNetCLI.dll -i=testReports/${{ matrix.targetPlatform }}/editmode-results.xml -o testReports/${{ matrix.targetPlatform }}/
 
       # Upload test results
       - name: Upload Test Results

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - develop
     paths:
-      - 'docs/**'
+      - "docs/**"
 
 jobs:
   build:
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
-          ref: 'develop'
+          ref: "develop"
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        uses: mhausenblas/mkdocs-deploy-gh-pages@1.16
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
### Purpose
Improve readability using unified style and a few small fixes

### Notes:
- autofarmat workflow files
- use 2 spaces for indentation
- do not trust master action, branches, pin latest stable versions
- remove references to master branch as it is deleted
- remove deprecated set-env command
- fail early to save some time, if tests fail, report step will fail anyway
- rename autohelpers into pr_helpers for clarity

Draft because I am not sure if tests will work yet