### PR TITLE
Add suppressor to uplink.

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjects/PDA/UplinkCategoryList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/PDA/UplinkCategoryList.asset
@@ -56,6 +56,10 @@ MonoBehaviour:
       item: {fileID: 4335905146119127793, guid: ba0d71e0e5bfbac4e974fefc4ad1e300,
         type: 3}
       name: Miniature Energy Crossbow
+    - cost: 3
+      item: {fileID: 5065923221907874056, guid: 557cc8a1b0b8fd7409c7b846fb7f5c12,
+        type: 3}
+      name: Suppressor
     - cost: 1
       item: {fileID: 2883601815232707539, guid: 234e5bf5fd2610146adf689bbb987ddd,
         type: 3}


### PR DESCRIPTION
### Purpose
- Title. Adds the suppressor to the uplink. It can be found under the "Stealthy Weapons" section and costs 3 TC. Companion piece to #5666.

### Changelog
CL: Added suppressor to traitor uplink, found under Stealthy Weapons.
