### PR TITLE
Adds basic item and object wrapping

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -7,6 +7,7 @@ using Systems.Atmospherics;
 using Systems.Cargo;
 using Random = UnityEngine.Random;
 using DatabaseAPI;
+using Items;
 using ScriptableObjects;
 
 namespace IngameDebugConsole

--- a/UnityProject/Assets/Resources/Prefabs/Items/Cargo/WrappingPaper.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Cargo/WrappingPaper.prefab
@@ -1,0 +1,132 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-5852743292816086088
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7086413832420484247}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dcdb9f210c1446c8adeadb48d8d426b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  wrapType: 0
+--- !u!1001 &8830091880288565700
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: maxAmount
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: -6495101291114284292, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: initialAmount
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1787564279694303271, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1791647728409730387, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_Name
+      value: WrappingPaper
+      objectReference: {fileID: 0}
+    - target: {fileID: 1821991397738242279, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1886097303314001423, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 57436a8d4fcaebb4bb4ccea9d32dc532,
+        type: 3}
+    - target: {fileID: 1886097303314001423, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: initialName
+      value: Brown delivery wrapping paper
+      objectReference: {fileID: 0}
+    - target: {fileID: 2175428465337217585, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: initialDescription
+      value: A roll of brown paper used for packages.
+      objectReference: {fileID: 0}
+    - target: {fileID: 5592108624515032788, guid: c3138c3e8a46444199668b85070b1a39,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 11843ac3c75b109478c1e7769e42044a,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c3138c3e8a46444199668b85070b1a39, type: 3}
+--- !u!1 &7086413832420484247 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1791647728409730387, guid: c3138c3e8a46444199668b85070b1a39,
+    type: 3}
+  m_PrefabInstance: {fileID: 8830091880288565700}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Cargo/WrappingPaper.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Cargo/WrappingPaper.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 24acfe3e8c412064ab3e3aeab2759c1d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Cargo/WrappingPaperFestive.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Cargo/WrappingPaperFestive.prefab
@@ -1,0 +1,127 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6130692990045491198
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -5852743292816086088, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: itemParcel
+      value: 
+      objectReference: {fileID: 7230278577656183976, guid: b8b3979fac13b304c948ef72851ced85,
+        type: 3}
+    - target: {fileID: -5852743292816086088, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: objectParcel
+      value: 
+      objectReference: {fileID: 989532514442120172, guid: bba003073444ea344a3c1f58fba1edc5,
+        type: 3}
+    - target: {fileID: -5852743292816086088, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: wrapType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968200009823084304, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: ace964660365bf44d83711029187906f,
+        type: 2}
+    - target: {fileID: 6964265182918039499, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 69f1a120044b7ff4d85a4153169a6d87,
+        type: 3}
+    - target: {fileID: 7080923008892803555, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7080923008892803555, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7080923008892803555, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7080923008892803555, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7080923008892803555, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7080923008892803555, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7080923008892803555, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7080923008892803555, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7080923008892803555, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7080923008892803555, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7080923008892803555, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7086413832420484247, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_Name
+      value: WrappingPaperFestive
+      objectReference: {fileID: 0}
+    - target: {fileID: 7188811865976756515, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7258225220171566069, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 8cd39f8372d68e6438bf6b9b5359c26e,
+        type: 2}
+    - target: {fileID: 7258225220171566069, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: c6d52302231a8f7468cbf5f50b5a78dd,
+        type: 2}
+    - target: {fileID: 7258225220171566069, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: initialName
+      value: Festive wrapping paper
+      objectReference: {fileID: 0}
+    - target: {fileID: 7258225220171566069, guid: 24acfe3e8c412064ab3e3aeab2759c1d,
+        type: 3}
+      propertyPath: initialDescription
+      value: A roll of festive paper used for gifts!
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 24acfe3e8c412064ab3e3aeab2759c1d, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Cargo/WrappingPaperFestive.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Cargo/WrappingPaperFestive.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a610125a744ac1a4d9544f850a92f565
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Cargo/_ItemParcel.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Cargo/_ItemParcel.prefab
@@ -1,0 +1,183 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &923101175484867471
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1724179870811488903}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8724f2eb82049548ce89dde3d83dfa3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  randomContentList: []
+  unwrapSound: PosterRipped
+  originatorUnwrapText: You start unwrapping the {0}.
+  othersUnwrapText: '{0} starts unwrapping the {1}.'
+  packageType: 0
+--- !u!114 &6584571419482073629
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1724179870811488903}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89bf7311f10246d58a3a3606d45d78f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  initialNoteText: 
+  paperPrefab: {fileID: 8734328976324889014, guid: d3c71176f32c1274b929f3a88695a795,
+    type: 3}
+--- !u!1001 &1724337224369700413
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_Name
+      value: _ItemParcel
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 0c43d5e2441e6ea47ab90dc399971d60,
+        type: 3}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialName
+      value: Parcel
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialDescription
+      value: A brown paper delivery parcel.
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 9098ce4ef21de364d869fd299a05a546,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 2469f060531623641b96d9ce5c2031b4,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 14647ff23378a68459d08c08082cd366,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 704506fec3116e1428d5babe754d579d,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 3ef564ecf24d03a4eb01aa90ba7af5f6,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[3]
+      value: 
+      objectReference: {fileID: 11400000, guid: b78184431c4c8ae49b9893dafab429a9,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[4]
+      value: 
+      objectReference: {fileID: 11400000, guid: 820be22ff14a6a540927b6c2778e9874,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[5]
+      value: 
+      objectReference: {fileID: 11400000, guid: 3b9a5acf110cb7548a5bb35736fbef5f,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[6]
+      value: 
+      objectReference: {fileID: 11400000, guid: b78184431c4c8ae49b9893dafab429a9,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 14647ff23378a68459d08c08082cd366,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+--- !u!1 &1724179870811488903 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298,
+    type: 3}
+  m_PrefabInstance: {fileID: 1724337224369700413}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Cargo/_ItemParcel.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Cargo/_ItemParcel.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2b7b7624210ee9a4db29860a7e0d9105
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Cargo/_ItemParcelGift.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Cargo/_ItemParcelGift.prefab
@@ -1,0 +1,146 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8339145310064950831
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1225012913330515429, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: initialName
+      value: Gift
+      objectReference: {fileID: 0}
+    - target: {fileID: 1225012913330515429, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: initialDescription
+      value: PRESENTS!! eek!
+      objectReference: {fileID: 0}
+    - target: {fileID: 1225012913330515429, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: b1f2bf72cd721d341a38d2992caac8b0,
+        type: 2}
+    - target: {fileID: 1225012913330515429, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: bd2a26cef9119c44085c2f63d386a410,
+        type: 2}
+    - target: {fileID: 1521216023061869019, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: cd986716463bce042ac3b34fd53565ac,
+        type: 3}
+    - target: {fileID: 1619521172631142195, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1724179870811488903, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_Name
+      value: _ItemParcelGift
+      objectReference: {fileID: 0}
+    - target: {fileID: 1728826269211918323, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1728826269211918323, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1728826269211918323, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1728826269211918323, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1728826269211918323, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1728826269211918323, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1728826269211918323, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1728826269211918323, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1728826269211918323, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1728826269211918323, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1728826269211918323, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4804104138436360448, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: 9a4a32689f208374ab5ac958167d6213,
+        type: 2}
+    - target: {fileID: 4804104138436360448, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 9a4a32689f208374ab5ac958167d6213,
+        type: 2}
+    - target: {fileID: 4804104138436360448, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 2dc2c3df6a6dbc54ca599c510196ac68,
+        type: 2}
+    - target: {fileID: 4804104138436360448, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 115ca22571744d94bb7a09ca3aa4aefb,
+        type: 2}
+    - target: {fileID: 4804104138436360448, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[3]
+      value: 
+      objectReference: {fileID: 11400000, guid: 890ce3d9c1aa1154aa9474ac671d3e82,
+        type: 2}
+    - target: {fileID: 4804104138436360448, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[4]
+      value: 
+      objectReference: {fileID: 11400000, guid: 2044004f8492242439d69bb0d6e99d9f,
+        type: 2}
+    - target: {fileID: 4804104138436360448, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[5]
+      value: 
+      objectReference: {fileID: 11400000, guid: 91200d0b87221ff4c9735dcadf69d878,
+        type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2b7b7624210ee9a4db29860a7e0d9105, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Cargo/_ItemParcelGift.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Cargo/_ItemParcelGift.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b8b3979fac13b304c948ef72851ced85
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Item.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Item.prefab
@@ -20,6 +20,7 @@ GameObject:
   - component: {fileID: 114738972662350094}
   - component: {fileID: 1397050043076861577}
   - component: {fileID: -6201661749900855812}
+  - component: {fileID: 1373280397285383934}
   m_Layer: 10
   m_Name: Item
   m_TagString: Abstract
@@ -266,6 +267,29 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1373280397285383934
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1011433845357754}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af4d0e94e1b24623931ca59abaf6e1e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  actionTextOriginator: You start wrapping {0} with {1}.
+  actionTextOthers: '{0} starts wrapping {1} with {2}.'
+  normalPackagePrefab: {fileID: 1724179870811488903, guid: 2b7b7624210ee9a4db29860a7e0d9105,
+    type: 3}
+  festivePackagePrefab: {fileID: 7230278577656183976, guid: b8b3979fac13b304c948ef72851ced85,
+    type: 3}
+  wrapTime: 5
+  overrideAmountOfPaper: 0
+  customAmountOfPaper: 5
+  shapedPackage: 0
+  packageType: 0
 --- !u!1 &1344926539164060
 GameObject:
   m_ObjectHideFlags: 0
@@ -336,9 +360,9 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 11
+  m_SortingLayer: 13
   m_SortingOrder: 40
-  m_Sprite: {fileID: 21300000, guid: 66305a19e3614694f868c75a982e6b68, type: 3}
+  m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -346,7 +370,7 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!114 &6144467708197095229

--- a/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/ClosetBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/ClosetBase.prefab
@@ -49,7 +49,27 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  ReachableThrough: 1
+  passableExclusionsToThis: []
   closetType: 0
+--- !u!114 &-3721001473523075953
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 933576176691117832}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 383c1cad778d4da5bae4c4424e7b4e56, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  actionTextOriginator: You start wrapping {0} with {1}.
+  actionTextOthers: '{0} starts wrapping {1} with {2}.'
+  normalPackagePrefab: {fileID: 1641656296300560335, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+    type: 3}
+  festivePackagePrefab: {fileID: 989532514442120172, guid: bba003073444ea344a3c1f58fba1edc5,
+    type: 3}
 --- !u!114 &6872015153723498109
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -161,7 +181,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -932335445
-  m_SortingLayer: 18
+  m_SortingLayer: 22
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 69840ffd73e1ff04d9a13ad3beb8a641, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -243,7 +263,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -391668011
-  m_SortingLayer: 9
+  m_SortingLayer: 10
   m_SortingOrder: 11
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -357,7 +377,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -391668011
-  m_SortingLayer: 9
+  m_SortingLayer: 10
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 8ee5ee76aed095b45afc5f7f4f4b8a84, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -589,7 +609,7 @@ PrefabInstance:
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}
       propertyPath: m_SortingLayer
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8599771746108915149, guid: a7af28adb717b4c44b8b2002b27670bd,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/WrappedContainers.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/WrappedContainers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 85d8ac12171914e45b21d30d919117ef
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/WrappedContainers/_ObjectParcel.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/WrappedContainers/_ObjectParcel.prefab
@@ -1,0 +1,169 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-8227276952503592203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1641656296300560335}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89bf7311f10246d58a3a3606d45d78f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  initialNoteText: 
+  paperPrefab: {fileID: 8734328976324889014, guid: d3c71176f32c1274b929f3a88695a795,
+    type: 3}
+--- !u!114 &-4013052806318784159
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1641656296300560335}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f4ef768d0744d109305b5747e69ccd5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  randomContentList: []
+  unwrapSound: PosterRipped
+  originatorUnwrapText: You start unwrapping the {0}.
+  othersUnwrapText: '{0} starts unwrapping the {1}.'
+  timeToUnwrap: 2
+  typeSprite: 0
+--- !u!1001 &2075134345763629647
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 9dc9dd2fa4de75a48833926667cf56c3,
+        type: 3}
+    - target: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Name
+      value: _ObjectParcel
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3558259718671294003, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3558259718671294003, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3558259718671294003, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 2c505b10b5052a942bab95240cdbb7ca,
+        type: 2}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: fe7cf233f7af1c9449d4dbbd43268922,
+        type: 2}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: fe7cf233f7af1c9449d4dbbd43268922,
+        type: 2}
+    - target: {fileID: 7971921043980192432, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: initialName
+      value: Large parcel
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971921043980192432, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: initialDescription
+      value: A large delivery parcel.
+      objectReference: {fileID: 0}
+    - target: {fileID: 9212640593017544930, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b06b702714bab49b9ad949eab1ca4534, type: 3}
+--- !u!1 &1641656296300560335 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
+    type: 3}
+  m_PrefabInstance: {fileID: 2075134345763629647}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/WrappedContainers/_ObjectParcel.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/WrappedContainers/_ObjectParcel.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 32f0cc57303af3246a9a9a38acc8f3b5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/WrappedContainers/_ObjectParcelGift.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/WrappedContainers/_ObjectParcelGift.prefab
@@ -1,0 +1,110 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1978156797369955363
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1560613118720023512, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: cf7857ab58965ff49abf568c5f2cd8d3,
+        type: 3}
+    - target: {fileID: 1641656296300560335, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_Name
+      value: _ObjectParcelGift
+      objectReference: {fileID: 0}
+    - target: {fileID: 1647719872105216277, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1647719872105216277, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1647719872105216277, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1647719872105216277, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1647719872105216277, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1647719872105216277, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1647719872105216277, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1647719872105216277, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1647719872105216277, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1647719872105216277, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1647719872105216277, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6095803978648687893, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: d65d508ba34ca7e418a4bf74777805dc,
+        type: 2}
+    - target: {fileID: 6095803978648687893, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: a5a51892d4965954cab353c585f77b25,
+        type: 2}
+    - target: {fileID: 6095803978648687893, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: a5a51892d4965954cab353c585f77b25,
+        type: 2}
+    - target: {fileID: 7139758462616177325, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245431497286394111, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: initialName
+      value: Large gift
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245431497286394111, guid: 32f0cc57303af3246a9a9a38acc8f3b5,
+        type: 3}
+      propertyPath: initialDescription
+      value: PRESENTS! A HUGE ONE! eek!
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 32f0cc57303af3246a9a9a38acc8f3b5, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/WrappedContainers/_ObjectParcelGift.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/ClosetsAndCrates/WrappedContainers/_ObjectParcelGift.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bba003073444ea344a3c1f58fba1edc5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/ChemistryComponents/MorphableReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/MorphableReagentContainer.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Items;
 using UnityEngine;
 using Mirror;
 

--- a/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
+++ b/UnityProject/Assets/Scripts/ChemistryComponents/ReagentContainer.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Items;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Serialization;

--- a/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
+++ b/UnityProject/Assets/Scripts/Clothing/BackPack/InteractableStorage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 using Mirror;
 

--- a/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
+++ b/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 using Mirror;
 

--- a/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
+++ b/UnityProject/Assets/Scripts/Clothing/FacehuggerImpregnation.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Threading.Tasks;
+using Items;
 using Mirror;
 using UnityEngine;
 

--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
@@ -6,6 +6,7 @@ using DiscordWebhook;
 using DatabaseAPI;
 using Systems.MobAIs;
 using System.Text;
+using Items;
 
 /// <summary>
 /// The Chat API

--- a/UnityProject/Assets/Scripts/Core/Editor/GenerateSpriteSO.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/GenerateSpriteSO.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using System.Linq;
 using System.Reflection;
 using Systems.Botany;
+using Items;
 using Items.Botany;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/UnityProject/Assets/Scripts/Core/Input System/HandActivateSpawnItem.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/HandActivateSpawnItem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 
 public class HandActivateSpawnItem : MonoBehaviour, IInteractable<HandActivate>

--- a/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Validations.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/InteractionV2/Validations.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Items;
 using TileManagement;
 using UnityEngine;
 

--- a/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
+++ b/UnityProject/Assets/Scripts/Core/Transform/CustomNetTransform.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Diagnostics;
 using Initialisation;
+using Items;
 using UnityEngine;
 using UnityEngine.Events;
 using Mirror;

--- a/UnityProject/Assets/Scripts/Health/Electrocution.cs
+++ b/UnityProject/Assets/Scripts/Health/Electrocution.cs
@@ -1,3 +1,4 @@
+using Items;
 using UnityEngine;
 
 /// <summary>

--- a/UnityProject/Assets/Scripts/Health/RespiratoryHealth/RespiratorySystem.cs
+++ b/UnityProject/Assets/Scripts/Health/RespiratoryHealth/RespiratorySystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 using Systems.Atmospherics;
+using Items;
 using Objects.Atmospherics;
 
 /// <inheritdoc />

--- a/UnityProject/Assets/Scripts/Items/Attributes.cs
+++ b/UnityProject/Assets/Scripts/Items/Attributes.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using Mirror;
@@ -62,6 +59,12 @@ public class Attributes : NetworkBehaviour, IRightClickable, IExaminable
 	[SerializeField]
 	private string exportMessage = null;
 	public string ExportMessage => exportMessage;
+
+	[Server]
+	public void SetExportCost(int value)
+	{
+		exportCost = value;
+	}
 
 	[SyncVar(hook = nameof(SyncArticleDescription))]
 	private string articleDescription;

--- a/UnityProject/Assets/Scripts/Items/Botany/Hatchet.cs
+++ b/UnityProject/Assets/Scripts/Items/Botany/Hatchet.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 
 /// <summary>

--- a/UnityProject/Assets/Scripts/Items/Cargo/NoteAttachable.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/NoteAttachable.cs
@@ -1,0 +1,153 @@
+﻿using Mirror;
+using UnityEngine;
+using WebSocketSharp;
+
+namespace Items.Cargo
+{
+	public class NoteAttachable: NetworkBehaviour,
+		ICheckedInteractable<HandApply>,
+		ICheckedInteractable<InventoryApply>,
+		ICheckedInteractable<ContextMenuApply>,
+		IRightClickable,
+		IExaminable,
+		IServerSpawn
+	{
+		[SerializeField][Tooltip("Set this if you want this object to spawn with a note attached to it")]
+		private string initialNoteText;
+
+		[SyncVar(hook=nameof(SyncNoteText))]
+		private string noteText;
+
+		[SerializeField][Tooltip("Reference to the paper game object, needed for spawning notes when detaching")]
+		private GameObject paperPrefab;
+
+		/// <summary>
+		/// Attaches a note to the package. This will modify its examine message.
+		/// This method should only be called from server.
+		/// </summary>
+		/// <param name="performer"></param>
+		/// <param name="text"></param>
+		private void AttachNote(GameObject performer, string text)
+		{
+			if (noteText.IsNullOrEmpty() == false && performer != null)
+			{
+				Chat.AddExamineMsg(performer, $"{gameObject.ExpensiveName()} already has a note attached to it!");
+				return;
+			}
+
+			ServerSetNoteText(text);
+		}
+
+		private void DetachNote(GameObject performer)
+		{
+			var note = Spawn.ServerPrefab(paperPrefab, gameObject.AssumedWorldPosServer()).GameObject;
+			note.GetComponent<Paper>().SetServerString(noteText);
+			ServerSetNoteText(string.Empty);
+
+			Chat.AddActionMsgToChat(performer,
+				$"You detach the note from {gameObject.ExpensiveName()}",
+				$"{performer.ExpensiveName()} detaches the note from {gameObject.ExpensiveName()}");
+		}
+
+		private bool CommonWillInteract(TargetedInteraction interaction)
+		{
+			return interaction.TargetObject == gameObject &&
+			       interaction.UsedObject != null &&
+			       interaction.UsedObject.TryGetComponent<Paper>(out var paper) &&
+			       noteText.IsNullOrEmpty() &&
+			       paper.PaperString.IsNullOrEmpty() == false;
+		}
+
+		private void SyncNoteText(string oldVal, string newVal)
+		{
+			noteText = newVal;
+		}
+
+		[Server]
+		private void ServerSetNoteText(string newText)
+		{
+			SyncNoteText(noteText, newText);
+		}
+
+		public override void OnStartClient()
+		{
+			SyncNoteText(noteText, noteText);
+		}
+
+		#region Clicked in the world
+		public bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side) &&
+			       CommonWillInteract(interaction);
+		}
+
+		public void ServerPerformInteraction(HandApply interaction)
+		{
+			var text = interaction.HandObject.GetComponent<Paper>().PaperString;
+			AttachNote(interaction.Performer, text);
+			Inventory.ServerDespawn(interaction.HandObject);
+		}
+		#endregion
+
+		#region Clicked in inventory
+		public bool WillInteract(InventoryApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side) &&
+			       CommonWillInteract(interaction);
+		}
+
+		public void ServerPerformInteraction(InventoryApply interaction)
+		{
+			var text = interaction.UsedObject.GetComponent<Paper>().PaperString;
+			AttachNote(interaction.Performer, text);
+			Inventory.ServerDespawn(interaction.UsedObject);
+		}
+		#endregion
+
+		#region RightClick interaction
+		public RightClickableResult GenerateRightClickOptions()
+		{
+			var result = RightClickableResult.Create();
+			var detachInteraction = ContextMenuApply.ByLocalPlayer(gameObject, null);
+			if (WillInteract(detachInteraction, NetworkSide.Client) == false) return result;
+			if (noteText.IsNullOrEmpty()) return result;
+
+			return result.AddElement("Detach note", () => OnDetachClicked(detachInteraction));
+		}
+
+		private void OnDetachClicked(ContextMenuApply interaction)
+		{
+			InteractionUtils.RequestInteract(interaction, this);
+		}
+		public bool WillInteract(ContextMenuApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side) && noteText.IsNullOrEmpty() == false;
+		}
+
+		public void ServerPerformInteraction(ContextMenuApply interaction)
+		{
+			DetachNote(interaction.Performer);
+		}
+		#endregion
+
+		public string Examine(Vector3 worldPos = default(Vector3))
+		{
+			if (noteText.IsNullOrEmpty())
+			{
+				return "";
+			}
+
+			return "It has a note attached to it. It reads: \"" + noteText + "\".";
+		}
+
+		public void OnSpawnServer(SpawnInfo info)
+		{
+			if (initialNoteText.IsNullOrEmpty())
+			{
+				return;
+			}
+
+			AttachNote(null, initialNoteText);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Cargo/NoteAttachable.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Cargo/NoteAttachable.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 89bf7311f10246d58a3a3606d45d78f2
+timeCreated: 1606358728

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping.meta
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f05ddc821de4789ba67d904244eb800
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappableBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappableBase.cs
@@ -1,0 +1,44 @@
+﻿using UnityEngine;
+
+namespace Items.Cargo.Wrapping
+{
+	public abstract class WrappableBase: MonoBehaviour
+	{
+		[SerializeField]
+		[Tooltip("Text you see when you perform the wrapping action." +
+		         " {0} = object being wrapped, {1} = wrapping paper name.")]
+		protected string actionTextOriginator = "You start wrapping {0} with {1}.";
+
+		[SerializeField]
+		[Tooltip("Text others see when you perform the wrapping action. " +
+		         "{0} = your name, {1} = object being wrapped, {2} = wrapping paper name.")]
+		protected string actionTextOthers = "{0} starts wrapping {1} with {2}.";
+
+		[SerializeField][Tooltip("Prefab that will be used when spawning the package.")]
+		protected GameObject normalPackagePrefab = default;
+
+		[SerializeField][Tooltip("Prefab that will be used when spawning the package with festive paper.")]
+		protected GameObject festivePackagePrefab = default;
+
+		[SerializeField] [Tooltip("Time needed to wrap this object")]
+		protected float wrapTime = 5;
+
+		protected abstract bool CanBeWrapped(GameObject performer, WrappingPaper paper);
+		protected abstract void Wrap(GameObject performer, WrappingPaper paper);
+
+		/// <summary>
+		/// Entry point for wrapping interaction of wrappable objects/items.
+		/// Will evaluate if the wrap can happen, giving a message to the performer in case it can not
+		/// and doing the wrap if successful.
+		/// </summary>
+		/// <param name="performer"></param>
+		/// <param name="paper"></param>
+		public void TryWrap(GameObject performer, WrappingPaper paper)
+		{
+			if (CanBeWrapped(performer, paper))
+			{
+				Wrap(performer, paper);
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappableBase.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappableBase.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0102eef3516e425ca16da469e4aeaa8f
+timeCreated: 1606435070

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappableItem.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappableItem.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using NaughtyAttributes;
+using UnityEngine;
+
+namespace Items.Cargo.Wrapping
+{
+	public class WrappableItem: WrappableBase
+	{
+		[SerializeField] [Tooltip("True if you want to set your own amount of paper.")]
+		private bool overrideAmountOfPaper = false;
+
+		[SerializeField,
+		 ShowIf(nameof(overrideAmountOfPaper)),
+		 Tooltip("How much paper should this object consume when wrapped.")]
+		private int customAmountOfPaper = 5;
+
+		[SerializeField] [Tooltip("Set to true if you want the package of this item to have a shape in particular.")]
+		private bool shapedPackage = false;
+
+		[SerializeField,
+		 ShowIf(nameof(shapedPackage)),
+		 Tooltip("Manually set the shape of the package this object will have once wrapped.")]
+		private PackageType packageType = PackageType.Box;
+
+		private ItemAttributesV2 itemAttributesV2;
+		private Pickupable pickupable;
+
+
+		private void Awake()
+		{
+			itemAttributesV2 = GetComponent<ItemAttributesV2>();
+			pickupable = GetComponent<Pickupable>();
+		}
+
+		protected override bool CanBeWrapped(GameObject performer, WrappingPaper paper)
+		{
+			if (paper.PaperAmount >= GetPaperAmount())
+			{
+				return true;
+			}
+
+			Chat.AddExamineMsg(
+				performer,
+				$"It seems like I don't have enough {paper.gameObject.ExpensiveName()} to wrap {gameObject.ExpensiveName()}");
+
+			return false;
+		}
+
+		protected override void Wrap(GameObject performer, WrappingPaper paper)
+		{
+			var cfg = new StandardProgressActionConfig(
+				StandardProgressActionType.Restrain);
+
+			Chat.AddActionMsgToChat(
+				performer,
+				string.Format(actionTextOriginator, gameObject.ExpensiveName(), paper.gameObject.ExpensiveName()),
+				string.Format(actionTextOthers, performer.ExpensiveName(), gameObject.ExpensiveName(), paper.gameObject.ExpensiveName()));
+
+			StandardProgressAction.Create(
+				cfg,
+				() => FinishWrapping(paper)
+			).ServerStartProgress(ActionTarget.Object(performer.RegisterTile()), wrapTime, performer);
+		}
+
+		private void FinishWrapping(WrappingPaper paper)
+		{
+			GameObject result = null;
+
+			switch (paper.WrapType)
+			{
+				case WrapType.Normal:
+					result = normalPackagePrefab;
+					break;
+				case WrapType.Festive:
+					result = festivePackagePrefab;
+					break;
+				default:
+					Logger.LogError($"Tried to wrap {gameObject} with unknown type of paper", Category.Interaction);
+					result = normalPackagePrefab;
+					break;
+			}
+
+			result = Spawn.ServerPrefab(result, gameObject.AssumedWorldPosServer()).GameObject;
+			var wrap = result.GetComponent<WrappedItem>();
+			var package = GetPackageType();
+			wrap.SetSprite(package);
+			wrap.SetSize(itemAttributesV2.Size);
+
+			if (pickupable != null && pickupable.ItemSlot != null)
+			{
+				Inventory.ServerAdd(
+					wrap.gameObject,
+					pickupable.ItemSlot,
+					ReplacementStrategy.DropOther);
+			}
+
+			wrap.SetContent(gameObject);
+			Inventory.ServerConsume(paper.ItemSlot, GetPaperAmount());
+
+		}
+
+		private PackageType GetPackageType()
+		{
+			if (shapedPackage)
+			{
+				return packageType;
+			}
+
+			return (PackageType) itemAttributesV2.Size;
+		}
+
+		private int GetPaperAmount()
+		{
+			if (overrideAmountOfPaper)
+			{
+				return customAmountOfPaper;
+			}
+
+			return (int) itemAttributesV2.Size;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappableItem.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappableItem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: af4d0e94e1b24623931ca59abaf6e1e2
+timeCreated: 1607214336

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappableObject.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappableObject.cs
@@ -1,0 +1,89 @@
+﻿using UnityEngine;
+
+namespace Items.Cargo.Wrapping
+{
+	public class WrappableObject: WrappableBase
+	{
+		[SerializeField][Tooltip("Needed stacks of paper for wrapping this object.")]
+		private int neededPaperAmount = 8;
+
+		private RegisterCloset registerCloset;
+
+		private void Awake()
+		{
+			registerCloset = GetComponent<RegisterCloset>();
+		}
+
+		protected override bool CanBeWrapped(GameObject performer, WrappingPaper paper)
+		{
+			if (paper.PaperAmount >= neededPaperAmount)
+			{
+				return true;
+			}
+
+			Chat.AddExamineMsg(
+				performer,
+				$"It seems like I don't have enough {paper.gameObject.ExpensiveName()} to wrap {gameObject.ExpensiveName()}");
+
+			return false;
+		}
+
+		protected override void Wrap(GameObject performer, WrappingPaper paper)
+		{
+			var cfg = new StandardProgressActionConfig(
+				StandardProgressActionType.Restrain);
+
+			Chat.AddActionMsgToChat(
+				performer,
+				string.Format(actionTextOriginator, gameObject.ExpensiveName(), paper.gameObject.ExpensiveName()),
+				string.Format(actionTextOthers, performer.ExpensiveName(), gameObject.ExpensiveName(), paper.gameObject.ExpensiveName()));
+
+			StandardProgressAction.Create(
+				cfg,
+				() => FinishWrapping(paper)
+			).ServerStartProgress(ActionTarget.Object(performer.RegisterTile()), wrapTime, performer);
+		}
+
+		private void FinishWrapping(WrappingPaper paper)
+		{
+			GameObject result = null;
+
+			switch (paper.WrapType)
+			{
+				case WrapType.Normal:
+					result = normalPackagePrefab;
+					break;
+				case WrapType.Festive:
+					result = festivePackagePrefab;
+					break;
+				default:
+					Logger.LogError($"Tried to wrap {gameObject} with unknown type of paper", Category.Interaction);
+					result = normalPackagePrefab;
+					break;
+			}
+
+			result = Spawn.ServerPrefab(result, gameObject.AssumedWorldPosServer()).GameObject;
+			var wrap = result.GetComponent<WrappedObject>();
+			wrap.SetContent(gameObject);
+			ContainerTypeSprite spriteType;
+
+			switch (registerCloset.closetType)
+			{
+				case ClosetType.LOCKER:
+					spriteType = ContainerTypeSprite.Locker;
+					break;
+				case ClosetType.CRATE:
+					spriteType = ContainerTypeSprite.Crate;
+					break;
+				default:
+					Logger.LogWarning($"{gameObject} is not a locker nor crate but it an attempt to wrap mas done." +
+					                  "We set the crate sprite and go on.");
+					spriteType = ContainerTypeSprite.Crate;
+					break;
+			}
+
+			wrap.SetContainerTypeSprite(spriteType);
+			Inventory.ServerConsume(paper.ItemSlot, neededPaperAmount);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappableObject.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappableObject.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 383c1cad778d4da5bae4c4424e7b4e56
+timeCreated: 1606452994

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappedBase.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappedBase.cs
@@ -1,0 +1,99 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace Items.Cargo.Wrapping
+{
+	public abstract class WrappedBase: MonoBehaviour
+	{
+		[SerializeField][Tooltip("When unwrapped, if no content was defined, we will spawn one of these")]
+		private List<GameObject> randomContentList;
+
+		// TODO implement the new way to play sounds when addressables are in
+		[SerializeField] [Tooltip("Sound when unwrapped")]
+		private string unwrapSound = "PosterRipped";
+
+		[SerializeField][Tooltip("Message you read when you start unwrapping the package. " +
+		                         "{0} = this object's name.")]
+		protected string originatorUnwrapText = "You start unwrapping the {0}.";
+
+		[SerializeField][Tooltip("Message others read when someone starts unwrapping this package." +
+		                         "{0} = performer, {1} = this object's name")]
+		protected string othersUnwrapText = "{0} starts unwrapping the {1}.";
+
+		[SerializeField] [Tooltip("Time to unwrap.")]
+		private float timeToUnwrap = 2;
+
+		private PushPull content;
+		private PushPull pushPull;
+		private Attributes attributes;
+		protected SpriteHandler spriteHandler;
+
+		protected virtual void Awake()
+		{
+			pushPull = GetComponent<PushPull>();
+			spriteHandler = GetComponentInChildren<SpriteHandler>();
+			attributes = GetComponent<Attributes>();
+		}
+
+		public void SetContent(GameObject toWrap)
+		{
+			content = toWrap.GetComponent<PushPull>();
+			var exportCost = toWrap.GetComponent<Attributes>().ExportCost;
+			UpdateExportCost(exportCost);
+			content.parentContainer = pushPull;
+			content.VisibleState = false;
+		}
+
+		private void UpdateExportCost(int value)
+		{
+			attributes.SetExportCost(value);
+		}
+
+		protected void PlayUnwrappingSound()
+		{
+			SoundManager.PlayNetworkedAtPos(unwrapSound, gameObject.AssumedWorldPosServer());
+		}
+
+		protected void StartUnwrapAction(GameObject performer)
+		{
+			var cfg = new StandardProgressActionConfig(
+				StandardProgressActionType.Restrain);
+
+			Chat.AddActionMsgToChat(
+				performer,
+				string.Format(originatorUnwrapText, gameObject.ExpensiveName()),
+				string.Format(othersUnwrapText, performer.ExpensiveName(), gameObject.ExpensiveName()));
+
+			StandardProgressAction.Create(cfg, UnWrap)
+				.ServerStartProgress(ActionTarget.Object(performer.RegisterTile()), timeToUnwrap, performer);
+		}
+
+		protected abstract void UnWrap();
+
+		/// <summary>
+		/// Used to get the content of the current package. If no content was set, then it will try to generate
+		/// random content. Useful for mapping!
+		/// </summary>
+		/// <returns>The game object related to the content of this package</returns>
+		protected GameObject GetOrGenerateContent()
+		{
+			if (content == null && randomContentList.Count > 0)
+			{
+				var unwrapped = Spawn.ServerPrefab(randomContentList.PickRandom(), gameObject.AssumedWorldPosServer()).GameObject;
+				content = unwrapped.GetComponent<PushPull>();
+				return unwrapped;
+			}
+
+			return content.gameObject;
+		}
+
+		protected void MakeContentVisible()
+		{
+			var netTransform = content.gameObject.GetComponent<CustomNetTransform>();
+			var pos = gameObject.RegisterTile().WorldPositionServer;
+			content.parentContainer = null;
+			netTransform.AppearAtPositionServer(pos);
+			content = null;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappedBase.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappedBase.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 01d3f68658d84fb48eee3f8aa943cc0b
+timeCreated: 1606357963

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappedItem.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappedItem.cs
@@ -1,0 +1,98 @@
+﻿using UnityEngine;
+
+namespace Items.Cargo.Wrapping
+{
+	public class WrappedItem: WrappedBase, ICheckedInteractable<HandApply>, ICheckedInteractable<InventoryApply>, IServerSpawn
+	{
+		[SerializeField]
+		[Tooltip("Use this to set the initial type of this object. " +
+		         "The sprite will change to represent this change when the object is spawned. " +
+		         "Useful for mapping!")]
+		private PackageType packageType;
+
+		private Pickupable pickupable;
+		private ItemAttributesV2 itemAttributesV2;
+
+		protected override void Awake()
+		{
+			base.Awake();
+			pickupable = GetComponent<Pickupable>();
+			itemAttributesV2 = GetComponent<ItemAttributesV2>();
+		}
+
+		protected override void UnWrap()
+		{
+			PlayUnwrappingSound();
+			var unwrapped = GetOrGenerateContent();
+			if (unwrapped == null) return;
+			MakeContentVisible();
+
+			if (pickupable.ItemSlot == null)
+			{
+				Despawn.ServerSingle(gameObject);
+			}
+			else
+			{
+				Inventory.ServerAdd(
+					unwrapped,
+					pickupable.ItemSlot,
+					ReplacementStrategy.DespawnOther);
+			}
+		}
+
+		public void SetSprite(PackageType type)
+		{
+			spriteHandler.ChangeSprite((int) type);
+		}
+
+		public void SetSize(ItemSize size)
+		{
+			itemAttributesV2.ServerSetSize(size);
+		}
+
+		#region Click in the world
+		public bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side) &&
+			       interaction.HandObject == null &&
+			       interaction.Intent == Intent.Harm;
+		}
+
+		public void ServerPerformInteraction(HandApply interaction)
+		{
+			StartUnwrapAction(interaction.Performer);
+		}
+		#endregion
+
+		#region Click in inventory
+		public bool WillInteract(InventoryApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side) &&
+			       interaction.UsedObject == null &&
+			       interaction.Intent == Intent.Harm;
+		}
+
+		public void ServerPerformInteraction(InventoryApply interaction)
+		{
+			StartUnwrapAction(interaction.Performer);
+		}
+		#endregion
+
+		public void OnSpawnServer(SpawnInfo info)
+		{
+			if (info.SpawnType != SpawnType.Mapped) return;
+
+			SetSprite(packageType);
+		}
+	}
+
+	public enum PackageType
+	{
+		Box,
+		Tiny,
+		Small,
+		Medium,
+		Large,
+		Sphere
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappedItem.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappedItem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c8724f2eb82049548ce89dde3d83dfa3
+timeCreated: 1606363742

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappedObject.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappedObject.cs
@@ -1,0 +1,61 @@
+﻿using UnityEngine;
+
+namespace Items.Cargo.Wrapping
+{
+	public class WrappedObject: WrappedBase, ICheckedInteractable<HandApply>, IServerSpawn
+	{
+		[SerializeField]
+		[Tooltip("Use this to set the initial type of this object. " +
+		         "The sprite will change to represent this change when the object is spawned. " +
+		         "Useful for mapping!")]
+		private ContainerTypeSprite typeSprite;
+		protected override void UnWrap()
+		{
+			PlayUnwrappingSound();
+			var unwrapped = GetOrGenerateContent();
+			if (unwrapped == null)
+			{
+				Chat.AddActionMsgToChat(
+					gameObject,
+					"",
+					$"The {gameObject.ExpensiveName()} finishes unwrapping itself but there is no content! " +
+					$"What is this magic?!");
+				Despawn.ServerSingle(gameObject);
+				return;
+			}
+
+			MakeContentVisible();
+			Despawn.ServerSingle(gameObject);
+		}
+
+		public bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side) &&
+			       interaction.TargetObject == gameObject &&
+			       interaction.HandObject == null &&
+			       interaction.Intent == Intent.Harm;
+		}
+
+		public void ServerPerformInteraction(HandApply interaction)
+		{
+			StartUnwrapAction(interaction.Performer);
+		}
+
+		public void SetContainerTypeSprite(ContainerTypeSprite type)
+		{
+			spriteHandler.ChangeSprite((int) type);
+		}
+
+		public void OnSpawnServer(SpawnInfo info)
+		{
+			if (info.SpawnType != SpawnType.Mapped) return;
+			SetContainerTypeSprite(typeSprite);
+		}
+	}
+
+	public enum ContainerTypeSprite
+	{
+		Crate,
+		Locker
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappedObject.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappedObject.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1f4ef768d0744d109305b5747e69ccd5
+timeCreated: 1606362155

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappingPaper.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappingPaper.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using UnityEngine;
+
+namespace Items.Cargo.Wrapping
+{
+	public class WrappingPaper : MonoBehaviour, ICheckedInteractable<HandApply>, ICheckedInteractable<InventoryApply>
+	{
+		[SerializeField][Tooltip("What kind of paper will be used to wrap. Determines the package appearance.")]
+		private WrapType wrapType;
+		public WrapType WrapType => wrapType;
+		private Stackable stackable;
+		public int PaperAmount => stackable.Amount;
+		private Pickupable pickupable;
+		public ItemSlot ItemSlot => pickupable.ItemSlot;
+
+		private void Awake()
+		{
+			stackable = GetComponent<Stackable>();
+			pickupable = GetComponent<Pickupable>();
+		}
+
+		private bool CommonWillInteract(TargetedInteraction interaction, NetworkSide side)
+		{
+			return interaction.TargetObject != gameObject &&
+			       interaction.Intent == Intent.Help &&
+			       interaction.TargetObject.TryGetComponent(out WrappableBase _);
+		}
+
+		#region Clicked object in the world
+
+		public bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side) &&
+			       CommonWillInteract(interaction, side);
+		}
+
+		public void ServerPerformInteraction(HandApply interaction)
+		{
+			interaction.TargetObject.GetComponent<WrappableBase>().TryWrap(interaction.Performer, this);
+		}
+
+		#endregion
+
+		#region Clicked object in inventory
+
+		public bool WillInteract(InventoryApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side) &&
+			       CommonWillInteract(interaction, side);
+		}
+
+		public void ServerPerformInteraction(InventoryApply interaction)
+		{
+			interaction.TargetObject.GetComponent<WrappableBase>().TryWrap(interaction.Performer, this);
+		}
+
+		#endregion
+
+	}
+
+	public enum WrapType
+	{
+		Normal,
+		Festive
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappingPaper.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Cargo/Wrapping/WrappingPaper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dcdb9f210c1446c8adeadb48d8d426b3
+timeCreated: 1606265548

--- a/UnityProject/Assets/Scripts/Items/ClothingItem.cs
+++ b/UnityProject/Assets/Scripts/Items/ClothingItem.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System.Collections.Generic;
+using Items;
 
 public enum SpriteHandType
 {

--- a/UnityProject/Assets/Scripts/Items/Devices/RemoteSignaller.cs
+++ b/UnityProject/Assets/Scripts/Items/Devices/RemoteSignaller.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 using Mirror;
 

--- a/UnityProject/Assets/Scripts/Items/Dice/RollSpaceCube.cs
+++ b/UnityProject/Assets/Scripts/Items/Dice/RollSpaceCube.cs
@@ -1,4 +1,6 @@
-﻿public class RollSpaceCube : RollDie
+﻿using Items;
+
+public class RollSpaceCube : RollDie
 {
 	ItemAttributesV2 itemAttributes;
 

--- a/UnityProject/Assets/Scripts/Items/Food/DrinkableContainer.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/DrinkableContainer.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Items;
 using ScriptableObjects;
 using UnityEngine;
 

--- a/UnityProject/Assets/Scripts/Items/Food/XenomorphFood.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/XenomorphFood.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using UnityEngine;
 using System.Threading.Tasks;
+using Items;
 
 [RequireComponent(typeof(RegisterItem))]
 [RequireComponent(typeof(ItemAttributesV2))]

--- a/UnityProject/Assets/Scripts/Items/Headset.cs
+++ b/UnityProject/Assets/Scripts/Items/Headset.cs
@@ -1,4 +1,5 @@
-﻿using Mirror;
+﻿using Items;
+using Mirror;
 
 /// <summary>
 ///     Headset properties

--- a/UnityProject/Assets/Scripts/Items/IDCard.cs
+++ b/UnityProject/Assets/Scripts/Items/IDCard.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 using Mirror;
 using UnityEngine.Serialization;

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -1,306 +1,306 @@
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
 using Mirror;
-using Objects;
+using UnityEngine;
 
-/// <summary>
-/// Various attributes associated with a particular item.
-/// New and improved, removes need for UniCloth type stuff, works
-/// well with using prefab variants.
-/// </summary>
-[RequireComponent(typeof(Pickupable))] //Inventory interaction
-[RequireComponent(typeof(ObjectBehaviour))] //pull and Push
-[RequireComponent(typeof(RegisterItem))] //Registry with subsistence
-public class ItemAttributesV2 : Attributes
+namespace Items
 {
-	[SerializeField]
-	[Tooltip("Initial traits of this item on spawn.")]
-	private List<ItemTrait> initialTraits = null;
-
-	[Tooltip("Size of this item when spawned. Is none by default, which you should probably change.")]
-	[SerializeField]
-	private ItemSize initialSize = ItemSize.None;
-
 	/// <summary>
-	/// Current size.
+	/// Various attributes associated with a particular item.
+	/// New and improved, removes need for UniCloth type stuff, works
+	/// well with using prefab variants.
 	/// </summary>
-	[SyncVar(hook = nameof(SyncSize))]
-	private ItemSize size;
-
-	/// <summary>
-	/// Current size
-	/// </summary>
-	public ItemSize Size => size;
-
-	[Tooltip("Damage when we click someone with harm intent")]
-	[Range(0, 100)]
-	[SerializeField]
-	private float hitDamage = 0;
-
-	/// <summary>
-	/// Damage when we click someone with harm intent, tracked server side only.
-	/// </summary>
-	public float ServerHitDamage
+	[RequireComponent(typeof(Pickupable))] //Inventory interaction
+	[RequireComponent(typeof(ObjectBehaviour))] //pull and Push
+	[RequireComponent(typeof(RegisterItem))] //Registry with subsistence
+	public class ItemAttributesV2 : Attributes
 	{
-		get
+		[SerializeField]
+		[Tooltip("Initial traits of this item on spawn.")]
+		private List<ItemTrait> initialTraits = null;
+
+		[Tooltip("Size of this item when spawned. Is none by default, which you should probably change.")]
+		[SerializeField]
+		private ItemSize initialSize = ItemSize.None;
+
+		/// <summary>
+		/// Current size.
+		/// </summary>
+		[SyncVar(hook = nameof(SyncSize))]
+		private ItemSize size;
+
+		/// <summary>
+		/// Current size
+		/// </summary>
+		public ItemSize Size => size;
+
+		[Tooltip("Damage when we click someone with harm intent")]
+		[Range(0, 100)]
+		[SerializeField]
+		private float hitDamage = 0;
+
+		/// <summary>
+		/// Damage when we click someone with harm intent, tracked server side only.
+		/// </summary>
+		public float ServerHitDamage
 		{
-			//If item has an ICustomDamageCalculation component, use that instead.
-			ICustomDamageCalculation part = GetComponent<ICustomDamageCalculation>();
-			if (part != null)
+			get
 			{
-				return part.ServerPerformDamageCalculation();
+				//If item has an ICustomDamageCalculation component, use that instead.
+				ICustomDamageCalculation part = GetComponent<ICustomDamageCalculation>();
+				if (part != null)
+				{
+					return part.ServerPerformDamageCalculation();
+				}
+
+				return hitDamage;
+			}
+			set => hitDamage = value;
+		}
+
+		[Tooltip("Type of damage done when this is thrown or used for melee.")]
+		[SerializeField]
+		private DamageType damageType = DamageType.Brute;
+		/// <summary>
+		/// Type of damage done when this is thrown or used for melee, tracked server side only.
+		/// </summary>
+		public DamageType ServerDamageType
+		{
+			get => damageType;
+			set => damageType = value;
+		}
+
+		[Tooltip("How painful it is when someone throws it at you")]
+		[Range(0, 100)]
+		[SerializeField]
+		private float throwDamage = 0;
+		/// <summary>
+		/// Amout of damage done when this is thrown, tracked server side only.
+		/// </summary>
+		public float ServerThrowDamage
+		{
+			get => throwDamage;
+			set => throwDamage = value;
+		}
+
+		[Tooltip("How many tiles to move per 0.1s when being thrown")]
+		[SerializeField]
+		private float throwSpeed = 2;
+		/// <summary>
+		/// How many tiles to move per 0.1s when being thrown
+		/// </summary>
+		public float ThrowSpeed => throwSpeed;
+
+		[Tooltip("Max throw distance")]
+		[SerializeField]
+		private float throwRange = 7;
+		/// <summary>
+		/// Max throw distance
+		/// </summary>
+		public float ThrowRange => throwRange;
+
+		[Tooltip("Sound to be played when we click someone with harm intent")]
+		[SerializeField]
+		private string hitSound = "genericHit";
+
+
+		[Tooltip("How to play sounds.")]
+		[SerializeField]
+		public SoundItemSettings hitSoundSettings;
+		/// <summary>
+		/// Sound to be played when we click someone with harm intent, tracked server side only
+		/// </summary>
+		public string ServerHitSound
+		{
+			get => hitSound;
+			set => hitSound = value;
+		}
+
+		//TODO: tank / eva fields should probably be migrated to a different component as they are very specific to clothing, particularly
+		//suits and masks. Probably belong in the Clothing component.
+		[Tooltip("Is this a mask that can connect to a tank?")]
+		[SerializeField]
+		private bool canConnectToTank = false;
+		/// <summary>
+		/// Whether this item can connect to a gas tank.
+		/// </summary>
+		public bool CanConnectToTank => canConnectToTank;
+
+
+		[Tooltip("Can this item protect humans against spess?")]
+		[SerializeField]
+		private bool isEVACapable = false;
+		/// <summary>
+		/// Can this item protect humans against spess?
+		/// </summary>
+		public bool IsEVACapable => isEVACapable;
+
+		[Tooltip("Possible verbs used to describe the attack when this is used for melee.")]
+		[SerializeField]
+		private List<string> attackVerbs;
+		/// <summary>
+		/// Possible verbs used to describe the attack when this is used for melee, tracked server side only.
+		/// </summary>
+		public IEnumerable<string> ServerAttackVerbs
+		{
+			get => attackVerbs;
+			set => attackVerbs = new List<string>(value);
+		}
+
+		/// <summary>
+		/// Actual current traits, accounting for dynamic add / remove. Note that these adds / removes
+		/// are not currently synced between client / server.
+		/// </summary>
+		private HashSet<ItemTrait> traits = new HashSet<ItemTrait>();
+
+		private bool hasInit;
+
+
+		public ItemsSprites ItemSprites => itemSprites;
+
+		[Tooltip("The In hands Sprites If it has any")]
+		[SerializeField]
+		private ItemsSprites itemSprites;
+
+		#region Lifecycle
+
+		private void Awake()
+		{
+			EnsureInit();
+		}
+
+		private void EnsureInit()
+		{
+			if (hasInit) return;
+			foreach (var definedTrait in initialTraits)
+			{
+				traits.Add(definedTrait);
 			}
 
-			return hitDamage;
+			hasInit = true;
 		}
-		set => hitDamage = value;
-	}
 
-	[Tooltip("Type of damage done when this is thrown or used for melee.")]
-	[SerializeField]
-	private DamageType damageType = DamageType.Brute;
-	/// <summary>
-	/// Type of damage done when this is thrown or used for melee, tracked server side only.
-	/// </summary>
-	public DamageType ServerDamageType
-	{
-		get => damageType;
-		set => damageType = value;
-	}
-
-	[Tooltip("How painful it is when someone throws it at you")]
-	[Range(0, 100)]
-	[SerializeField]
-	private float throwDamage = 0;
-	/// <summary>
-	/// Amout of damage done when this is thrown, tracked server side only.
-	/// </summary>
-	public float ServerThrowDamage
-	{
-		get => throwDamage;
-		set => throwDamage = value;
-	}
-
-	[Tooltip("How many tiles to move per 0.1s when being thrown")]
-	[SerializeField]
-	private float throwSpeed = 2;
-	/// <summary>
-	/// How many tiles to move per 0.1s when being thrown
-	/// </summary>
-	public float ThrowSpeed => throwSpeed;
-
-	[Tooltip("Max throw distance")]
-	[SerializeField]
-	private float throwRange = 7;
-	/// <summary>
-	/// Max throw distance
-	/// </summary>
-	public float ThrowRange => throwRange;
-
-	[Tooltip("Sound to be played when we click someone with harm intent")]
-	[SerializeField]
-	private string hitSound = "genericHit";
-
-
-	[Tooltip("How to play sounds.")]
-	[SerializeField]
-	public SoundItemSettings hitSoundSettings;
-	/// <summary>
-	/// Sound to be played when we click someone with harm intent, tracked server side only
-	/// </summary>
-	public string ServerHitSound
-	{
-		get => hitSound;
-		set => hitSound = value;
-	}
-
-	//TODO: tank / eva fields should probably be migrated to a different component as they are very specific to clothing, particularly
-	//suits and masks. Probably belong in the Clothing component.
-	[Tooltip("Is this a mask that can connect to a tank?")]
-	[SerializeField]
-	private bool canConnectToTank = false;
-	/// <summary>
-	/// Whether this item can connect to a gas tank.
-	/// </summary>
-	public bool CanConnectToTank => canConnectToTank;
-
-
-	[Tooltip("Can this item protect humans against spess?")]
-	[SerializeField]
-	private bool isEVACapable = false;
-	/// <summary>
-	/// Can this item protect humans against spess?
-	/// </summary>
-	public bool IsEVACapable => isEVACapable;
-
-	[Tooltip("Possible verbs used to describe the attack when this is used for melee.")]
-	[SerializeField]
-	private List<string> attackVerbs;
-	/// <summary>
-	/// Possible verbs used to describe the attack when this is used for melee, tracked server side only.
-	/// </summary>
-	public IEnumerable<string> ServerAttackVerbs
-	{
-		get => attackVerbs;
-		set => attackVerbs = new List<string>(value);
-	}
-
-	/// <summary>
-	/// Actual current traits, accounting for dynamic add / remove. Note that these adds / removes
-	/// are not currently synced between client / server.
-	/// </summary>
-	private HashSet<ItemTrait> traits = new HashSet<ItemTrait>();
-
-	private bool hasInit;
-
-
-	public ItemsSprites ItemSprites => itemSprites;
-
-	[Tooltip("The In hands Sprites If it has any")]
-	[SerializeField]
-	private ItemsSprites itemSprites;
-
-	#region Lifecycle
-
-	private void Awake()
-	{
-		EnsureInit();
-	}
-
-	private void EnsureInit()
-	{
-		if (hasInit) return;
-		foreach (var definedTrait in initialTraits)
+		public override void OnStartClient()
 		{
-			traits.Add(definedTrait);
+			EnsureInit();
+			SyncSize(size, this.size);
+			base.OnStartClient();
 		}
 
-		hasInit = true;
-	}
-
-	public override void OnStartClient()
-	{
-		EnsureInit();
-		SyncSize(size, this.size);
-		base.OnStartClient();
-	}
-
-	public void OnSpawnServer(SpawnInfo info)
-	{
-		SyncSize(size, initialSize);
-	}
-
-	#endregion Lifecycle
-
-	/// <summary>
-	/// All traits currently on the item.
-	/// NOTE: Dynamically added / removed traits are not synced between client / server
-	/// </summary>
-	/// <returns></returns>
-	public IEnumerable<ItemTrait> GetTraits()
-	{
-		return traits;
-	}
-
-	/// <summary>
-	/// Does it have the given trait?
-	/// NOTE: Dynamically added / removed traits are not synced between client / server
-	/// </summary>
-	/// <param name="itemTrait"></param>
-	public bool HasTrait(ItemTrait toCheck)
-	{
-		return traits.Contains(toCheck);
-	}
-
-	/// <summary>
-	/// Does it have any of the given traits?
-	/// </summary>
-	/// <param name="expectedTraits"></param>
-	/// <returns></returns>
-	public bool HasAnyTrait(IEnumerable<ItemTrait> expectedTraits)
-	{
-		return traits.Any(expectedTraits.Contains);
-	}
-
-	/// <summary>
-	/// Does it have all of the given traits?
-	/// </summary>
-	/// <param name="expectedTraits"></param>
-	/// <returns></returns>
-	public bool HasAllTraits(IEnumerable<ItemTrait> expectedTraits)
-	{
-		return traits.All(expectedTraits.Contains);
-	}
-
-	/// <summary>
-	/// Adds the trait dynamically.
-	/// NOTE: Not synced between client / server
-	/// </summary>
-	/// <param name="itemTrait"></param>
-	public void AddTrait(ItemTrait toAdd)
-	{
-		traits.Add(toAdd);
-	}
-
-	private void SyncSize(ItemSize oldSize, ItemSize newSize)
-	{
-		EnsureInit();
-		size = newSize;
-	}
-
-	/// <summary>
-	/// Removes the trait dynamically.
-	/// NOTE: Not synced between client / server
-	/// </summary>
-	/// <param name="itemTrait"></param>
-	public void RemoveTrait(ItemTrait toRemove)
-	{
-		traits.Remove(toRemove);
-	}
-
-	private static string GetMasterTypeHandsString(SpriteType masterType)
-	{
-		switch (masterType)
+		public void OnSpawnServer(SpawnInfo info)
 		{
-			case SpriteType.Clothing: return "clothing";
+			SyncSize(size, initialSize);
+		}
 
-			default: return "items";
+		#endregion Lifecycle
+
+		/// <summary>
+		/// All traits currently on the item.
+		/// NOTE: Dynamically added / removed traits are not synced between client / server
+		/// </summary>
+		/// <returns></returns>
+		public IEnumerable<ItemTrait> GetTraits()
+		{
+			return traits;
+		}
+
+		/// <summary>
+		/// Does it have the given trait?
+		/// NOTE: Dynamically added / removed traits are not synced between client / server
+		/// </summary>
+		/// <param name="itemTrait"></param>
+		public bool HasTrait(ItemTrait toCheck)
+		{
+			return traits.Contains(toCheck);
+		}
+
+		/// <summary>
+		/// Does it have any of the given traits?
+		/// </summary>
+		/// <param name="expectedTraits"></param>
+		/// <returns></returns>
+		public bool HasAnyTrait(IEnumerable<ItemTrait> expectedTraits)
+		{
+			return traits.Any(expectedTraits.Contains);
+		}
+
+		/// <summary>
+		/// Does it have all of the given traits?
+		/// </summary>
+		/// <param name="expectedTraits"></param>
+		/// <returns></returns>
+		public bool HasAllTraits(IEnumerable<ItemTrait> expectedTraits)
+		{
+			return traits.All(expectedTraits.Contains);
+		}
+
+		/// <summary>
+		/// Adds the trait dynamically.
+		/// NOTE: Not synced between client / server
+		/// </summary>
+		/// <param name="itemTrait"></param>
+		public void AddTrait(ItemTrait toAdd)
+		{
+			traits.Add(toAdd);
+		}
+
+		private void SyncSize(ItemSize oldSize, ItemSize newSize)
+		{
+			EnsureInit();
+			size = newSize;
+		}
+
+		/// <summary>
+		/// Removes the trait dynamically.
+		/// NOTE: Not synced between client / server
+		/// </summary>
+		/// <param name="itemTrait"></param>
+		public void RemoveTrait(ItemTrait toRemove)
+		{
+			traits.Remove(toRemove);
+		}
+
+		private static string GetMasterTypeHandsString(SpriteType masterType)
+		{
+			switch (masterType)
+			{
+				case SpriteType.Clothing: return "clothing";
+
+				default: return "items";
+			}
+		}
+
+		/// <summary>
+		/// Change this item's size and sync it to clients.
+		/// </summary>
+		/// <param name="newSize"></param>
+		[Server]
+		public void ServerSetSize(ItemSize newSize)
+		{
+			SyncSize(size, newSize);
+		}
+
+		/// <summary>
+		/// Use SpriteHandlerController.SetSprites instead. (SpriteHandlerController may now be deprecated)
+		/// </summary>
+		/// <param name="newSprites">New sprites</param>
+		public void SetSprites(ItemsSprites newSprites)
+		{
+			itemSprites = newSprites;
+		}
+
+		[ContextMenu("Propagate Palette Changes")]
+		public void PropagatePaletteChanges()
+		{
+			ClothingV2 clothing = GetComponent<ClothingV2>();
+			if (clothing != null) clothing.AssignPaletteToSprites(this.ItemSprites.Palette);
 		}
 	}
 
-	/// <summary>
-	/// Change this item's size and sync it to clients.
-	/// </summary>
-	/// <param name="newSize"></param>
-	[Server]
-	public void ServerSetSize(ItemSize newSize)
+	public enum SoundItemSettings
 	{
-		SyncSize(size, newSize);
+		Both = 0,
+		OnlyItem = 1,
+		OnlyObject = 2
 	}
-
-	/// <summary>
-	/// Use SpriteHandlerController.SetSprites instead. (SpriteHandlerController may now be deprecated)
-	/// </summary>
-	/// <param name="newSprites">New sprites</param>
-	public void SetSprites(ItemsSprites newSprites)
-	{
-		itemSprites = newSprites;
-	}
-
-	[ContextMenu("Propagate Palette Changes")]
-	public void PropagatePaletteChanges()
-	{
-		ClothingV2 clothing = GetComponent<ClothingV2>();
-		if (clothing != null) clothing.AssignPaletteToSprites(this.ItemSprites.Palette);
-	}
-}
-
-public enum SoundItemSettings
-{
-	Both = 0,
-	OnlyItem = 1,
-	OnlyObject = 2
 }

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -13,7 +13,7 @@ namespace Items
 	[RequireComponent(typeof(Pickupable))] //Inventory interaction
 	[RequireComponent(typeof(ObjectBehaviour))] //pull and Push
 	[RequireComponent(typeof(RegisterItem))] //Registry with subsistence
-	public class ItemAttributesV2 : Attributes
+	public class ItemAttributesV2 : Attributes, IServerSpawn
 	{
 		[SerializeField]
 		[Tooltip("Initial traits of this item on spawn.")]
@@ -189,7 +189,7 @@ namespace Items
 
 		public void OnSpawnServer(SpawnInfo info)
 		{
-			SyncSize(size, initialSize);
+			size = initialSize;
 		}
 
 		#endregion Lifecycle
@@ -203,6 +203,7 @@ namespace Items
 		{
 			return traits;
 		}
+
 
 		/// <summary>
 		/// Does it have the given trait?
@@ -295,6 +296,8 @@ namespace Items
 			ClothingV2 clothing = GetComponent<ClothingV2>();
 			if (clothing != null) clothing.AssignPaletteToSprites(this.ItemSprites.Palette);
 		}
+
+
 	}
 
 	public enum SoundItemSettings

--- a/UnityProject/Assets/Scripts/Items/Others/ItemMagBoots.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/ItemMagBoots.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 using Mirror;
 using UI.Action;

--- a/UnityProject/Assets/Scripts/Items/Others/Knife.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Knife.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 
 /// <summary>

--- a/UnityProject/Assets/Scripts/Items/Others/RollingPin.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/RollingPin.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 
 /// <summary>

--- a/UnityProject/Assets/Scripts/Items/Others/TransformableItem.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/TransformableItem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 
 public class TransformableItem : MonoBehaviour , IPredictedCheckedInteractable<HandApply>

--- a/UnityProject/Assets/Scripts/Items/Renameable.cs
+++ b/UnityProject/Assets/Scripts/Items/Renameable.cs
@@ -1,3 +1,4 @@
+using Items;
 using Mirror;
 using UnityEngine;
 using WebSocketSharp;

--- a/UnityProject/Assets/Scripts/Items/Tool/EmptyFullSync.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/EmptyFullSync.cs
@@ -1,4 +1,5 @@
 
+using Items;
 using Mirror;
 using UnityEngine;
 using UnityEngine.Serialization;

--- a/UnityProject/Assets/Scripts/Items/Tool/Welder.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Welder.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using Mirror;
 using UnityEngine.Events;
 using Chemistry.Components;
+using Items;
 
 [RequireComponent(typeof(Pickupable))]
 public class Welder : NetworkBehaviour, IInteractable<HandActivate>, IServerSpawn

--- a/UnityProject/Assets/Scripts/Items/Traits/BestSlotForTrait.cs
+++ b/UnityProject/Assets/Scripts/Items/Traits/BestSlotForTrait.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Items;
 using ScriptableObjects;
 using UnityEngine;
 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using Items;
 using AddressableReferences;
 using Mirror;
 using UnityEditor;

--- a/UnityProject/Assets/Scripts/Items/Weapons/Melee/EnergySword.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Melee/EnergySword.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Items;
 using AddressableReferences;
 using UnityEngine;
 using Mirror;

--- a/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/WeaponNetworkActions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using Items;
 using UnityEngine;
 using Utility = UnityEngine.Networking.Utility;
 using Mirror;

--- a/UnityProject/Assets/Scripts/Mobs/Equipment/Equipment.cs
+++ b/UnityProject/Assets/Scripts/Mobs/Equipment/Equipment.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 using Mirror;
 using Objects.Atmospherics;

--- a/UnityProject/Assets/Scripts/NPC/AI/Friendly/ChickenAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Friendly/ChickenAI.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Items;
 using Items.Others;
 using UnityEngine;
 

--- a/UnityProject/Assets/Scripts/NPC/AI/MobExplore.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobExplore.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using Items;
 using NaughtyAttributes;
 using Objects.Construction;
 

--- a/UnityProject/Assets/Scripts/Objects/Botany/HydroponicsTray.cs
+++ b/UnityProject/Assets/Scripts/Objects/Botany/HydroponicsTray.cs
@@ -6,6 +6,7 @@ using Mirror;
 using Systems.Botany;
 using Chemistry;
 using Chemistry.Components;
+using Items;
 using Items.Botany;
 
 namespace Objects.Botany

--- a/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.Events;
 using Systems.Electricity;
 using Systems.Botany;
+using Items;
 using Items.Botany;
 
 namespace Objects.Botany

--- a/UnityProject/Assets/Scripts/Objects/Kitchen/InteractableGrinder.cs
+++ b/UnityProject/Assets/Scripts/Objects/Kitchen/InteractableGrinder.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 using Chemistry.Components;
+using Items;
 
 namespace Objects.Kitchen
 {

--- a/UnityProject/Assets/Scripts/Objects/Machines/Microwave.cs
+++ b/UnityProject/Assets/Scripts/Objects/Machines/Microwave.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Mirror;
 using Systems.Electricity;
+using Items;
 
 namespace Objects.Kitchen
 {

--- a/UnityProject/Assets/Scripts/Objects/Mining/OreRedemptionMachine.cs
+++ b/UnityProject/Assets/Scripts/Objects/Mining/OreRedemptionMachine.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using System;
+using Items;
 using UnityEngine.Serialization;
 
 namespace Objects.Mining

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Doors;
+using Items;
 using UnityEngine;
 using UnityEngine.Events;
 using Objects;

--- a/UnityProject/Assets/Scripts/Robotics/Bots/BotConstruction.cs
+++ b/UnityProject/Assets/Scripts/Robotics/Bots/BotConstruction.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using Items;
+using UnityEngine;
 using Mirror;
 /// <summary>
 /// The component used in the botassembly prefabs that keeps track of the "stage" the bot is on before spawning the actual simplebot prefab

--- a/UnityProject/Assets/Scripts/Robotics/Bots/ContainerConstruct.cs
+++ b/UnityProject/Assets/Scripts/Robotics/Bots/ContainerConstruct.cs
@@ -1,4 +1,5 @@
 ﻿using Chemistry.Components;
+using Items;
 using UnityEngine;
 
 /// <summary>

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objective.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objective.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 
 namespace Antagonists

--- a/UnityProject/Assets/Scripts/Systems/Construction/MachineFrame.cs
+++ b/UnityProject/Assets/Scripts/Systems/Construction/MachineFrame.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 using Mirror;
 using ScriptableObjects;

--- a/UnityProject/Assets/Scripts/Systems/Crafting/IngredientMarker.cs
+++ b/UnityProject/Assets/Scripts/Systems/Crafting/IngredientMarker.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 
 /// <summary>

--- a/UnityProject/Assets/Scripts/Systems/Inventory/DamageOnPickUp.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/DamageOnPickUp.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 
 public class DamageOnPickUp : MonoBehaviour, IServerInventoryMove

--- a/UnityProject/Assets/Scripts/Systems/Inventory/ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/ItemSlot.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Items;
 using Mirror;
 using UnityEngine;
 using UnityEngine.Events;

--- a/UnityProject/Assets/Scripts/Systems/Inventory/Structure/DefinedSlotCapacity.cs
+++ b/UnityProject/Assets/Scripts/Systems/Inventory/Structure/DefinedSlotCapacity.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Items;
 using UnityEngine;
 
 /// <summary>

--- a/UnityProject/Assets/Scripts/UI/Core/Net/Elements/Dynamic/Prefab/ItemEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Net/Elements/Dynamic/Prefab/ItemEntry.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Items;
 using UnityEngine;
 
 /// <summary>

--- a/UnityProject/Assets/Scripts/UI/Core/Net/Elements/Dynamic/Prefab/ItemList.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/Net/Elements/Dynamic/Prefab/ItemList.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Items;
 using UnityEngine;
 
 /// <summary>

--- a/UnityProject/Assets/Scripts/UI/Core/RightClick/RightClickManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/RightClick/RightClickManager.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using DatabaseAPI;
 using Doors;
+using Items;
 using Objects.Wallmounts;
 using UnityEngine;
 using UnityEngine.EventSystems;

--- a/UnityProject/Assets/Scripts/UI/Objects/Commons/Vending/VendorItemEntry.cs
+++ b/UnityProject/Assets/Scripts/UI/Objects/Commons/Vending/VendorItemEntry.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Items;
 using UnityEngine;
 using Objects;
 

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/DevSpawnerListItemController.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/DevSpawnerListItemController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using DatabaseAPI;
+using Items;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;

--- a/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevCloner.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/AdminTools/DevTools/GUI_DevCloner.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using DatabaseAPI;
+using Items;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/ControlInternals.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/ControlInternals.cs
@@ -1,6 +1,7 @@
 using System;
 using Objects.Atmospherics;
 using Systems.Atmospherics;
+using Items;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemImage.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemImage.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Items;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/MainHUD/UI Bottom/UI_ItemSlot.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Items;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.EventSystems;

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using Objects;
 using Random = UnityEngine.Random;
 using System.Text;
+using Items;
 
 public static class SweetExtensions
 {


### PR DESCRIPTION
### Description
All items, crates and lockers get a new component, WrappableItem/WrappableObject, which will make them able to be wrapped in paper. Use the lame brown paper to wrap stuff and make delivery parcels. Use the festive paper to make gifts!

Items and objects are made a child of the spawned package item/object and are moved to hiddenPos. You can retrieve the content by unwrapping the package interacting with an empty hand in harm intent.

Wrapping paper, both in brown and festive, are stackable. A specific amount of stacks are required to wrap an object/item. For lockers and crates, the only way to get the amount is by setting it on inspector. For items, the default behavior is based on the size of the item, but devs can override it and set an amount manually.

Players can also attach notes to the packages if they are holding a paper sheet with something written on it. The note can be read by examining the package and can be dettached with a right click interaction.

- [x] Wrappable component to add the ability to wrap game objects.
- [x] Wrapped component to add the ability to unwrap items and retrieve its "content".
- [x] Wrapped component to add the ability to unwrap game objects and retrieve its "content".
- [x] Wrapped item and wrapped object prefabs.
- [ ] Ability to write in a paper and attach it to a package as a note. Readable by examining the object.

### Notes
The last time I tried, notes weren't working on client. I will do more debugging tomorrow, but if you know what is wrong and can give a hand, that'd be much appreciated. 

### Changelog 
CL: added ability to wrap all items, crates and lockers.