### PR TITLE
Remaining random bvold references

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Living/SimpleAnimals/Friendly/Cats/Cat.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Living/SimpleAnimals/Friendly/Cats/Cat.prefab
@@ -42,8 +42,7 @@ MonoBehaviour:
   activated: 0
   tickRate: 1
   followTarget: {fileID: 0}
-  spriteHolder: {fileID: 5751403467835134051, guid: a990bc1742ffa46c39c5839d3e7ec915,
-    type: 3}
+  spriteHolder: {fileID: 8081786582678036113}
   targetOtherPlayersWhoGetInWay: 0
   onlyHitTarget: 1
   hitDamage: 70
@@ -185,6 +184,12 @@ PrefabInstance:
 --- !u!1 &2144788095502372098 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7540635897288641467, guid: f74cbb9054020dd4f8c9dcdedd7398eb,
+    type: 3}
+  m_PrefabInstance: {fileID: 8459564455701055161}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8081786582678036113 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 382294827147974696, guid: f74cbb9054020dd4f8c9dcdedd7398eb,
     type: 3}
   m_PrefabInstance: {fileID: 8459564455701055161}
   m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Machines/VendingMachines/MegaseedServitor.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Machines/VendingMachines/MegaseedServitor.prefab
@@ -36,12 +36,12 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
         type: 3}
-      propertyPath: InitialVendorContent.Array.size
-      value: 12
+      propertyPath: VendorContent.Array.size
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
         type: 3}
-      propertyPath: VendorContent.Array.size
+      propertyPath: InitialVendorContent.Array.size
       value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
@@ -58,198 +58,6 @@ PrefabInstance:
         type: 3}
       propertyPath: HullColor.b
       value: 0.227451
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[0].ItemName
-      value: Apple Seed Packet
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[0].Item
-      value: 
-      objectReference: {fileID: 11639533463445157, guid: 301047244e720e040b17d641c872719d,
-        type: 3}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[0].Stock
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[1].ItemName
-      value: Banana Seed Packet
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[1].Item
-      value: 
-      objectReference: {fileID: 7274953645499099385, guid: 394037cafd8e7314993ff56030057547,
-        type: 3}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[1].Stock
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[2].ItemName
-      value: Wheat Seed Packet
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[2].Item
-      value: 
-      objectReference: {fileID: 7404372689460169919, guid: 3664fa301ba81ad40b12d9c4aef81309,
-        type: 3}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[2].Stock
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[3].ItemName
-      value: Onion Seed Packet
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[3].Item
-      value: 
-      objectReference: {fileID: 4594834270324246992, guid: dd4594ac73662a6459eb44ef7e1e8aeb,
-        type: 3}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[3].Stock
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[4].ItemName
-      value: Tomato Seed Packet
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[4].Item
-      value: 
-      objectReference: {fileID: 4800437225270224827, guid: 4a594e9982e674045b0d1535eed5e9fb,
-        type: 3}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[4].Stock
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[5].ItemName
-      value: Lemon Seed Packet
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[5].Item
-      value: 
-      objectReference: {fileID: 7929132545395035327, guid: 6b278dfd25eca3a458046704b9670b4c,
-        type: 3}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[5].Stock
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[6].ItemName
-      value: Sugar Cane Seed Packet
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[6].Item
-      value: 
-      objectReference: {fileID: 2137730739785068106, guid: 136edf62b0583ca4bb9be826a8e06a54,
-        type: 3}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[6].Stock
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[7].ItemName
-      value: Potato Seed Packet
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[7].Item
-      value: 
-      objectReference: {fileID: 8753333360308224092, guid: 405f1aae79bee6a4f8c83bc2a1ffae7a,
-        type: 3}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[7].Stock
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[8].ItemName
-      value: Rice Seed Packet
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[8].Item
-      value: 
-      objectReference: {fileID: 1020831183681200399, guid: 5186709fe798b0f41850799bfda96a6b,
-        type: 3}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[8].Stock
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[9].ItemName
-      value: Cotton Seed Packet
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[9].Item
-      value: 
-      objectReference: {fileID: 11639533463445157, guid: c5a9cf9eaa1364fa0a48ff032bc4c5d7,
-        type: 3}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[9].Stock
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[10].ItemName
-      value: Tower Cap Mycelium
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[10].Item
-      value: 
-      objectReference: {fileID: 1860393792048079318, guid: 5a874a6991a07424e8b1b339fb51157e,
-        type: 3}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[10].Stock
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[11].ItemName
-      value: Nutriment Bottle
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[11].Item
-      value: 
-      objectReference: {fileID: 6656006178777128666, guid: 809a686030c00e84f8fbf8ddb3b545ea,
-        type: 3}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[11].Stock
-      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
         type: 3}
@@ -275,25 +83,196 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
         type: 3}
-      propertyPath: InitialVendorContent.Array.data[12].ItemName
-      value: Bucket
+      propertyPath: InitialVendorContent.Array.data[0].Item
+      value: 
+      objectReference: {fileID: 11639533463445157, guid: 301047244e720e040b17d641c872719d,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[1].Item
+      value: 
+      objectReference: {fileID: 7274953645499099385, guid: 394037cafd8e7314993ff56030057547,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[2].Item
+      value: 
+      objectReference: {fileID: 7404372689460169919, guid: 3664fa301ba81ad40b12d9c4aef81309,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[3].Item
+      value: 
+      objectReference: {fileID: 4594834270324246992, guid: dd4594ac73662a6459eb44ef7e1e8aeb,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[4].Item
+      value: 
+      objectReference: {fileID: 4800437225270224827, guid: 4a594e9982e674045b0d1535eed5e9fb,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[5].Item
+      value: 
+      objectReference: {fileID: 7929132545395035327, guid: 6b278dfd25eca3a458046704b9670b4c,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[6].Item
+      value: 
+      objectReference: {fileID: 2137730739785068106, guid: 136edf62b0583ca4bb9be826a8e06a54,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[7].Item
+      value: 
+      objectReference: {fileID: 8753333360308224092, guid: 405f1aae79bee6a4f8c83bc2a1ffae7a,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[8].Item
+      value: 
+      objectReference: {fileID: 1020831183681200399, guid: 5186709fe798b0f41850799bfda96a6b,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[9].Item
+      value: 
+      objectReference: {fileID: 11639533463445157, guid: c5a9cf9eaa1364fa0a48ff032bc4c5d7,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[10].Item
+      value: 
+      objectReference: {fileID: 1860393792048079318, guid: 5a874a6991a07424e8b1b339fb51157e,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[11].Item
+      value: 
+      objectReference: {fileID: 6656006178777128666, guid: 809a686030c00e84f8fbf8ddb3b545ea,
+        type: 3}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[11].Stock
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
         type: 3}
-      propertyPath: InitialVendorContent.Array.data[13].ItemName
-      value: Bucket
-      objectReference: {fileID: 0}
-    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
-        type: 3}
-      propertyPath: InitialVendorContent.Array.data[12].Stock
+      propertyPath: InitialVendorContent.Array.data[10].Stock
       value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
         type: 3}
-      propertyPath: InitialVendorContent.Array.data[12].Item
-      value: 
-      objectReference: {fileID: 8724836040044288808, guid: ba46a81cbd3cd9c4faea0e047fbae79f,
+      propertyPath: InitialVendorContent.Array.data[9].Stock
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
         type: 3}
+      propertyPath: InitialVendorContent.Array.data[8].Stock
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[6].Stock
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[7].Stock
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[5].Stock
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[4].Stock
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[3].Stock
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[2].Stock
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[1].Stock
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[0].Stock
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[0].ItemName
+      value: Apple Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[1].ItemName
+      value: Banana Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[2].ItemName
+      value: Wheat Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[3].ItemName
+      value: Onion Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[4].ItemName
+      value: Tomato Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[5].ItemName
+      value: Lemon Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[6].ItemName
+      value: Sugar Cane Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[8].ItemName
+      value: Rice Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[9].ItemName
+      value: Cotton Seed Packet
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[10].ItemName
+      value: Tower Cap Mycelium
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[11].ItemName
+      value: EZ Nutriment Bottle
+      objectReference: {fileID: 0}
+    - target: {fileID: 4813939428139522015, guid: 2f2954acc32d9d3468c620e34a625966,
+        type: 3}
+      propertyPath: InitialVendorContent.Array.data[7].ItemName
+      value: Potato Seed Packet
+      objectReference: {fileID: 0}
     - target: {fileID: 7077253877563091611, guid: 2f2954acc32d9d3468c620e34a625966,
         type: 3}
       propertyPath: MachineParts

--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/WizardPopulator.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Populators/Occupations/WizardPopulator.asset
@@ -14,7 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Entries:
   - NamedSlot: 12
-    Prefab: {fileID: 835768756810601639, guid: 3d08b6dbf08774e8681378945dec4edf, type: 3}
+    Prefab: {fileID: 2720625993976664686, guid: 6c06d764ea0ea9e4f9dff0e83cbb46e6,
+      type: 3}
   - NamedSlot: 10
     Prefab: {fileID: 4188245363048309518, guid: da93b0f7c392d46ba85123e2516cfa49,
       type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/RandomItemPools/TrashOrGrille.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/RandomItemPools/TrashOrGrille.asset
@@ -21,7 +21,8 @@ MonoBehaviour:
       type: 3}
     maxAmount: 1
     probability: 100
-  - prefab: {fileID: 1722833055556988, guid: 3867b56bd9960f84a8f76cfd857c80b9, type: 3}
+  - prefab: {fileID: 4267452151052300856, guid: 959aef1c36706b7428a7e700a978e648,
+      type: 3}
     maxAmount: 1
     probability: 100
   - prefab: {fileID: 5558746297286370, guid: 7433fede76bc68c40851a73d529d8b3a, type: 3}

--- a/UnityProject/Assets/Scenes/AdditionalScenes/SyndicatePog.unity
+++ b/UnityProject/Assets/Scenes/AdditionalScenes/SyndicatePog.unity
@@ -22910,12 +22910,12 @@ PrefabInstance:
     - target: {fileID: 2551198247602037549, guid: ad5a934e24a15504e9f6ef0dbabfacea,
         type: 3}
       propertyPath: InitialVendorContent.Array.size
-      value: 7
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 2551198247602037549, guid: ad5a934e24a15504e9f6ef0dbabfacea,
         type: 3}
       propertyPath: VendorContent.Array.size
-      value: 4
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2551198247602037549, guid: ad5a934e24a15504e9f6ef0dbabfacea,
         type: 3}
@@ -22930,7 +22930,7 @@ PrefabInstance:
     - target: {fileID: 2551198247602037549, guid: ad5a934e24a15504e9f6ef0dbabfacea,
         type: 3}
       propertyPath: InitialVendorContent.Array.data[1].ItemName
-      value: L6SAW_Ballistic
+      value: Buzzsaw LMG
       objectReference: {fileID: 0}
     - target: {fileID: 2551198247602037549, guid: ad5a934e24a15504e9f6ef0dbabfacea,
         type: 3}
@@ -22940,7 +22940,7 @@ PrefabInstance:
     - target: {fileID: 2551198247602037549, guid: ad5a934e24a15504e9f6ef0dbabfacea,
         type: 3}
       propertyPath: InitialVendorContent.Array.data[2].ItemName
-      value: Magazine_a762
+      value: Magazine Box (7.12x82mm)
       objectReference: {fileID: 0}
     - target: {fileID: 2551198247602037549, guid: ad5a934e24a15504e9f6ef0dbabfacea,
         type: 3}
@@ -23006,13 +23006,13 @@ PrefabInstance:
         type: 3}
       propertyPath: InitialVendorContent.Array.data[0].Item
       value: 
-      objectReference: {fileID: 4224399380362315448, guid: 0469b3922aa40e04d9c576979353df72,
+      objectReference: {fileID: 8594439505056330043, guid: 838a4732b2dece64497d074b7a700be6,
         type: 3}
     - target: {fileID: 2551198247602037549, guid: ad5a934e24a15504e9f6ef0dbabfacea,
         type: 3}
       propertyPath: InitialVendorContent.Array.data[1].Item
       value: 
-      objectReference: {fileID: 2524481489369203327, guid: 24274bda3be42c049b4bbb150f6e1220,
+      objectReference: {fileID: 4168018088976029867, guid: f021fb89430b809c6aa885598328383b,
         type: 3}
     - target: {fileID: 2551198247602037549, guid: ad5a934e24a15504e9f6ef0dbabfacea,
         type: 3}

--- a/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Static_Placeholders/Library/library_1.asset
+++ b/UnityProject/Assets/Tilemaps/Resources/Tiles/Objects/Static_Placeholders/Library/library_1.asset
@@ -3,19 +3,54 @@
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1f6d9c91341f45b9b64b432bc7100ddc, type: 3}
   m_Name: library_1
   m_EditorClassIdentifier: 
+  displayName: 
   LayerType: 2
   TileType: 0
   RequiredTiles: []
-  Object: {fileID: 1468530452120236, guid: 2bb5f063746e04c5db932418b39030dc, type: 2}
-  Rotatable: 0
-  KeepOrientation: 0
-  Offset: 0
+  floorTileType: 0
+  atmosPassable: 0
+  isSealed: 0
+  SpawnWithNoAir: 0
+  passable: 0
+  mineable: 0
+  doesReflectBullet: 0
+  passableException:
+    m_keys: 
+    m_values: 
+  maxHealth: 0
+  damageDeflection: 0
+  armor:
+    Melee: 90
+    Bullet: 90
+    Laser: 90
+    Energy: 90
+    Bomb: 90
+    Rad: 100
+    Fire: 100
+    Acid: 90
+    Magic: 0
+    Bio: 100
+  tileInteractions: []
+  spawnOnDeconstruct: {fileID: 0}
+  spawnAmountOnDeconstruct: 1
+  lootOnDespawn: {fileID: 0}
+  soundOnHit: 
   IsItem: 0
+  KeepOrientation: 0
+  Object: {fileID: 6686380441727672918, guid: f8db3418b6542874396d1eaa52946e19, type: 3}
+  Offset: 0
+  Rotatable: 0
+  IsWire: 0
+  WireEndA: 0
+  WireEndB: 0
+  CableType: 0
+  wireSprite: {fileID: 0}


### PR DESCRIPTION
### Purpose
Sets cat prefab to use its own sprite object rather than finding the bvold cat one.
Fixes the seed vendor from using bvold objects.
Wizards will now spawn with a non bvold headset.
The trash random pool will now use a non bvold rat.
Dark jungle evil sheep will now spawn a non bvold meat.
Dark jungle cult spawner will now use a non bvold npc.
The library photocopier tile will now reference a non bvold one.
Changes the pogstation syndicate shuttle vendor to use non bvold objects.