### PR TITLE
Suit storage slot whitelist.

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/Equip/SuitStorageCapacity.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Inventory/Structure/Equip/SuitStorageCapacity.asset
@@ -13,6 +13,18 @@ MonoBehaviour:
   m_Name: SuitStorageCapacity
   m_EditorClassIdentifier: 
   MaxItemSize: 4
-  Whitelist: []
+  Whitelist:
+  - {fileID: 11400000, guid: 499c5f7e8067145d3b31ba4b21a2fa74, type: 2}
+  - {fileID: 11400000, guid: 0ed64735be8ec47f99cd4c93bce388ac, type: 2}
+  - {fileID: 11400000, guid: 772b89f17c514364fa86a100fa6de780, type: 2}
+  - {fileID: 11400000, guid: e97648598582a134b94dc1e17fb1ef56, type: 2}
+  - {fileID: 11400000, guid: 3e088c6c232d4894ab39e95b28c63f9a, type: 2}
+  - {fileID: 11400000, guid: f6f122bac4fb34653b5921cfbf89d313, type: 2}
+  - {fileID: 11400000, guid: a88f1555ca8abf643aea180c637f5329, type: 2}
+  - {fileID: 11400000, guid: 6dfa39f936b18f24b833015a255aa6f2, type: 2}
+  - {fileID: 11400000, guid: fe33f4bf42dd236b39e97b3cdcbc7515, type: 2}
+  - {fileID: 11400000, guid: 58fb39d3789532541a56acc786a8a620, type: 2}
+  - {fileID: 11400000, guid: 71367280777879a43bd776fb7c23136b, type: 2}
+  - {fileID: 11400000, guid: 3858899698cc1425f86b8b93032ca57d, type: 2}
   Required: []
   Blacklist: []


### PR DESCRIPTION
### Purpose
CL: Made the suit storage slot use a whitelist which includes: guns, PDAs, melee weapons, magazines, ammo casings, handcuffs, oxygen tanks, power cells, flashlights, spray bottles, radios, and masks.
