### PR TITLE
Better stun baton script. Remove refs to stun baton in MeleeStun.cs.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Security/Stun Baton.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Security/Stun Baton.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &2744419419948037400
+--- !u!114 &1299614092489003431
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -9,16 +9,20 @@ MonoBehaviour:
   m_GameObject: {fileID: 8127442588295923452}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1026994845132ff428323bab7b3d5fd5, type: 3}
+  m_Script: {fileID: 11500000, guid: aa907c138d911104886acf35c9807dd3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
   spriteHandler: {fileID: 2705650514114133371}
-  soundToggle: Sparks01
-  spriteActive: {fileID: 21300000, guid: 0e5edf73e36bedf4b8b621aff4559d78, type: 3}
-  spriteInactive: {fileID: 21300000, guid: d692e3351e1ae8443a57daf8b9695ddd, type: 3}
-  active: 0
+  meleeStun: {fileID: 7515531381510586654}
+  ToggleSound:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/Effects/EGloves.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &7515531381510586654
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31,7 +35,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9bc379e328bc3bd44a6541cd4f3e5a57, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  stunTime: 14
+  stunTime: 10
   delay: 3
   stunSound: EGloves
 --- !u!1001 &8127288814593014342
@@ -103,27 +107,17 @@ PrefabInstance:
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialTraits.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialName
-      value: Stun baton
+      value: stun baton
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialDescription
       value: A stun baton for incapacitating people with.
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: exportCost
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: exportName
-      value: stun baton
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -226,11 +220,40 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 5f15b95301f00cd4cbe7d54fd6f9828f,
         type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 5eafba0d7388d428c8e08ed1b5d5d260,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: PresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 370aa0cb44d52b4408afbc9bc79c9c66,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 370aa0cb44d52b4408afbc9bc79c9c66,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 9e3d66e158fbfe644ae8d90f8ad024cd,
+        type: 2}
+    - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 1aa766851992da949a87275ed747bc5d,
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Security/Stun Baton.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Security/Stun Baton.prefab
@@ -14,8 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  spriteHandler: {fileID: 2705650514114133371}
-  meleeStun: {fileID: 7515531381510586654}
   ToggleSound:
     SetLoadSetting: 0
     AssetAddress: Assets/Prefabs/Effects/EGloves.prefab
@@ -263,15 +261,3 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 8127288814593014342}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2705650514114133371 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
-    type: 3}
-  m_PrefabInstance: {fileID: 8127288814593014342}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Scripts/Items/Weapons/Melee/StunBatonV2.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Melee/StunBatonV2.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using AddressableReferences;
+using Mirror;
+using UnityEngine;
+
+[RequireComponent(typeof(Pickupable))]
+public class StunBatonV2 : NetworkBehaviour, ICheckedInteractable<HandActivate>, IServerSpawn
+{
+	public SpriteHandler spriteHandler;
+
+    public MeleeStun meleeStun;
+	
+	// Sound played when turning this baton on/off.
+	public AddressableAudioSource ToggleSound;
+
+	///Both used as states for the baton and for the sub-catalogue in the sprite handler.
+	private enum BatonState
+	{
+		Off,
+		On,
+		NoCell
+	}
+
+	private BatonState batonState;
+
+    private void Awake()
+    {
+        meleeStun = GetComponent<MeleeStun>();
+    }
+
+	// Calls TurnOff() when baton is spawned, see below.
+	public void OnSpawnServer(SpawnInfo info)
+	{
+		TurnOff();
+	}
+
+	// Enables melee stun component and sets baton state to on.
+    private void TurnOn()
+        {
+        meleeStun.enabled = true;
+		batonState = BatonState.On;
+		spriteHandler.ChangeSprite((int) BatonState.On);
+        }
+
+	// Disables melee stun component and sets baton state to off.
+    private void TurnOff()
+    {
+        //logic to turn the baton off.
+        meleeStun.enabled = false;
+		batonState = BatonState.Off;
+		spriteHandler.ChangeSprite((int) BatonState.Off);
+    }
+
+	//For making sure the user is actually conscious.
+	public bool WillInteract(HandActivate interaction, NetworkSide side)
+	{
+		return DefaultWillInteract.Default(interaction, side);
+	}
+
+	//Activating the baton in-hand turns it off, on, or does nothing depending on its state.
+	public void ServerPerformInteraction(HandActivate interaction)
+	{
+		if (batonState == BatonState.Off)
+		{
+			TurnOn();
+			SoundManager.PlayNetworkedAtPos(ToggleSound, interaction.Performer.AssumedWorldPosServer(), sourceObj: interaction.Performer);
+		}
+		else
+		{
+			TurnOff();
+			SoundManager.PlayNetworkedAtPos(ToggleSound, interaction.Performer.AssumedWorldPosServer(), sourceObj: interaction.Performer);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Weapons/Melee/StunBatonV2.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Melee/StunBatonV2.cs
@@ -6,11 +6,12 @@ using Mirror;
 using UnityEngine;
 
 [RequireComponent(typeof(Pickupable))]
+[RequireComponent(typeof(MeleeStun))]
 public class StunBatonV2 : NetworkBehaviour, ICheckedInteractable<HandActivate>, IServerSpawn
 {
-	public SpriteHandler spriteHandler;
+	private SpriteHandler spriteHandler;
 
-    public MeleeStun meleeStun;
+	private MeleeStun meleeStun;
 	
 	// Sound played when turning this baton on/off.
 	public AddressableAudioSource ToggleSound;
@@ -25,10 +26,11 @@ public class StunBatonV2 : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 
 	private BatonState batonState;
 
-    private void Awake()
-    {
-        meleeStun = GetComponent<MeleeStun>();
-    }
+	private void Awake()
+	{
+		spriteHandler = GetComponentInChildren<SpriteHandler>();
+		meleeStun = GetComponent<MeleeStun>();
+	}
 
 	// Calls TurnOff() when baton is spawned, see below.
 	public void OnSpawnServer(SpawnInfo info)
@@ -36,22 +38,20 @@ public class StunBatonV2 : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		TurnOff();
 	}
 
-	// Enables melee stun component and sets baton state to on.
-    private void TurnOn()
-        {
-        meleeStun.enabled = true;
+	private void TurnOn()
+	{
+		meleeStun.enabled = true;
 		batonState = BatonState.On;
 		spriteHandler.ChangeSprite((int) BatonState.On);
-        }
+	}
 
-	// Disables melee stun component and sets baton state to off.
-    private void TurnOff()
-    {
-        //logic to turn the baton off.
-        meleeStun.enabled = false;
+	private void TurnOff()
+	{
+		//logic to turn the baton off.
+		meleeStun.enabled = false;
 		batonState = BatonState.Off;
 		spriteHandler.ChangeSprite((int) BatonState.Off);
-    }
+	}
 
 	//For making sure the user is actually conscious.
 	public bool WillInteract(HandActivate interaction, NetworkSide side)
@@ -59,18 +59,17 @@ public class StunBatonV2 : NetworkBehaviour, ICheckedInteractable<HandActivate>,
 		return DefaultWillInteract.Default(interaction, side);
 	}
 
-	//Activating the baton in-hand turns it off, on, or does nothing depending on its state.
+	//Activating the baton in-hand turns it off or off depending on its state.
 	public void ServerPerformInteraction(HandActivate interaction)
 	{
+		SoundManager.PlayNetworkedAtPos(ToggleSound, interaction.Performer.AssumedWorldPosServer(), sourceObj: interaction.Performer);
 		if (batonState == BatonState.Off)
 		{
 			TurnOn();
-			SoundManager.PlayNetworkedAtPos(ToggleSound, interaction.Performer.AssumedWorldPosServer(), sourceObj: interaction.Performer);
 		}
 		else
 		{
 			TurnOff();
-			SoundManager.PlayNetworkedAtPos(ToggleSound, interaction.Performer.AssumedWorldPosServer(), sourceObj: interaction.Performer);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/Melee/StunBatonV2.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Melee/StunBatonV2.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa907c138d911104886acf35c9807dd3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
- Adds a new stun baton script, hopefully cleaner than the old one.
- Removes references to stun baton script and batons in general in MeleeStun.cs
- You no longer hurt people when stunning them on disarm and grab intents with batons and other stunning melee weapons.

Credit to Gilles for helping me with StunBatonV2.cs.

### Changelog:
CL: Removed ability for stun batons to hurt people when used to stun on disarm and grab intent.
