### PR TITLE
allow inital filter values to be mapped

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Filter.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Filter.cs
@@ -11,15 +11,60 @@ namespace Pipes
 
 		private MixAndVolume IntermediateMixAndVolume = new MixAndVolume();
 
-		public int ToMaxPressure = 9999;
+		public Dictionary<string, Gas> CapableFiltering = new Dictionary<string, Gas>()
+		{
+			{"O2",Gas.Oxygen},
+			{"N2",Gas.Nitrogen},
+			{"PLS",Gas.Plasma},
+			{"CO2",Gas.CarbonDioxide},
+			{"N2O",Gas.NitrousOxide},
+			{"H2",Gas.Hydrogen},
+			{"H2O",Gas.WaterVapor},
+			{"BZ",Gas.BZ},
+			{"MIAS",Gas.Miasma},
+			{"NO2",Gas.Nitryl},
+			{"TRIT",Gas.Tritium},
+			{"HN",Gas.HyperNoblium},
+			{"STIM",Gas.Stimulum},
+			{"PLX",Gas.Pluoxium},
+			{"FRE",Gas.Freon},
+		};
+
+		//This is only used to set the inital filter values, nothing else
+		//the names contained within should always match the key of the above Dictionary
+		private enum FilterValues
+		{
+			O2,
+			N2,
+			PLS,
+			CO2,
+			N2O,
+			H2,
+			H2O,
+			BZ,
+			MIAS,
+			NO2,
+			TRIT,
+			HN,
+			STIM,
+			PLX,
+			FRE,
+		}
+
+		[SerializeField]
+		private FilterValues initalFilterValue;
+
+		public int MaxPressure = 9999;
 		private float TransferMoles = 500f;
 
 		public bool IsOn = false;
 
 		public Gas GasIndex = Gas.Oxygen;
 		public Chemistry.Reagent FilterReagent;
+
 		public override void Start()
 		{
+			GasIndex = CapableFiltering[initalFilterValue.ToString()];
 			pipeData.PipeAction = new MonoActions();
 			base.Start();
 
@@ -54,7 +99,6 @@ namespace Pipes
 		public override void TickUpdate()
 		{
 
-
 			pipeData.mixAndVolume.EqualiseWithOutputs(pipeData.Outputs);
 
 			if (IsOn == false)
@@ -79,8 +123,8 @@ namespace Pipes
 					var PressureDensity = Connection.Connected.GetMixAndVolume.Density();
 
 
-					var tomove = new Vector2(Mathf.Abs((PressureDensity.x / ToMaxPressure) - 1),
-						Mathf.Abs((PressureDensity.y / ToMaxPressure) - 1));
+					var tomove = new Vector2(Mathf.Abs((PressureDensity.x / MaxPressure) - 1),
+						Mathf.Abs((PressureDensity.y / MaxPressure) - 1));
 
 					Vector2 AvailableReagents = new Vector2(0f, 0f);
 					AvailableReagents+= pipeData.mixAndVolume.Total;
@@ -104,11 +148,11 @@ namespace Pipes
 							}
 							var FilteredPressureDensity = GetConnection.Connected.GetMixAndVolume.Density();
 
-							if (FilteredPressureDensity.x > ToMaxPressure ||  FilteredPressureDensity.y > ToMaxPressure)
+							if (FilteredPressureDensity.x > MaxPressure ||  FilteredPressureDensity.y > MaxPressure)
 							{
 								IntermediateMixAndVolume.TransferSpecifiedTo(pipeData.mixAndVolume,
 									GasIndex, FilterReagent);
-								if (PressureDensity.x > ToMaxPressure && PressureDensity.y > ToMaxPressure)
+								if (PressureDensity.x > MaxPressure && PressureDensity.y > MaxPressure)
 								{
 									IntermediateMixAndVolume.TransferTo(pipeData.mixAndVolume, IntermediateMixAndVolume.Total);
 								}
@@ -120,7 +164,7 @@ namespace Pipes
 								return;
 							}
 
-							if (PressureDensity.x > ToMaxPressure && PressureDensity.y > ToMaxPressure)
+							if (PressureDensity.x > MaxPressure && PressureDensity.y > MaxPressure)
 							{
 								IntermediateMixAndVolume.TransferSpecifiedTo(GetConnection.Connected.GetMixAndVolume,
 									GasIndex, FilterReagent);
@@ -148,4 +192,3 @@ namespace Pipes
 		}
 	}
 }
-

--- a/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/GUI_PipeDispenser.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/GUI_PipeDispenser.cs
@@ -35,6 +35,7 @@ namespace UI.Objects.Atmospherics
 
 		private void Awake()
 		{
+			pipeColor = colors[0];
 			// This assumes that each category page has only the toggles for children
 			// and that the dispensePages are sequential with accordance to category.
 			previousCategoryPages = new int[]

--- a/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/Pipes/GUI_Filter.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/Pipes/GUI_Filter.cs
@@ -20,7 +20,7 @@ namespace UI.Objects.Atmospherics
 		{
 			foreach (var INFilter in Filter.CapableFiltering)
 			{
-				if (INFilter.Key == gasName.ToString()) //Checks what button has been pressed  And sets the correct position appropriate
+				if (INFilter.Key == gasName) //Checks what button has been pressed  And sets the correct position appropriate
 				{
 					((NetUIElement<string>)this[INFilter.Key]).SetValueServer("1");
 				}

--- a/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/Pipes/GUI_Filter.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/Pipes/GUI_Filter.cs
@@ -8,7 +8,6 @@ namespace UI.Objects.Atmospherics
 {
 	public class GUI_Filter : NetTab
 	{
-		public string CurrentlyFiltering = "O2";
 		public Pipes.Filter Filter;
 
 		public NetWheel NetWheel;
@@ -17,32 +16,9 @@ namespace UI.Objects.Atmospherics
 
 		public NetToggle PToggle;
 
-
-		private Dictionary<string, Gas> CapableFiltering = new Dictionary<string, Gas>()
-	{
-		{"O2",Gas.Oxygen},
-		{"N2",Gas.Nitrogen},
-		{"PLS",Gas.Plasma},
-		{"CO2",Gas.CarbonDioxide},
-		{"N2O",Gas.NitrousOxide},
-		{"H2",Gas.Hydrogen},
-		{"H2O",Gas.WaterVapor},
-		{"BZ",Gas.BZ},
-		{"MIAS",Gas.Miasma},
-		{"NO2",Gas.Nitryl},
-		{"TRIT",Gas.Tritium},
-		{"HN",Gas.HyperNoblium},
-		{"STIM",Gas.Stimulum},
-		{"PLX",Gas.Pluoxium},
-		{"FRE",Gas.Freon},
-	};
-
-
 		public void SetFilterAmount(string Number)
 		{
-			CurrentlyFiltering = Number;
-
-			foreach (var INFilter in CapableFiltering)
+			foreach (var INFilter in Filter.CapableFiltering)
 			{
 				if (INFilter.Key == Number.ToString()) //Checks what button has been pressed  And sets the correct position appropriate
 				{
@@ -54,7 +30,7 @@ namespace UI.Objects.Atmospherics
 				}
 			}
 
-			Filter.GasIndex = CapableFiltering[Number];
+			Filter.GasIndex = Filter.CapableFiltering[Number];
 		}
 
 		void Start()
@@ -63,13 +39,23 @@ namespace UI.Objects.Atmospherics
 			{
 				Filter = Provider.GetComponentInChildren<Pipes.Filter>();
 			}
-			numberSpinner.ServerSpinTo(Filter.ToMaxPressure);
-			numberSpinner.DisplaySpinTo(Filter.ToMaxPressure);
-			NetWheel.SetValueServer(Filter.ToMaxPressure.ToString());
+			numberSpinner.ServerSpinTo(Filter.MaxPressure);
+			numberSpinner.DisplaySpinTo(Filter.MaxPressure);
+			NetWheel.SetValueServer(Filter.MaxPressure.ToString());
 			numberSpinner.OnValueChange.AddListener(SetMaxPressure);
 			PToggle.SetValueServer(BOOLTOstring(Filter.IsOn));
-			((NetUIElement<string>)this["O2"]).SetValueServer("1");
+			SetFilteredGasValue(Filter.GasIndex);
+		}
 
+		public void SetFilteredGasValue(Gas GasIndex)
+		{
+			foreach (var INFilter in Filter.CapableFiltering)
+			{
+				if (INFilter.Value == GasIndex) //Checks what button has been pressed  And sets the correct position appropriate
+				{
+					((NetUIElement<string>)this[INFilter.Key]).SetValueServer("1");
+				}
+			}
 		}
 
 		public string BOOLTOstring(bool Bool)
@@ -90,9 +76,9 @@ namespace UI.Objects.Atmospherics
 		}
 
 
-		public void SetMaxPressure(int To)
+		public void SetMaxPressure(int Value)
 		{
-			Filter.ToMaxPressure = To;
+			Filter.MaxPressure = Value;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/Pipes/GUI_Filter.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Atmospherics/Pipes/GUI_Filter.cs
@@ -16,11 +16,11 @@ namespace UI.Objects.Atmospherics
 
 		public NetToggle PToggle;
 
-		public void SetFilterAmount(string Number)
+		public void SetFilterAmount(string gasName)
 		{
 			foreach (var INFilter in Filter.CapableFiltering)
 			{
-				if (INFilter.Key == Number.ToString()) //Checks what button has been pressed  And sets the correct position appropriate
+				if (INFilter.Key == gasName.ToString()) //Checks what button has been pressed  And sets the correct position appropriate
 				{
 					((NetUIElement<string>)this[INFilter.Key]).SetValueServer("1");
 				}
@@ -30,7 +30,7 @@ namespace UI.Objects.Atmospherics
 				}
 			}
 
-			Filter.GasIndex = Filter.CapableFiltering[Number];
+			Filter.GasIndex = Filter.CapableFiltering[gasName];
 		}
 
 		void Start()
@@ -43,7 +43,7 @@ namespace UI.Objects.Atmospherics
 			numberSpinner.DisplaySpinTo(Filter.MaxPressure);
 			NetWheel.SetValueServer(Filter.MaxPressure.ToString());
 			numberSpinner.OnValueChange.AddListener(SetMaxPressure);
-			PToggle.SetValueServer(BOOLTOstring(Filter.IsOn));
+			PToggle.SetValueServer(BoolToString(Filter.IsOn));
 			SetFilteredGasValue(Filter.GasIndex);
 		}
 
@@ -58,7 +58,7 @@ namespace UI.Objects.Atmospherics
 			}
 		}
 
-		public string BOOLTOstring(bool Bool)
+		public string BoolToString(bool Bool)
 		{
 			if (Bool)
 			{
@@ -76,9 +76,9 @@ namespace UI.Objects.Atmospherics
 		}
 
 
-		public void SetMaxPressure(int Value)
+		public void SetMaxPressure(int value)
 		{
-			Filter.MaxPressure = Value;
+			Filter.MaxPressure = value;
 		}
 	}
 }


### PR DESCRIPTION
maybe
- implements a var to change what the filter is set to initally
- change the gui so it will reflect this properly, instead of always showing o2 as being fiiltered intially
- remove currently filtering as it was unused
- renamed ToMaxPressure to MaxPressure to better reflect its usage
notes: id rename the setFilterAmount(Number) to something else as its somewhat inaccurate considering it has a string passed to it, not a number, but its used in the tab prefab and i cant be bothered to update that ¯\\\_(ツ)\_\/¯