### PR TITLE
Fixes ghost roles, paper, objectives (restarting)

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Bureaucracy/Paper.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Bureaucracy/Paper.prefab
@@ -45,103 +45,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   NetTabType: 4
   paper: {fileID: 585395312865148023}
---- !u!114 &4134974076236390094
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8734328976324889014}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 0
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 0}
-  m_TextViewport: {fileID: 0}
-  m_TextComponent: {fileID: 0}
-  m_Placeholder: {fileID: 0}
-  m_VerticalScrollbar: {fileID: 0}
-  m_VerticalScrollbarEventHandler: {fileID: 0}
-  m_LayoutGroup: {fileID: 0}
-  m_ScrollSensitivity: 1
-  m_ContentType: 0
-  m_InputType: 0
-  m_AsteriskChar: 42
-  m_KeyboardType: 0
-  m_LineType: 0
-  m_HideMobileInput: 0
-  m_HideSoftKeyboard: 0
-  m_CharacterValidation: 0
-  m_RegexValue: 
-  m_GlobalPointSize: 14
-  m_CharacterLimit: 0
-  m_OnEndEdit:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnSubmit:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnSelect:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnDeselect:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnTextSelection:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnEndTextSelection:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnValueChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnTouchScreenKeyboardStatusChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_CustomCaretColor: 0
-  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
-  m_Text: 
-  m_CaretBlinkRate: 0.85
-  m_CaretWidth: 1
-  m_ReadOnly: 0
-  m_RichText: 1
-  m_GlobalFontAsset: {fileID: 0}
-  m_OnFocusSelectAll: 1
-  m_ResetOnDeActivation: 1
-  m_RestoreOriginalTextOnEscape: 1
-  m_isRichTextEditingAllowed: 0
-  m_LineLimit: 0
-  m_InputValidator: {fileID: 0}
 --- !u!1001 &8733893691203122444
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -208,6 +111,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 66064101faf2cf84d8db3ffd022fd141,
         type: 3}
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: initialTraits.Array.size

--- a/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/TabPaper.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/UI/Tabs/Resources/TabPaper.prefab
@@ -12,8 +12,6 @@ GameObject:
   - component: {fileID: 222622871631726896}
   - component: {fileID: 114769899820182462}
   - component: {fileID: 1142769440901816531}
-  - component: {fileID: 114459991742813864}
-  - component: {fileID: 114955105891380638}
   m_Layer: 5
   m_Name: InputField
   m_TagString: Untagged
@@ -35,13 +33,13 @@ RectTransform:
   - {fileID: 224302566920053472}
   - {fileID: 224026978416182424}
   m_Father: {fileID: 224663602153563088}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -3.3, y: -101}
-  m_SizeDelta: {x: 648.1, y: 0}
-  m_Pivot: {x: 0.5, y: 1.000001}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -100}
+  m_SizeDelta: {x: -50, y: 675}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &222622871631726896
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -131,12 +129,12 @@ MonoBehaviour:
   m_InputType: 0
   m_AsteriskChar: 42
   m_KeyboardType: 0
-  m_LineType: 1
+  m_LineType: 2
   m_HideMobileInput: 0
   m_HideSoftKeyboard: 0
   m_CharacterValidation: 0
   m_RegexValue: 
-  m_GlobalPointSize: 14
+  m_GlobalPointSize: 26
   m_CharacterLimit: 0
   m_OnEndEdit:
     m_PersistentCalls:
@@ -173,19 +171,10 @@ MonoBehaviour:
         m_CallState: 2
   m_OnDeselect:
     m_PersistentCalls:
-      m_Calls: []
-  m_OnTextSelection:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnEndTextSelection:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnValueChanged:
-    m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 114356089685367662}
         m_TargetAssemblyTypeName: GUI_Paper, Assets
-        m_MethodName: OnTextValueChange
+        m_MethodName: OnTextEditEnd
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -195,6 +184,15 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  m_OnTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnEndTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
   m_OnTouchScreenKeyboardStatusChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -207,55 +205,12 @@ MonoBehaviour:
   m_ReadOnly: 0
   m_RichText: 1
   m_GlobalFontAsset: {fileID: 0}
-  m_OnFocusSelectAll: 1
-  m_ResetOnDeActivation: 1
-  m_RestoreOriginalTextOnEscape: 1
+  m_OnFocusSelectAll: 0
+  m_ResetOnDeActivation: 0
+  m_RestoreOriginalTextOnEscape: 0
   m_isRichTextEditingAllowed: 0
-  m_LineLimit: 20
+  m_LineLimit: 22
   m_InputValidator: {fileID: 0}
---- !u!114 &114459991742813864
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1073871676340802}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalFit: 0
-  m_VerticalFit: 2
---- !u!114 &114955105891380638
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1073871676340802}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Delegates:
-  - eventID: 4
-    callback:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 114356089685367662}
-          m_TargetAssemblyTypeName: 
-          m_MethodName: OnEditStart
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 0
 --- !u!1 &1155826666078090
 GameObject:
   m_ObjectHideFlags: 0
@@ -267,7 +222,6 @@ GameObject:
   - component: {fileID: 224026978416182424}
   - component: {fileID: 222842931053061846}
   - component: {fileID: 4237915105962269265}
-  - component: {fileID: 114143921897934410}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -291,7 +245,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 4.9000015}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &222842931053061846
@@ -381,7 +335,7 @@ MonoBehaviour:
   m_verticalMapping: 0
   m_uvLineOffset: 0
   m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
+  m_IsTextObjectScaleStatic: 1
   m_VertexBufferAutoSizeReduction: 1
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
@@ -391,20 +345,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!114 &114143921897934410
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1155826666078090}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalFit: 0
-  m_VerticalFit: 2
 --- !u!1 &1297454887248136
 GameObject:
   m_ObjectHideFlags: 0
@@ -433,10 +373,10 @@ RectTransform:
   m_GameObject: {fileID: 1297454887248136}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.9999994, y: 0.9999994, z: 0.9999994}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 224868005608327740}
   - {fileID: 224046292090504698}
+  - {fileID: 224868005608327740}
   m_Father: {fileID: 224120160830574892}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -525,8 +465,8 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1502172408805726}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.5625}
-  m_LocalScale: {x: 0.6953704, y: 0.6953704, z: 0.6953704}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.6953704, y: 0.6953704, z: 1}
   m_Children:
   - {fileID: 224120160830574892}
   m_Father: {fileID: 0}
@@ -534,7 +474,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 956, y: 550}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 700, y: 800}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &222946214041701798
@@ -569,7 +509,6 @@ MonoBehaviour:
   ProviderRegisterTile: {fileID: 0}
   Type: 4
   textField: {fileID: 1142769440901816531}
-  contentSizeFitter: {fileID: 114459991742813864}
 --- !u!114 &114055117178974294
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -700,8 +639,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 4.9000015}
-  m_SizeDelta: {x: -20, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &222074925701012412
 CanvasRenderer:
@@ -744,7 +683,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: click to edit (requires pen)..
+  m_Text: click to edit (requires pen)...
 --- !u!1 &1718948510130994
 GameObject:
   m_ObjectHideFlags: 0
@@ -867,12 +806,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 224663602153563088}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -663, y: -39}
-  m_SizeDelta: {x: 28.570007, y: 28.570007}
+  m_SizeDelta: {x: 30, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &222096006444898966
 CanvasRenderer:

--- a/UnityProject/Assets/Scripts/Messages/Server/GhostRoles/GhostRoleUpdateMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/GhostRoles/GhostRoleUpdateMessage.cs
@@ -34,7 +34,7 @@ namespace Messages.Server
 		{
 			GhostRoleServer role = GhostRoleManager.Instance.serverAvailableRoles[key];
 
-			foreach (ConnectedPlayer player in PlayerList.Instance.AllPlayers)
+			foreach (ConnectedPlayer player in PlayerList.Instance.InGamePlayers)
 			{
 				if (player.Script.IsDeadOrGhost == false) continue;
 				SendTo(player, key, role);

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objective.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objective.cs
@@ -119,7 +119,7 @@ namespace Antagonists
 			if (slot.IsEmpty) return 0;
 
 			//Check if current Item is the one we need
-			if (slot.ItemObject.TryGetComponent(component, out _) ||
+			if ((component != null && slot.ItemObject.TryGetComponent(component, out _)) ||
 					slot.ItemObject.GetComponent<ItemAttributesV2>()?.InitialName == name)
 			{
 				//If stackable count stack

--- a/UnityProject/Assets/Scripts/UI/Items/GUI_Paper.cs
+++ b/UnityProject/Assets/Scripts/UI/Items/GUI_Paper.cs
@@ -9,8 +9,6 @@ public class GUI_Paper : NetTab
 {
 	[SerializeField]
 	private TMP_InputField textField = default;
-	[SerializeField]
-	private ContentSizeFitter contentSizeFitter = default;
 
 	public override void OnEnable()
 	{
@@ -96,12 +94,5 @@ public class GUI_Paper : NetTab
 		PlayerManager.LocalPlayerScript.playerNetworkActions.CmdRequestPaperEdit(Provider.gameObject, textField.text);
 		UIManager.IsInputFocus = false;
 		UIManager.PreventChatInput = false;
-	}
-
-	public void OnTextValueChange()
-	{
-		//Only way to refresh it to get it to do its job (unity bug):
-		contentSizeFitter.enabled = false;
-		contentSizeFitter.enabled = true;
 	}
 }


### PR DESCRIPTION
- Fixes paper. Issues possibly introduced by #5561.
    - Fixes being unable to add new lines.
    - Fixes not being able to click anywhere on the paper to begin editing (had to click directly on the existing text).
- Fixes ghost roles. Players in the lobby are no longer considered as potential candidates. Introduced by #5675.
- Fixes objectives. Round restarting is no longer broken when there are antagonists with steal objective. Introduced by #5624.

### Note
> Paper continues to act weird after about halfway down the page.