### PR TITLE
Welding fuel no longer creates plasma when removed from containers.

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -127,10 +127,12 @@ public class MetaDataLayer : MonoBehaviour
 				case "SpaceCleaner":
 					Clean(worldPosInt, localPosInt, false);
 					break;
+			
+				/*PM: Commenting out so others can see an example of gas getting created by chemistry.
 				case "WeldingFuel":
 					//temporary: converting spilled fuel to plasma
 					Get(localPosInt).GasMix.AddGas(Gas.Plasma, reagent.Value);
-					break;
+					break; */
 				case "SpaceLube":
 				{
 					//( ͡° ͜ʖ ͡°)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -127,12 +127,6 @@ public class MetaDataLayer : MonoBehaviour
 				case "SpaceCleaner":
 					Clean(worldPosInt, localPosInt, false);
 					break;
-			
-				/*PM: Commenting out so others can see an example of gas getting created by chemistry.
-				case "WeldingFuel":
-					//temporary: converting spilled fuel to plasma
-					Get(localPosInt).GasMix.AddGas(Gas.Plasma, reagent.Value);
-					break; */
 				case "SpaceLube":
 				{
 					//( ͡° ͜ʖ ͡°)


### PR DESCRIPTION
### Purpose
- Welding fuel no longer creates plasma gas when it is removed from containers like welding tools or fuel tanks.

CL: Removed ability for welding fuel to create plasma gas when it is emptied out of containers.
