### PR TITLE
Now when the player tries to unbuckle while handcuffed, it is possible to do so (in a minute)

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Furniture/BuckleInteract.cs
+++ b/UnityProject/Assets/Scripts/Objects/Furniture/BuckleInteract.cs
@@ -14,6 +14,13 @@ namespace Objects
 		private OccupiableDirectionalSprite occupiableDirectionalSprite;
 		private Integrity integrity;
 
+		/// <summary>
+		/// The time that a mob will spend trying to unbuckle himself from a chair when he is handcuffed.
+		/// </summary>
+		[SerializeField]
+		private float resistTime = 60;
+		public float ResistTime => resistTime;
+
 		public bool forceLayingDown;
 
 		private void Start()

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -12,7 +12,8 @@ using Objects;
 ///     handles interaction with objects that can
 ///     be walked into it.
 /// </summary>
-public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActionGUI, ICheckedInteractable<ContextMenuApply>
+public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActionGUI,
+	ICheckedInteractable<ContextMenuApply>
 {
 	public PlayerScript PlayerScript => playerScript;
 
@@ -28,6 +29,7 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 	/// Object this player is buckled to (if buckled). Null if not buckled.
 	/// </summary>
 	public GameObject BuckledObject => buckledObject;
+
 	//cached for fast access
 	private GameObject buckledObject;
 
@@ -54,8 +56,7 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 	/// <summary>
 	/// Invoked on server side when the cuffed state is changed
 	/// </summary>
-	[NonSerialized]
-	public CuffEvent OnCuffChangeServer = new CuffEvent();
+	[NonSerialized] public CuffEvent OnCuffChangeServer = new CuffEvent();
 
 	/// <summary>
 	/// Whether this player meets all the conditions for being swapped with, but only
@@ -64,20 +65,19 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 	/// Doesn't incorporate any other conditions into this
 	/// flag, but IsSwappable does.
 	/// </summary>
-	[SyncVar]
-	private bool isSwappable;
+	[SyncVar] private bool isSwappable;
 
 	/// <summary>
 	/// server side only, tracks whether this player has indicated they are on help intent. Used
 	/// for checking for swaps.
 	/// </summary>
 	public bool IsHelpIntentServer => isHelpIntentServer;
+
 	//starts true because all players spawn with help intent.
 	private bool isHelpIntentServer = true;
 
 
-	[SerializeField]
-	private ActionData actionData = null;
+	[SerializeField] private ActionData actionData = null;
 	public ActionData ActionData => actionData;
 
 	/// <summary>
@@ -107,6 +107,7 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 				//rely on server synced value
 				canSwap = isSwappable;
 			}
+
 			return canSwap
 			       //don't swap with ghosts
 			       && !PlayerScript.IsGhost
@@ -128,8 +129,12 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 
 	[HideInInspector] public PlayerNetworkActions pna;
 
-	[HideInInspector] [SyncVar(hook = nameof(SyncRunSpeed))] public float RunSpeed;
-	[HideInInspector] [SyncVar(hook = nameof(SyncWalkSpeed))] public float WalkSpeed;
+	[HideInInspector] [SyncVar(hook = nameof(SyncRunSpeed))]
+	public float RunSpeed;
+
+	[HideInInspector] [SyncVar(hook = nameof(SyncWalkSpeed))]
+	public float WalkSpeed;
+
 	[HideInInspector] public float CrawlSpeed;
 
 	/// <summary>
@@ -212,11 +217,11 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 
 		for (int i = 0; i < moveList.Length; i++)
 		{
-			if (actionKeys.Contains((int)moveList[i]) && !moveActionList.Contains(moveList[i]))
+			if (actionKeys.Contains((int) moveList[i]) && !moveActionList.Contains(moveList[i]))
 			{
 				moveActionList.Add(moveList[i]);
 			}
-			else if (!actionKeys.Contains((int)moveList[i]) && moveActionList.Contains(moveList[i]))
+			else if (!actionKeys.Contains((int) moveList[i]) && moveActionList.Contains(moveList[i]))
 			{
 				moveActionList.Remove(moveList[i]);
 			}
@@ -335,10 +340,6 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 	[Command]
 	public void CmdUnbuckle()
 	{
-		if (IsCuffed)
-		{
-			return;
-		}
 		Unbuckle();
 	}
 
@@ -359,7 +360,7 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 		if (previouslyBuckledTo == null) return;
 
 		var integrityBuckledObject = previouslyBuckledTo.GetComponent<Integrity>();
-		if(integrityBuckledObject != null) integrityBuckledObject.OnServerDespawnEvent -= Unbuckle;
+		if (integrityBuckledObject != null) integrityBuckledObject.OnServerDespawnEvent -= Unbuckle;
 
 		//we are unbuckled but still will drift with the object.
 		var buckledCNT = previouslyBuckledTo.GetComponent<CustomNetTransform>();
@@ -381,6 +382,7 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 		{
 			PlayerDirectional = gameObject.GetComponent<Directional>();
 		}
+
 		PlayerDirectional.FaceDirection(newDir);
 	}
 
@@ -443,10 +445,30 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 
 	public void CallActionClient()
 	{
-		if (CanUnBuckleSelf())
+		if (!CanUnBuckleSelf())
 		{
-			CmdUnbuckle();
+			return;
 		}
+
+		if (IsCuffed)
+		{
+			Chat.AddActionMsgToChat(
+				playerScript.gameObject,
+				"You're trying to ubuckle yourself from the chair! (this will take some time...)",
+				playerScript.name + " is trying to ubuckle themself from the chair!"
+			);
+			StandardProgressAction.Create(
+				new StandardProgressActionConfig(StandardProgressActionType.Unbuckle),
+				Unbuckle
+			).ServerStartProgress(
+				buckledObject.RegisterTile(),
+				buckledObject.GetComponent<BuckleInteract>().ResistTime,
+				playerScript.gameObject
+			);
+			return;
+		}
+
+		CmdUnbuckle();
 	}
 
 	private bool CanUnBuckleSelf()
@@ -527,7 +549,8 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 	/// </summary>
 	public void ServerPerformInteraction(ContextMenuApply interaction)
 	{
-		var handcuffs = interaction.TargetObject.GetComponent<ItemStorage>().GetNamedItemSlot(NamedSlot.handcuffs).ItemObject;
+		var handcuffs = interaction.TargetObject.GetComponent<ItemStorage>().GetNamedItemSlot(NamedSlot.handcuffs)
+			.ItemObject;
 		if (handcuffs == null) return;
 
 		var restraint = handcuffs.GetComponent<Restraint>();

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -340,6 +340,23 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 	[Command]
 	public void CmdUnbuckle()
 	{
+		if (IsCuffed)
+		{
+			Chat.AddActionMsgToChat(
+				playerScript.gameObject,
+				"You're trying to ubuckle yourself from the chair! (this will take some time...)",
+				playerScript.name + " is trying to ubuckle themself from the chair!"
+			);
+			StandardProgressAction.Create(
+				new StandardProgressActionConfig(StandardProgressActionType.Unbuckle),
+				Unbuckle
+			).ServerStartProgress(
+				buckledObject.RegisterTile(),
+				buckledObject.GetComponent<BuckleInteract>().ResistTime,
+				playerScript.gameObject
+			);
+			return;
+		}
 		Unbuckle();
 	}
 
@@ -445,30 +462,10 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 
 	public void CallActionClient()
 	{
-		if (!CanUnBuckleSelf())
+		if (CanUnBuckleSelf())
 		{
-			return;
+			CmdUnbuckle();
 		}
-
-		if (IsCuffed)
-		{
-			Chat.AddActionMsgToChat(
-				playerScript.gameObject,
-				"You're trying to ubuckle yourself from the chair! (this will take some time...)",
-				playerScript.name + " is trying to ubuckle themself from the chair!"
-			);
-			StandardProgressAction.Create(
-				new StandardProgressActionConfig(StandardProgressActionType.Unbuckle),
-				Unbuckle
-			).ServerStartProgress(
-				buckledObject.RegisterTile(),
-				buckledObject.GetComponent<BuckleInteract>().ResistTime,
-				playerScript.gameObject
-			);
-			return;
-		}
-
-		CmdUnbuckle();
 	}
 
 	private bool CanUnBuckleSelf()

--- a/UnityProject/Assets/Scripts/UI/Core/ProgressBar/StandardProgressActionType.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/ProgressBar/StandardProgressActionType.cs
@@ -13,5 +13,6 @@ public enum StandardProgressActionType
 	CPR = 4,
 	Disrobe = 5,
 	Mop = 6,
-	Escape = 7
+	Escape = 7,
+	Unbuckle = 8
 }


### PR DESCRIPTION
### Purpose

fixes #5757 

- If a player is handcuffed, when he tries to get up from the chair, a message will be displayed that it will not be possible to unbuckle immediately
- If the player is handcuffed, when he tries to get up from the chair, the action "attempt to unbuckle from the chair" begins. After 60 seconds, the player will get up from the chair(but the handcuffs will remain on him).

P.S. well, it was partly my fault: https://github.com/unitystation/unitystation/pull/4772