### PR TITLE
Shorter projectile names in chat

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_40mmGrenade.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_40mmGrenade.prefab
@@ -84,6 +84,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 3329127183625617249, guid: b343aea0e51a4c44694589195b8eae77,
+        type: 3}
+      propertyPath: visibleName
+      value: explosive
+      objectReference: {fileID: 0}
     - target: {fileID: 4204988295596267492, guid: b343aea0e51a4c44694589195b8eae77,
         type: 3}
       propertyPath: damageData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_5.56mmPhasic.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_5.56mmPhasic.prefab
@@ -28,6 +28,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 4fab0cb03fccc3741a50b40bd6205513,
         type: 2}
+    - target: {fileID: 135057619453994908, guid: cc1c44d01fdcc26409ca9bb9c3cfba80,
+        type: 3}
+      propertyPath: visibleName
+      value: phasic bolt
+      objectReference: {fileID: 0}
     - target: {fileID: 534665058073187466, guid: cc1c44d01fdcc26409ca9bb9c3cfba80,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Dart.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Dart.prefab
@@ -66,6 +66,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 931388571632054408, guid: 5858b89c4790c084bb1915952309853d,
+        type: 3}
+      propertyPath: visibleName
+      value: dart
+      objectReference: {fileID: 0}
     - target: {fileID: 2164135355554094252, guid: 5858b89c4790c084bb1915952309853d,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_EnergyBolt.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_EnergyBolt.prefab
@@ -84,6 +84,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Bullet_EnergyBolt
       objectReference: {fileID: 0}
+    - target: {fileID: 1935881749266089153, guid: 33dfe2b5f12db3a43af6d409a2b599e5,
+        type: 3}
+      propertyPath: visibleName
+      value: energy bolt
+      objectReference: {fileID: 0}
     - target: {fileID: 2047434722705749975, guid: 33dfe2b5f12db3a43af6d409a2b599e5,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_ExplosiveBolt.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_ExplosiveBolt.prefab
@@ -84,6 +84,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 3329127183625617249, guid: b343aea0e51a4c44694589195b8eae77,
+        type: 3}
+      propertyPath: visibleName
+      value: explosive
+      objectReference: {fileID: 0}
     - target: {fileID: 4204988295596267492, guid: b343aea0e51a4c44694589195b8eae77,
         type: 3}
       propertyPath: damageData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_FoamDart.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_FoamDart.prefab
@@ -78,6 +78,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 3197533338917694831, guid: f25010d606133144e891ff583654cfe2,
+        type: 3}
+      propertyPath: visibleName
+      value: foam dart
+      objectReference: {fileID: 0}
     - target: {fileID: 4520368254274666827, guid: f25010d606133144e891ff583654cfe2,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_HEDPRocket.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_HEDPRocket.prefab
@@ -71,7 +71,7 @@ PrefabInstance:
     - target: {fileID: 2511337419890708861, guid: b343aea0e51a4c44694589195b8eae77,
         type: 3}
       propertyPath: m_Name
-      value: Bullet_BallisticHEDPRocket
+      value: Bullet_HEDPRocket
       objectReference: {fileID: 0}
     - target: {fileID: 2567588430541566183, guid: b343aea0e51a4c44694589195b8eae77,
         type: 3}
@@ -83,6 +83,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3329127183625617249, guid: b343aea0e51a4c44694589195b8eae77,
+        type: 3}
+      propertyPath: visibleName
+      value: missile
       objectReference: {fileID: 0}
     - target: {fileID: 4204988295596267492, guid: b343aea0e51a4c44694589195b8eae77,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_HERocket.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_HERocket.prefab
@@ -71,7 +71,7 @@ PrefabInstance:
     - target: {fileID: 2511337419890708861, guid: b343aea0e51a4c44694589195b8eae77,
         type: 3}
       propertyPath: m_Name
-      value: Bullet_BallisticHERocket
+      value: Bullet_HERocket
       objectReference: {fileID: 0}
     - target: {fileID: 2567588430541566183, guid: b343aea0e51a4c44694589195b8eae77,
         type: 3}
@@ -83,6 +83,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3329127183625617249, guid: b343aea0e51a4c44694589195b8eae77,
+        type: 3}
+      propertyPath: visibleName
+      value: missile
       objectReference: {fileID: 0}
     - target: {fileID: 4204988295596267492, guid: b343aea0e51a4c44694589195b8eae77,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_ImprovisedPellet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_ImprovisedPellet.prefab
@@ -90,5 +90,10 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 6759010976462222496, guid: 82a46ae55230fa045b2b0a0ebe8e32e0,
+        type: 3}
+      propertyPath: visibleName
+      value: pellet
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 82a46ae55230fa045b2b0a0ebe8e32e0, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_IncapacitatingPellet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_IncapacitatingPellet.prefab
@@ -96,5 +96,10 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 6759010976462222496, guid: 82a46ae55230fa045b2b0a0ebe8e32e0,
+        type: 3}
+      propertyPath: visibleName
+      value: pellet
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 82a46ae55230fa045b2b0a0ebe8e32e0, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_IncendiarySlug.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_IncendiarySlug.prefab
@@ -65,7 +65,17 @@ PrefabInstance:
     - target: {fileID: 295309866684077521, guid: 4b892092eb80e8a47818725986c23fd8,
         type: 3}
       propertyPath: m_Name
-      value: _Bullet_IncendiaryBase
+      value: Bullet_IncendiarySlug
+      objectReference: {fileID: 0}
+    - target: {fileID: 644112986742324173, guid: 4b892092eb80e8a47818725986c23fd8,
+        type: 3}
+      propertyPath: visibleName
+      value: pellet
+      objectReference: {fileID: 0}
+    - target: {fileID: 1027955826083104987, guid: 4b892092eb80e8a47818725986c23fd8,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4b892092eb80e8a47818725986c23fd8, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_IonBolt.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_IonBolt.prefab
@@ -72,6 +72,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 931388571632054408, guid: 5858b89c4790c084bb1915952309853d,
+        type: 3}
+      propertyPath: visibleName
+      value: ion bolt
+      objectReference: {fileID: 0}
     - target: {fileID: 1766684164047083533, guid: 5858b89c4790c084bb1915952309853d,
         type: 3}
       propertyPath: damageData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_KineticShot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_KineticShot.prefab
@@ -51,6 +51,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: be48ef09efcb47f3b8d706239572ce59, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  visibleName: bolt
   distance: 4
   maskData: {fileID: 11400000, guid: b3e8cb63acff04f4d9bad4da9027eb40, type: 2}
 --- !u!114 &-8693131252183625486
@@ -68,6 +69,7 @@ MonoBehaviour:
   layersToHit:
     serializedVersion: 2
     m_Bits: 547314432
+  LayerTypeSelection: 22
 --- !u!114 &9003359558003690106
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Laser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Laser.prefab
@@ -13,6 +13,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: f4938a4c08d6a03429b7743c81b0932a,
         type: 2}
+    - target: {fileID: 3550068636447019177, guid: f8f5682e74c42bb45851c71a4b53b20b,
+        type: 3}
+      propertyPath: visibleName
+      value: laser
+      objectReference: {fileID: 0}
     - target: {fileID: 4030776248151696319, guid: f8f5682e74c42bb45851c71a4b53b20b,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_LaserWeak.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_LaserWeak.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2404555472885326642, guid: 49a8364f6515be34bac52c48c9214d85,
+        type: 3}
+      propertyPath: visibleName
+      value: laser
+      objectReference: {fileID: 0}
     - target: {fileID: 2876361243148079140, guid: 49a8364f6515be34bac52c48c9214d85,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_MeteorSlug.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_MeteorSlug.prefab
@@ -84,6 +84,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 3329127183625617249, guid: b343aea0e51a4c44694589195b8eae77,
+        type: 3}
+      propertyPath: visibleName
+      value: meteor slug
+      objectReference: {fileID: 0}
     - target: {fileID: 4204988295596267492, guid: b343aea0e51a4c44694589195b8eae77,
         type: 3}
       propertyPath: damageData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_PlasmaBlast.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_PlasmaBlast.prefab
@@ -66,6 +66,7 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -90,6 +91,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &9130202135194877776
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -209,6 +211,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 7f6813fe44dae6449977fd4a4ed8eef3,
         type: 2}
+    - target: {fileID: 931388571632054408, guid: 5858b89c4790c084bb1915952309853d,
+        type: 3}
+      propertyPath: visibleName
+      value: beam
+      objectReference: {fileID: 0}
     - target: {fileID: 1766684164047083533, guid: 5858b89c4790c084bb1915952309853d,
         type: 3}
       propertyPath: damageData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_PracticeLaser.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_PracticeLaser.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3550068636447019177, guid: f8f5682e74c42bb45851c71a4b53b20b,
+        type: 3}
+      propertyPath: visibleName
+      value: laser
+      objectReference: {fileID: 0}
     - target: {fileID: 4030776248151696319, guid: f8f5682e74c42bb45851c71a4b53b20b,
         type: 3}
       propertyPath: m_AssetId

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Pulse.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Pulse.prefab
@@ -19,6 +19,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: af5afa6303df4934e85c668cd234fce3,
         type: 2}
+    - target: {fileID: 3550068636447019177, guid: f8f5682e74c42bb45851c71a4b53b20b,
+        type: 3}
+      propertyPath: visibleName
+      value: pulse beam
+      objectReference: {fileID: 0}
     - target: {fileID: 4030776248151696319, guid: f8f5682e74c42bb45851c71a4b53b20b,
         type: 3}
       propertyPath: m_AssetId
@@ -110,7 +115,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300002, guid: 4dc73d95ee9f1c842bc6c7ba57d09130,
+      objectReference: {fileID: 21300000, guid: 4dc73d95ee9f1c842bc6c7ba57d09130,
         type: 3}
     - target: {fileID: 5134017693424603158, guid: f8f5682e74c42bb45851c71a4b53b20b,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_RubbershotPellet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_RubbershotPellet.prefab
@@ -104,6 +104,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 6759010976462222496, guid: 82a46ae55230fa045b2b0a0ebe8e32e0,
+        type: 3}
+      propertyPath: visibleName
+      value: pellet
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 82a46ae55230fa045b2b0a0ebe8e32e0, type: 3}
 --- !u!1 &513614875607323754 stripped

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Stunslug.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Stunslug.prefab
@@ -118,6 +118,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 3329127183625617249, guid: b343aea0e51a4c44694589195b8eae77,
+        type: 3}
+      propertyPath: visibleName
+      value: electrode
+      objectReference: {fileID: 0}
     - target: {fileID: 4204988295596267492, guid: b343aea0e51a4c44694589195b8eae77,
         type: 3}
       propertyPath: damageData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Syringe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/Bullet_Syringe.prefab
@@ -12,6 +12,11 @@ PrefabInstance:
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 7469771346657726622, guid: d10477987defc1744a7b9a9e197a1ce0,
+        type: 3}
+      propertyPath: visibleName
+      value: syringe
+      objectReference: {fileID: 0}
     - target: {fileID: 7617621916873639912, guid: d10477987defc1744a7b9a9e197a1ce0,
         type: 3}
       propertyPath: m_Sprite

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/FireballProjectile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/FireballProjectile.prefab
@@ -1,5 +1,20 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1265072362877118434
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2753221760574229709}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 677d1c676f75fa24f944b81b107944d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  createsHotspots: 1
+  setsMobsOnFire: 1
+  fireStacksToGive: 4
 --- !u!114 &1975193729791461851
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -16,21 +31,6 @@ MonoBehaviour:
   explosionPrefab: {fileID: 6047024076387894157, guid: 149046cdfc1612243b807dc4fcae16f2,
     type: 3}
   explosionStrength: 150
---- !u!114 &1265072362877118434
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2753221760574229709}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 677d1c676f75fa24f944b81b107944d7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  createsHotspots: 1
-  setsMobsOnFire: 1
-  fireStacksToGive: 4
 --- !u!1 &8299584809117081542
 GameObject:
   m_ObjectHideFlags: 0
@@ -155,6 +155,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 06156561f3b9fb44cbaa273d95b8a2b3,
         type: 2}
+    - target: {fileID: 4262510491891678648, guid: b3e452483c7f60f4b9fdf04e19571591,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 5717873336927598056, guid: b3e452483c7f60f4b9fdf04e19571591,
         type: 3}
       propertyPath: maxDistance
@@ -236,6 +241,11 @@ PrefabInstance:
         type: 3}
       propertyPath: overrideVelocity
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7592575146021449342, guid: b3e452483c7f60f4b9fdf04e19571591,
+        type: 3}
+      propertyPath: visibleName
+      value: fireball
       objectReference: {fileID: 0}
     - target: {fileID: 8064381124288617832, guid: b3e452483c7f60f4b9fdf04e19571591,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/_BeamProjectileBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/_BeamProjectileBase.prefab
@@ -81,6 +81,7 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -105,6 +106,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &2223176685149824503
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -122,7 +124,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1560634355228308, guid: 5858b89c4790c084bb1915952309853d, type: 3}
       propertyPath: m_Name
-      value: Bullet_BeamBase
+      value: _BeamProjectileBase
       objectReference: {fileID: 0}
     - target: {fileID: 4714298942886824, guid: 5858b89c4790c084bb1915952309853d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -196,6 +198,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 7f6813fe44dae6449977fd4a4ed8eef3,
         type: 2}
+    - target: {fileID: 931388571632054408, guid: 5858b89c4790c084bb1915952309853d,
+        type: 3}
+      propertyPath: visibleName
+      value: beam
+      objectReference: {fileID: 0}
     - target: {fileID: 1766684164047083533, guid: 5858b89c4790c084bb1915952309853d,
         type: 3}
       propertyPath: damageData

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/_EnergyProjectileBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/_EnergyProjectileBase.prefab
@@ -23,7 +23,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1560634355228308, guid: 5858b89c4790c084bb1915952309853d, type: 3}
       propertyPath: m_Name
-      value: Bullet_EnergyBase
+      value: _EnergyProjectileBase
       objectReference: {fileID: 0}
     - target: {fileID: 4714298942886824, guid: 5858b89c4790c084bb1915952309853d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -79,6 +79,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 931388571632054408, guid: 5858b89c4790c084bb1915952309853d,
+        type: 3}
+      propertyPath: visibleName
+      value: electrode
       objectReference: {fileID: 0}
     - target: {fileID: 2164135355554094252, guid: 5858b89c4790c084bb1915952309853d,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/_LaserTagBeamBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/_LaserTagBeamBase.prefab
@@ -13,6 +13,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 8c130860233322c458badee8145ebb82,
         type: 2}
+    - target: {fileID: 3550068636447019177, guid: f8f5682e74c42bb45851c71a4b53b20b,
+        type: 3}
+      propertyPath: visibleName
+      value: laser tag beam
+      objectReference: {fileID: 0}
     - target: {fileID: 4030776248151696319, guid: f8f5682e74c42bb45851c71a4b53b20b,
         type: 3}
       propertyPath: m_AssetId
@@ -21,7 +26,7 @@ PrefabInstance:
     - target: {fileID: 4444242521069764277, guid: f8f5682e74c42bb45851c71a4b53b20b,
         type: 3}
       propertyPath: m_Name
-      value: Bullet_LaserTagBase
+      value: _LaserTagBeamBase
       objectReference: {fileID: 0}
     - target: {fileID: 4447352754948125577, guid: f8f5682e74c42bb45851c71a4b53b20b,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/_MagicProjectileBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Resources/_MagicProjectileBase.prefab
@@ -25,7 +25,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1560634355228308, guid: 5858b89c4790c084bb1915952309853d, type: 3}
       propertyPath: m_Name
-      value: _Bullet_MagicBase
+      value: _MagicProjectileBase
       objectReference: {fileID: 0}
     - target: {fileID: 4714298942886824, guid: 5858b89c4790c084bb1915952309853d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -81,6 +81,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 931388571632054408, guid: 5858b89c4790c084bb1915952309853d,
+        type: 3}
+      propertyPath: visibleName
+      value: magic missile
       objectReference: {fileID: 0}
     - target: {fileID: 2164135355554094252, guid: 5858b89c4790c084bb1915952309853d,
         type: 3}

--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
@@ -417,7 +417,7 @@ public partial class Chat : MonoBehaviour
 		}
 
 		var message =
-			$"{victim.ExpensiveName()} has been hit by {item.Item()?.ArticleName ?? item.name}{InTheZone(effectiveHitZone)}";
+			$"{victim.ExpensiveName()} has been hit by a {item.Item()?.ArticleName ?? item.name}{InTheZone(effectiveHitZone)}";
 		Instance.addChatLogServer.Invoke(new ChatEvent
 		{
 			channels = ChatChannel.Combat,

--- a/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Projectile.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Projectiles/Projectile.cs
@@ -1,9 +1,16 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace Weapons.Projectiles
 {
 	public abstract class Projectile : MonoBehaviour
 	{
+		public string visibleName = "bullet";
+		public void Start()
+		{
+			gameObject.name = visibleName;
+		}
+
 		public abstract void Suicide(GameObject controlledByPlayer, Gun fromWeapon, BodyPartType targetZone = BodyPartType.Chest);
 
 		public abstract void Shoot(Vector2 direction, GameObject controlledByPlayer, Gun fromWeapon, BodyPartType targetZone = BodyPartType.Chest);


### PR DESCRIPTION
### Purpose
Projectiles will now appear with a smaller and more vague text description when hitting a target.

instead of:
"X person has been hit by Bullet_7.62x38mmR" 

it'll be:
"X person has been hit by a bullet"