### PR TITLE
Fixes rounds starting with no air

### DIFF
--- a/UnityProject/Assets/Scripts/Systems/Fluids/MixAndVolume.cs
+++ b/UnityProject/Assets/Scripts/Systems/Fluids/MixAndVolume.cs
@@ -19,7 +19,7 @@ namespace Pipes
 			get => mix.InternalEnergy + gasMix.InternalEnergy;
 			set
 			{
-				if (Mathf.Approximately(WholeHeatCapacity, 0))
+				if (CodeUtilities.IsEqual(WholeHeatCapacity, 0))
 				{
 					return;
 				}
@@ -114,7 +114,7 @@ namespace Pipes
 
 		public Tuple<ReagentMix, GasMix> Take(MixAndVolume inMixAndVolume, bool removeVolume = true)
 		{
-			if (Mathf.Approximately(Volume, 0))
+			if (CodeUtilities.IsEqual(Volume, 0))
 			{
 				Logger.LogError(" divide by 0 in Take ");
 			}
@@ -146,7 +146,7 @@ namespace Pipes
 
 		public void Divide(float divideAmount, bool changeVolume = true)
 		{
-			if (Mathf.Approximately(divideAmount, 0))
+			if (CodeUtilities.IsEqual(divideAmount, 0))
 			{
 				Logger.LogError(" divide by 0 in Divide");
 			}
@@ -284,7 +284,7 @@ namespace Pipes
 			{
 				float totalVolume = Volume + PipeFunctions.PipeOrNet(another).Volume;
 				float totalReagents = mix.Total + PipeFunctions.PipeOrNet(another).mix.Total;
-				if (Mathf.Approximately(totalVolume, 0))
+				if (CodeUtilities.IsEqual(totalVolume, 0))
 				{
 					Logger.LogError(" divide by 0 in EqualiseWith TotalVolume ");
 				}
@@ -328,7 +328,7 @@ namespace Pipes
 					totalReagents += PipeFunctions.PipeOrNet(pipe).mix.Total;
 				}
 
-				if (Mathf.Approximately(totalVolume, 0))
+				if (CodeUtilities.IsEqual(totalVolume, 0))
 				{
 					Logger.LogError(" divide by 0 in EqualiseWithMultiple TotalVolume ");
 				}

--- a/UnityProject/Assets/Scripts/Systems/Fluids/MixAndVolume.cs
+++ b/UnityProject/Assets/Scripts/Systems/Fluids/MixAndVolume.cs
@@ -37,7 +37,7 @@ namespace Pipes
 		{
 			get
 			{
-				if (Mathf.Approximately(WholeHeatCapacity, 0))
+				if (CodeUtilities.IsEqual(WholeHeatCapacity, 0))
 				{
 					return 0;
 				}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/GasMix.cs
@@ -115,21 +115,21 @@ namespace Systems.Atmospherics
 		public static void TransferGas(GasMix target, GasMix source, float molesTransferred)
 		{
 			var sourceStartMoles = source.Moles;
-			if (Mathf.Approximately(molesTransferred, 0) || Mathf.Approximately(sourceStartMoles, 0))
+			if (CodeUtilities.IsEqual(molesTransferred, 0) || CodeUtilities.IsEqual(sourceStartMoles, 0))
 				return;
 			var percentage =  molesTransferred / sourceStartMoles;
 			var targetStartMoles = target.Moles;
 
 			for (int i = 0; i < Gas.Count; i++)
 			{
-				if (Mathf.Approximately(source.Gases[i], 0))
+				if (CodeUtilities.IsEqual(source.Gases[i], 0))
 					continue;
 				var transfer = source.Gases[i] * percentage;
 				target.Gases[i] += transfer;
 				source.Gases[i] -= transfer;
 			}
 
-			if (Mathf.Approximately(target.Temperature, source.Temperature))
+			if (CodeUtilities.IsEqual(target.Temperature, source.Temperature))
 			{
 				target.RecalculatePressure();
 			}
@@ -141,7 +141,7 @@ namespace Systems.Atmospherics
 				target.SetTemperature(targetTempFinal);
 			}
 
-			if (Mathf.Approximately(percentage, 1)) //transferred everything, source is empty
+			if (CodeUtilities.IsEqual(percentage, 1)) //transferred everything, source is empty
 			{
 				source.SetPressure(0);
 			}

--- a/UnityProject/Assets/Scripts/Util/CodeUtilities.cs
+++ b/UnityProject/Assets/Scripts/Util/CodeUtilities.cs
@@ -19,4 +19,13 @@ public static class CodeUtilities
 
 		return String.Empty;
 	}
+
+	public static bool IsEqual(float a, float b)
+	{
+		if (a >= b - Mathf.Epsilon && a <= b + Mathf.Epsilon)
+		{
+			return true;
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
### Purpose
Fixes rounds starting with no air and the million errors popping out making it unplayable.
Adds a new static function called IsEqual() in CodeUtilities.cs to replace Mathf.Approximately() who seems to not work properly at times when comparing two 0s.