### PR TITLE
allows linuxserver target and cleanup

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Editor/BuildServer.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/BuildServer.cs
@@ -1,100 +1,11 @@
 ﻿using UnityEditor;
 using System.Linq;
 using System;
-using System.IO;
 using System.Collections.Generic;
-using DatabaseAPI;
-using UnityEditor.SceneManagement;
-using UnityEngine;
 using UnityEditor.Build.Reporting;
 
 static class BuildScript
 {
-	[Obsolete]
-	private static void PerformServerBuild()
-	{
-		BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions();
-		buildPlayerOptions.scenes = new[] {"Assets/scenes/StartUp.unity","Assets/scenes/Lobby.unity",
-			"Assets/scenes/BoxStationV1.unity", "Assets/scenes/OutpostStation.unity",
-			"Assets/scenes/PogStation.unity", "Assets/scenes/AsteroidStation.unity"
-		};
-		buildPlayerOptions.locationPathName = "../Tools/ContentBuilder/content/Server/Unitystation-Server";
-		buildPlayerOptions.target = BuildTarget.StandaloneLinux64;
-		buildPlayerOptions.options = BuildOptions.Development;
-		BuildPreferences.SetRelease(true);
-		BuildPipeline.BuildPlayer(buildPlayerOptions);
-	}
-
-	//IMPORTANT: ALWAYS DO WINDOWS BUILD FIRST IN YOUR BUILD CYCLE:
-	[Obsolete]
-	private static void PerformWindowsBuild()
-	{
-		//Always build windows client first so that build info can increment the build number
-		var buildInfo = JsonUtility.FromJson<BuildInfo>(File.ReadAllText(Path.Combine(Application.streamingAssetsPath, "buildinfo.json")));
-		BuildInfo buildInfoUpdate = new BuildInfo();
-		if (File.Exists(Path.Combine(Application.streamingAssetsPath, "buildinfoupdate.json")))
-		{
-			buildInfoUpdate = JsonUtility.FromJson<BuildInfo>(File.ReadAllText(Path.Combine(Application.streamingAssetsPath, "buildinfoupdate.json")));
-
-			//Allows build number ranges to be forced by committing a change to buildinfo.json
-			//buildinfoupdate is gitignored so it can be stored on the build server
-			if (buildInfoUpdate.BuildNumber < buildInfo.BuildNumber)
-			{
-				buildInfoUpdate.BuildNumber = buildInfo.BuildNumber;
-			}
-		}
-		else
-		{
-			buildInfoUpdate.BuildNumber = buildInfo.BuildNumber;
-		}
-
-		buildInfoUpdate.BuildNumber++;
-		buildInfo.BuildNumber = buildInfoUpdate.BuildNumber;
-		File.WriteAllText(Path.Combine(Application.streamingAssetsPath, "buildinfo.json"), JsonUtility.ToJson(buildInfo));
-		File.WriteAllText(Path.Combine(Application.streamingAssetsPath, "buildinfoupdate.json"), JsonUtility.ToJson(buildInfoUpdate));
-
-		BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions();
-		buildPlayerOptions.scenes = new[] {"Assets/scenes/StartUp.unity","Assets/scenes/Lobby.unity",
-			"Assets/scenes/BoxStationV1.unity", "Assets/scenes/OutpostStation.unity",
-			"Assets/scenes/PogStation.unity", "Assets/scenes/AsteroidStation.unity"
-		};
-		buildPlayerOptions.locationPathName = "../Tools/ContentBuilder/content/Windows/Unitystation.exe";
-		buildPlayerOptions.target = BuildTarget.StandaloneWindows64;
-		buildPlayerOptions.options = BuildOptions.CompressWithLz4HC;
-		BuildPreferences.SetRelease(true);
-		BuildPipeline.BuildPlayer(buildPlayerOptions);
-	}
-
-	[Obsolete]
-	private static void PerformOSXBuild()
-	{
-		BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions();
-		buildPlayerOptions.scenes = new[] {"Assets/scenes/StartUp.unity","Assets/scenes/Lobby.unity",
-			"Assets/scenes/BoxStationV1.unity", "Assets/scenes/OutpostStation.unity",
-			"Assets/scenes/PogStation.unity", "Assets/scenes/AsteroidStation.unity"
-		};
-		buildPlayerOptions.locationPathName = "../Tools/ContentBuilder/content/OSX/Unitystation.app";
-		buildPlayerOptions.target = BuildTarget.StandaloneOSX;
-		buildPlayerOptions.options = BuildOptions.CompressWithLz4HC;
-		BuildPreferences.SetRelease(true);
-		BuildPipeline.BuildPlayer(buildPlayerOptions);
-	}
-
-	[Obsolete]
-	private static void PerformLinuxBuild()
-	{
-		BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions();
-		buildPlayerOptions.scenes = new[] {"Assets/scenes/StartUp.unity","Assets/scenes/Lobby.unity",
-			"Assets/scenes/BoxStationV1.unity", "Assets/scenes/OutpostStation.unity",
-			"Assets/scenes/PogStation.unity", "Assets/scenes/AsteroidStation.unity"
-		};
-		buildPlayerOptions.locationPathName = "../Tools/ContentBuilder/content/Linux/Unitystation";
-		buildPlayerOptions.target = BuildTarget.StandaloneLinux64;
-		buildPlayerOptions.options = BuildOptions.CompressWithLz4HC;
-		BuildPreferences.SetRelease(true);
-		BuildPipeline.BuildPlayer(buildPlayerOptions);
-	}
-
 	// ##################################
 	// #   Command Line Build Methods   #
 	// ##################################
@@ -145,7 +56,9 @@ static class BuildScript
 			EditorApplication.Exit(120);
 		}
 
-		if (!Enum.IsDefined(typeof(BuildTarget), buildTarget)) {
+		if (!Enum.IsDefined(typeof(BuildTarget), buildTarget) &&
+		    !buildTarget.ToLower().Equals("linuxserver")) {
+
 			EditorApplication.Exit(121);
 		}
 
@@ -191,20 +104,37 @@ static class BuildScript
 		var scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(s => s.path).ToArray();
 		// var locationPathName = $"{buildPath}/{buildName}{GetFileExtension(buildTarget)}";
 		var locationPathName = buildPath;
-		var target = (BuildTarget) Enum.Parse(typeof(BuildTarget), buildTarget);
 
 		// Define BuildPlayer Options
 		var buildOptions = new BuildPlayerOptions {
 			scenes = scenes,
 			locationPathName = locationPathName,
-			target = target,
+			// target = target,
 			options = BuildOptions.CompressWithLz4HC
 		};
 
-		if (target == BuildTarget.StandaloneLinux64)
+		var target = BuildTarget.StandaloneWindows64;
+
+		// Try to parse the BuildTarget. If it isn't our custom "linuxserver" target, quit
+		try
 		{
-			buildOptions.options |= BuildOptions.Development;
+			target = (BuildTarget) Enum.Parse(typeof(BuildTarget), buildTarget);
+
 		}
+		catch (ArgumentException)
+		{
+			if (buildTarget.ToLower().Equals("linuxserver"))
+			{
+				target = BuildTarget.StandaloneLinux64;
+				buildOptions.options |= BuildOptions.Development;
+			}
+			else
+			{
+				EditorApplication.Exit(121);
+			}
+		}
+
+		buildOptions.target = target;
 
 		ReportOptions(buildOptions);
 

--- a/UnityProject/Assets/Scripts/Core/Editor/BuildServer.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/BuildServer.cs
@@ -58,7 +58,7 @@ static class BuildScript
 
 		if (!Enum.IsDefined(typeof(BuildTarget), buildTarget) &&
 		    !buildTarget.ToLower().Equals("linuxserver")) {
-
+			Console.WriteLine("Invalid value for argument -buildTarget");
 			EditorApplication.Exit(121);
 		}
 
@@ -104,22 +104,20 @@ static class BuildScript
 		var scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(s => s.path).ToArray();
 		// var locationPathName = $"{buildPath}/{buildName}{GetFileExtension(buildTarget)}";
 		var locationPathName = buildPath;
+		var target = BuildTarget.StandaloneWindows64;
 
 		// Define BuildPlayer Options
 		var buildOptions = new BuildPlayerOptions {
 			scenes = scenes,
 			locationPathName = locationPathName,
-			// target = target,
+			target = target,
 			options = BuildOptions.CompressWithLz4HC
 		};
-
-		var target = BuildTarget.StandaloneWindows64;
 
 		// Try to parse the BuildTarget. If it isn't our custom "linuxserver" target, quit
 		try
 		{
 			target = (BuildTarget) Enum.Parse(typeof(BuildTarget), buildTarget);
-
 		}
 		catch (ArgumentException)
 		{
@@ -130,6 +128,7 @@ static class BuildScript
 			}
 			else
 			{
+				Console.WriteLine("Invalid value for argument -buildTarget");
 				EditorApplication.Exit(121);
 			}
 		}


### PR DESCRIPTION
### Purpose
This PR will handle a "custom target" called ``linuxserver`` so we can differentitate server and player builds and only assign ``dev build`` to the server. 

Linux players have had to download a bigger file and also deal with the console spewing errors on top of the game, so this is trying to solve that.

### Notes
I also deleted all ``[Obsolete]`` methods in the file.
