### PR TITLE
Fixes some PDA issues, improve player identity behaviour

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/BioHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BioHoods/BioHood.prefab
@@ -165,6 +165,11 @@ PrefabInstance:
       propertyPath: hideClothingFlags
       value: 1008
       objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5406248525527790680, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BlackRedSpaceHelmetReplica.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BlackRedSpaceHelmetReplica.prefab
@@ -106,6 +106,11 @@ PrefabInstance:
       propertyPath: hideClothingFlags
       value: 1008
       objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5406248525527790680, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BombHoods/BombHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/BombHoods/BombHood.prefab
@@ -174,6 +174,11 @@ PrefabInstance:
       propertyPath: hidesSlots
       value: 12832
       objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5406248525527790680, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/CrusaderHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/CrusaderHelmet.prefab
@@ -155,6 +155,11 @@ PrefabInstance:
       propertyPath: hideClothingFlags
       value: 1008
       objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5406248525527790680, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/RadiationHood.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/RadiationHood.prefab
@@ -146,6 +146,11 @@ PrefabInstance:
       propertyPath: hideClothingFlags
       value: 1008
       objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5406248525527790680, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/OfficersBeret.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/OfficersBeret.prefab
@@ -24,6 +24,11 @@ PrefabInstance:
       propertyPath: hideClothingFlags
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4548501816867735510, guid: 5269bbb43ef5a0b40a2676310664d6c6,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7029879816411904817, guid: 5269bbb43ef5a0b40a2676310664d6c6,
         type: 3}
       propertyPath: initialDescription

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/PirateBandanaSpace.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/PirateBandanaSpace.prefab
@@ -89,6 +89,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 9f80f4bb8ca25244690cbb2db6adddf0,
         type: 2}
+    - target: {fileID: 6087241806471426201, guid: 6f89cd3560254ff4ca7d644a8a72ba16,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6431456478879029403, guid: 6f89cd3560254ff4ca7d644a8a72ba16,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/PirateHatSpace.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/PirateHatSpace.prefab
@@ -24,6 +24,11 @@ PrefabInstance:
       propertyPath: hideClothingFlags
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4548501816867735510, guid: 5269bbb43ef5a0b40a2676310664d6c6,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7029879816411904817, guid: 5269bbb43ef5a0b40a2676310664d6c6,
         type: 3}
       propertyPath: initialDescription

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SpaceHelmetBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/SpacesuitHelmets/SpaceHelmetBase.prefab
@@ -23,6 +23,11 @@ PrefabInstance:
       propertyPath: hidesSlots
       value: 12832
       objectReference: {fileID: 0}
+    - target: {fileID: 3568482238077595727, guid: fceccba0296eb5b4983bdfe2fc9ccdd0,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4377197623706982477, guid: fceccba0296eb5b4983bdfe2fc9ccdd0,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/WeldingHelmet.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Headwear/WeldingHelmet.prefab
@@ -161,6 +161,11 @@ PrefabInstance:
       propertyPath: hideClothingFlags
       value: 208
       objectReference: {fileID: 0}
+    - target: {fileID: 5061482891772091482, guid: a7a048f6c330048e9a2358fb6f71d385,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5406248525527790680, guid: a7a048f6c330048e9a2358fb6f71d385,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear.prefab
@@ -123,6 +123,11 @@ PrefabInstance:
       propertyPath: initialSize
       value: 3
       objectReference: {fileID: 0}
+    - target: {fileID: 8183805690938991015, guid: 6b5f74a79e023479cb5b30a2879621da,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8982871833932450213, guid: 6b5f74a79e023479cb5b30a2879621da,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear/BreathMask.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear/BreathMask.prefab
@@ -18,6 +18,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 7396b9308d8284df280e4b2036e0a90d,
         type: 2}
+    - target: {fileID: 3532393564309681412, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4341101185987976454, guid: 05a135eab68164d34bb02b82fff3cde0,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear/CarpMask.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear/CarpMask.prefab
@@ -13,6 +13,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 2db45a32b89526041ba92645bbaedba5,
         type: 2}
+    - target: {fileID: 44155453462962640, guid: 996d62bfe3bf26c4e95c2a77cadabbd2,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 984030586657343954, guid: 996d62bfe3bf26c4e95c2a77cadabbd2,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear/MedicalMask.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear/MedicalMask.prefab
@@ -13,6 +13,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 2c6527d6fadb93b4a976552eb96fc5e3,
         type: 2}
+    - target: {fileID: 44155453462962640, guid: dce8e376d2eca40eabe3f055b41a021c,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 984030586657343954, guid: dce8e376d2eca40eabe3f055b41a021c,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear/SecurityGasMask.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear/SecurityGasMask.prefab
@@ -18,6 +18,11 @@ PrefabInstance:
       propertyPath: hideClothingFlags
       value: 640
       objectReference: {fileID: 0}
+    - target: {fileID: 3532393564309681412, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4341101185987976454, guid: 05a135eab68164d34bb02b82fff3cde0,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear/SterileMask.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Clothing/Maskwear/SterileMask.prefab
@@ -23,6 +23,11 @@ PrefabInstance:
       propertyPath: hideClothingFlags
       value: 128
       objectReference: {fileID: 0}
+    - target: {fileID: 3532393564309681412, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4341101185987976454, guid: 05a135eab68164d34bb02b82fff3cde0,
         type: 3}
       propertyPath: PresentSpriteSet

--- a/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
+++ b/UnityProject/Assets/Scripts/Clothing/ClothingV2.cs
@@ -22,6 +22,10 @@ public class ClothingV2 : NetworkBehaviour
 	[SerializeField][SyncVar(hook = nameof(SyncSprites))]
 	private ClothingVariantType variantType = ClothingVariantType.Default;
 
+	[Tooltip("Determine whether this piece of clothing obscures the identity of the wearer (head, maskwear)")]
+	[SerializeField]
+	private bool hidesIdentity = false;
+
 	[Tooltip("Determine which slots this clothing should obscure.")]
 	[SerializeField, EnumFlag]
 	private NamedSlotFlagged hidesSlots = NamedSlotFlagged.None;
@@ -50,6 +54,9 @@ public class ClothingV2 : NetworkBehaviour
 	/// The index of the sprites that should currently be used for rendering this, an index into SpriteData.List
 	/// </summary>
 	public int SpriteInfoState => isAdjusted ? 1 : 0;
+
+	/// <summary> Whether this piece of clothing obscures the identity of the wearer (head, maskwear). </summary>
+	public bool HidesIdentity => hidesIdentity;
 
 	/// <summary>
 	/// When this item is equipped, these are the slots that should be hidden.

--- a/UnityProject/Assets/Scripts/Health/Sickness/SicknessManager.cs
+++ b/UnityProject/Assets/Scripts/Health/Sickness/SicknessManager.cs
@@ -235,7 +235,7 @@ namespace Health.Sickness
 		private void PerformSymptomSneeze(SymptomManifestation symptomManifestation)
 		{
 			GameObject performer = symptomManifestation.PlayerHealth.gameObject;
-			Chat.AddActionMsgToChat(performer, "You sneeze.", $"{performer.name} sneezes");
+			Chat.AddActionMsgToChat(performer, "You sneeze.", $"{performer.ExpensiveName()} sneezes!");
 
 			if (symptomManifestation.SicknessAffliction.Sickness.Contagious)
 			{
@@ -249,7 +249,7 @@ namespace Health.Sickness
 		private void PerformSymptomCough(SymptomManifestation symptomManifestation)
 		{
 			GameObject performer = symptomManifestation.PlayerHealth.gameObject;
-			Chat.AddActionMsgToChat(performer, "You cough.", $"{performer.name} coughs");
+			Chat.AddActionMsgToChat(performer, "You cough.", $"{performer.ExpensiveName()} coughs!");
 
 			if (symptomManifestation.SicknessAffliction.Sickness.Contagious)
 			{
@@ -270,8 +270,9 @@ namespace Health.Sickness
 			int randomMessage = Random.Range(0, customMessageParameter.CustomMessages.Count);
 			CustomMessage customMessage = customMessageParameter.CustomMessages[randomMessage];
 
-			string privateMessage = (customMessage.privateMessage ?? "").Replace("%PLAYERNAME%", performer.name);
-			string publicMessage = (customMessage.publicMessage ?? "").Replace("%PLAYERNAME%", performer.name);
+			string performerName = performer.ExpensiveName();
+			string privateMessage = (customMessage.privateMessage ?? "").Replace("%PLAYERNAME%", performerName);
+			string publicMessage = (customMessage.publicMessage ?? "").Replace("%PLAYERNAME%", performerName);
 
 			if (string.IsNullOrWhiteSpace(publicMessage))
 				Chat.AddExamineMsg(performer, privateMessage);

--- a/UnityProject/Assets/Scripts/Items/ClothingItem.cs
+++ b/UnityProject/Assets/Scripts/Items/ClothingItem.cs
@@ -9,7 +9,7 @@ public enum SpriteHandType
 	LeftHand
 }
 
-public delegate void OnClothingEquippedDelegate(ClothingV2 clothing, bool isEquiped);
+public delegate void OnClothingEquippedDelegate(ClothingV2 clothing, bool isEquipped);
 
 /// <summary>
 /// For the Individual clothing player sprite renderers

--- a/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
+++ b/UnityProject/Assets/Scripts/Managers/ConnectedPlayer.cs
@@ -53,6 +53,9 @@ public class ConnectedPlayer
 		}
 	}
 
+	/// <summary>
+	/// The in-game name of the player. Does not take into account recognition (unknown identity).
+	/// </summary>
 	public string Name
 	{
 		get

--- a/UnityProject/Assets/Scripts/Player/PlayerScript.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerScript.cs
@@ -17,9 +17,9 @@ public class PlayerScript : ManagedNetworkBehaviour, IMatrixRotation, IAdminInfo
 	/// </summary>
 	public CharacterSettings characterSettings = new CharacterSettings();
 
-	[SyncVar(hook = nameof(SyncPlayerName))] public string playerName = " ";
+	[HideInInspector, SyncVar(hook = nameof(SyncPlayerName))] public string playerName = " ";
 
-	[SyncVar(hook = nameof(SyncVisibleName))] public string visibleName = " ";
+	[HideInInspector, SyncVar(hook = nameof(SyncVisibleName))] public string visibleName = " ";
 	public PlayerNetworkActions playerNetworkActions { get; set; }
 
 	public WeaponNetworkActions weaponNetworkActions { get; set; }
@@ -421,16 +421,19 @@ public class PlayerScript : ManagedNetworkBehaviour, IMatrixRotation, IAdminInfo
 	//Update visible name.
 	public void RefreshVisibleName()
 	{
-		// TODO: Check inventory for head/mask items that hide face - atm just check you are not wearing a mask.
-		// needs helmet/hideface trait to be added and checked for. This way, we start with a "face name" our characters might know...
-		if (IsGhost || ItemStorage.GetNamedItemSlot(NamedSlot.mask).IsEmpty)
+		string newVisibleName;
+
+		if (IsGhost || Equipment.IsIdentityObscured() == false)
 		{
-			SyncVisibleName(playerName, playerName);
+			newVisibleName = playerName; // can see face so real identity is known
 		}
 		else
 		{
-			SyncVisibleName("Unknown", "Unknown");
+			// Returns Unknown if identity could not be found via equipment (ID, PDA)
+			newVisibleName = Equipment.GetPlayerNameByEquipment();
 		}
+
+		SyncVisibleName(newVisibleName, newVisibleName);
 	}
 
 	//Tooltips inspector bar

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/AntagManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/AntagManager.cs
@@ -79,11 +79,9 @@ namespace Antagonists
 		public void ServerSpawnAntag(Antagonist chosenAntag, PlayerSpawnRequest spawnRequest)
 		{
 			//spawn the antag using their custom spawn logic
-			var spawnedPlayer = chosenAntag.ServerSpawn(spawnRequest);
+			ConnectedPlayer spawnedPlayer = chosenAntag.ServerSpawn(spawnRequest);
 
-			var connectedPlayer = PlayerList.Instance.Get(spawnedPlayer);
-
-			ServerFinishAntag(chosenAntag, connectedPlayer, spawnedPlayer);
+			ServerFinishAntag(chosenAntag, spawnedPlayer);
 		}
 
 		public IEnumerator ServerRespawnAsAntag(ConnectedPlayer connectedPlayer, Antagonist antagonist)
@@ -108,7 +106,7 @@ namespace Antagonists
 			}
 
 			PlayerSpawn.ServerRespawnPlayer(connectedPlayer.Script.mind);
-			ServerFinishAntag(antagonist, connectedPlayer, connectedPlayer.GameObject);
+			ServerFinishAntag(antagonist, connectedPlayer);
 		}
 
 		private SpawnedAntag SetAntagDetails(Antagonist chosenAntag, ConnectedPlayer connectedPlayer)
@@ -121,28 +119,43 @@ namespace Antagonists
 			return spawnedAntag;
 		}
 
-		public void ServerFinishAntag(Antagonist chosenAntag, ConnectedPlayer connectedPlayer, GameObject spawnedPlayer)
+		public void ServerFinishAntag(Antagonist chosenAntag, ConnectedPlayer connectedPlayer)
 		{
 			var spawnedAntag = SetAntagDetails(chosenAntag, connectedPlayer);
 			ActiveAntags.Add(spawnedAntag);
-			ShowAntagBanner(spawnedPlayer, chosenAntag);
+			ShowAntagBanner(connectedPlayer, chosenAntag);
 
 			Logger.Log(
 				$"Created new antag. Made {connectedPlayer.Name} a {chosenAntag.AntagName} with objectives:\n{spawnedAntag.GetObjectivesForLog()}",
 				Category.Antags);
 		}
 
-
+		/// <summary>
+		/// Searches for the first PDA on the given player and installs an uplink.
+		/// </summary>
+		/// <param name="player">The player that should receive an uplink in the first PDA found on them.</param>
+		/// <param name="tcCount">The amount of telecrystals the uplink should be given.</param>
+		public static void TryInstallPDAUplink(ConnectedPlayer player, int tcCount)
+		{
+			foreach (ItemSlot slot in player.Script.ItemStorage.GetItemSlotTree())
+			{
+				if (slot.IsEmpty) continue;
+				if (slot.Item.TryGetComponent<Items.PDA.PDALogic>(out var pda))
+				{
+					pda.InstallUplink(player, tcCount);
+				}
+			}
+		}
 
 		/// <summary>
 		/// Sends a message to the antag player and tells it to start the antag banner animation.
 		/// </summary>
 		/// <param name="player">Who</param>
 		/// <param name="antag">What antag data</param>
-		private static void ShowAntagBanner(GameObject player, Antagonist antag)
+		private static void ShowAntagBanner(ConnectedPlayer player, Antagonist antag)
 		{
 			AntagBannerMessage.Send(
-				player,
+				player.GameObject,
 				antag.AntagName,
 				antag.SpawnSound,
 				antag.TextColor,

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antagonist.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antagonist.cs
@@ -104,7 +104,7 @@ namespace Antagonists
 		/// </summary>
 		/// <param name="spawnRequest">player's requested spawn</param>
 		/// <returns>gameobject of the spawned antag that he player is now in control of</returns>
-		public abstract GameObject ServerSpawn(PlayerSpawnRequest spawnRequest);
+		public abstract ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest);
 
 		public void AddObjective(Objective objective)
 		{

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/Blob.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/Blob.cs
@@ -6,13 +6,13 @@ namespace Antagonists
 	[CreateAssetMenu(menuName="ScriptableObjects/Antagonist/Blob")]
 	public class Blob : Antagonist
 	{
-		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
 		{
 			// spawn them normally, with their preferred occupation
-			var spawn = PlayerSpawn.ServerSpawnPlayer(spawnRequest);
+			var spawn = PlayerSpawn.ServerSpawnPlayer(spawnRequest).Player();
 
 			//Add blob player to game object
-			spawn.AddComponent<BlobStarter>();
+			spawn.GameObject.AddComponent<BlobStarter>();
 
 			return spawn;
 		}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Cargonian.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Cargonian.cs
@@ -6,10 +6,10 @@ namespace Antagonists
 	[CreateAssetMenu(menuName="ScriptableObjects/Antagonist/Cargonian")]
 	public class Cargonian : Antagonist
 	{
-		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
 		{
-			var newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest);
-			UpdateChatMessage.Send(newPlayer, ChatChannel.System, ChatModifier.None,
+			var newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest).Player();
+			UpdateChatMessage.Send(newPlayer.GameObject, ChatChannel.System, ChatModifier.None,
 				"<color=red>Something has awoken in you. You feel the urgent need to rebel alongside all your brothers in your deparment against this station.</color>");
 			// spawn them normally, with their preferred occupation
 			return newPlayer;

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Fugitive.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Fugitive.cs
@@ -41,19 +41,19 @@ namespace Antagonists
 			GameManager.Instance.CentComm.MakeCommandReport(warnMessage, CentComm.UpdateSound.notice);
 		}
 
-		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
 		{
 			var newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest.JoinedViewer, AntagOccupation,
-				spawnRequest.CharacterSettings);
+				spawnRequest.CharacterSettings).Player();
 
-			UpdateChatMessage.Send(newPlayer, ChatChannel.Local, ChatModifier.Whisper,
+			UpdateChatMessage.Send(newPlayer.GameObject, ChatChannel.Local, ChatModifier.Whisper,
 				"I can't believe we managed to break out of a Nanotrasen superjail! Sadly though," +
 				" our work is not done. The emergency teleport at the station logs everyone who uses it," +
 				" and where they went. It won't be long until Centcom tracks where we've gone off to." +
 				" I need to move in the shadows and keep out of sight," +
 				" I'm not going back.");
 
-			_ = StationWarning(newPlayer.Player().Name);
+			_ = StationWarning(newPlayer.Script.playerName);
 
 			return newPlayer;
 		}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/NuclearOperative.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/NuclearOperative.cs
@@ -7,23 +7,26 @@ namespace Antagonists
 	public class NuclearOperative : Antagonist
 	{
 		[Tooltip("For use in Syndicate Uplinks")]
-		public int initialTC = 20;
+		[SerializeField]
+		private int initialTC = 20;
 
 		// add any NuclearOperative specific logic here
-		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
 		{
 			//spawn as a nuke op regardless of the requested occupation
 			var newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest.JoinedViewer, AntagOccupation,
-				spawnRequest.CharacterSettings);
+				spawnRequest.CharacterSettings).Player();
 
 			//send the code:
 			//Check to see if there is a nuke and communicate the nuke code:
 			Nuke nuke = Object.FindObjectOfType<Nuke>();
 			if (nuke != null)
 			{
-				UpdateChatMessage.Send(newPlayer, ChatChannel.Syndicate, ChatModifier.None,
-					"We have intercepted the code for the nuclear weapon: " + nuke.NukeCode);
+				UpdateChatMessage.Send(newPlayer.GameObject, ChatChannel.Syndicate, ChatModifier.None,
+					$"We have intercepted the code for the nuclear weapon: <b>{nuke.NukeCode}</b>.");
 			}
+
+			AntagManager.TryInstallPDAUplink(newPlayer, initialTC);
 
 			return newPlayer;
 		}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Survivor.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Survivor.cs
@@ -6,10 +6,10 @@ namespace Antagonists
 	[CreateAssetMenu(menuName = "ScriptableObjects/Antagonist/Survivor")]
 	public class Survivor : Antagonist
 	{
-		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
 		{
 			// spawn them normally, with their preferred occupation
-			return PlayerSpawn.ServerSpawnPlayer(spawnRequest);
+			return PlayerSpawn.ServerSpawnPlayer(spawnRequest).Player();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Traitor.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Traitor.cs
@@ -7,12 +7,17 @@ namespace Antagonists
 	public class Traitor : Antagonist
 	{
 		[Tooltip("For use in Syndicate Uplinks")]
-		public int initialTC = 20;
+		[SerializeField]
+		private int initialTC = 20;
 
-		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
 		{
 			// spawn them normally, with their preferred occupation
-			return PlayerSpawn.ServerSpawnPlayer(spawnRequest);
+			ConnectedPlayer player = PlayerSpawn.ServerSpawnPlayer(spawnRequest).Player();
+
+			AntagManager.TryInstallPDAUplink(player, initialTC);
+
+			return player;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Wizard.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Wizard.cs
@@ -26,11 +26,10 @@ namespace Antagonists
 
 		public int StartingSpellCount => startingSpellCount;
 
-		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
 		{
-			GameObject newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest.JoinedViewer, AntagOccupation,
-					spawnRequest.CharacterSettings);
-			ConnectedPlayer player = newPlayer.Player();
+			ConnectedPlayer player = PlayerSpawn.ServerSpawnPlayer(
+					spawnRequest.JoinedViewer, AntagOccupation, spawnRequest.CharacterSettings).Player();
 
 			GiveRandomSpells(player);
 
@@ -41,7 +40,7 @@ namespace Antagonists
 
 			SetPapers(player);
 
-			return newPlayer;
+			return player;
 		}
 
 		public string GetRandomWizardName()

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventSpawnBlob.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventSpawnBlob.cs
@@ -42,7 +42,7 @@ public class EventSpawnBlob : EventScriptBase
 		//Set up objectives
 		if (antag == null || antag.Antagonist.AntagJobType != JobType.BLOB)
 		{
-			AntagManager.Instance.ServerFinishAntag(SOAdminJobsList.Instance.Antags.First(a => a.AntagJobType == JobType.BLOB), player, player.GameObject);
+			AntagManager.Instance.ServerFinishAntag(SOAdminJobsList.Instance.Antags.First(a => a.AntagJobType == JobType.BLOB), player);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventSummonGuns.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventSummonGuns.cs
@@ -47,7 +47,7 @@ namespace InGameEvents
 		private void SetAsAntagSurvivor(ConnectedPlayer player)
 		{
 			Chat.AddExamineMsgFromServer(player, "<color='red'><size=60>You are the survivalist!</size></color>");
-			AntagManager.Instance.ServerFinishAntag(survivorAntag, player, player.GameObject);
+			AntagManager.Instance.ServerFinishAntag(survivorAntag, player);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Systems/Jobs/CrewManifestManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Jobs/CrewManifestManager.cs
@@ -1,4 +1,4 @@
-﻿using Objects.Security;
+using Objects.Security;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -66,8 +66,10 @@ namespace Systems
 				Name = script.playerName,
 				JobType = jobType,
 			};
+			CrewManifest.Add(entry);
 
 			if (jobType == JobType.AI || jobType == JobType.CYBORG) return entry;
+
 			entry.SecurityRecord = GenerateSecurityRecord(script, jobType);
 			SecurityRecords.Add(entry.SecurityRecord);
 


### PR DESCRIPTION
- Fixes coughing, sneezing revealing the player's true identity.
- Fixes a couple issues with PDAs.
    - Syndicate uplink activation is now handled through `AntagManager`. Fixes #5239.
    - PDA object name is now generated similar to that of ID cards. Closes #5689.
    - Removes unused, commented out messenger code. Probably best to start anew.
- `Antagonist` now returns `ConnectedPlayer` (which is great; I'd like to see it used more elsewhere) as `AntagManager`.
### Update
- Crew manifest list is now populating. Fixes #5723.
- Adds new serialized boolean for determining whether an article of clothing (for masks, headwear) obscures the identity of the wearer. Updates most relevant prefabs to reflect the changes. Partially implements #5711.
- Player identity is now derived from whether their face is obscured or not, falling back to what equipment (ID card, PDA) they have in their ID slot. Partially implements #5711.