### PR TITLE
Stops pull when you push an object into blocked tile

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -734,30 +734,19 @@ public partial class MatrixManager : MonoBehaviour
 				}
 			}
 
+			// If the object being Push/Pulled is a player, and that player is buckled, we should use the pushPull object that the player is buckled to.
+			// By design, chairs are not "solid" so, the condition above will filter chairs but won't filter players
 			PushPull pushable = pushPull;
-			if (isServer ? pushPull.CanPushServer(pushableLocation, dir) : pushPull.CanPushClient(pushableLocation, dir))
+			PlayerMove playerMove = pushPull.GetComponent<PlayerMove>();
+			if (playerMove && playerMove.IsBuckled)
 			{
+				PushPull buckledPushPull = playerMove.BuckledObject.GetComponent<PushPull>();
 
-
-				// If the object being Push/Pulled is a player, and that player is buckled, we should use the pushPull object that the player is buckled to.
-				// By design, chairs are not "solid" so, the condition above will filter chairs but won't filter players
-				PlayerMove playerMove = pushPull.GetComponent<PlayerMove>();
-				if (playerMove && playerMove.IsBuckled)
-				{
-					PushPull buckledPushPull = playerMove.BuckledObject.GetComponent<PushPull>();
-
-					if (buckledPushPull)
-						pushable = buckledPushPull;
-				}
-
-				if (isServer
-					? pushable.CanPushServer(pushableLocation, Vector2Int.RoundToInt(dir))
-					: pushable.CanPushClient(pushableLocation, Vector2Int.RoundToInt(dir))
-				)
-				{
-					pushableList.Add(pushable);
-				}
+				if (buckledPushPull)
+					pushable = buckledPushPull;
 			}
+
+			pushableList.Add(pushable);
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -993,6 +993,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 		return false;
 	}
 
+	[Client]
 	public bool TryPredictivePush(Vector3Int from, Vector2Int dir, float speed = Single.NaN)
 	{
 		if (isNotPushable || CanPredictPush == false || Pushable == null || isAllowedDir(dir) == false)

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -520,7 +520,7 @@ public partial class PlayerSync
 
 		//we only lerp back if the client thinks it's passable  but server does not...if client
 		//thinks it's not passable and server thinks it's passable, then it's okay to let the client continue
-		if (!isClientBump && serverBump != BumpType.None && serverBump != BumpType.Swappable)
+		if (isClientBump == false && serverBump != BumpType.None && serverBump != BumpType.Swappable)
 		{
 			Logger.LogWarningFormat("isBump mismatch, resetting: C={0} S={1}", Category.Movement, isClientBump, serverBump != BumpType.None);
 			RollbackPosition();
@@ -730,6 +730,12 @@ public partial class PlayerSync
 		{
 			foreach ( PushPull pushable in pushables)
 			{
+				// whether or not we actually manage to push it, make sure we aren't pulling it!
+				if (pushPull.PulledObjectServer == pushable)
+				{
+					pushPull.ServerStopPulling();
+				}
+
 				// if player can't reach, player can't push
 				if (MatrixManager.IsPassableAtAllMatrices(worldOrigin, pushableLocation, isServer: true, includingPlayers: false, 
 						context: pushable.gameObject, isReach: true) == false)
@@ -737,8 +743,11 @@ public partial class PlayerSync
 					continue;
 				}
 
-				pushable.TryPush(twoIntDirection);
-				break;
+				// Try pushables until we get one that moves
+				if (pushable.TryPush(twoIntDirection))
+				{
+					break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Pushing an object you are pulling now makes you stop pulling it, even if it is pushed into a wall or other object.

Removes some redundant pushable checks.
Makes it consistent that only one object at most is told to be pushed (does not break buckled pushing)
Closes #2214