### PR TITLE
Add wizard summoning rituals

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/InGameEventsManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/InGameEventsManager.prefab
@@ -1,5 +1,61 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &464558627155228391
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1986124767922438636}
+  - component: {fileID: 1509154772117394094}
+  m_Layer: 0
+  m_Name: WizardSummonGuns
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1986124767922438636
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464558627155228391}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 739026179657658727}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1509154772117394094
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464558627155228391}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99dc2640e77c4114690e615bae1779c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  EventName: Wizard - Summon Guns
+  StartTimer: 0
+  EndTimer: 0
+  EventType: 3
+  ChanceToHappen: 0
+  MinPlayersToTrigger: 0
+  parametersPageType: 0
+  FakeEvent: 0
+  AnnounceEvent: 1
+  gunList: {fileID: 11400000, guid: b4c25bef2920de643af01571c6e46a17, type: 2}
+  antagChance: 20
+  survivorAntag: {fileID: 11400000, guid: 1f76130a96885d1458294f8986f12bb4, type: 2}
+  objective: {fileID: 11400000, guid: 7502e63ba2052fe4f821bdd278b06dae, type: 2}
 --- !u!1 &879242159864812802
 GameObject:
   m_ObjectHideFlags: 0
@@ -254,6 +310,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2814037277566469169}
+  - {fileID: 1986124767922438636}
   m_Father: {fileID: 8934140032923375002}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -344,39 +401,7 @@ MonoBehaviour:
   parametersPageType: 0
   FakeEvent: 0
   AnnounceEvent: 1
-  gunList:
-  - {fileID: 2524481489369203327, guid: 24274bda3be42c049b4bbb150f6e1220, type: 3}
-  - {fileID: 4490747135017947362, guid: fc502f4e927543d4ea7c77161dc70761, type: 3}
-  - {fileID: 5753027621056683192, guid: 065437736dfc00d44b10f9cb995081ad, type: 3}
-  - {fileID: 6552933947037394245, guid: 24b21da59a1c48248805096709dceca1, type: 3}
-  - {fileID: 6151918675202351009, guid: dd9b2da27626d1e4caa9524384c4b472, type: 3}
-  - {fileID: 8594955878468889041, guid: 035def552b915ed429f1572133201dcb, type: 3}
-  - {fileID: 4174271899233501010, guid: be5f2723f27ad4148af60edd344e340a, type: 3}
-  - {fileID: 5906183653279542145, guid: 176e0188c0d52184ca00dcaf9607abca, type: 3}
-  - {fileID: 5551584941237599514, guid: f03322d9ffd16e644abae72db1d8950a, type: 3}
-  - {fileID: 3168944121209824662, guid: 0a7ba29086818cf4a8010f3b2743a7ac, type: 3}
-  - {fileID: 331383614235509145, guid: ed9f88270aae41443a71e5406ac73acb, type: 3}
-  - {fileID: 1637236327471730624, guid: 29de35ce9f3e2ae4daa8de0460cc3009, type: 3}
-  - {fileID: 6001714909860223023, guid: 50242f69ac50a104794f0968b058a161, type: 3}
-  - {fileID: 731148093348330813, guid: be9977f921fbedf46ad84d50a0411c2c, type: 3}
-  - {fileID: 9055840952218545467, guid: c719369bf54a9534ebb5c67d4c8be937, type: 3}
-  - {fileID: 4996160304479888755, guid: 9363154ec4a288f41b8c9681e3531539, type: 3}
-  - {fileID: 4024192966601867823, guid: d9c42e1e7b801ab408872be5bb5b1264, type: 3}
-  - {fileID: 436234263232269494, guid: 9ef5119f9e27f424fbca5021ab7b66ce, type: 3}
-  - {fileID: 5110185232032146699, guid: 04e181bad9e993944bf2465d48cb41d4, type: 3}
-  - {fileID: 4117137691947961148, guid: 538cebc4fa9119344aa630d0f273bced, type: 3}
-  - {fileID: 5276687137666177651, guid: ee6796c2c2708be4e9b9b06e5c4062ad, type: 3}
-  - {fileID: 198146816443172997, guid: 9f68bba630ca7a8459c3b56476c9e10a, type: 3}
-  - {fileID: 7976047108222217108, guid: 630e95b6bf6f9e2439487630ee85cfaf, type: 3}
-  - {fileID: 6090044955677669620, guid: 3e40ece6d5f0e6f4897ad698318e760e, type: 3}
-  - {fileID: 8947746899163356516, guid: 1e9a929a33dead54e9b3584af40d2605, type: 3}
-  - {fileID: 1589173924654635063, guid: d74ac2d52680e6844a56741b2f09deaf, type: 3}
-  - {fileID: 4996720944469767526, guid: a36e3e799a7d05a4db2554f4bd1b6719, type: 3}
-  - {fileID: 3814654046910142495, guid: ab8d1f5a3e841a043bc60cdf2f5d9495, type: 3}
-  - {fileID: 8261965186490909529, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f, type: 3}
-  - {fileID: 650305787758157290, guid: 4bd7026a3da7b0143b5fb4d06bc94a5f, type: 3}
-  - {fileID: 8059468518805232750, guid: 8976db5cf8f59bc4cb85f61e8737b468, type: 3}
-  - {fileID: 3396079434555916715, guid: 3da1d244806a96340a48e959ecc816e4, type: 3}
+  gunList: {fileID: 11400000, guid: b4c25bef2920de643af01571c6e46a17, type: 2}
 --- !u!114 &7640521655157332548
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/InGameEventsManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/InGameEventsManager.prefab
@@ -53,9 +53,67 @@ MonoBehaviour:
   FakeEvent: 0
   AnnounceEvent: 1
   gunList: {fileID: 11400000, guid: b4c25bef2920de643af01571c6e46a17, type: 2}
+  globalSound: LesserSummonGuns
   antagChance: 20
   survivorAntag: {fileID: 11400000, guid: 1f76130a96885d1458294f8986f12bb4, type: 2}
   objective: {fileID: 11400000, guid: 7502e63ba2052fe4f821bdd278b06dae, type: 2}
+--- !u!1 &622157989691017065
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3219844687204394920}
+  - component: {fileID: 7371302063270046852}
+  m_Layer: 0
+  m_Name: WizardSummonMagic
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3219844687204394920
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 622157989691017065}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 739026179657658727}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7371302063270046852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 622157989691017065}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99dc2640e77c4114690e615bae1779c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  EventName: Wizard - Summon Magic
+  StartTimer: 0
+  EndTimer: 0
+  EventType: 3
+  ChanceToHappen: 0
+  MinPlayersToTrigger: 0
+  parametersPageType: 0
+  FakeEvent: 0
+  AnnounceEvent: 1
+  gunList: {fileID: 11400000, guid: b31575fc3fe98884fbac380727b6a5c5, type: 2}
+  globalSound: TeleportAppear
+  antagChance: 20
+  survivorAntag: {fileID: 11400000, guid: 1f76130a96885d1458294f8986f12bb4, type: 2}
+  objective: {fileID: 11400000, guid: f4ccc2a0477e62741a7d9fafa6d73154, type: 2}
 --- !u!1 &879242159864812802
 GameObject:
   m_ObjectHideFlags: 0
@@ -311,6 +369,7 @@ Transform:
   m_Children:
   - {fileID: 2814037277566469169}
   - {fileID: 1986124767922438636}
+  - {fileID: 3219844687204394920}
   m_Father: {fileID: 8934140032923375002}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Antags/Survivor.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Antags/Survivor.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8f38101b104a0494c823c19e8abfbdcb, type: 3}
+  m_Name: Survivor
+  m_EditorClassIdentifier: 
+  antagName: Survivor
+  antagJobType: 0
+  playSound: 0
+  spawnSound: Notice1
+  textColor: {r: 1, g: 1, b: 1, a: 1}
+  backgroundColor: {r: 1, g: 0.39215687, b: 0, a: 1}
+  numberOfObjectives: 1
+  canUseSharedObjectives: 0
+  needsEscapeObjective: 0
+  coreObjectives:
+  - {fileID: 11400000, guid: b6107e1c868bada4da25dc2fc840e411, type: 2}
+  antagOccupation: {fileID: 0}
+  showInPreferences: 0

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Antags/Survivor.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Antags/Survivor.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f76130a96885d1458294f8986f12bb4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Objectives/SurvivalistGuns.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Objectives/SurvivalistGuns.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 642644d3e2513ce4e8c02e9fdaa18eea, type: 3}
+  m_Name: SurvivalistGuns
+  m_EditorClassIdentifier: 
+  objectiveName: Acquire Guns
+  IsUnique: 1
+  description: Your own safety matters above all else, and the only way to ensure
+    your safety is to stockpile weapons! Grab as many guns as possible, by any means
+    necessary. Kill anyone who gets in your way.
+  minimumGunsNeeded: 2

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Objectives/SurvivalistGuns.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Objectives/SurvivalistGuns.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7502e63ba2052fe4f821bdd278b06dae
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Objectives/SurvivalistMagic.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Objectives/SurvivalistMagic.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 439196e0e466efe419a0f5b7835f90d6, type: 3}
+  m_Name: SurvivalistMagic
+  m_EditorClassIdentifier: 
+  objectiveName: Amateur Magician
+  IsUnique: 1
+  description: Grow your newfound talent! Grab as many magical artefacts as possible,
+    by any means necessary. Kill anyone who gets in your way.
+  minimumSpellsNeeded: 1

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Objectives/SurvivalistMagic.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Objectives/SurvivalistMagic.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f4ccc2a0477e62741a7d9fafa6d73154
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Gun/GunList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Gun/GunList.asset
@@ -1,0 +1,48 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ae6d45af30f03645930ec8385e559d3, type: 3}
+  m_Name: GunList
+  m_EditorClassIdentifier: 
+  gameObjects:
+  - {fileID: 4168018088976029867, guid: f021fb89430b809c6aa885598328383b, type: 3}
+  - {fileID: 9033182129080977681, guid: c5c2333c6c1a8a8858b888665c068175, type: 3}
+  - {fileID: 5753027621056683192, guid: 065437736dfc00d44b10f9cb995081ad, type: 3}
+  - {fileID: 2665621619267001517, guid: a5027447659489d10ae1b27b000a46d6, type: 3}
+  - {fileID: 6151918675202351009, guid: dd9b2da27626d1e4caa9524384c4b472, type: 3}
+  - {fileID: 8594955878468889041, guid: 035def552b915ed429f1572133201dcb, type: 3}
+  - {fileID: 4174271899233501010, guid: be5f2723f27ad4148af60edd344e340a, type: 3}
+  - {fileID: 5906183653279542145, guid: 176e0188c0d52184ca00dcaf9607abca, type: 3}
+  - {fileID: 5551584941237599514, guid: f03322d9ffd16e644abae72db1d8950a, type: 3}
+  - {fileID: 7603708067170911382, guid: 41b85b342eb093b0aa16a069dbb73fd2, type: 3}
+  - {fileID: 331383614235509145, guid: ed9f88270aae41443a71e5406ac73acb, type: 3}
+  - {fileID: 1637236327471730624, guid: 29de35ce9f3e2ae4daa8de0460cc3009, type: 3}
+  - {fileID: 6001714909860223023, guid: 50242f69ac50a104794f0968b058a161, type: 3}
+  - {fileID: 731148093348330813, guid: be9977f921fbedf46ad84d50a0411c2c, type: 3}
+  - {fileID: 9055840952218545467, guid: c719369bf54a9534ebb5c67d4c8be937, type: 3}
+  - {fileID: 4996160304479888755, guid: 9363154ec4a288f41b8c9681e3531539, type: 3}
+  - {fileID: 4024192966601867823, guid: d9c42e1e7b801ab408872be5bb5b1264, type: 3}
+  - {fileID: 436234263232269494, guid: 9ef5119f9e27f424fbca5021ab7b66ce, type: 3}
+  - {fileID: 5110185232032146699, guid: 04e181bad9e993944bf2465d48cb41d4, type: 3}
+  - {fileID: 4117137691947961148, guid: 538cebc4fa9119344aa630d0f273bced, type: 3}
+  - {fileID: 5276687137666177651, guid: ee6796c2c2708be4e9b9b06e5c4062ad, type: 3}
+  - {fileID: 198146816443172997, guid: 9f68bba630ca7a8459c3b56476c9e10a, type: 3}
+  - {fileID: 7976047108222217108, guid: 630e95b6bf6f9e2439487630ee85cfaf, type: 3}
+  - {fileID: 6090044955677669620, guid: 3e40ece6d5f0e6f4897ad698318e760e, type: 3}
+  - {fileID: 8947746899163356516, guid: 1e9a929a33dead54e9b3584af40d2605, type: 3}
+  - {fileID: 1589173924654635063, guid: d74ac2d52680e6844a56741b2f09deaf, type: 3}
+  - {fileID: 4996720944469767526, guid: a36e3e799a7d05a4db2554f4bd1b6719, type: 3}
+  - {fileID: 3814654046910142495, guid: ab8d1f5a3e841a043bc60cdf2f5d9495, type: 3}
+  - {fileID: 8261965186490909529, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f, type: 3}
+  - {fileID: 650305787758157290, guid: 4bd7026a3da7b0143b5fb4d06bc94a5f, type: 3}
+  - {fileID: 8059468518805232750, guid: 8976db5cf8f59bc4cb85f61e8737b468, type: 3}
+  - {fileID: 3396079434555916715, guid: 3da1d244806a96340a48e959ecc816e4, type: 3}
+  - {fileID: 7030603212881018072, guid: 5332ea8dee0701a43bb873e71327923e, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Gun/GunList.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Gun/GunList.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b4c25bef2920de643af01571c6e46a17
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Rituals.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Rituals.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b38560fae8c45ff4ba8eb4bf4dd4f2ec
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Rituals/SummonGuns.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Rituals/SummonGuns.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 85e89e90114aa83449cdaee7c0a5d3b2, type: 3}
+  m_Name: SummonGuns
+  m_EditorClassIdentifier: 
+  description: Nothing could possibly go wrong with arming a crew of lunatics just
+    itching for an excuse to kill you. There is a good chance that they will shoot
+    each other first.
+  note: 
+  cost: 2
+  conflictsWith: []
+  name: Summon Guns
+  eventType: 3
+  eventIndex: 1
+  invocationMessage: 
+  castSound: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Rituals/SummonGuns.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Rituals/SummonGuns.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5edec36434aa4cd468a0585821e2a0e6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Rituals/SummonMagic.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Rituals/SummonMagic.asset
@@ -10,16 +10,15 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 85e89e90114aa83449cdaee7c0a5d3b2, type: 3}
-  m_Name: SummonGuns
+  m_Name: SummonMagic
   m_EditorClassIdentifier: 
-  description: Nothing could possibly go wrong with arming a crew of lunatics just
-    itching for an excuse to kill you. There is a good chance that they will shoot
-    each other first.
+  description: Share the wonders of magic with the crew and show them why they aren't
+    to be trusted with it at the same time.
   note: 
   cost: 2
   conflictsWith: []
-  name: Summon Guns
+  name: Summon Magic
   eventType: 3
-  eventIndex: 2
+  eventIndex: 1
   invocationMessage: 
   castSound: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Rituals/SummonMagic.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Rituals/SummonMagic.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 92e61ea6a855f76459fbf69005072284
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/SpellBookData.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/SpellBookData.asset
@@ -39,4 +39,5 @@ MonoBehaviour:
   - name: Rituals
     description: These powerful spells change the very fabric of reality. Not always
       in your favour.
-    entryList: []
+    entryList:
+    - {fileID: 11400000, guid: 5edec36434aa4cd468a0585821e2a0e6, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/SpellBookData.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/SpellBookData.asset
@@ -41,3 +41,4 @@ MonoBehaviour:
       in your favour.
     entryList:
     - {fileID: 11400000, guid: 5edec36434aa4cd468a0585821e2a0e6, type: 2}
+    - {fileID: 11400000, guid: 92e61ea6a855f76459fbf69005072284, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Spells/Wizard/MagicList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Spells/Wizard/MagicList.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ae6d45af30f03645930ec8385e559d3, type: 3}
+  m_Name: MagicList
+  m_EditorClassIdentifier: 
+  gameObjects:
+  - {fileID: 7792469808048322689, guid: 496bd7f7917a94e44878b6f2a57900a0, type: 3}
+  - {fileID: 776659237916025105, guid: 651304d8cd4458e4097191da621c0f30, type: 3}
+  - {fileID: 6459217844356408720, guid: 22253e0e1cd72bf48892031645a51198, type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Spells/Wizard/MagicList.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Spells/Wizard/MagicList.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b31575fc3fe98884fbac380727b6a5c5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Others/Magical/BookOfSpells.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Magical/BookOfSpells.cs
@@ -133,6 +133,8 @@ namespace Items.Magical
 			}
 
 			InGameEventsManager.Instance.TriggerSpecificEvent(ritualEntry.EventIndex, ritualEntry.EventType, announceEvent: false);
+
+			points -= ritualEntry.Cost;
 		}
 
 		#region Interaction

--- a/UnityProject/Assets/Scripts/Items/Others/Magical/BookOfSpells.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Magical/BookOfSpells.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using Systems.Spells;
 using ScriptableObjects.Systems.Spells;
 using ScriptableObjects.Items.SpellBook;
+using InGameEvents;
 
 namespace Items.Magical
 {
@@ -113,6 +114,25 @@ namespace Items.Magical
 					}
 				}
 			}
+		}
+
+		public void CastRitual(SpellBookRitual ritualEntry)
+		{
+			if (ritualEntry.Cost > Points) return;
+
+			ConnectedPlayer player = GetLastReader();
+
+			if (ritualEntry.InvocationMessage != default)
+			{
+				Chat.AddChatMsgToChat(player, ritualEntry.InvocationMessage, ChatChannel.Local);
+			}
+
+			if (ritualEntry.CastSound != default)
+			{
+				SoundManager.PlayNetworkedAtPos(ritualEntry.CastSound, player.Script.WorldPos, sourceObj: player.GameObject);
+			}
+
+			InGameEventsManager.Instance.TriggerSpecificEvent(ritualEntry.EventIndex, ritualEntry.EventType, announceEvent: false);
 		}
 
 		#region Interaction

--- a/UnityProject/Assets/Scripts/ScriptableObjects/GameObjectList.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/GameObjectList.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using UnityEngine;
+using NaughtyAttributes;
+
+namespace ScriptableObjects
+{
+	/// <summary>
+	/// A generic ScriptableObject with which a list of GameObject prefabs can be defined via the inspector.
+	/// </summary>
+	[CreateAssetMenu(fileName = "MyGameObjectList", menuName = "ScriptableObjects/GameObjectList")]
+	public class GameObjectList : ScriptableObject
+	{
+		[Tooltip("Define a list of your GameObject prefabs here.")]
+		[SerializeField, ReorderableList]
+		private GameObject[] gameObjects = default;
+
+		/// <summary>
+		/// Gets the array of GameObject prefabs, as defined via the inspector.
+		/// </summary>
+		public GameObject[] GameObjectPrefabs => gameObjects;
+
+		/// <summary>
+		/// Gets a random GameObject prefab from the array of GameObject prefabs as defined via the inspector.
+		/// </summary>
+		/// <returns>a random GameObject prefab</returns>
+		public GameObject GetRandom()
+		{
+			return GameObjectPrefabs.PickRandom();
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/ScriptableObjects/GameObjectList.cs.meta
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/GameObjectList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ae6d45af30f03645930ec8385e559d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/ScriptableObjects/Items/SpellBook/SpellBookRitual.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/Items/SpellBook/SpellBookRitual.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections;
+using UnityEngine;
+using NaughtyAttributes;
+using InGameEvents;
+
+namespace ScriptableObjects.Items.SpellBook
+{
+	/// <summary>
+	/// An ritual-type entry for a wizard's Book of Spells.
+	/// </summary>
+	[CreateAssetMenu(fileName = "SpellBookRitual", menuName = "ScriptableObjects/Items/SpellBook/Ritual")]
+	[Serializable]
+	public class SpellBookRitual : SpellBookEntry
+	{
+		[SerializeField]
+		private new string name = default;
+		[SerializeField]
+		private InGameEventType eventType = default;
+		[Tooltip("The index of the event to trigger (in the event type), as found in InGameEventsManager.")]
+		[SerializeField]
+		private int eventIndex = default;
+		[SerializeField]
+		private string invocationMessage = default;
+		[SerializeField]
+		private string castSound = default;
+
+		public string Name => name;
+		public InGameEventType EventType => eventType;
+		public int EventIndex => eventIndex;
+		public string InvocationMessage => invocationMessage;
+		public string CastSound => castSound;
+
+		public enum RitualType
+		{
+			Event = 0,
+			CustomImplementation,
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/ScriptableObjects/Items/SpellBook/SpellBookRitual.cs.meta
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/Items/SpellBook/SpellBookRitual.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85e89e90114aa83449cdaee7c0a5d3b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antagonist.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antagonist.cs
@@ -105,5 +105,17 @@ namespace Antagonists
 		/// <param name="spawnRequest">player's requested spawn</param>
 		/// <returns>gameobject of the spawned antag that he player is now in control of</returns>
 		public abstract GameObject ServerSpawn(PlayerSpawnRequest spawnRequest);
+
+		public void AddObjective(Objective objective)
+		{
+			numberOfObjectives++;
+			coreObjectives.Add(objective);
+		}
+
+		public void RemoveObjective(Objective objective)
+		{
+			coreObjectives.Remove(objective);
+			numberOfObjectives--;
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Survivor.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Survivor.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using UnityEngine;
+
+namespace Antagonists
+{
+	[CreateAssetMenu(menuName = "ScriptableObjects/Antagonist/Survivor")]
+	public class Survivor : Antagonist
+	{
+		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
+		{
+			// spawn them normally, with their preferred occupation
+			return PlayerSpawn.ServerSpawnPlayer(spawnRequest);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Survivor.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Survivor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f38101b104a0494c823c19e8abfbdcb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/Steal.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/Steal.cs
@@ -28,11 +28,6 @@ namespace Antagonists
 		private int Amount;
 
 		/// <summary>
-		/// The amount that has been found by the completion check so far.
-		/// </summary>
-		private int CheckAmount = 0;
-
-		/// <summary>
 		/// Make sure there's at least one item which hasn't been targeted
 		/// </summary>
 		public override bool IsPossible(PlayerScript candidate)
@@ -83,61 +78,9 @@ namespace Antagonists
 			description = $"Steal {Amount} {ItemName}";
 		}
 
-		/// <summary>
-		/// Checks through all the storage recursively
-		/// </summary>
 		protected override bool CheckCompletion()
 		{
-			return CheckStorage(Owner.body.ItemStorage);
-		}
-
-		private bool CheckStorage(ItemStorage itemStorage)
-		{
-			foreach (var slot in itemStorage.GetItemSlots())
-			{
-				if (CheckSlot(slot))
-				{
-					return true;
-				}
-			}
-
-			return false;
-		}
-
-		private bool CheckSlot(ItemSlot slot)
-		{
-			if (slot.ItemObject == null) return false;
-
-			//Check if current Item is the one we need
-			if (slot.ItemObject.GetComponent<ItemAttributesV2>()?.InitialName == ItemName)
-			{
-				//If stackable count stack
-				if (slot.ItemObject.TryGetComponent<Stackable>(out var stackable))
-				{
-					CheckAmount += stackable.Amount;
-				}
-				else
-				{
-					CheckAmount++;
-				}
-
-				//Check to see if count has been passed
-				if (CheckAmount >= Amount)
-				{
-					return true;
-				}
-			}
-
-			//Check to see if this item has storage, and do checks on that
-			if (slot.ItemObject.TryGetComponent<ItemStorage>(out var itemStorage))
-			{
-				if (CheckStorage(itemStorage))
-				{
-					return true;
-				}
-			}
-
-			return false;
+			return CheckStorageFor(ItemName, Amount);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/SurvivalistGuns.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/SurvivalistGuns.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Weapons;
+
+namespace Antagonists
+{
+	/// <summary>
+	/// Acquire x amount of guns.
+	/// </summary>
+	[CreateAssetMenu(menuName = "ScriptableObjects/Objectives/SurvivalistGuns")]
+	public class SurvivalistGuns : Objective
+	{
+		[SerializeField]
+		private int minimumGunsNeeded = 2;
+
+		protected override void Setup()
+		{
+		}
+
+		protected override bool CheckCompletion()
+		{
+			return CheckStorageFor(typeof(Gun), minimumGunsNeeded);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/SurvivalistGuns.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/SurvivalistGuns.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 642644d3e2513ce4e8c02e9fdaa18eea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/SurvivalistMagic.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/SurvivalistMagic.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Weapons;
+
+namespace Antagonists
+{
+	/// <summary>
+	/// Acquire x amount of spells.
+	/// </summary>
+	[CreateAssetMenu(menuName = "ScriptableObjects/Objectives/SurvivalistMagic")]
+	public class SurvivalistMagic : Objective
+	{
+		[SerializeField]
+		private int minimumSpellsNeeded = 1;
+
+		protected override void Setup()
+		{
+		}
+
+		protected override bool CheckCompletion()
+		{
+			return Owner.Spells.Count > 0;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/SurvivalistMagic.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/SurvivalistMagic.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 439196e0e466efe419a0f5b7835f90d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventSummonGuns.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventSummonGuns.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections;
+using UnityEngine;
+using NaughtyAttributes;
+using Antagonists;
+
+namespace InGameEvents
+{
+	public class EventSummonGuns : EventGiveGuns
+	{
+		[SerializeField]
+		private string globalSound = default;
+
+		[Tooltip("Set the percent chance a player will become an antagonist with a survival/steal guns objective.")]
+		[SerializeField, Range(0, 100)]
+		private int antagChance = 25;
+
+		[Tooltip("The antagonist to spawn (survivor).")]
+		[SerializeField, ShowIf(nameof(WillCreateAntags))]
+		private Antagonist survivorAntag;
+
+		[Tooltip("The unique objective to give to each survivor.")]
+		[SerializeField, ShowIf(nameof(WillCreateAntags))]
+		private Objective objective;
+
+		private bool WillCreateAntags => antagChance > 0;
+
+		public override void OnEventStart()
+		{
+			SoundManager.PlayNetworked(globalSound);
+
+			survivorAntag.AddObjective(objective);
+			SpawnGuns();
+			survivorAntag.RemoveObjective(objective); // remove lest we reuse survivor antag for other events like SummonMagic
+		}
+
+		protected override void HandlePlayer(ConnectedPlayer player)
+		{
+			GiveGunToPlayer(player);
+
+			if (Random.Range(0, 100) < antagChance && player.Script.mind.IsAntag == false)
+			{
+				SetAsAntagSurvivor(player);
+			}
+		}
+
+		private void SetAsAntagSurvivor(ConnectedPlayer player)
+		{
+			AntagManager.Instance.ServerFinishAntag(survivorAntag, player, player.GameObject);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventSummonGuns.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventSummonGuns.cs
@@ -30,7 +30,7 @@ namespace InGameEvents
 
 			survivorAntag.AddObjective(objective);
 			SpawnGuns();
-			survivorAntag.RemoveObjective(objective); // remove lest we reuse survivor antag for other events like SummonMagic
+			survivorAntag.RemoveObjective(objective); // remove lest we reuse survivor antag for other events
 		}
 
 		protected override void HandlePlayer(ConnectedPlayer player)
@@ -45,6 +45,7 @@ namespace InGameEvents
 
 		private void SetAsAntagSurvivor(ConnectedPlayer player)
 		{
+			Chat.AddExamineMsgFromServer(player, "<color='red'><size=60>You are the survivalist!</size></color>");
 			AntagManager.Instance.ServerFinishAntag(survivorAntag, player, player.GameObject);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventSummonGuns.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventSummonGuns.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99dc2640e77c4114690e615bae1779c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/Items/SpellBook/GUI_SpellBook.cs
+++ b/UnityProject/Assets/Scripts/UI/Items/SpellBook/GUI_SpellBook.cs
@@ -63,6 +63,10 @@ namespace UI.SpellBook
 				spellBook.SpawnArtifacts(artifactEntry);
 				ServerCloseTabFor(spellBook.GetLastReader()); // We close tab so that the player is aware of the dropping pod.
 			}
+			else if (entry is SpellBookRitual ritualEntry)
+			{
+				spellBook.CastRitual(ritualEntry);
+			}
 
 			RefreshCategory();
 			UpdatePoints();

--- a/UnityProject/Assets/Scripts/UI/Items/SpellBook/GUI_SpellBookEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Items/SpellBook/GUI_SpellBookEntry.cs
@@ -41,6 +41,10 @@ namespace UI.SpellBook
 			{
 				SetArtifactValues(artifactEntry);
 			}
+			else if (entry is SpellBookRitual ritualEntry)
+			{
+				SetRitualValues(ritualEntry);
+			}
 
 			// Enable or disable button interactivity based on affordability.
 			button.SetValueServer(entry.Cost > bookGUI.Points ? "false" : "true");
@@ -73,6 +77,14 @@ namespace UI.SpellBook
 			cooldownLabel.SetValueServer(default);
 			noteLabel.SetValueServer(artifactEntry.Note);
 			buttonLabel.SetValueServer("Summon");
+		}
+
+		private void SetRitualValues(SpellBookRitual ritualEntry)
+		{
+			spellLabel.SetValueServer(ritualEntry.Name);
+			cooldownLabel.SetValueServer(default);
+			noteLabel.SetValueServer(ritualEntry.Note);
+			buttonLabel.SetValueServer("Cast");
 		}
 
 		public void Activate()


### PR DESCRIPTION
- Adds the `Survivor` antagonist.
- Adds the `AcquireGuns` and `AcquireMagic` objectives for the aforementioned `Survivor` antagonist.
- Adds the `Summon Guns` and `Summon Magic` wizard rituals. Continues #5160.
    - Gives guns or magic books to each player.
    - 20 percent chance to set each player the aforementioned antagonist and respective objective when the above rituals are cast.


CL:Added SummonGuns and SummonMagic wizard rituals.