### PR TITLE
Partly fix NoteAttachable not working as client

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Cargo/NoteAttachable.cs
+++ b/UnityProject/Assets/Scripts/Items/Cargo/NoteAttachable.cs
@@ -1,4 +1,4 @@
-﻿using Mirror;
+using Mirror;
 using UnityEngine;
 using WebSocketSharp;
 
@@ -52,10 +52,11 @@ namespace Items.Cargo
 		private bool CommonWillInteract(TargetedInteraction interaction)
 		{
 			return interaction.TargetObject == gameObject &&
-			       interaction.UsedObject != null &&
-			       interaction.UsedObject.TryGetComponent<Paper>(out var paper) &&
-			       noteText.IsNullOrEmpty() &&
-			       paper.PaperString.IsNullOrEmpty() == false;
+					interaction.UsedObject != null &&
+					interaction.UsedObject.TryGetComponent<Paper>(out var paper) &&
+					noteText.IsNullOrEmpty() &&
+					(paper.ServerString.IsNullOrEmpty() == false || paper.PaperString.IsNullOrEmpty() == false);
+					// Server uses ServerString, clients; PaperString.
 		}
 
 		private void SyncNoteText(string oldVal, string newVal)


### PR DESCRIPTION
- Partly fixes NoteAttachable not working as client for #5680.
While this fixes one problem, it seems notes still don't appear (no new examination message or context menu interaction to remove the note).