### PR TITLE
Fix the NaN temperature in gas mixing.

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -244,7 +244,7 @@ namespace Systems.Atmospherics
 		{
 			float totalInternalEnergy = InternalEnergy + otherGas.InternalEnergy;
 			float totalWholeHeatCapacity = WholeHeatCapacity + otherGas.WholeHeatCapacity;
-			float newTemperature = totalWholeHeatCapacity == 0 ? 0 : totalInternalEnergy / totalWholeHeatCapacity;
+			float newTemperature = totalWholeHeatCapacity > 0 ? totalInternalEnergy / totalWholeHeatCapacity : 0;
 			float totalVolume = Volume + otherGas.Volume;
 			for (int i = 0; i < Gas.Count; i++)
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -244,7 +244,7 @@ namespace Systems.Atmospherics
 		{
 			float totalInternalEnergy = InternalEnergy + otherGas.InternalEnergy;
 			float totalWholeHeatCapacity = WholeHeatCapacity + otherGas.WholeHeatCapacity;
-			float Newtemperature = totalInternalEnergy / totalWholeHeatCapacity;
+			float newTemperature = totalWholeHeatCapacity == 0 ? 0 : totalInternalEnergy / totalWholeHeatCapacity;
 			float totalVolume = Volume + otherGas.Volume;
 			for (int i = 0; i < Gas.Count; i++)
 			{
@@ -258,8 +258,8 @@ namespace Systems.Atmospherics
 				otherGas.Gases[i] = gas * otherGas.Volume;
 			}
 
-			SetTemperature(Newtemperature);
-			otherGas.SetTemperature(Newtemperature);
+			SetTemperature(newTemperature);
+			otherGas.SetTemperature(newTemperature);
 			return otherGas;
 		}
 


### PR DESCRIPTION
Fixes #5630

When there were gasses with a total heat capacity of 0, the temperature was determined through a division by 0 causing a NaN temperature to be set to the resulting mix.