### PR TITLE
Fixes weapons being unable to fire

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Weapons/GunElectrical.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/GunElectrical.cs
@@ -16,8 +16,6 @@ public class GunElectrical : Gun, ICheckedInteractable<HandActivate>
 	[SyncVar(hook = nameof(UpdateFiremode))]
 	private int currentFiremode = 0;
 
-	public int CurrentFiremode => currentFiremode;
-
 	public Battery battery =>
 			magSlot.Item != null ? magSlot.Item.GetComponent<Battery>() : null;
 
@@ -27,7 +25,7 @@ public class GunElectrical : Gun, ICheckedInteractable<HandActivate>
 	public override void OnSpawnServer(SpawnInfo info)
 	{
 		UpdateFiremode(currentFiremode, 0);
-  		base.OnSpawnServer(info);
+		base.OnSpawnServer(info);
 	}
 
 	public bool WillInteract(HandActivate interaction, NetworkSide side)
@@ -37,22 +35,14 @@ public class GunElectrical : Gun, ICheckedInteractable<HandActivate>
 
 	public override bool WillInteract(AimApply interaction, NetworkSide side)
 	{
-		if (firemodeUsage[currentFiremode] > battery.Watts) 
+		if (firemodeUsage[currentFiremode] > battery.Watts)
 		{
-			base.PlayEmptySFX();
+			PlayEmptySFX();
+			return false;
 		}
 		CurrentMagazine.containedBullets[0] = firemodeProjectiles[currentFiremode];
 		currentElectricalMag.toRemove = firemodeUsage[currentFiremode];
-		return base.WillInteract(interaction, side); 
-	}
-
-	public override void ClientPredictInteraction(AimApply interaction)
-	{
-		if (firemodeUsage[currentFiremode] > battery.Watts) 
-		{
-			return;
-		}
-		base.ClientPredictInteraction(interaction);
+		return base.WillInteract(interaction, side);
 	}
 
 	public void ServerPerformInteraction(HandActivate interaction)
@@ -68,12 +58,14 @@ public class GunElectrical : Gun, ICheckedInteractable<HandActivate>
 			UpdateFiremode(currentFiremode, currentFiremode + 1);
 		}
 		Chat.AddExamineMsgFromServer(interaction.Performer, $"You switch your {gameObject.ExpensiveName()} into {firemodeName[currentFiremode]} mode");
+		CurrentMagazine.ServerSetAmmoRemains(battery.Watts / firemodeUsage[currentFiremode]);
 	}
 
 	public override void ServerPerformInteraction(AimApply interaction)
 	{
 		if (firemodeUsage[currentFiremode] > battery.Watts) return;
-		base.ServerPerformInteraction(interaction);		
+		base.ServerPerformInteraction(interaction);
+		CurrentMagazine.ServerSetAmmoRemains(battery.Watts / firemodeUsage[currentFiremode]);
 	}
 
 	public void UpdateFiremode(int oldValue, int newState)

--- a/UnityProject/Assets/Scripts/Items/Weapons/GunPKA.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/GunPKA.cs
@@ -40,7 +40,10 @@ public class GunPKA : Gun
 		CurrentMagazine.LoadProjectile(Projectile, 1);
 		if (isSuppressed)
 		{
-			Chat.AddExamineMsgFromServer(serverHolder, $"Your {gameObject.ExpensiveName()} silently recharges");
+			if (serverHolder != null)
+			{
+				Chat.AddExamineMsgFromServer(serverHolder, $"The {gameObject.ExpensiveName()} silently recharges");
+			}
 		}
 		else
 		{

--- a/UnityProject/Assets/Scripts/Items/Weapons/GunTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/GunTrigger.cs
@@ -24,70 +24,33 @@ namespace Weapons
 			BodyPartType damageZone, bool isSuicideShot)
         {
             JobType job = PlayerList.Instance.Get(shotBy).Job;
-            if (PlayerList.Instance.Get(shotBy).Job == setRestriction || (setRestriction == JobType.NULL && 
-            (job != JobType.CLOWN && allowNonClumsy || job == JobType.CLOWN && allowClumsy)))
-            {
-    			gun.ServerShoot(shotBy , target, damageZone, isSuicideShot);
-            }
-            else if (setRestriction == JobType.NULL && (job == JobType.CLOWN && !allowClumsy))
-            {
-                int chance = rnd.Next(0 ,2);
-                if (chance == 0)
-                {
-    		   	    gun.ServerShoot(shotBy , target, damageZone, true);
-                    Chat.AddActionMsgToChat(
-	                shotBy,
-			        "You fumble up and shoot yourself!",
-			        $"{shotBy.ExpensiveName()} fumbles up and shoots themself!");
-                }
-                else
-                {
-            	    gun.ServerShoot(shotBy , target, damageZone, isSuicideShot);
-                }
-            }
-            else if (setRestriction == JobType.NULL && (job != JobType.CLOWN && !allowNonClumsy))
-            {
-    		   	gun.ServerShoot(shotBy , target, damageZone, true);
-                Chat.AddActionMsgToChat(
-				shotBy,
-				"You somehow shoot yourself in the face! How the hell?!",
-				$"{shotBy.ExpensiveName()} somehow manages to shoot themself in the face!");
-            }
-            else
-            {
-                Chat.AddExamineMsgToClient($"The {gameObject.ExpensiveName()} displays \'User authentication failed\'");
-            }
-       }
 
-        public void TriggerPullClient(GameObject shotBy, Vector2 target,
-			BodyPartType damageZone, bool isSuicideShot, string proj, int quant)
-        {
-            JobType job = PlayerManager.LocalPlayer.Player().Job;
-            if (job == setRestriction || (setRestriction == JobType.NULL && 
-            (job != JobType.CLOWN && allowNonClumsy || job == JobType.CLOWN && allowClumsy)))
+            if (setRestriction == JobType.NULL)
             {
-                gun.DisplayShot(shotBy, target, damageZone, isSuicideShot, proj, quant);
+	            if (job == JobType.CLOWN && !allowClumsy)
+	            {
+		            int chance = rnd.Next(0 ,2);
+		            if (chance == 0)
+		            {
+			            gun.ServerShoot(shotBy , target, damageZone, true);
+			            Chat.AddActionMsgToChat(
+				            shotBy,
+				            "You fumble up and shoot yourself!",
+				            $"{shotBy.ExpensiveName()} fumbles up and shoots themself!");
+			            return;
+		            }
+	            }
+	            else if (job != JobType.CLOWN && !allowNonClumsy)
+	            {
+		            gun.ServerShoot(shotBy , target, damageZone, true);
+		            Chat.AddActionMsgToChat(
+			            shotBy,
+			            "You somehow shoot yourself in the face! How the hell?!",
+			            $"{shotBy.ExpensiveName()} somehow manages to shoot themself in the face!");
+		            return;
+	            }
             }
-            else if (setRestriction == JobType.NULL && (job == JobType.CLOWN && !allowClumsy))
-            {
-                int chance = rnd.Next(0 ,2);
-                if (chance == 0)
-                {
-                    gun.DisplayShot(shotBy, target, damageZone, true, proj, quant);
-                }
-                else
-                {
-                    gun.DisplayShot(shotBy, target, damageZone, isSuicideShot, proj, quant);        	    
-                }
-            }
-            else if (setRestriction == JobType.NULL && (job != JobType.CLOWN && !allowNonClumsy))
-            {
-                gun.DisplayShot(shotBy, target, damageZone, true, proj, quant);
-            }
-            else
-            {
-                Chat.AddExamineMsgToClient($"The {gameObject.ExpensiveName()} displays \'User authentication failed\'");
-            }
-       }
+            gun.ServerShoot(shotBy , target, damageZone, isSuicideShot);
+        }
     }
 }


### PR DESCRIPTION
### Purpose
Fixes PKA guns never recharging if the gun was dropped mid-recharge.
Fixes all guns from firing on clients.
Fixes energy guns showing more shots than they actually have on clients.
Made guncode if chains easier to read with less repeated checks.
Fixes #5573

### Notes:
Guncode still remains hacky, buggy and with unwanted results specially for predictions 
