### PR TITLE
Fixes rounds being unable to start

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -321,7 +321,7 @@ public class SoundManager : MonoBehaviour
 	public static async Task<string> PlayNetworkedAtPos(List<AddressableAudioSource> addressableAudioSources, Vector3 worldPos, AudioSourceParameters audioSourceParameters,
 			bool polyphonic = false, bool Global = true, GameObject sourceObj = null, ShakeParameters shakeParameters = null)
 	{
-		AddressableAudioSource addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSources).ConfigureAwait(false);
+		AddressableAudioSource addressableAudioSource = await GetAddressableAudioSourceFromCache(addressableAudioSources);
 
 		if (Global)
 		{


### PR DESCRIPTION
### Purpose
Fixes the sound manager sending an exception object error to mirror due to a possible thread swap after an await, causing the game from being unable to run once mirror stops.
