### PR TITLE
Adds RockDrop spell

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/JungleVegetationPrefabs/Rocks/RandomRockLarge.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/JungleVegetationPrefabs/Rocks/RandomRockLarge.prefab
@@ -1,0 +1,165 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-1844278453393155234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7208620287548955600}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b1a9eacdeba95b4cb0c7a488920e027, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mineTime: 4
+--- !u!1001 &7930319906333298256
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -7628244273918246941, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: isInitiallyNotPushable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 9f2a39e3a0dd222449bdc7bd0f7ea961,
+        type: 3}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Name
+      value: RandomRockLarge
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: c8d87c8972a790a45a4aae7d51b993f4,
+        type: 2}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: c84f3f4bfe7f3e640abe6d7ed6efb1fb,
+        type: 2}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 3826d854151b70e41a9bedcb49ff5821,
+        type: 2}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: 651f17a0e6446ea4e8d23c619d77f9f3,
+        type: 2}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: randomInitialSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971921043980192432, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: initialName
+      value: rock
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971921043980192432, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: initialDescription
+      value: A large, mysterious rock. A pickaxe would be good for clearing this.
+      objectReference: {fileID: 0}
+    - target: {fileID: 9212640593017544930, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b06b702714bab49b9ad949eab1ca4534, type: 3}
+--- !u!1 &7208620287548955600 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
+    type: 3}
+  m_PrefabInstance: {fileID: 7930319906333298256}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/JungleVegetationPrefabs/Rocks/RandomRockLarge.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/JungleVegetationPrefabs/Rocks/RandomRockLarge.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5e3d3dfb1d4c2e74ba2e05503ea9cec0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/JungleVegetationPrefabs/Rocks/RandomRockSmall.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/JungleVegetationPrefabs/Rocks/RandomRockSmall.prefab
@@ -1,0 +1,175 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &9196919466183676349
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7208620287548955600}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b1a9eacdeba95b4cb0c7a488920e027, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mineTime: 2
+--- !u!1001 &7930319906333298256
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -7628244273918246941, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: isInitiallyNotPushable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 1b95b7faa486b9c499eb5c336814a8f7,
+        type: 3}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 676721839806558615, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_Name
+      value: RandomRockSmall
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 725567512822600538, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: f9fdf66baec64454bb3a1e78f2a3ce12,
+        type: 2}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 1ecc8757e4a5d244b95a59f761c9d088,
+        type: 2}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 30b3cdfc42838ab4d9c2603d41ed5057,
+        type: 2}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[2]
+      value: 
+      objectReference: {fileID: 11400000, guid: c3fa0dd7e0e03474eb9192faf1b33607,
+        type: 2}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: pushTextureOnStartUp
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212070883374448474, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: randomInitialSprite
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971921043980192432, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: initialName
+      value: rocks
+      objectReference: {fileID: 0}
+    - target: {fileID: 7971921043980192432, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: initialDescription
+      value: Some small, mysterious rocks. A pickaxe would be good for clearing these.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8275826183322400200, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: Passable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9212640593017544930, guid: b06b702714bab49b9ad949eab1ca4534,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b06b702714bab49b9ad949eab1ca4534, type: 3}
+--- !u!1 &7208620287548955600 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 721717256067945856, guid: b06b702714bab49b9ad949eab1ca4534,
+    type: 3}
+  m_PrefabInstance: {fileID: 7930319906333298256}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/JungleVegetationPrefabs/Rocks/RandomRockSmall.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Furniture/JungleVegetationPrefabs/Rocks/RandomRockSmall.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6859337e044ce514f8079ab0f89a62f5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/SpellImplementations/Wizard/Rockdrop.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SpellImplementations/Wizard/Rockdrop.prefab
@@ -9,10 +9,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2091150287816295887}
-  - component: {fileID: 7985153769566280728}
-  - component: {fileID: -2961367611600828348}
+  - component: {fileID: 1785456988025682625}
+  - component: {fileID: 6794817751832701430}
   m_Layer: 0
-  m_Name: LesserSummonGuns
+  m_Name: Rockdrop
   m_TagString: Untagged
   m_Icon: {fileID: 2800000, guid: b60b1105383115d43b5360612f8f44b6, type: 3}
   m_NavMeshLayer: 0
@@ -32,7 +32,7 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7985153769566280728
+--- !u!114 &1785456988025682625
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -48,7 +48,7 @@ MonoBehaviour:
   sceneId: 0
   serverOnly: 0
   m_AssetId: 
---- !u!114 &-2961367611600828348
+--- !u!114 &6794817751832701430
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -57,22 +57,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 7469762742606550612}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5aed59c8bd3a97f48ab9ef8aa5bff7e1, type: 3}
+  m_Script: {fileID: 11500000, guid: 207b67e169344ad4782d3d724bf97a71, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
   portalPrefab: {fileID: 4686069471335676681, guid: 6ca11e1a2337f494d8337d3d47f0a042,
     type: 3}
-  gunPrefab: {fileID: 331383614235509145, guid: ed9f88270aae41443a71e5406ac73acb,
+  mainRockPrefab: {fileID: 7208620287548955600, guid: 5e3d3dfb1d4c2e74ba2e05503ea9cec0,
     type: 3}
-  LesserSummonGunsSFX:
-    SetLoadSetting: 0
-    AssetAddress: Assets/Prefabs/Magic/SummonGuns.prefab
-    AssetReference:
-      m_AssetGUID: 
-      m_SubObjectName: 
-      m_SubObjectType: 
-  gunSpawnCount: 4
-  scatterRadius: 3
-  timeBetweenPortals: 0.3
+  smallRockPrefab: {fileID: 7208620287548955600, guid: 6859337e044ce514f8079ab0f89a62f5,
+    type: 3}
+  smallRocksToSpawn: 7
+  timeBetweenRocks: 0.1

--- a/UnityProject/Assets/Resources/Prefabs/SpellImplementations/Wizard/Rockdrop.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/SpellImplementations/Wizard/Rockdrop.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 744b0cb256b76454bb452aa847daf921
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/SpellBookData.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/SpellBookData.asset
@@ -24,6 +24,7 @@ MonoBehaviour:
       reducing foes' ability to attack.
     entryList:
     - {fileID: 11400000, guid: 6208b5c364e9cd34baf190050eb8fcb6, type: 2}
+    - {fileID: 11400000, guid: 44511df05170f664092854b97d7ba799, type: 2}
     - {fileID: 11400000, guid: 958b94163c62ac943b3adbaa26976ae1, type: 2}
   - name: Mobility
     description: Spells and items geared towards improving your ability to move.

--- a/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Spells/Rockdrop.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Spells/Rockdrop.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f46fbaf230eb28d45baade2d17e5f92f, type: 3}
+  m_Name: Rockdrop
+  m_EditorClassIdentifier: 
+  description: Summons lethal rocks that fall from portals. Great for discouraging
+    the station crew from following you during a retreat.
+  note: 
+  cost: 1
+  conflictsWith: []
+  spell: {fileID: 11400000, guid: ffd853d4e6af54647a5486b12b7f1424, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Spells/Rockdrop.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Items/SpellBook/Spells/Rockdrop.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 44511df05170f664092854b97d7ba799
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/SOs singletons/SpellList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/SOs singletons/SpellList.asset
@@ -28,3 +28,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 5f4b8b36713a15b4384a86bc4a7f63e2, type: 2}
   - {fileID: 11400000, guid: f5d5399c9e7826a4fa95c9d5ee93799b, type: 2}
   - {fileID: 11400000, guid: 75213e88f6e86cb4d8a637d0eeee77c6, type: 2}
+  - {fileID: 11400000, guid: ffd853d4e6af54647a5486b12b7f1424, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Spells/Wizard/Rockdrop.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Spells/Wizard/Rockdrop.asset
@@ -10,36 +10,37 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d9d639585f97bb841bc468b21539740e, type: 3}
-  m_Name: LesserSummonGuns
+  m_Name: Rockdrop
   m_EditorClassIdentifier: 
-  actionType: 0
+  actionType: 1
   activeSpriteIndex: 1
   callOnClient: 0
-  callOnServer: 1
-  actionName: Lesser Summon Guns
-  description: Summons an unending stream of bolt action rifles.
+  callOnServer: 0
+  actionName: Rockdrop
+  description: Summons lethal rocks that fall from portals.
   Sprites:
-  - {fileID: 11400000, guid: 1ac4be7eddf403d45bc6037a31dfbd01, type: 2}
+  - {fileID: 11400000, guid: c8d87c8972a790a45a4aae7d51b993f4, type: 2}
+  - {fileID: 11400000, guid: 3826d854151b70e41a9bedcb49ff5821, type: 2}
   Backgrounds:
   - {fileID: 11400000, guid: 8f7b96a7712804949a79f2ec18abee2c, type: 2}
   PreventBeingControlledBy: 
   DisableOnEvent: 
-  isAimable: 0
-  useCustomCursor: 0
-  cursorTexture: {fileID: 0}
-  cursorOffsetType: 0
+  isAimable: 1
+  useCustomCursor: 1
+  cursorTexture: {fileID: 2800000, guid: a98858de92927fd4c844f441140f55fe, type: 3}
+  cursorOffsetType: 1
   cursorOffset: {x: 0, y: 0}
-  spellImplementation: {fileID: 7469762742606550612, guid: 751d903cc6682e04ba5dd33466daddab,
+  spellImplementation: {fileID: 7469762742606550612, guid: 744b0cb256b76454bb452aa847daf921,
     type: 3}
   chargeType: 0
-  cooldownTime: 75
+  cooldownTime: 45
   startingCharges: 10
-  castSound: LesserSummonGuns
+  castSound: 
   range: 0
   stillRechargingMessage: The spell is still recharging!
   affectedMessage: 
-  invocationType: 0
-  invocationMessage: 
+  invocationType: 2
+  invocationMessage: BALDERDASH!
   invocationMessageSelf: 
   summonType: 0
   summonObjects: []
@@ -49,4 +50,4 @@ MonoBehaviour:
   replaceExisting: 0
   requireWizardGarb: 1
   tierCount: 5
-  cooldownModifierPC: 25
+  cooldownModifierPC: 20

--- a/UnityProject/Assets/Resources/ScriptableObjects/Spells/Wizard/Rockdrop.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Spells/Wizard/Rockdrop.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ffd853d4e6af54647a5486b12b7f1424
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
@@ -22,6 +22,7 @@ public class SpriteHandler : MonoBehaviour
 	[SerializeField] private SpriteDataSO PresentSpriteSet;
 	private SpriteDataSO.Frame PresentFrame = null;
 
+	[Tooltip("If checked, a random sprite SO will be selected during initialization from the catalogue of sprite SOs.")]
 	[SerializeField] private bool randomInitialSprite = false;
 
 	private SpriteRenderer spriteRenderer;

--- a/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
+++ b/UnityProject/Assets/Scripts/Core/Sprite Handler/SpriteHandler.cs
@@ -22,6 +22,8 @@ public class SpriteHandler : MonoBehaviour
 	[SerializeField] private SpriteDataSO PresentSpriteSet;
 	private SpriteDataSO.Frame PresentFrame = null;
 
+	[SerializeField] private bool randomInitialSprite = false;
+
 	private SpriteRenderer spriteRenderer;
 	private Image image;
 
@@ -692,7 +694,11 @@ public class SpriteHandler : MonoBehaviour
 		ImageComponentStatus(false);
 		Initialised = true;
 
-		if (PresentSpriteSet != null)
+		if (randomInitialSprite && CatalogueCount > 0)
+		{
+			ChangeSprite(Random.Range(0, CatalogueCount), NetworkThis);
+		}
+		else if (PresentSpriteSet != null)
 		{
 			if (HasImageComponent() && pushTextureOnStartUp)
 			{

--- a/UnityProject/Assets/Scripts/Items/Food/Cigarette.cs
+++ b/UnityProject/Assets/Scripts/Items/Food/Cigarette.cs
@@ -135,7 +135,7 @@ public class Cigarette : NetworkBehaviour, ICheckedInteractable<HandApply>,
 	{
 		var worldPos = gameObject.AssumedWorldPosServer();
 		var tr = gameObject.transform.parent;
-		var rotation = RandomUtils.RandomRotatation2D();
+		var rotation = RandomUtils.RandomRotation2D();
 
 		// Print burn out message if in players inventory
 		if (pickupable && pickupable.ItemSlot != null)

--- a/UnityProject/Assets/Scripts/Messages/Server/PortalSpawnAnimateMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/PortalSpawnAnimateMessage.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections;
+using UnityEngine;
+using Mirror;
+using Systems.Spells.Wizard;
+
+namespace Messages.Server
+{
+	/// <summary>
+	/// Sends a message to nearby clients, informing them to animate the given portal with the given settings.
+	/// </summary>
+	public class PortalSpawnAnimateMessage : ServerMessage
+	{
+		public GameObject Entity;
+		public PortalSpawnInfo Settings;
+		public AnimateType Type;
+
+		/// <summary>
+		/// <inheritdoc cref="PortalSpawnAnimateMessage"/>
+		/// </summary>
+		/// <param name="portal">The portal GameObject that the client should animate.</param>
+		/// <param name="settings">The settings the portal should be animated with.</param>
+		/// <returns></returns>
+		public static PortalSpawnAnimateMessage SendToVisible(GameObject entity, PortalSpawnInfo settings, AnimateType type)
+		{
+			var msg = new PortalSpawnAnimateMessage()
+			{
+				Entity = entity,
+				Settings = settings,
+				Type = type,
+			};
+
+			msg.SendToVisiblePlayers(entity.RegisterTile().WorldPositionServer.To2Int());
+
+			return msg;
+		}
+
+		public override void Process()
+		{
+			if (Type == AnimateType.Portal)
+			{
+				SpawnByPortal.AnimatePortal(Entity, Settings);
+			}
+			else
+			{
+				SpawnByPortal.AnimateObject(Entity, Settings);
+			}
+		}
+
+		public override void Deserialize(NetworkReader reader)
+		{
+			base.Deserialize(reader);
+
+			Entity = reader.ReadGameObject();
+			Settings.PortalHeight = reader.ReadInt32();
+			Settings.PortalOpenTime = reader.ReadSingle();
+			Settings.PortalCloseTime = reader.ReadSingle();
+			Settings.PortalSuspenseTime = reader.ReadSingle();
+			Settings.EntityRotate = reader.ReadBoolean();
+			Type = (AnimateType)reader.ReadInt32();
+		}
+
+		public override void Serialize(NetworkWriter writer)
+		{
+			base.Serialize(writer);
+
+			writer.WriteGameObject(Entity);
+			writer.WriteInt32(Settings.PortalHeight);
+			writer.WriteSingle(Settings.PortalOpenTime);
+			writer.WriteSingle(Settings.PortalCloseTime);
+			writer.WriteSingle(Settings.PortalSuspenseTime);
+			writer.WriteBoolean(Settings.EntityRotate);
+			writer.WriteInt32((int)Type);
+		}
+
+		public enum AnimateType
+		{
+			Portal,
+			Entity,
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Messages/Server/PortalSpawnAnimateMessage.cs.meta
+++ b/UnityProject/Assets/Scripts/Messages/Server/PortalSpawnAnimateMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6fbd6e4bffdd1e54881fe9cfb232a588
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Objects/Mining/PickaxeMineable.cs
+++ b/UnityProject/Assets/Scripts/Objects/Mining/PickaxeMineable.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections;
+using UnityEngine;
+
+namespace Objects.Mining
+{
+	/// <summary>
+	/// Simple script to allow objects to be mined. Destroys the object upon completion.
+	/// </summary>
+	public class PickaxeMineable : MonoBehaviour, ICheckedInteractable<HandApply>
+	{
+		[SerializeField]
+		private float mineTime = 3;
+
+		private string objectName;
+
+		public bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			objectName = gameObject.ExpensiveName();
+
+			if (DefaultWillInteract.Default(interaction, side) == false) return false;
+
+			return Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Pickaxe);
+		}
+
+		public void ServerPerformInteraction(HandApply interaction)
+		{
+			ToolUtils.ServerUseToolWithActionMessages(
+					interaction, mineTime,
+					$"You start mining the {objectName}...",
+					$"{interaction.Performer} starts mining the {objectName}...",
+					default, default,
+					() =>
+					{
+						SoundManager.PlayNetworkedAtPos(SingletonSOSounds.Instance.BreakStone,
+								interaction.PerformerPlayerScript.WorldPos, sourceObj: interaction.Performer);
+						Despawn.ServerSingle(gameObject);
+					});
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Objects/Mining/PickaxeMineable.cs.meta
+++ b/UnityProject/Assets/Scripts/Objects/Mining/PickaxeMineable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b1a9eacdeba95b4cb0c7a488920e027
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/Spells/Wizard/LesserSummonGuns.cs
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Wizard/LesserSummonGuns.cs
@@ -1,84 +1,55 @@
-﻿using System.Collections;
+using System.Collections;
 using UnityEngine;
-using Mirror;
+using NaughtyAttributes;
 using AddressableReferences;
 
 namespace Systems.Spells.Wizard
 {
+	/// <summary>
+	/// A wizard spell that spawns several guns via portals around the caster.
+	/// </summary>
 	public class LesserSummonGuns : Spell
 	{
-		[SerializeField] private AddressableAudioSource LesserSummonGunsSFX = null;
-		
-		private const float TIME_BETWEEN_PORTALS = 0.5f;
-		private const int PORTAL_HEIGHT = 2;
-		private const float PORTAL_OPEN_TIME = 0.8f;
-		private const float PORTAL_CLOSE_TIME = 0.5f;
-		private const float PORTAL_ACTIVE_TIME = 1;
-		private const float GUN_FALLING_TIME = 0.7f;
-
-		[Header("References")]
 		[Tooltip("What portals to spawn. The guns will appear to drop out of these.")]
-		[SerializeField]
+		[SerializeField, BoxGroup("References")]
 		private GameObject portalPrefab = default;
-
 		[Tooltip("What guns to spawn.")]
-		[SerializeField]
+		[SerializeField, BoxGroup("References")]
 		private GameObject gunPrefab = default;
+		[SerializeField, BoxGroup("References")]
+		private AddressableAudioSource LesserSummonGunsSFX = null;
 
-		[Header("Settings")]
 		[Tooltip("How many guns to spawn around the caster. Does not include the caster's hand spawn.")]
-		[SerializeField]
+		[SerializeField, BoxGroup("Settings")]
 		private int gunSpawnCount = 4;
-
 		[Tooltip("The maximum radius the guns should be scattered in, centred on the player.")]
-		[SerializeField]
+		[SerializeField, BoxGroup("Settings")]
 		private int scatterRadius = 2;
-
-		private Vector3Int epicentre;
-
-		[SyncVar(hook = nameof(SyncLatestPortal))]
-		private GameObject latestPortal;
-
-		[SyncVar(hook = nameof(SyncLatestGun))]
-		private GameObject latestGun;
+		[SerializeField, BoxGroup("Settings"), Range(0, 1)]
+		private float timeBetweenPortals = 0.3f;
 
 		public override bool CastSpellServer(ConnectedPlayer caster)
 		{
-			epicentre = caster.Script.WorldPos;
-			StartCoroutine(SpawnPortals());
+			StartCoroutine(SpawnPortals(caster.Script.WorldPos));
 
 			return SpawnGunInHand(caster);
 		}
 
-		private IEnumerator SpawnPortals()
+		private IEnumerator SpawnPortals(Vector3Int centrepoint)
 		{
 			for (int i = 0; i < gunSpawnCount; i++)
 			{
-				StartCoroutine(SpawnPortal());
-				yield return WaitFor.Seconds(TIME_BETWEEN_PORTALS);
+				Vector3Int spawnPosition = GetRandomPosition(centrepoint);
+				new SpawnByPortal(gunPrefab, portalPrefab, spawnPosition);
+				// TODO: consider using OnObjectSpawn to trigger sound if sound aligns with animation nicely.
+				StartCoroutine(DelaySoundFX(spawnPosition));
+				yield return WaitFor.Seconds(timeBetweenPortals);
 			}
-		}
-
-		private IEnumerator SpawnPortal()
-		{
-			Vector3Int randomPos = GetRandomPosition();
-			var portalPos = randomPos;
-			portalPos.y += PORTAL_HEIGHT; // Spawn portal two tiles above the landing zone.
-			StartCoroutine(DelaySoundFX(portalPos));
-
-			var newPortal = Spawn.ServerPrefab(portalPrefab, portalPos).GameObject;
-			latestPortal = newPortal;
-
-			yield return WaitFor.Seconds(PORTAL_OPEN_TIME + (PORTAL_ACTIVE_TIME / 2));
-			latestGun = Spawn.ServerPrefab(gunPrefab, randomPos).GameObject;
-
-			yield return WaitFor.Seconds(PORTAL_OPEN_TIME + PORTAL_ACTIVE_TIME + PORTAL_CLOSE_TIME + 1); // Wait a good while first.
-			Despawn.ServerSingle(newPortal);
 		}
 
 		private IEnumerator DelaySoundFX(Vector3Int position)
 		{
-			yield return WaitFor.Seconds(0.6f);
+			yield return WaitFor.Seconds(0.6f); // TODO: likely needs tweaking; wait for sounds to work again.
 			SoundManager.PlayNetworkedAtPos(LesserSummonGunsSFX, position);
 		}
 
@@ -87,9 +58,9 @@ namespace Systems.Spells.Wizard
 			SpawnResult result = Spawn.ServerPrefab(gunPrefab, caster.Script.WorldPos);
 			if (result.Successful)
 			{
-				GameObject firstGun = result.GameObject;
-				ItemSlot bestSlot = caster.Script.ItemStorage.GetBestHandOrSlotFor(firstGun);
-				Inventory.ServerAdd(firstGun, bestSlot);
+				GameObject gun = result.GameObject;
+				ItemSlot bestSlot = caster.Script.ItemStorage.GetBestHandOrSlotFor(gun);
+				Inventory.ServerAdd(gun, bestSlot);
 
 				return true;
 			}
@@ -98,51 +69,9 @@ namespace Systems.Spells.Wizard
 			return false;
 		}
 
-		#region Sync
-
-		private void SyncLatestPortal(GameObject oldPortal, GameObject newPortal)
+		private Vector3Int GetRandomPosition(Vector3Int centrepoint)
 		{
-			latestPortal = newPortal;
-			StartCoroutine(AnimatePortal());
-		}
-
-		private void SyncLatestGun(GameObject oldGun, GameObject newGun)
-		{
-			latestGun = newGun;
-			AnimateGun();
-		}
-
-		#endregion Sync
-
-		#region Animation
-
-		private IEnumerator AnimatePortal()
-		{
-			Transform portalTransform = latestPortal.transform;
-
-			portalTransform.localScale = Vector3.zero;
-			portalTransform.transform.LeanScale(Vector3.one, PORTAL_OPEN_TIME);
-
-			yield return WaitFor.Seconds(PORTAL_OPEN_TIME + PORTAL_ACTIVE_TIME);
-
-			portalTransform.LeanScale(Vector3.zero, PORTAL_CLOSE_TIME);
-		}
-
-		private void AnimateGun()
-		{
-			Transform latestGunTransform = latestGun.transform.Find("Sprite").transform;
-
-			latestGunTransform.LeanSetLocalPosY(PORTAL_HEIGHT);
-			latestGunTransform.localRotation = RandomUtils.RandomRotatation2D();
-			latestGunTransform.LeanMoveLocalY(0, GUN_FALLING_TIME);
-			latestGunTransform.LeanRotateZ(Random.Range(0, 720), GUN_FALLING_TIME);
-		}
-
-		#endregion Animation
-
-		private Vector3Int GetRandomPosition()
-		{
-			return epicentre + RandomUtils.RandomAnnulusPoint(0, scatterRadius).CutToInt();
+			return centrepoint + RandomUtils.RandomAnnulusPoint(0, scatterRadius).CutToInt();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Spells/Wizard/Rockdrop.cs
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Wizard/Rockdrop.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using NaughtyAttributes;
+using Systems.Explosions;
+
+namespace Systems.Spells.Wizard
+{
+	// TODO: no sounds; wait for addressable sounds to work.
+
+	/// <summary>
+	/// A wizard spell that summons a bunch of rocks at the target position.
+	/// </summary>
+	public class Rockdrop : Spell
+	{
+		[SerializeField, BoxGroup("References")]
+		private GameObject portalPrefab = default;
+		[SerializeField, BoxGroup("References")]
+		private GameObject mainRockPrefab = default;
+		[SerializeField, BoxGroup("References")]
+		private GameObject smallRockPrefab = default;
+
+		[SerializeField, BoxGroup("Settings"), Range(0, 10)]
+		private int smallRocksToSpawn = 5;
+		[SerializeField, BoxGroup("Settings"), Range(0, 1)]
+		private float timeBetweenRocks = 0.1f;
+
+		private readonly List<Vector3Int> usedPositions = new List<Vector3Int>();
+
+		public override bool CastSpellServer(ConnectedPlayer caster, Vector3 clickPosition)
+		{
+			PortalSpawnInfo settings = PortalSpawnInfo.DefaultSettings();
+			settings.EntityRotate = false; // A rotated large rock doesn't look great on landing.
+
+			var rockPortalSpawn = new SpawnByPortal(mainRockPrefab, portalPrefab, clickPosition, settings);
+			rockPortalSpawn.OnObjectSpawned += (GameObject mainRock) =>
+			{
+				mainRock.GetComponent<RegisterObject>().Passable = true; // Passable until it lands.
+			};
+			rockPortalSpawn.OnObjectLanded += (GameObject mainRock) =>
+			{
+				OnRockLanded(mainRock, 120);
+				mainRock.GetComponent<RegisterObject>().Passable = false;
+			};
+
+			StartCoroutine(SpawnSmallRocks(clickPosition));
+
+			return true;
+		}
+
+		private IEnumerator SpawnSmallRocks(Vector3 centrepoint)
+		{
+			for (int i = 0; i < smallRocksToSpawn; i++)
+			{
+				yield return WaitFor.Seconds(timeBetweenRocks);
+
+				new SpawnByPortal(smallRockPrefab, portalPrefab, TryGetUniqueRandomPosition(centrepoint.CutToInt()))
+						.OnObjectLanded += (GameObject smallRock) =>
+				{
+					OnRockLanded(smallRock, 60);
+				};
+			}
+		}
+
+		private void OnRockLanded(GameObject rock, float damage)
+		{
+			var landingPosition = rock.RegisterTile().WorldPositionServer;
+			var matrixInfo = MatrixManager.AtPoint(landingPosition, true);
+
+			Explosion.StartExplosion(landingPosition, damage, matrixInfo.Matrix);
+			ExplosionUtils.PlaySoundAndShake(landingPosition, 16, 4);
+		}
+
+		private Vector3Int TryGetUniqueRandomPosition(Vector3Int centrepoint)
+		{
+			Vector3Int randomPosition = Vector3Int.zero;
+
+			// Quick solution to try get unique positions.
+			for (int i = 0; i < 5; i++)
+			{
+				randomPosition = RandomUtils.RandomAnnulusPoint(1, 2).CutToInt();
+				if (usedPositions.Contains(randomPosition) == false) break;
+			}
+
+			usedPositions.Add(randomPosition);
+			return centrepoint + randomPosition;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Spells/Wizard/Rockdrop.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Wizard/Rockdrop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 207b67e169344ad4782d3d724bf97a71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/Spells/Wizard/SpawnByPortal.cs
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Wizard/SpawnByPortal.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections;
+using UnityEngine;
+using Messages.Server;
+
+namespace Systems.Spells.Wizard
+{
+	/// <summary>
+	/// Spawns an object via a portal, animating the process. Informs clients about the animation.
+	/// </summary>
+	public class SpawnByPortal
+	{
+		public event Action<GameObject> OnPortalReady;
+		public event Action<GameObject> OnObjectSpawned;
+		public event Action<GameObject> OnObjectLanded;
+
+		/// <summary>
+		/// <inheritdoc cref="SpawnByPortal"/>
+		/// </summary>
+		public SpawnByPortal(GameObject entityPrefab, GameObject portalPrefab, Vector3 worldPosition)
+		{
+			ServerSpawnPortalAndObject(entityPrefab, portalPrefab, worldPosition, PortalSpawnInfo.DefaultSettings());
+		}
+
+		/// <summary>
+		/// <inheritdoc cref="SpawnByPortal"/>
+		/// </summary>
+		/// <param name="entityPrefab">the entity which should be dropped from the portal</param>
+		/// <param name="portalPrefab">the portal the entity drops out of</param>
+		/// <param name="worldPosition">the position the entity will land at</param>
+		/// <param name="settings">settings such as portal height, durations</param>
+		public SpawnByPortal(GameObject entityPrefab, GameObject portalPrefab, Vector3 worldPosition, PortalSpawnInfo settings)
+		{
+			ServerSpawnPortalAndObject(entityPrefab, portalPrefab, worldPosition, settings);
+		}
+
+		/// <summary>
+		/// Animates the portal. Intended to be called from PortalSpawnMessages.
+		/// </summary>
+		public static void AnimatePortal(GameObject portal, PortalSpawnInfo settings)
+		{
+			portal.transform.localScale = Vector3.zero;
+
+			// Portal expands
+			LeanTween.scale(portal, Vector3.one, settings.PortalOpenTime);
+
+			// Portal shrinks and despawns
+			LeanTween.scale(portal, Vector3.zero, settings.PortalCloseTime).setDelay(settings.PortalOpenTime + settings.PortalSuspenseTime);
+		}
+
+		/// <summary>
+		/// Animates the object. Intended to be called from PortalSpawnMessages.
+		/// </summary>
+		public static void AnimateObject(GameObject entity, PortalSpawnInfo settings)
+		{
+			Transform spriteObject = entity.transform.Find("Sprite");
+			float fallingTime = GetFallingTime(settings.PortalHeight);
+
+			// Animate entity falling.
+			spriteObject.LeanSetLocalPosY(settings.PortalHeight);
+			LeanTween.moveLocalY(spriteObject.gameObject, 0, fallingTime).setEaseInQuad();
+
+			// Animate entity rotating during fall.
+			if (settings.EntityRotate)
+			{
+				spriteObject.localRotation = RandomUtils.RandomRotation2D();
+				spriteObject.LeanRotateZ(UnityEngine.Random.Range(0, 720), fallingTime);
+			}
+		}
+
+		private void ServerSpawnPortalAndObject(GameObject entityPrefab, GameObject portalPrefab, Vector3 worldPosition, PortalSpawnInfo settings)
+		{
+			GameObject portal = ServerSpawnPortal(portalPrefab, worldPosition, settings);
+			PortalSpawnAnimateMessage.SendToVisible(portal, settings, PortalSpawnAnimateMessage.AnimateType.Portal);
+
+			OnPortalReady += (_) =>
+			{
+				GameObject entity = ServerSpawnObject(entityPrefab, worldPosition, settings);
+				PortalSpawnAnimateMessage.SendToVisible(entity, settings, PortalSpawnAnimateMessage.AnimateType.Entity);
+			};
+		}
+
+		private GameObject ServerSpawnPortal(GameObject portalPrefab, Vector3 worldPosition, PortalSpawnInfo settings)
+		{
+			// Spawn portal at some "height" above the landing zone.
+			worldPosition.y += settings.PortalHeight;
+			GameObject portal = Spawn.ServerPrefab(portalPrefab, worldPosition).GameObject;
+			UpdateManager.Instance.StartCoroutine(ServerRunPortalSequence(portal, settings));
+
+			return portal;
+		}
+
+		private GameObject ServerSpawnObject(GameObject entityPrefab, Vector3 worldPosition, PortalSpawnInfo settings)
+		{
+			// Spawn object at landing zone, (sprite will move back up to worldPosition for animation).
+			GameObject entity = Spawn.ServerPrefab(entityPrefab, worldPosition).GameObject;
+			OnObjectSpawned?.Invoke(entity);
+			UpdateManager.Instance.StartCoroutine(ServerRunObjectSequence(entity, settings));
+
+			return entity;
+		}
+
+		private IEnumerator ServerRunPortalSequence(GameObject portal, PortalSpawnInfo settings)
+		{
+			yield return WaitFor.Seconds(settings.PortalOpenTime + (settings.PortalSuspenseTime / 2));
+			OnPortalReady?.Invoke(portal);
+			yield return WaitFor.Seconds(settings.PortalCloseTime + (settings.PortalSuspenseTime / 2));
+			Despawn.ServerSingle(portal);
+		}
+
+		private IEnumerator ServerRunObjectSequence(GameObject entity, PortalSpawnInfo settings)
+		{
+			yield return WaitFor.Seconds(GetFallingTime(settings.PortalHeight));
+			OnObjectLanded?.Invoke(entity);
+		}
+
+		private static float GetFallingTime(float height)
+		{
+			return Mathf.Sqrt((height * 2) / 9.81f);
+		}
+	}
+
+	/// <summary>
+	/// Settings used to define portal and object spawn animation behaviour.
+	/// </summary>
+	public struct PortalSpawnInfo
+	{
+		public int PortalHeight;
+		public float PortalOpenTime;
+		public float PortalCloseTime;
+		public float PortalSuspenseTime;
+
+		public bool EntityRotate;
+
+		public static PortalSpawnInfo DefaultSettings()
+		{
+			return new PortalSpawnInfo
+			{
+				PortalHeight = 2,
+				PortalOpenTime = 0.5f,
+				PortalCloseTime = 0.5f,
+				PortalSuspenseTime = 0.5f,
+				EntityRotate = true,
+			};
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/Spells/Wizard/SpawnByPortal.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/Spells/Wizard/SpawnByPortal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26b5b5d00032f434c817017b4ef37a2b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Util/RandomUtils.cs
+++ b/UnityProject/Assets/Scripts/Util/RandomUtils.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 public class RandomUtils
 {
-	public static Quaternion RandomRotatation2D()
+	public static Quaternion RandomRotation2D()
 	{
 		var axis = new Vector3(0, 0, 1);
 		var randomRotation = Quaternion.AngleAxis(UnityEngine.Random.Range(-180f, 180f), axis);


### PR DESCRIPTION
- Adds a new wizard spell, `Rockdrop`. The final spell for #5160.
![balderdash](https://user-images.githubusercontent.com/6926225/102714202-ef2b8f80-4331-11eb-98da-5e4e1e328ad7.gif)
- Converts `Lesser Summon Guns` to use new portal spawning method.
    - Should fix issue of portal and gun animations not working on clients.
- New component `RandomInitialSprite`. Simply sets the SpriteHandler to use a random SO from the list at initialisation.

CL:Added RockDrop spell.

### Note
> Sprites are not final.
> There is no sound for the spell yet.