### PR TITLE
Fixes speech inside a locker reaching all players.

### DIFF
--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
@@ -348,8 +348,7 @@ namespace Chemistry.Components
 			}
 			else
 			{
-				Chat.AddLocalMsgToChat($"{gameObject.ExpensiveName()}'s contents spill all over the floor!",
-					(Vector3)worldPos, gameObject);
+				Chat.AddLocalMsgToChat($"{gameObject.ExpensiveName()}'s contents spill all over the floor!", gameObject);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.Process.cs
@@ -20,7 +20,7 @@ public partial class Chat
 	private struct DestroyChatMessage
 	{
 		public string Message;
-		public Vector2Int WorldPosition;
+		public Vector2 WorldPosition;
 	}
 
 	public Color oocColor;
@@ -356,7 +356,7 @@ public partial class Chat
 
 //			int averageX = 0;
 //			int averageY = 0;
-			Vector2Int lastPos = Vector2Int.zero;
+			var lastPos = Vector2.zero;
 			int count = 1;
 
 			while (messageQueue.TryDequeue(out DestroyChatMessage msg))

--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
@@ -102,7 +102,7 @@ public partial class Chat : MonoBehaviour
 			message = isOOC ? message : processedMessage.message,
 			modifiers = (player == null) ? ChatModifier.None : processedMessage.chatModifiers,
 			speaker = (player == null) ? sentByPlayer.Username : player.name,
-			position = (player == null) ? TransformState.HiddenPos : player.WorldPos,
+			position = (player == null) ? TransformState.HiddenPos : player.gameObject.AssumedWorldPosServer(),
 			channels = channels,
 			originator = sentByPlayer.GameObject
 		};
@@ -248,7 +248,7 @@ public partial class Chat : MonoBehaviour
 			speaker = originator.name,
 			message = originatorMessage,
 			messageOthers = othersMessage,
-			position = originator.WorldPosServer(),
+			position = originator.AssumedWorldPosServer(),
 			originator = originator
 		});
 	}
@@ -281,7 +281,7 @@ public partial class Chat : MonoBehaviour
 			message = originatorMsg,
 			messageOthers = othersMsg,
 			speaker = originator.name,
-			position = originator.WorldPosServer(),
+			position = originator.AssumedWorldPosServer(),
 			originator = originator
 		});
 	}
@@ -381,7 +381,7 @@ public partial class Chat : MonoBehaviour
 		var messageOthers = $"{attackerName} has {attackVerb} {victimNameOthers}{InTheZone(hitZone)}{attack}!";
 		var message = $"You {attackVerb} {victimName}{InTheZone(hitZone)}{attack}!";
 
-		var pos = attacker.WorldPosServer();
+		var pos = attacker.AssumedWorldPosServer();
 
 		if (posOverride != Vector3.zero)
 		{
@@ -422,7 +422,7 @@ public partial class Chat : MonoBehaviour
 		{
 			channels = ChatChannel.Combat,
 			message = message,
-			position = victim.WorldPosServer(),
+			position = victim.AssumedWorldPosServer(),
 			originator = victim
 		});
 	}
@@ -434,14 +434,14 @@ public partial class Chat : MonoBehaviour
 	/// <param name="message"></param>
 	/// <param name="postfix">Common, amount agnostic postfix</param>
 	/// <param name="worldPos"></param>
-	public static void AddLocalDestroyMsgToChat(string message, string postfix, Vector2Int worldPos)
+	public static void AddLocalDestroyMsgToChat(string message, string postfix, GameObject destroyedObject)
 	{
 		if (!messageQueueDict.ContainsKey(postfix))
 		{
 			messageQueueDict.Add(postfix, new UniqueQueue<DestroyChatMessage>());
 		}
 
-		messageQueueDict[postfix].Enqueue(new DestroyChatMessage { Message = message, WorldPosition = worldPos });
+		messageQueueDict[postfix].Enqueue(new DestroyChatMessage { Message = message, WorldPosition = destroyedObject.AssumedWorldPosServer() });
 
 		if (composeMessageHandle == null)
 		{
@@ -479,10 +479,9 @@ public partial class Chat : MonoBehaviour
 	/// </summary>
 	/// <param name="message">The message to show in the chat stream</param>
 	/// <param name="originator">The object (i.e. vending machine) that said message</param>
-	public static void AddLocalMsgToChat(string message, GameObject originator)
+	public static void AddLocalMsgToChat(string message, GameObject originator, string speakerName = null)
 	{
-		if (!IsServer()) return;
-		AddLocalMsgToChat(message, originator.WorldPosServer(), originator);
+		AddLocalMsgToChat(message, originator.AssumedWorldPosServer(), originator, speakerName);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
@@ -34,7 +34,7 @@ public class ChatRelay : NetworkBehaviour
 		if (Instance == null)
 		{
 			Instance = this;
-			Chat.RegisterChatRelay(Instance, AddToChatLogServer, AddToChatLogClient, AddPrivMessageToClient);
+			Chat.RegisterChatRelay(Instance, PropagateChatToClients, AddToChatLogClient, AddPrivMessageToClient);
 		}
 		else
 		{
@@ -50,12 +50,6 @@ public class ChatRelay : NetworkBehaviour
 		npcMask = LayerMask.GetMask("NPC");
 
 		rconManager = RconManager.Instance;
-	}
-
-	[Server]
-	private void AddToChatLogServer(ChatEvent chatEvent)
-	{
-		PropagateChatToClients(chatEvent);
 	}
 
 	[Server]
@@ -89,8 +83,8 @@ public class ChatRelay : NetworkBehaviour
 					continue;
 				}
 
-				if (Vector2.Distance(chatEvent.position,
-						(Vector3)players[i].Script.WorldPos) > 14f)
+				var playerPosition = players[i].GameObject.AssumedWorldPosServer();
+				if (Vector2.Distance(chatEvent.position, playerPosition) > 14f)
 				{
 					//Player in the list is too far away for local chat, remove them:
 					players.RemoveAt(i);
@@ -99,7 +93,7 @@ public class ChatRelay : NetworkBehaviour
 				{
 					//within range, but check if they are in another room or hiding behind a wall
 					if (MatrixManager.Linecast(chatEvent.position, LayerTypeSelection.Walls
-						 , layerMask,(Vector3)players[i].Script.WorldPos).ItHit)
+						 , layerMask,playerPosition).ItHit)
 					{
 						//if it hit a wall remove that player
 						players.RemoveAt(i);
@@ -111,8 +105,9 @@ public class ChatRelay : NetworkBehaviour
 			var npcs = Physics2D.OverlapCircleAll(chatEvent.position, 14f, npcMask);
 			foreach (Collider2D coll in npcs)
 			{
+				var npcPosition = coll.gameObject.AssumedWorldPosServer();
 				if (MatrixManager.Linecast(chatEvent.position,LayerTypeSelection.Walls,
-					 layerMask,coll.transform.position).ItHit ==false)
+					 layerMask,npcPosition).ItHit ==false)
 				{
 					//NPC is in hearing range, pass the message on:
 					var mobAi = coll.GetComponent<MobAI>();

--- a/UnityProject/Assets/Scripts/Core/Input System/MouseInputController.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/MouseInputController.cs
@@ -562,7 +562,7 @@ public class MouseInputController : MonoBehaviour
 					Logger.LogFormat($"Forcefully updated atmos at worldPos {position}/ localPos {localPos} of {matrix.Name}");
 				});
 
-				Chat.AddLocalMsgToChat("Ping " + DateTime.Now.ToFileTimeUtc(), (Vector3)position, PlayerManager.LocalPlayer);
+				Chat.AddLocalMsgToChat("Ping " + DateTime.Now.ToFileTimeUtc(), PlayerManager.LocalPlayer);
 			}
 			return true;
 		}

--- a/UnityProject/Assets/Scripts/Health/Living/HumanHealth/PlayerHealth.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/HumanHealth/PlayerHealth.cs
@@ -203,7 +203,7 @@ public class PlayerHealth : LivingHealthBehaviour
 					descriptor = "their";
 				}
 
-				Chat.AddLocalMsgToChat($"<b>{playerName}</b> seizes up and falls limp, {descriptor} eyes dead and lifeless...", (Vector3)registerPlayer.WorldPositionServer, gameObject);
+				Chat.AddLocalMsgToChat($"<b>{playerName}</b> seizes up and falls limp, {descriptor} eyes dead and lifeless...", gameObject);
 			}
 
 			PlayerDeathMessage.Send(gameObject);

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -310,7 +310,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	{
 		Profiler.BeginSample("DefaultBurnUp");
 		registerTile.TileChangeManager.UpdateOverlay(registerTile.LocalPosition, isLarge ? LARGE_ASH : SMALL_ASH);
-		Chat.AddLocalDestroyMsgToChat(gameObject.ExpensiveName(), " burnt to ash.", gameObject.TileWorldPosition());
+		Chat.AddLocalDestroyMsgToChat(gameObject.ExpensiveName(), " burnt to ash.", gameObject);
 		Logger.LogTraceFormat("{0} burning up, onfire is {1} (burningObject enabled {2})", Category.Health, name, this.onFire, burningObjectOverlay?.enabled);
 		Despawn.ServerSingle(gameObject);
 		Profiler.EndSample();
@@ -321,13 +321,13 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	{
 		if (info.DamageType == DamageType.Brute)
 		{
-			Chat.AddLocalDestroyMsgToChat(gameObject.ExpensiveName(), " got smashed to pieces.", gameObject.TileWorldPosition());
+			Chat.AddLocalDestroyMsgToChat(gameObject.ExpensiveName(), " got smashed to pieces.", gameObject);
 			Despawn.ServerSingle(gameObject);
 		}
 		//TODO: Other damage types (acid)
 		else
 		{
-			Chat.AddLocalDestroyMsgToChat(gameObject.ExpensiveName(), " got destroyed.", gameObject.TileWorldPosition());
+			Chat.AddLocalDestroyMsgToChat(gameObject.ExpensiveName(), " got destroyed.", gameObject);
 			Despawn.ServerSingle(gameObject);
 		}
 	}

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/ParrotAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/ParrotAI.cs
@@ -73,7 +73,6 @@ namespace Systems.MobAIs
 			//TODO use the actual chat api when it allows it!
 			Chat.AddLocalMsgToChat(
 				text,
-				gameObject.transform.position,
 				gameObject,
 				mobNameCap);
 			ChatBubbleManager.ShowAChatBubble(gameObject.transform, text);

--- a/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
@@ -66,7 +66,7 @@ namespace Objects.Botany
 			Inventory.ServerDespawn(grownFood.gameObject);
 			if (foodToBeProcessed.Count == 0)
 			{
-				Chat.AddLocalMsgToChat("The seed extractor finishes processing", (Vector2Int)registerObject.WorldPosition, this.gameObject);
+				Chat.AddLocalMsgToChat("The seed extractor finishes processing", gameObject);
 			}
 		}
 
@@ -83,7 +83,7 @@ namespace Objects.Botany
 			netTransform.AppearAtPositionServer(spawnPos);
 
 			//Notify chat
-			Chat.AddLocalMsgToChat($"{seedPacket.gameObject.ExpensiveName()} was dispensed from the seed extractor", gameObject.RegisterTile().WorldPosition.To2Int(), gameObject);
+			Chat.AddLocalMsgToChat($"{seedPacket.gameObject.ExpensiveName()} was dispensed from the seed extractor", gameObject);
 
 			//Remove spawned entry from list
 			seedPackets.Remove(seedPacket);
@@ -124,7 +124,7 @@ namespace Objects.Botany
 						$"{interaction.Performer.name} places the {foodAtributes.name} into the seed extractor");
 				if (foodToBeProcessed.Count == 0 && currentState != PowerStates.Off)
 				{
-					Chat.AddLocalMsgToChat("The seed extractor begins processing", (Vector2Int)registerObject.WorldPosition, this.gameObject);
+					Chat.AddLocalMsgToChat("The seed extractor begins processing", gameObject);
 				}
 				foodToBeProcessed.Enqueue(grownFood);
 				return;
@@ -156,12 +156,12 @@ namespace Objects.Botany
 				//Any state other than off
 				if (currentState == PowerStates.Off)
 				{
-					Chat.AddLocalMsgToChat("The seed extractor begins processing", (Vector2Int)registerObject.WorldPosition, this.gameObject);
+					Chat.AddLocalMsgToChat("The seed extractor begins processing", gameObject);
 				}
 				//Off state
 				else if (newState == PowerStates.Off)
 				{
-					Chat.AddLocalMsgToChat("The seed extractor shuts down!", (Vector2Int)registerObject.WorldPosition, this.gameObject);
+					Chat.AddLocalMsgToChat("The seed extractor shuts down!", gameObject);
 				}
 			}
 			currentState = newState;

--- a/UnityProject/Assets/Scripts/Objects/GasContainer.cs
+++ b/UnityProject/Assets/Scripts/Objects/GasContainer.cs
@@ -82,7 +82,7 @@ namespace Objects.Atmospherics
 			ReleaseContentsInstantly();
 
 			ExplosionUtils.PlaySoundAndShake(WorldPosition, shakeIntensity, (int)shakeDistance);
-			Chat.AddLocalDestroyMsgToChat(gameObject.ExpensiveName(), " exploded!", WorldPosition.To2Int());
+			Chat.AddLocalDestroyMsgToChat(gameObject.ExpensiveName(), " exploded!", gameObject);
 
 			ServerContainerExplode?.Invoke();
 			// Disable this script, gameObject has no valid container now.

--- a/UnityProject/Assets/Scripts/Objects/Posters/PosterBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Objects/Posters/PosterBehaviour.cs
@@ -135,7 +135,7 @@ namespace Objects
 			}
 
 			Chat.AddLocalMsgToChat(interaction.Performer.ExpensiveName() +
-								   " rips the poster in a single, decisive motion!", pos, gameObject);
+								   " rips the poster in a single, decisive motion!", interaction.Performer);
 			SoundManager.PlayNetworkedAtPos("PosterRipped", pos, sourceObj: gameObject);
 
 			SyncPosterType(posterVariant, Posters.Ripped);

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/BlobPlayer.cs
@@ -747,7 +747,7 @@ namespace Blob
 
 					if (!autoExpanding)
 					{
-						Chat.AddLocalMsgToChat($"The blob attacks the {hit.gameObject.ExpensiveName()}", worldPos, gameObject);
+						Chat.AddLocalMsgToChat($"The blob attacks the {hit.gameObject.ExpensiveName()}", gameObject);
 					}
 
 					PlayAttackEffect(pos);

--- a/UnityProject/Assets/Scripts/UI/Objects/Botany/SeedExtractor/GUI_SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Botany/SeedExtractor/GUI_SeedExtractor.cs
@@ -185,7 +185,7 @@ namespace UI.Objects.Botany
 
 		private void SendToChat(string messageToSend)
 		{
-			Chat.AddLocalMsgToChat(messageToSend, seedExtractor.gameObject.RegisterTile().WorldPosition.To2Int(), seedExtractor?.gameObject);
+			Chat.AddLocalMsgToChat(messageToSend, seedExtractor.gameObject);
 		}
 
 		private IEnumerator VendorInputCoolDown()


### PR DESCRIPTION
### Purpose
Fixes speech and other messages appearing if the originator is inside a locker.
Fixes players inside lockers being unable to hear or see anything around them.
Changes most chat display messages calls to use a simpler version, just sending the message and the originator object.

