### PR TITLE
Moves pipes and atmospheric reactions to the atmospherics thread.

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Initialisation/LoadManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Initialisation/LoadManager.cs
@@ -71,6 +71,7 @@ namespace Initialisation
 				stopwatch.Stop();
 				//Logger.Log(stopwatch.ElapsedMilliseconds.ToString() + " < ElapsedMilliseconds ");
 			}
+			SpawnSafeThread.Process();
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/SpawnSafeThread.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/SpawnSafeThread.cs
@@ -5,7 +5,7 @@ using System.Collections.Concurrent;
 /// <summary>
 /// Using main thread to spawn prefabs into the world
 /// </summary>
-public class SpawnSafeThread
+public static class SpawnSafeThread
 {
 	private static ConcurrentQueue<Tuple<Vector3, GameObject>> prefabsToSpawn = new ConcurrentQueue<Tuple<Vector3, GameObject>>();
 

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/SpawnSafeThread.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/SpawnSafeThread.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using UnityEngine;
+using System.Collections.Concurrent;
+
+/// <summary>
+/// Using main thread to spawn prefabs into the world
+/// </summary>
+public class SpawnSafeThread
+{
+	private static ConcurrentQueue<Tuple<Vector3, GameObject>> prefabsToSpawn = new ConcurrentQueue<Tuple<Vector3, GameObject>>();
+
+	public static void Process()
+	{
+		if (prefabsToSpawn.IsEmpty)
+			return;
+
+		Tuple<Vector3, GameObject> tuple;
+		while (prefabsToSpawn.TryDequeue(out tuple))
+		{
+			Spawn.ServerPrefab(tuple.Item2, tuple.Item1, MatrixManager.GetDefaultParent(tuple.Item1, true));
+		}
+	}
+
+	public static void SpawnPrefab(Vector3 tilePos, GameObject prefabObject)
+	{
+		prefabsToSpawn.Enqueue(new Tuple<Vector3, GameObject>(tilePos, prefabObject));
+	}
+}

--- a/UnityProject/Assets/Scripts/Core/Lifecycle/SpawnSafeThread.cs.meta
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/SpawnSafeThread.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9d7e12b1caae4aed80df95c8b8be8068
+timeCreated: 1607585058

--- a/UnityProject/Assets/Scripts/Messages/Server/RemoveTileMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/RemoveTileMessage.cs
@@ -1,0 +1,30 @@
+﻿using UnityEngine;
+using Mirror;
+
+public class RemoveTileMessage : ServerMessage
+{
+	public Vector3 Position;
+	public LayerType LayerType;
+	public bool RemoveAll;
+	public uint TileChangeManager;
+
+	public override void Process()
+	{
+		LoadNetworkObject(TileChangeManager);
+		var tileChangerManager = NetworkObject.GetComponent<TileChangeManager>();
+		tileChangerManager.InternalRemoveTile(Position, LayerType, RemoveAll);
+	}
+
+	public static RemoveTileMessage Send(uint tileChangeManagerNetID, Vector3 position, LayerType layerType, bool removeAll)
+	{
+		RemoveTileMessage msg = new RemoveTileMessage
+		{
+			Position = position,
+			LayerType = layerType,
+			RemoveAll = removeAll,
+			TileChangeManager = tileChangeManagerNetID
+		};
+		msg.SendToAll();
+		return msg;
+	}
+}

--- a/UnityProject/Assets/Scripts/Messages/Server/RemoveTileMessage.cs.meta
+++ b/UnityProject/Assets/Scripts/Messages/Server/RemoveTileMessage.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7a60bbd91985473889a3ba35dee51353
+timeCreated: 1607756918

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateTileMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateTileMessage.cs
@@ -1,0 +1,35 @@
+﻿using UnityEngine;
+using Mirror;
+
+public class UpdateTileMessage : ServerMessage
+{
+	public Vector3Int Position;
+	public TileType TileType;
+	public string TileName;
+	public Matrix4x4 TransformMatrix;
+	public Color Colour;
+	public uint TileChangeManager;
+
+	public override void Process()
+	{
+		LoadNetworkObject(TileChangeManager);
+		var tileChangerManager = NetworkObject.GetComponent<TileChangeManager>();
+		tileChangerManager.InternalUpdateTile(Position, TileType, TileName, TransformMatrix, Colour);
+	}
+
+	public static UpdateTileMessage Send(uint tileChangeManagerNetID, Vector3Int position, TileType tileType, string tileName,
+		Matrix4x4 transformMatrix, Color colour)
+	{
+		UpdateTileMessage msg = new UpdateTileMessage
+		{
+			Position = position,
+			TileType = tileType,
+			TileName = tileName,
+			TransformMatrix = transformMatrix,
+			Colour = colour,
+			TileChangeManager = tileChangeManagerNetID
+		};
+		msg.SendToAll();
+		return msg;
+	}
+}

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateTileMessage.cs.meta
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateTileMessage.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 239dcfbe6f604ae787fe832aac253bb2
+timeCreated: 1607734793

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/AirVent.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/AirVent.cs
@@ -7,7 +7,7 @@ using Pipes;
 
 namespace Pipes
 {
-	public class AirVent : MonoPipe
+	public class AirVent : MonoPipe, IServerSpawn
 	{
 		public bool SelfSufficient = false;
 
@@ -28,19 +28,14 @@ namespace Pipes
 			base.Start();
 		}
 
+		public void OnSpawnServer(SpawnInfo info)
+		{
+			metaDataLayer = MatrixManager.AtPoint(registerTile.WorldPositionServer, true).MetaDataLayer;
+			metaNode = metaDataLayer.Get(registerTile.LocalPositionServer, false);
+		}
+
 		public override void TickUpdate()
 		{
-			if (metaDataLayer == null)
-			{
-				metaDataLayer = MatrixManager.AtPoint(registerTile.WorldPositionServer, true).MetaDataLayer;
-			}
-
-			if (metaNode == null)
-			{
-				metaNode = metaDataLayer.Get(registerTile.LocalPositionServer, false);
-			}
-
-
 			base.TickUpdate();
 			pipeData.mixAndVolume.EqualiseWithOutputs(pipeData.Outputs);
 			CheckAtmos();

--- a/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Scrubber.cs
+++ b/UnityProject/Assets/Scripts/Objects/Pipes/Devices/Scrubber.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace Pipes
 {
-	public class Scrubber : MonoPipe
+	public class Scrubber : MonoPipe, IServerSpawn
 	{
 		public bool SelfSufficient = false;
 		// minimum pressure needs to be a little lower because of floating point inaccuracies
@@ -27,19 +27,14 @@ namespace Pipes
 			base.Start();
 		}
 
+		public void OnSpawnServer(SpawnInfo info)
+		{
+			metaDataLayer = MatrixManager.AtPoint(registerTile.WorldPositionServer, true).MetaDataLayer;
+			metaNode = metaDataLayer.Get(registerTile.LocalPositionServer, false);
+		}
+
 		public override void TickUpdate()
 		{
-			if (metaDataLayer == null)
-			{
-				metaDataLayer = MatrixManager.AtPoint(registerTile.WorldPositionServer, true).MetaDataLayer;
-			}
-
-			if (metaNode == null)
-			{
-				metaNode = metaDataLayer.Get(registerTile.LocalPositionServer, false);
-			}
-
-
 			base.TickUpdate();
 			pipeData.mixAndVolume.EqualiseWithOutputs(pipeData.Outputs);
 			CheckAtmos();

--- a/UnityProject/Assets/Scripts/Objects/Wallmounts/FireAlarm.cs
+++ b/UnityProject/Assets/Scripts/Objects/Wallmounts/FireAlarm.cs
@@ -69,7 +69,7 @@ namespace Objects.Wallmounts
 		{
 			var integrity = GetComponent<Integrity>();
 			integrity.OnExposedEvent.AddListener(SendCloseAlerts);
-			AtmosManager.Instance.inGameFireAlarms.Add(this);
+			AtmosManager.Instance.AddFireAlarm(this);
 			RegisterTile registerTile = GetComponent<RegisterTile>();
 			MetaDataLayer metaDataLayer = MatrixManager.AtPoint(registerTile.WorldPositionServer, true).MetaDataLayer;
 			var wallMount = GetComponent<WallmountBehavior>();
@@ -101,7 +101,7 @@ namespace Objects.Wallmounts
 
 		public void OnDespawnServer(DespawnInfo info)
 		{
-			AtmosManager.Instance.inGameFireAlarms.Remove(this);
+			AtmosManager.Instance.RemoveFireAlarm(this);
 		}
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)

--- a/UnityProject/Assets/Scripts/Systems/Fluids/LiquidPipeNet.cs
+++ b/UnityProject/Assets/Scripts/Systems/Fluids/LiquidPipeNet.cs
@@ -197,12 +197,12 @@ namespace Pipes
 	{
 		public override void OnEnable()
 		{
-			AtmosManager.Instance.inGameNewPipes.Add(this);
+			AtmosManager.Instance.AddPipe(this);
 		}
 
 		public override void OnDisable()
 		{
-			AtmosManager.Instance.inGameNewPipes.Remove(this);
+			AtmosManager.Instance.RemovePipe(this);
 		}
 
 		public override void TickUpdate()

--- a/UnityProject/Assets/Scripts/Systems/Fluids/PipeData.cs
+++ b/UnityProject/Assets/Scripts/Systems/Fluids/PipeData.cs
@@ -85,7 +85,7 @@ namespace Pipes
 				PipeAction.pipeData = this;
 			}
 
-			AtmosManager.Instance.inGameNewPipes.Add(this);
+			AtmosManager.Instance.AddPipe(this);
 			ConnectedPipes =
 				PipeFunctions.GetConnectedPipes(ConnectedPipes, this, MatrixPos, matrix);
 
@@ -138,7 +138,7 @@ namespace Pipes
 
 		public virtual void OnDisable()
 		{
-			AtmosManager.Instance.inGameNewPipes.Remove(this);
+			AtmosManager.Instance.RemovePipe(this);
 			foreach (var Pipe in ConnectedPipes)
 			{
 				if(Pipe == null) continue;

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventOxyToPlasma.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventOxyToPlasma.cs
@@ -53,7 +53,7 @@ namespace InGameEvents
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			gasMix.AddGas(Gas.Plasma, 1f);
 

--- a/UnityProject/Assets/Scripts/Systems/Radiation/RadiationManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Radiation/RadiationManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using UnityEngine;
+using UnityEngine.PlayerLoop;
 using UnityEngine.Profiling;
 
 namespace Systems.Radiation
@@ -13,7 +14,7 @@ namespace Systems.Radiation
 		public List<RadiationPulse> PulseQueue = new List<RadiationPulse>();
 		private List<RadiationPulse> WorkingPulseQueue = new List<RadiationPulse>();
 
-		public static RadiationManager Instance;
+		public static RadiationManager Instance {get; private set;}
 
 		public bool Running { get; private set; }
 		public float MSSpeed = 100;
@@ -22,7 +23,6 @@ namespace Systems.Radiation
 		{
 			StopSim();
 		}
-
 		void OnEnable()
 		{
 			Instance = this;

--- a/UnityProject/Assets/Scripts/Systems/Radiation/RadiationManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Radiation/RadiationManager.cs
@@ -13,21 +13,7 @@ namespace Systems.Radiation
 		public List<RadiationPulse> PulseQueue = new List<RadiationPulse>();
 		private List<RadiationPulse> WorkingPulseQueue = new List<RadiationPulse>();
 
-		public static RadiationManager Instance
-		{
-			get
-			{
-				if (instance == null)
-				{
-					instance = FindObjectOfType<RadiationManager>();
-				}
-
-				return instance;
-			}
-			set { instance = value; }
-		}
-
-		private static RadiationManager instance;
+		public static RadiationManager Instance;
 
 		public bool Running { get; private set; }
 		public float MSSpeed = 100;
@@ -39,6 +25,7 @@ namespace Systems.Radiation
 
 		void OnEnable()
 		{
+			Instance = this;
 			EventManager.AddHandler(EVENT.RoundStarted, StartSim);
 			EventManager.AddHandler(EVENT.RoundEnded, StopSim);
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaDataLayer.cs
@@ -31,7 +31,7 @@ public class MetaDataLayer : MonoBehaviour
 		{
 			if (createIfNotExists)
 			{
-				nodes[localPosition] = new MetaDataNode(localPosition, reactionManager);
+				nodes[localPosition] = new MetaDataNode(localPosition, reactionManager, matrix);
 			}
 			else
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/MetaTileMap.cs
@@ -439,11 +439,11 @@ namespace TileManagement
 			return false;
 		}
 
-		public void SetTile(Vector3Int position, LayerTile tile, Matrix4x4? matrixTransform = null, Color? color = null)
+		public void SetTile(Vector3Int position, LayerTile tile, Matrix4x4? matrixTransform = null, Color? color = null, bool isPlaying = true)
 		{
 			if (Layers.TryGetValue(tile.LayerType, out var layer))
 			{
-				if (Application.isPlaying == false)
+				if (isPlaying == false) //is the game playing or is this the levelbrush?
 				{
 					layer.SetTile(position, tile,
 						matrixTransform.GetValueOrDefault(Matrix4x4.identity),

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSimulation.cs
@@ -18,11 +18,6 @@ namespace Systems.Atmospherics
 	public class AtmosSimulation
 	{
 		/// <summary>
-		/// True if the atmos simulation has no updates to perform
-		/// </summary>
-		public bool IsIdle => updateList.IsEmpty;
-
-		/// <summary>
 		/// Number of updates remaining for the atmos simulation to process
 		/// </summary>
 		public int UpdateListCount => updateList.Count;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosThread.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosThread.cs
@@ -19,6 +19,8 @@ public static class AtmosThread
 
 	private static CustomSampler sampler;
 
+	public static List<ReactionManager> reactionManagerList {get; private set;} = new List<ReactionManager>();
+
 	static AtmosThread()
 	{
 		simulation = new AtmosSimulation();
@@ -70,7 +72,6 @@ public static class AtmosThread
 		return simulation.UpdateListCount;
 	}
 
-	public static List<ReactionManager> reactionManagerList = new List<ReactionManager>();
 	public static void RunStep()
 	{
 		simulation.Run();

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/BZFormation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/BZFormation.cs
@@ -11,7 +11,7 @@ namespace Systems.Atmospherics
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			var oldHeatCap = gasMix.WholeHeatCapacity;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/FreonFireReaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/FreonFireReaction.cs
@@ -6,12 +6,13 @@ namespace Systems.Atmospherics
 {
 	public class FreonFireReaction : Reaction
 	{
+		private static System.Random rnd = new System.Random();
 		public bool Satisfies(GasMix gasMix)
 		{
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			var energyReleased = 0f;
 			var oldHeatCap = gasMix.WholeHeatCapacity;
@@ -52,9 +53,9 @@ namespace Systems.Atmospherics
 
 					gasMix.AddGas(Gas.CarbonDioxide, freonBurnRate);
 
-					if (gasMix.Temperature < 160 && gasMix.Temperature > 120 && UnityEngine.Random.Range(0, 2) == 0)
+					if (gasMix.Temperature < 160 && gasMix.Temperature > 120 && rnd.Next(0, 2) == 0)
 					{
-						Spawn.ServerPrefab(AtmosManager.Instance.hotIce, tilePos, MatrixManager.GetDefaultParent(tilePos, true));
+						SpawnSafeThread.SpawnPrefab(tilePos, AtmosManager.Instance.hotIce);
 					}
 
 					energyReleased += AtmosDefines.FIRE_FREON_ENERGY_RELEASED * freonBurnRate;

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/FreonFormation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/FreonFormation.cs
@@ -11,7 +11,7 @@ namespace Systems.Atmospherics
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			var oldHeatCap = gasMix.WholeHeatCapacity;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/FusionReaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/FusionReaction.cs
@@ -8,12 +8,14 @@ namespace Systems.Atmospherics
 {
 	public class FusionReaction : Reaction
 	{
+
+		private static System.Random rnd = new System.Random();
 		public bool Satisfies(GasMix gasMix)
 		{
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			var oldHeatCap = gasMix.WholeHeatCapacity;
 
@@ -30,6 +32,7 @@ namespace Systems.Atmospherics
 			                                                AtmosDefines.TOROID_VOLUME_BREAKEVEN));
 
 			var gasPower = 0f;
+
 
 			foreach (var gas in Gas.All)
 			{
@@ -79,7 +82,7 @@ namespace Systems.Atmospherics
 
 			if (reactionEnergy != 0)
 			{
-				RadiationManager.Instance.RequestPulse(MatrixManager.AtPoint(tilePos.RoundToInt(), true).Matrix, tilePos.RoundToInt(), Mathf.Max((AtmosDefines.FUSION_RAD_COEFFICIENT/instability)+ AtmosDefines.FUSION_RAD_MAX, 0), UnityEngine.Random.Range(Int32.MinValue, Int32.MaxValue));
+				RadiationManager.Instance.RequestPulse(matrix, tilePos.RoundToInt(), Mathf.Max((AtmosDefines.FUSION_RAD_COEFFICIENT/instability)+ AtmosDefines.FUSION_RAD_MAX, 0), rnd.Next(Int32.MinValue, Int32.MaxValue));
 
 				var newHeatCap = gasMix.WholeHeatCapacity;
 				if (newHeatCap > 0.0003f && (gasMix.Temperature <= AtmosDefines.FUSION_MAXIMUM_TEMPERATURE || reactionEnergy <= 0))

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/HyperNobliumFormation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/HyperNobliumFormation.cs
@@ -11,7 +11,7 @@ namespace Systems.Atmospherics
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			var oldHeatCap = gasMix.WholeHeatCapacity;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/MiasmaDecomposition.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/MiasmaDecomposition.cs
@@ -11,7 +11,7 @@ namespace Systems.Atmospherics
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			if (gasMix.GetMoles(Gas.WaterVapor) != 0 && gasMix.GetMoles(Gas.WaterVapor) / gasMix.Moles > 0.1)
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/NO2Decomposition.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/NO2Decomposition.cs
@@ -11,7 +11,7 @@ namespace Systems.Atmospherics
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			var oldHeatCap = gasMix.WholeHeatCapacity;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/NO2Formation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/NO2Formation.cs
@@ -11,7 +11,7 @@ namespace Systems.Atmospherics
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			var oldHeatCap = gasMix.WholeHeatCapacity;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/NitrylFormation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/NitrylFormation.cs
@@ -11,7 +11,7 @@ namespace Systems.Atmospherics
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			var oldHeatCap = gasMix.WholeHeatCapacity;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/PlasmaFireReaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/PlasmaFireReaction.cs
@@ -25,7 +25,7 @@ namespace Systems.Atmospherics
 			return false;
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			float temperature = gasMix.Temperature;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/Reaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/Reaction.cs
@@ -8,7 +8,7 @@ namespace Systems.Atmospherics
 	{
 		bool Satisfies(GasMix gasMix);
 
-		void React(GasMix gasMix, Vector3 tilePos);
+		void React(GasMix gasMix, Vector3 tilePos, Matrix matrix);
 	}
 
 	public struct GasReactions

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/Reactions.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/Reactions.cs
@@ -20,13 +20,13 @@ namespace Systems.Atmospherics
 			reactions.Add(new PlasmaFireReaction());
 		}
 
-		public static void React(GasMix gasMix)
+		public static void React(GasMix gasMix, Matrix matrix)
 		{
 			foreach (Reaction reaction in reactions)
 			{
 				if (reaction.Satisfies(gasMix))
 				{
-					reaction.React(gasMix, Vector3.zero);
+					reaction.React(gasMix, Vector3.zero, matrix);
 				}
 			}
 		}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/StimBallReaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/StimBallReaction.cs
@@ -12,7 +12,7 @@ namespace Systems.Atmospherics
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			var oldHeatCap = gasMix.WholeHeatCapacity;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/StimulumFormation.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/StimulumFormation.cs
@@ -11,7 +11,7 @@ namespace Systems.Atmospherics
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			var oldHeatCap = gasMix.WholeHeatCapacity;
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/TritiumFireReaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/TritiumFireReaction.cs
@@ -3,18 +3,18 @@ using System.Collections;
 using System.Collections.Generic;
 using Systems.Radiation;
 using UnityEngine;
-using Random = UnityEngine.Random;
 
 namespace Systems.Atmospherics
 {
 	public class TritiumFireReaction : Reaction
 	{
+		private static System.Random rnd = new System.Random();
 		public bool Satisfies(GasMix gasMix)
 		{
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			var energyReleased = 0f;
 			var oldHeatCap = gasMix.WholeHeatCapacity;
@@ -37,9 +37,10 @@ namespace Systems.Atmospherics
 			{
 				energyReleased += AtmosDefines.FIRE_HYDROGEN_ENERGY_RELEASED * burnedFuel;
 
-				if (Random.Range(0,10) == 0 && burnedFuel > AtmosDefines.TRITIUM_MINIMUM_RADIATION_ENERGY)
+				if (rnd.Next(0,10) == 0 && burnedFuel > AtmosDefines.TRITIUM_MINIMUM_RADIATION_ENERGY)
 				{
-					RadiationManager.Instance.RequestPulse(MatrixManager.AtPoint(tilePos.RoundToInt(), true).Matrix, tilePos.RoundToInt(), energyReleased / AtmosDefines.TRITIUM_BURN_RADIOACTIVITY_FACTOR, Random.Range(Int32.MinValue, Int32.MaxValue));
+					SpawnSafeThread.SpawnPrefab(tilePos, AtmosManager.Instance.iceShard);
+					RadiationManager.Instance.RequestPulse(matrix, tilePos.RoundToInt(), energyReleased / AtmosDefines.TRITIUM_BURN_RADIOACTIVITY_FACTOR, rnd.Next(Int32.MinValue, Int32.MaxValue));
 				}
 
 				gasMix.AddGas(Gas.WaterVapor, burnedFuel / AtmosDefines.TRITIUM_BURN_OXY_FACTOR);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/TritiumFireReaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/TritiumFireReaction.cs
@@ -39,7 +39,6 @@ namespace Systems.Atmospherics
 
 				if (rnd.Next(0,10) == 0 && burnedFuel > AtmosDefines.TRITIUM_MINIMUM_RADIATION_ENERGY)
 				{
-					SpawnSafeThread.SpawnPrefab(tilePos, AtmosManager.Instance.iceShard);
 					RadiationManager.Instance.RequestPulse(matrix, tilePos.RoundToInt(), energyReleased / AtmosDefines.TRITIUM_BURN_RADIOACTIVITY_FACTOR, rnd.Next(Int32.MinValue, Int32.MaxValue));
 				}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/WaterVapourReaction.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Data/Reactions/WaterVapourReaction.cs
@@ -11,7 +11,7 @@ namespace Systems.Atmospherics
 			throw new System.NotImplementedException();
 		}
 
-		public void React(GasMix gasMix, Vector3 tilePos)
+		public void React(GasMix gasMix, Vector3 tilePos, Matrix matrix)
 		{
 			if (gasMix.Temperature <= AtmosDefines.WATER_VAPOR_FREEZE)
 			{
@@ -25,7 +25,7 @@ namespace Systems.Atmospherics
 
 				for (var i = 0; i < numberOfIceToSpawn; i++)
 				{
-					Spawn.ServerPrefab(AtmosManager.Instance.iceShard, tilePos, MatrixManager.GetDefaultParent(tilePos, true));
+					SpawnSafeThread.SpawnPrefab(tilePos, AtmosManager.Instance.iceShard);
 				}
 
 				gasMix.RemoveGas(Gas.WaterVapor, numberOfIceToSpawn * 2f);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Hotspot.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/Hotspot.cs
@@ -16,14 +16,9 @@ namespace Systems.Atmospherics
 			node = newNode;
 		}
 
-		public bool Process()
+		public void Process()
 		{
-			if (PlasmaFireReaction.CanHoldHotspot(node.GasMix))
-			{
-				Reactions.React(node.GasMix);
-				return true;
-			}
-			return false;
+			Reactions.React(node.GasMix, node.PositionMatrix);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -31,7 +31,7 @@ namespace Systems.Atmospherics
 		private MetaDataLayer metaDataLayer;
 		private Matrix matrix;
 
-		private Dictionary<Vector3Int, MetaDataNode> hotspots;
+		private ConcurrentDictionary<Vector3Int, MetaDataNode> hotspots;
 		private UniqueQueue<MetaDataNode> winds;
 
 		private UniqueQueue<FogEffect> addFog; //List of tiles to add chemcial fx to
@@ -44,7 +44,7 @@ namespace Systems.Atmospherics
 		private TilemapDamage[] tilemapDamages;
 
 		private float timePassed;
-		private float timePassed2;
+		private int reactionTick;
 
 		/// <summary>
 		/// reused when applying exposures to lots of tiles to avoid creating GC from
@@ -58,7 +58,7 @@ namespace Systems.Atmospherics
 			metaDataLayer = GetComponent<MetaDataLayer>();
 			matrix = GetComponent<Matrix>();
 
-			hotspots = new Dictionary<Vector3Int, MetaDataNode>();
+			hotspots = new ConcurrentDictionary<Vector3Int, MetaDataNode>();
 			winds = new UniqueQueue<MetaDataNode>();
 
 			addFog = new UniqueQueue<FogEffect>();
@@ -74,13 +74,11 @@ namespace Systems.Atmospherics
 		private void Start()
 		{
 			fireLight = AtmosManager.Instance.fireLight;
+			AtmosThread.reactionManagerList.Add(this);
 		}
 
 		private void Update()
 		{
-			timePassed += Time.deltaTime;
-			timePassed2 += Time.deltaTime;
-
 			#region wind
 
 			Profiler.BeginSample("Wind");
@@ -134,44 +132,8 @@ namespace Systems.Atmospherics
 					}
 				}
 			}
-
-			timePassed2 = 0;
-
 			Profiler.EndSample();
-
 			#endregion
-
-			if (timePassed < 0.5)
-			{
-				return;
-			}
-
-
-			//process the current hotspots, potentially adding new ones and removing ones that have expired.
-			//(but we actually perform the add / remove after this loop so we don't concurrently modify the dict)
-			foreach (MetaDataNode node in hotspots.Values)
-			{
-				if (node.Hotspot != null)
-				{
-					if (node.Hotspot.Process())
-					{
-						foreach (var neighbor in node.Neighbors)
-						{
-							if (neighbor != null)
-							{
-								ExposeHotspot(neighbor.Position);
-							}
-						}
-					}
-					else
-					{
-						Profiler.BeginSample("MarkForRemoval");
-						RemoveHotspot(node);
-						Profiler.EndSample();
-					}
-				}
-			}
-
 
 			Profiler.BeginSample("HotspotModify");
 			//perform the actual logic that needs to happen for adding / removing hotspots that have been
@@ -179,12 +141,12 @@ namespace Systems.Atmospherics
 			foreach (var addedHotspot in hotspotsToAdd)
 			{
 				if (!hotspots.ContainsKey(addedHotspot.node.Position) &&
-					// only process the addition if it hasn't already been done, which
-					// could happen if multiple things try to add a hotspot to the same tile
-					addedHotspot.node.Hotspot == null)
+				    // only process the addition if it hasn't already been done, which
+				    // could happen if multiple things try to add a hotspot to the same tile
+				    addedHotspot.node.Hotspot == null)
 				{
 					addedHotspot.node.Hotspot = addedHotspot;
-					hotspots.Add(addedHotspot.node.Position, addedHotspot.node);
+					hotspots.TryAdd(addedHotspot.node.Position, addedHotspot.node);
 					tileChangeManager.UpdateTile(
 						new Vector3Int(addedHotspot.node.Position.x, addedHotspot.node.Position.y, FIRE_FX_Z),
 						TileType.Effects, "Fire");
@@ -200,15 +162,15 @@ namespace Systems.Atmospherics
 			foreach (var removedHotspot in hotspotsToRemove)
 			{
 				if (hotspots.TryGetValue(removedHotspot, out var affectedNode) &&
-					// only process the removal if it hasn't already been done, which
-					// could happen if multiple things try to remove a hotspot to the same tile)
-					affectedNode.HasHotspot)
+				    // only process the removal if it hasn't already been done, which
+				    // could happen if multiple things try to remove a hotspot to the same tile)
+				    affectedNode.HasHotspot)
 				{
 					affectedNode.Hotspot = null;
 					tileChangeManager.RemoveTile(
 						new Vector3Int(affectedNode.Position.x, affectedNode.Position.y, FIRE_FX_Z),
 						LayerType.Effects, false);
-					hotspots.Remove(removedHotspot);
+					hotspots.TryRemove(removedHotspot, out var value);
 
 					if (!fireLightDictionary.ContainsKey(affectedNode.Position)) continue;
 
@@ -225,7 +187,57 @@ namespace Systems.Atmospherics
 
 			hotspotsToAdd.Clear();
 			hotspotsToRemove.Clear();
+
+			timePassed += Time.deltaTime;
+			if (timePassed < 0.5)
+			{
+				return;
+			}
+
+			timePassed = 0;
+			reactionTick++;
+
+			//hotspot spread to adjacent tiles and damage
+			foreach (MetaDataNode node in hotspots.Values)
+			{
+				foreach (var neighbor in node.Neighbors)
+				{
+					if (neighbor != null)
+					{
+						ExposeHotspot(neighbor.Position);
+					}
+				}
+			}
+
 			Profiler.EndSample();
+		}
+
+
+		public void DoTick()
+		{
+			if (reactionTick == 0)
+			{
+				return;
+			}
+
+			reactionTick--;
+
+			//process the current hotspots, removing ones that can't sustain anymore.
+			//(but we actually perform the add / remove after this loop so we don't concurrently modify the dict)
+			foreach (MetaDataNode node in hotspots.Values)
+			{
+				if (node.Hotspot != null)
+				{
+					if (PlasmaFireReaction.CanHoldHotspot(node.GasMix))
+					{
+						node.Hotspot.Process();
+					}
+					else
+					{
+						RemoveHotspot(node);
+					}
+				}
+			}
 
 			Profiler.BeginSample("GasReactions");
 
@@ -238,7 +250,7 @@ namespace Systems.Atmospherics
 					{
 						var gasMix = addReactionNode.metaDataNode.GasMix;
 
-						addReactionNode.gasReaction.Reaction.React(gasMix, addReactionNode.metaDataNode.Position);
+						addReactionNode.gasReaction.Reaction.React(gasMix, addReactionNode.metaDataNode.Position, addReactionNode.metaDataNode.PositionMatrix);
 
 						if (reactions.TryGetValue(addReactionNode.metaDataNode.Position, out var gasHashSet) &&
 							gasHashSet.Count == 1)
@@ -319,8 +331,6 @@ namespace Systems.Atmospherics
 			Profiler.EndSample();
 
 			#endregion
-
-			timePassed = 0;
 		}
 
 		/// Same as ExposeHotspot but allows providing a world position and handles the conversion
@@ -329,7 +339,7 @@ namespace Systems.Atmospherics
 			ExposeHotspot(MatrixManager.WorldToLocalInt(tileWorldPosition.To3Int(), MatrixManager.Get(matrix)));
 		}
 
-		private void RemoveHotspot(MetaDataNode node)
+		public void RemoveHotspot(MetaDataNode node)
 		{
 			//removal will be processed later in update
 			hotspotsToRemove.Add(node.Position);

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -191,6 +191,7 @@ namespace Systems.Atmospherics
 			timePassed += Time.deltaTime;
 			if (timePassed < 0.5)
 			{
+				Profiler.EndSample();
 				return;
 			}
 

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataNode.cs
@@ -15,6 +15,11 @@ public class MetaDataNode : IGasMixContainer
 	public static readonly MetaDataNode None;
 
 	/// <summary>
+	/// Contains the matrix of the current node
+	/// </summary>
+	public Matrix PositionMatrix = null;
+
+	/// <summary>
 	/// Used for calculating explosion data
 	/// </summary>
 	public ExplosionNode ExplosionNode = null;
@@ -123,8 +128,9 @@ public class MetaDataNode : IGasMixContainer
 	/// Create a new MetaDataNode on the specified local position (within the parent matrix)
 	/// </summary>
 	/// <param name="position">local position (within the matrix) the node exists on</param>
-	public MetaDataNode(Vector3Int position, ReactionManager reactionManager)
+	public MetaDataNode(Vector3Int position, ReactionManager reactionManager, Matrix matrix)
 	{
+		PositionMatrix = matrix;
 		Position = position;
 		neighborList = new List<MetaDataNode>(4);
 		for (var i = 0; i < neighborList.Capacity; i++)
@@ -137,7 +143,7 @@ public class MetaDataNode : IGasMixContainer
 
 	static MetaDataNode()
 	{
-		None = new MetaDataNode(Vector3Int.one * -1000000, null);
+		None = new MetaDataNode(Vector3Int.one * -1000000, null, null);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Tilemaps/Editor/Brushes/LevelBrush.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Editor/Brushes/LevelBrush.cs
@@ -115,7 +115,7 @@ public class LevelBrush : GridBrush
 		foreach (LayerTile tile in metaTile.GetTiles())
 		{
 			//metaTileMap.RemoveTileWithlayer(position, tile.LayerType);
-			metaTileMap.SetTile(position, tile, cells[0].matrix);
+			metaTileMap.SetTile(position, tile, cells[0].matrix, isPlaying: true);
 		}
 	}
 
@@ -132,6 +132,6 @@ public class LevelBrush : GridBrush
 			SetTile(metaTileMap, position, requiredTile);
 		}
 
-		metaTileMap.SetTile(position, tile, cells[0].matrix, cells[0].color);
+		metaTileMap.SetTile(position, tile, cells[0].matrix, cells[0].color, isPlaying: true);
 	}
 }

--- a/UnityProject/Assets/Scripts/Tilemaps/Editor/Brushes/LevelBrush.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Editor/Brushes/LevelBrush.cs
@@ -115,7 +115,7 @@ public class LevelBrush : GridBrush
 		foreach (LayerTile tile in metaTile.GetTiles())
 		{
 			//metaTileMap.RemoveTileWithlayer(position, tile.LayerType);
-			metaTileMap.SetTile(position, tile, cells[0].matrix, isPlaying: true);
+			metaTileMap.SetTile(position, tile, cells[0].matrix, isPlaying: false);
 		}
 	}
 
@@ -132,6 +132,6 @@ public class LevelBrush : GridBrush
 			SetTile(metaTileMap, position, requiredTile);
 		}
 
-		metaTileMap.SetTile(position, tile, cells[0].matrix, cells[0].color, isPlaying: true);
+		metaTileMap.SetTile(position, tile, cells[0].matrix, cells[0].color, isPlaying: false);
 	}
 }


### PR DESCRIPTION
### Purpose
Moves pipes and atmospheric reactions to the atmospherics thread.
Adds SpawnSafeThread for threads to queue prefabs that will be spawned on the main thread.
Adds UpdateTileMessage and  to replace the RPC calls from TileChangeManager.
Fixes #5124
