### PR TITLE
Fix custom flag error

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Editor/BuildServer.cs
+++ b/UnityProject/Assets/Scripts/Core/Editor/BuildServer.cs
@@ -74,7 +74,7 @@ static class BuildScript
 		if (validatedOptions.TryGetValue("devBuild", out var devBuild))
 		{
 			Console.WriteLine("Found -devBuild argument. This build will be a devBuild");
-			validatedOptions.Add("devBuild", "true");
+			validatedOptions["devBuild"] = "true";
 		}
 		else
 		{
@@ -173,10 +173,6 @@ static class BuildScript
 			case BuildResult.Cancelled:
 				Console.WriteLine("Build cancelled!");
 				EditorApplication.Exit(102);
-				break;
-			case BuildResult.Unknown:
-				Console.WriteLine("Build result is unknown!");
-				EditorApplication.Exit(103);
 				break;
 			default:
 				Console.WriteLine("Build result is unknown!");


### PR DESCRIPTION
### Purpose
Aight so I was adding the flag to a dictionary that already had the key if the flag was present in the command. I fixed the error now. 

Last time, I promise.