### PR TITLE
Enables memory logging by default on the admin tool profiling

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/AdminCommandsManager.cs
@@ -368,6 +368,7 @@ namespace AdminCommands
 			runningProfile = true;
 
 			Directory.CreateDirectory("Profiles");
+			Profiler.SetAreaEnabled(ProfilerArea.Memory, true);
 			Profiler.logFile = "Profiles/" + DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss");
 			Profiler.enableBinaryLog = true;
 			Profiler.enabled = true;


### PR DESCRIPTION
### Purpose
Enables memory logging by default on the admin tool profiling

### Notes:
It was only profiling CPU