### PR TITLE
Add custom flag for dev builds

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Editor/BuildServer.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/BuildServer.cs
@@ -58,7 +58,7 @@ static class BuildScript
 
 		if (!Enum.IsDefined(typeof(BuildTarget), buildTarget) &&
 		    !buildTarget.ToLower().Equals("linuxserver")) {
-
+			Console.WriteLine("Invalid value for argument -buildTarget");
 			EditorApplication.Exit(121);
 		}
 
@@ -104,22 +104,20 @@ static class BuildScript
 		var scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(s => s.path).ToArray();
 		// var locationPathName = $"{buildPath}/{buildName}{GetFileExtension(buildTarget)}";
 		var locationPathName = buildPath;
+		var target = BuildTarget.StandaloneWindows64;
 
 		// Define BuildPlayer Options
 		var buildOptions = new BuildPlayerOptions {
 			scenes = scenes,
 			locationPathName = locationPathName,
-			// target = target,
+			target = target,
 			options = BuildOptions.CompressWithLz4HC
 		};
-
-		var target = BuildTarget.StandaloneWindows64;
 
 		// Try to parse the BuildTarget. If it isn't our custom "linuxserver" target, quit
 		try
 		{
 			target = (BuildTarget) Enum.Parse(typeof(BuildTarget), buildTarget);
-
 		}
 		catch (ArgumentException)
 		{
@@ -130,6 +128,7 @@ static class BuildScript
 			}
 			else
 			{
+				Console.WriteLine("Invalid value for argument -buildTarget");
 				EditorApplication.Exit(121);
 			}
 		}

--- a/UnityProject/Assets/Scripts/Core/Editor/BuildServer.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/BuildServer.cs
@@ -58,7 +58,7 @@ static class BuildScript
 
 		if (!Enum.IsDefined(typeof(BuildTarget), buildTarget) &&
 		    !buildTarget.ToLower().Equals("linuxserver")) {
-			Console.WriteLine("Invalid value for argument -buildTarget");
+
 			EditorApplication.Exit(121);
 		}
 
@@ -104,20 +104,22 @@ static class BuildScript
 		var scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(s => s.path).ToArray();
 		// var locationPathName = $"{buildPath}/{buildName}{GetFileExtension(buildTarget)}";
 		var locationPathName = buildPath;
-		var target = BuildTarget.StandaloneWindows64;
 
 		// Define BuildPlayer Options
 		var buildOptions = new BuildPlayerOptions {
 			scenes = scenes,
 			locationPathName = locationPathName,
-			target = target,
+			// target = target,
 			options = BuildOptions.CompressWithLz4HC
 		};
+
+		var target = BuildTarget.StandaloneWindows64;
 
 		// Try to parse the BuildTarget. If it isn't our custom "linuxserver" target, quit
 		try
 		{
 			target = (BuildTarget) Enum.Parse(typeof(BuildTarget), buildTarget);
+
 		}
 		catch (ArgumentException)
 		{
@@ -128,7 +130,6 @@ static class BuildScript
 			}
 			else
 			{
-				Console.WriteLine("Invalid value for argument -buildTarget");
 				EditorApplication.Exit(121);
 			}
 		}


### PR DESCRIPTION
### Purpose
My [previous atttempt](https://github.com/unitystation/unitystation/pull/5756) on differentiating linux server and clients build didn't work. This time I further cleaned up unused stuff on build script and added a custom flag. I don't know if this will work, but I don't see a lot of the flags used in our script in [here](https://docs.unity3d.com/Manual/CommandLineArguments.html) so I'm assuming they are all custom made and only parsed on our build script.