### PR TITLE
Made some floor tile items no longer have infinite uses.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/BasaltTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/BasaltTile.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f,
         type: 2}
+    - target: {fileID: 3004788566835106784, guid: a435d5d64bc4b48baa27fecfcab9e111,
+        type: 3}
+      propertyPath: waysToPlace.Array.data[0].itemCost
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5209370598559660201, guid: a435d5d64bc4b48baa27fecfcab9e111,
         type: 3}
       propertyPath: initialName

--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/FairyGrassTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/FairyGrassTile.prefab
@@ -13,16 +13,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 60d003740ca847241ba7371b4c983219,
         type: 2}
-    - target: {fileID: 3004788566835106784, guid: a435d5d64bc4b48baa27fecfcab9e111,
-        type: 3}
-      propertyPath: waysToPlace.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3004788566835106784, guid: a435d5d64bc4b48baa27fecfcab9e111,
-        type: 3}
-      propertyPath: waysToPlace.Array.data[0].placeableOn
-      value: 4
-      objectReference: {fileID: 0}
     - target: {fileID: 5209370598559660201, guid: a435d5d64bc4b48baa27fecfcab9e111,
         type: 3}
       propertyPath: initialName
@@ -42,7 +32,7 @@ PrefabInstance:
     - target: {fileID: 5667494539314517963, guid: a435d5d64bc4b48baa27fecfcab9e111,
         type: 3}
       propertyPath: m_Name
-      value: TileFairygrass
+      value: FairyGrassTile
       objectReference: {fileID: 0}
     - target: {fileID: 5671578262437538495, guid: a435d5d64bc4b48baa27fecfcab9e111,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/AlienFloorTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/AlienFloorTile.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f,
         type: 2}
+    - target: {fileID: 4198906432554661683, guid: b122d05362087574ca3b106604026dd9,
+        type: 3}
+      propertyPath: waysToPlace.Array.data[0].itemCost
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6610653795340409978, guid: b122d05362087574ca3b106604026dd9,
         type: 3}
       propertyPath: initialDescription

--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/BananiumTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/BananiumTile.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f,
         type: 2}
+    - target: {fileID: 4198906432554661683, guid: b122d05362087574ca3b106604026dd9,
+        type: 3}
+      propertyPath: waysToPlace.Array.data[0].itemCost
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6610653795340409978, guid: b122d05362087574ca3b106604026dd9,
         type: 3}
       propertyPath: itemSprites.SpriteLeftHand

--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/DIamondTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/DIamondTile.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f,
         type: 2}
+    - target: {fileID: 4198906432554661683, guid: b122d05362087574ca3b106604026dd9,
+        type: 3}
+      propertyPath: waysToPlace.Array.data[0].itemCost
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6610653795340409978, guid: b122d05362087574ca3b106604026dd9,
         type: 3}
       propertyPath: initialDescription
@@ -120,7 +125,7 @@ PrefabInstance:
     - target: {fileID: 6723971198869811992, guid: b122d05362087574ca3b106604026dd9,
         type: 3}
       propertyPath: m_Name
-      value: DiamondTile
+      value: DIamondTile
       objectReference: {fileID: 0}
     - target: {fileID: 6890979888983081028, guid: b122d05362087574ca3b106604026dd9,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/GoldTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/GoldTile.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f,
         type: 2}
+    - target: {fileID: 4198906432554661683, guid: b122d05362087574ca3b106604026dd9,
+        type: 3}
+      propertyPath: waysToPlace.Array.data[0].itemCost
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6610653795340409978, guid: b122d05362087574ca3b106604026dd9,
         type: 3}
       propertyPath: itemSprites.SpriteLeftHand

--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/PlasmaTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/PlasmaTile.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f,
         type: 2}
+    - target: {fileID: 4198906432554661683, guid: b122d05362087574ca3b106604026dd9,
+        type: 3}
+      propertyPath: waysToPlace.Array.data[0].itemCost
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6610653795340409978, guid: b122d05362087574ca3b106604026dd9,
         type: 3}
       propertyPath: initialDescription

--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/PlastitaniumTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/PlastitaniumTile.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f,
         type: 2}
+    - target: {fileID: 4198906432554661683, guid: b122d05362087574ca3b106604026dd9,
+        type: 3}
+      propertyPath: waysToPlace.Array.data[0].itemCost
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6610653795340409978, guid: b122d05362087574ca3b106604026dd9,
         type: 3}
       propertyPath: initialDescription

--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/SilverTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/SilverTile.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f,
         type: 2}
+    - target: {fileID: 4198906432554661683, guid: b122d05362087574ca3b106604026dd9,
+        type: 3}
+      propertyPath: waysToPlace.Array.data[0].itemCost
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6610653795340409978, guid: b122d05362087574ca3b106604026dd9,
         type: 3}
       propertyPath: itemSprites.SpriteLeftHand

--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/TitaniumTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/TitaniumTile.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f,
         type: 2}
+    - target: {fileID: 4198906432554661683, guid: b122d05362087574ca3b106604026dd9,
+        type: 3}
+      propertyPath: waysToPlace.Array.data[0].itemCost
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6610653795340409978, guid: b122d05362087574ca3b106604026dd9,
         type: 3}
       propertyPath: itemSprites.SpriteLeftHand

--- a/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/UraniumTile.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Construction/PlaceableTiles/MineralTiles/UraniumTile.prefab
@@ -35,6 +35,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 83855008e43a2674d8d6a006ce94326f,
         type: 2}
+    - target: {fileID: 4198906432554661683, guid: b122d05362087574ca3b106604026dd9,
+        type: 3}
+      propertyPath: waysToPlace.Array.data[0].itemCost
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6610653795340409978, guid: b122d05362087574ca3b106604026dd9,
         type: 3}
       propertyPath: itemSprites.SpriteLeftHand


### PR DESCRIPTION
### Purpose
- Title. Several floor tile items didn't get properly consumed when you placed them down. They will now.

### Changelog:
CL: Fixed bug where some floor tile items didn't get used up when you placed them down.
