### PR TITLE
Remove redundant newlines in discord webhook messages

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/DiscordWebhookMessage.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/DiscordWebhookMessage.cs
@@ -181,7 +181,7 @@ namespace DiscordWebhook
 					break;
 				}
 
-				msg += queue.Dequeue() + "\n";
+				msg += queue.Dequeue();
 			}
 
 			var payLoad = new JsonPayloadContent()
@@ -262,7 +262,7 @@ namespace DiscordWebhook
 					logToSend = logToSend.Substring(0, 1950);
 				}
 
-				logToSend = $"```\n{logToSend}\n```\n";
+				logToSend = $"```\n{logToSend}```";
 
 				AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookErrorLogURL, logToSend, "");
 			}

--- a/UnityProject/Assets/Scripts/Core/Chat/DiscordWebhookMessage.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/DiscordWebhookMessage.cs
@@ -181,7 +181,7 @@ namespace DiscordWebhook
 					break;
 				}
 
-				msg += queue.Dequeue();
+				msg += queue.Dequeue() + "\n";
 			}
 
 			var payLoad = new JsonPayloadContent()


### PR DESCRIPTION
You don't actually need all these.
\`\`\`\nTEXT\`\`\` will render fine without newlines.

Discord automatically ads newline after codeblock closes, so you don't need \n when merging messages either. Currently 2! redundant newlines are placed: 
![image](https://user-images.githubusercontent.com/22667809/99153887-ac382580-26bc-11eb-9240-d3545b8749ec.png)
(one from the end of codeblock and other from joining messages)

