### PR TITLE
Feature 5309 bluespacebanana teleport on slip

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Trash/Banana bluespace peel.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Trash/Banana bluespace peel.prefab
@@ -74,7 +74,7 @@ PrefabInstance:
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -230,6 +230,12 @@ PrefabInstance:
       propertyPath: itemSprites.SpriteRightHand
       value: 
       objectReference: {fileID: 11400000, guid: ead0180d8430908498e20153d6c24363,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 6365ad3bdf400fc49915f8c5a3d2ccf1,
         type: 2}
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Effect/BluespaceActivity.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Effect/BluespaceActivity.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ccfe138752d4b66bcb7c56a0c9769c7, type: 3}
+  m_Name: BluespaceActivity
+  m_EditorClassIdentifier: 
+  traitDescription: Gives the plant bluespace properties, making it teleport people
+    hit if the plant has Liquid Contents, and on slip if it has Slippery Skin. Max
+    radius is determined by potency.

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/Effect/BluespaceActivity.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/Effect/BluespaceActivity.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6365ad3bdf400fc49915f8c5a3d2ccf1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
+++ b/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
@@ -65,4 +65,5 @@ public class CommonTraits : SingletonScriptableObject<CommonTraits>
 	public ItemTrait Loomable;
 	public ItemTrait WizardGarb;
 	public ItemTrait Suppressor;
+	public ItemTrait BluespaceActivity;
 }

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -983,6 +983,10 @@ public partial class PlayerSync
 			if (crossedItem.HasTrait(CommonTraits.Instance.Slippery))
 			{
 				registerPlayer.ServerSlip(slipWhileWalking: true);
+				if (crossedItem.HasTrait(CommonTraits.Instance.BluespaceActivity))
+				{
+					registerPlayer.ServerBluespaceActivity();
+				}
 			}
 		}
 	}

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.Server.cs
@@ -985,6 +985,7 @@ public partial class PlayerSync
 				registerPlayer.ServerSlip(slipWhileWalking: true);
 				if (crossedItem.HasTrait(CommonTraits.Instance.BluespaceActivity))
 				{
+					//TODO: Replace call with one that passes in potency once potency is trackable
 					registerPlayer.ServerBluespaceActivity();
 				}
 			}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using Mirror;
 using UnityEngine.Events;
 using Random = UnityEngine.Random;
+using Systems.Teleport;
 
 [RequireComponent(typeof(Directional))]
 [RequireComponent(typeof(UprightSprites))]
@@ -244,6 +245,20 @@ public class RegisterPlayer : RegisterTile, IServerSpawn
 		{
 			playerScript.playerMove.allowInput = true;
 		}
+	}
+	// <summary>
+	/// Performs bluespace activity on player if they have slipped on an object
+	/// with bluespace activity or are hit by an object with bluespace acivity and
+	/// has Liquid Contents.
+	/// </summary>
+	///
+	public void ServerBluespaceActivity(int potency = 100)
+	{
+		int maxRange = 11;
+		int potencyStrength = (int)Math.Round((potency * .01f) * maxRange, 0);
+		Vector3Int randomVector = new Vector3Int(Random.Range(0, potencyStrength), Random.Range(0, potencyStrength), Random.Range(0, potencyStrength));
+		Vector3Int randomPlayerLocation = playerScript.registerTile.WorldPositionServer + randomVector;
+		TeleportUtils.ServerTeleportRandom(playerScript.gameObject, 0, potencyStrength, false, true);
 	}
 }
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -247,7 +247,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn
 		}
 	}
 	// <summary>
-	/// Performs bluespace activity on player if they have slipped on an object
+	/// Performs bluespace activity (teleports randomly) on player if they have slipped on an object
 	/// with bluespace activity or are hit by an object with bluespace acivity and
 	/// has Liquid Contents.
 	/// Assumes max potency if none is given.
@@ -257,8 +257,6 @@ public class RegisterPlayer : RegisterTile, IServerSpawn
 	{
 		int maxRange = 11;
 		int potencyStrength = (int)Math.Round((potency * .01f) * maxRange, 0);
-		Vector3Int randomVector = new Vector3Int(Random.Range(0, potencyStrength), Random.Range(0, potencyStrength), Random.Range(0, potencyStrength));
-		Vector3Int randomPlayerLocation = playerScript.registerTile.WorldPositionServer + randomVector;
 		TeleportUtils.ServerTeleportRandom(playerScript.gameObject, 0, potencyStrength, false, true);
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Objects/RegisterPlayer.cs
@@ -250,6 +250,7 @@ public class RegisterPlayer : RegisterTile, IServerSpawn
 	/// Performs bluespace activity on player if they have slipped on an object
 	/// with bluespace activity or are hit by an object with bluespace acivity and
 	/// has Liquid Contents.
+	/// Assumes max potency if none is given.
 	/// </summary>
 	///
 	public void ServerBluespaceActivity(int potency = 100)


### PR DESCRIPTION
### Purpose
Adds feature #5309 bluespace banana teleport on slip

### Notes:
Currently it does not factor in potency when calculating max distance due to no way of detecting the potency of the banana peel slipped on. 