### PR TITLE
Tweaks Antagonist class; decouples spawning from after-spawn logic

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Other/CigarettesAndLighters/Smokeables/CigaretteBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Other/CigarettesAndLighters/Smokeables/CigaretteBase.prefab
@@ -13,8 +13,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isBurningOnSpawn: 0
-  flameTemperature: 700
-  flameVolume: 0.005
 --- !u!114 &5733160862123623072
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -81,6 +79,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 1c69162b3a40fb14896b480602231cae,
         type: 2}
+    - target: {fileID: 3532393564309681412, guid: 05a135eab68164d34bb02b82fff3cde0,
+        type: 3}
+      propertyPath: hidesIdentity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4341101185987976454, guid: 05a135eab68164d34bb02b82fff3cde0,
         type: 3}
       propertyPath: SubCatalogue.Array.size

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
@@ -201,6 +201,8 @@ public class ChatRelay : NetworkBehaviour
 
 		if (channels != ChatChannel.None)
 		{
+			// TODO: remove hardcoded "You" check; chat bubbles should be on their own channel or similar - see issue #5775.
+
 			// replace action messages with chat bubble
 			if(channels.HasFlag(ChatChannel.Combat) || channels.HasFlag(ChatChannel.Action) || channels.HasFlag(ChatChannel.Examine))
 			{

--- a/UnityProject/Assets/Scripts/Items/ThrowableBreakable.cs
+++ b/UnityProject/Assets/Scripts/Items/ThrowableBreakable.cs
@@ -7,6 +7,9 @@ using UnityEngine;
 
 namespace Items
 {
+	/// <summary>
+	/// Allows a gameobject to transform into a different object when it is thrown, upon landing.
+	/// </summary>
 	public class ThrowableBreakable : MonoBehaviour
 	{
 		[SerializeField]
@@ -23,9 +26,13 @@ namespace Items
 
 		private CustomNetTransform customNetTransform;
 
-		private void Start()
+		private void Awake()
 		{
 			customNetTransform = GetComponent<CustomNetTransform>();
+		}
+
+		private void OnEnable()
+		{
 			customNetTransform.OnThrowEnd.AddListener(OnThrown);
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/AntagManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/AntagManager.cs
@@ -79,7 +79,7 @@ namespace Antagonists
 		public void ServerSpawnAntag(Antagonist chosenAntag, PlayerSpawnRequest spawnRequest)
 		{
 			//spawn the antag using their custom spawn logic
-			ConnectedPlayer spawnedPlayer = chosenAntag.ServerSpawn(spawnRequest);
+			ConnectedPlayer spawnedPlayer = chosenAntag.ServerSpawn(spawnRequest).Player();
 
 			ServerFinishAntag(chosenAntag, spawnedPlayer);
 		}
@@ -124,6 +124,7 @@ namespace Antagonists
 			var spawnedAntag = SetAntagDetails(chosenAntag, connectedPlayer);
 			ActiveAntags.Add(spawnedAntag);
 			ShowAntagBanner(connectedPlayer, chosenAntag);
+			chosenAntag.AfterSpawn(connectedPlayer);
 
 			Logger.Log(
 				$"Created new antag. Made {connectedPlayer.Name} a {chosenAntag.AntagName} with objectives:\n{spawnedAntag.GetObjectivesForLog()}",

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antagonist.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antagonist.cs
@@ -104,7 +104,16 @@ namespace Antagonists
 		/// </summary>
 		/// <param name="spawnRequest">player's requested spawn</param>
 		/// <returns>gameobject of the spawned antag that he player is now in control of</returns>
-		public abstract ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest);
+		public virtual GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
+		{
+			// spawn them normally but override the player-requested occupation with the antagonist occupation
+			return PlayerSpawn.ServerSpawnPlayer(spawnRequest.JoinedViewer, AntagOccupation, spawnRequest.CharacterSettings);
+		}
+
+		/// <summary>
+		/// Called just after spawning or respawning.
+		/// </summary>
+		public abstract void AfterSpawn(ConnectedPlayer player);
 
 		public void AddObjective(Objective objective)
 		{

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/Blob.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Blob/Blob.cs
@@ -6,15 +6,16 @@ namespace Antagonists
 	[CreateAssetMenu(menuName="ScriptableObjects/Antagonist/Blob")]
 	public class Blob : Antagonist
 	{
-		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
 		{
 			// spawn them normally, with their preferred occupation
-			var spawn = PlayerSpawn.ServerSpawnPlayer(spawnRequest).Player();
+			return PlayerSpawn.ServerSpawnPlayer(spawnRequest);
+		}
 
+		public override void AfterSpawn(ConnectedPlayer player)
+		{
 			//Add blob player to game object
-			spawn.GameObject.AddComponent<BlobStarter>();
-
-			return spawn;
+			player.GameObject.AddComponent<BlobStarter>();
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Cargonian.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Cargonian.cs
@@ -6,13 +6,17 @@ namespace Antagonists
 	[CreateAssetMenu(menuName="ScriptableObjects/Antagonist/Cargonian")]
 	public class Cargonian : Antagonist
 	{
-		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
 		{
-			var newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest).Player();
-			UpdateChatMessage.Send(newPlayer.GameObject, ChatChannel.System, ChatModifier.None,
-				"<color=red>Something has awoken in you. You feel the urgent need to rebel alongside all your brothers in your deparment against this station.</color>");
 			// spawn them normally, with their preferred occupation
-			return newPlayer;
+			return PlayerSpawn.ServerSpawnPlayer(spawnRequest);
+		}
+
+		public override void AfterSpawn(ConnectedPlayer player)
+		{
+			UpdateChatMessage.Send(player.GameObject, ChatChannel.System, ChatModifier.None,
+				"<color=red>Something has awoken in you. You feel the urgent need to rebel " +
+				"alongside all your brothers in your department against this station.</color>");
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Fugitive.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Fugitive.cs
@@ -11,26 +11,39 @@ namespace Antagonists
 	{
 		[SerializeField]
 		[Tooltip("Min and max time in minutes it takes for Centcom to send a warning to the station about this fugitive." +
-		         "The real time will be a random time from the min to max values.")]
+				"The real time will be a random time from the min to max values.")]
 		private Vector2 timeToSendWarning = default;
 
 		[SerializeField][TextArea(3, 10)]
 		[Tooltip("The warning message that will be printed to command when Centcom alerts about this fugitive" +
-		         "{0} will be changed on runtime to the real name of the fugitive." +
-		         "{1} is just a random number to give some flavor.")]
-		private string warnMessage = "We have reliable information to think there is a dangerous fugitive " +
-		                             "from SuperJail in your station.\n" +
-		                             "It is your duty to capture and bring them to Centcom or neutralize the threat " +
-		                             "as soon as possible!\n\n" +
-		                             "Prisoner number: {1}.\n" +
-		                             "Prisoner name: {0}.\n" +
-		                             "Category: EXTREMELY DANGEROUS.\n\n" +
-		                             "<color=blue><size=32>New Station Objectives:</size></color>\n\n" +
-		                             "<size=24>- Find the fugitive\n\n" +
-		                             "- Arrest the fugitive and bring them to Centcom " +
-		                             "when the escape shuttle is called\n\n" +
-		                             "- If the fugitive is threatening the station production, neutralize immediately." +
-		                             "</size>";
+				"{0} will be changed on runtime to the real name of the fugitive." +
+				"{1} is just a random number to give some flavor.")]
+		private string warnMessage =
+				"We have reliable information to think there is a dangerous fugitive " +
+				"from SuperJail in your station.\n" +
+				"It is your duty to capture and bring them to Centcom or neutralize the threat " +
+				"as soon as possible!\n\n" +
+				"Prisoner number: {1}.\n" +
+				"Prisoner name: {0}.\n" +
+				"Category: EXTREMELY DANGEROUS.\n\n" +
+				"<color=blue><size=32>New Station Objectives:</size></color>\n\n" +
+				"<size=24>- Find the fugitive\n\n" +
+				"- Arrest the fugitive and bring them to Centcom " +
+				"when the escape shuttle is called\n\n" +
+				"- If the fugitive is threatening the station production, neutralize immediately." +
+				"</size>";
+
+		public override void AfterSpawn(ConnectedPlayer player)
+		{
+			UpdateChatMessage.Send(player.GameObject, ChatChannel.Local, ChatModifier.Whisper,
+				"I can't believe we managed to break out of a Nanotrasen superjail! Sadly though," +
+				" our work is not done. The emergency teleport at the station logs everyone who uses it," +
+				" and where they went. It won't be long until Centcom tracks where we've gone off to." +
+				" I need to move in the shadows and keep out of sight," +
+				" I'm not going back.");
+
+			_ = StationWarning(player.Script.playerName);
+		}
 
 		private async Task StationWarning(string fugitiveName)
 		{
@@ -39,23 +52,6 @@ namespace Antagonists
 			warnMessage = string.Format(warnMessage, fugitiveName, fugitiveNumber);
 
 			GameManager.Instance.CentComm.MakeCommandReport(warnMessage, CentComm.UpdateSound.notice);
-		}
-
-		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
-		{
-			var newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest.JoinedViewer, AntagOccupation,
-				spawnRequest.CharacterSettings).Player();
-
-			UpdateChatMessage.Send(newPlayer.GameObject, ChatChannel.Local, ChatModifier.Whisper,
-				"I can't believe we managed to break out of a Nanotrasen superjail! Sadly though," +
-				" our work is not done. The emergency teleport at the station logs everyone who uses it," +
-				" and where they went. It won't be long until Centcom tracks where we've gone off to." +
-				" I need to move in the shadows and keep out of sight," +
-				" I'm not going back.");
-
-			_ = StationWarning(newPlayer.Script.playerName);
-
-			return newPlayer;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/NuclearOperative.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/NuclearOperative.cs
@@ -10,25 +10,20 @@ namespace Antagonists
 		[SerializeField]
 		private int initialTC = 20;
 
-		// add any NuclearOperative specific logic here
-		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override void AfterSpawn(ConnectedPlayer player)
 		{
-			//spawn as a nuke op regardless of the requested occupation
-			var newPlayer = PlayerSpawn.ServerSpawnPlayer(spawnRequest.JoinedViewer, AntagOccupation,
-				spawnRequest.CharacterSettings).Player();
+			// add any NuclearOperative specific logic here
 
 			//send the code:
 			//Check to see if there is a nuke and communicate the nuke code:
-			Nuke nuke = Object.FindObjectOfType<Nuke>();
+			Nuke nuke = FindObjectOfType<Nuke>();
 			if (nuke != null)
 			{
-				UpdateChatMessage.Send(newPlayer.GameObject, ChatChannel.Syndicate, ChatModifier.None,
+				UpdateChatMessage.Send(player.GameObject, ChatChannel.Syndicate, ChatModifier.None,
 					$"We have intercepted the code for the nuclear weapon: <b>{nuke.NukeCode}</b>.");
 			}
 
-			AntagManager.TryInstallPDAUplink(newPlayer, initialTC);
-
-			return newPlayer;
+			AntagManager.TryInstallPDAUplink(player, initialTC);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Survivor.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Survivor.cs
@@ -6,10 +6,12 @@ namespace Antagonists
 	[CreateAssetMenu(menuName = "ScriptableObjects/Antagonist/Survivor")]
 	public class Survivor : Antagonist
 	{
-		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
 		{
 			// spawn them normally, with their preferred occupation
-			return PlayerSpawn.ServerSpawnPlayer(spawnRequest).Player();
+			return PlayerSpawn.ServerSpawnPlayer(spawnRequest);
 		}
+
+		public override void AfterSpawn(ConnectedPlayer player) { }
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Traitor.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Traitor.cs
@@ -10,14 +10,15 @@ namespace Antagonists
 		[SerializeField]
 		private int initialTC = 20;
 
-		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override GameObject ServerSpawn(PlayerSpawnRequest spawnRequest)
 		{
 			// spawn them normally, with their preferred occupation
-			ConnectedPlayer player = PlayerSpawn.ServerSpawnPlayer(spawnRequest).Player();
+			return PlayerSpawn.ServerSpawnPlayer(spawnRequest);
+		}
 
+		public override void AfterSpawn(ConnectedPlayer player)
+		{
 			AntagManager.TryInstallPDAUplink(player, initialTC);
-
-			return player;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Wizard.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Antags/Wizard.cs
@@ -26,11 +26,8 @@ namespace Antagonists
 
 		public int StartingSpellCount => startingSpellCount;
 
-		public override ConnectedPlayer ServerSpawn(PlayerSpawnRequest spawnRequest)
+		public override void AfterSpawn(ConnectedPlayer player)
 		{
-			ConnectedPlayer player = PlayerSpawn.ServerSpawnPlayer(
-					spawnRequest.JoinedViewer, AntagOccupation, spawnRequest.CharacterSettings).Player();
-
 			GiveRandomSpells(player);
 
 			if (assignRandomNameOnSpawn)
@@ -39,8 +36,6 @@ namespace Antagonists
 			}
 
 			SetPapers(player);
-
-			return player;
 		}
 
 		public string GetRandomWizardName()
@@ -96,7 +91,6 @@ namespace Antagonists
 						"\n<size=28><b>Known Issues</b></size>\n" +
 						"- The artifact Whizzamazon drop-pods do not display the landing target reticule. Watch out!\n" +
 						"- Unfortunately, you will lose your action spells if you disconnect from the game or are respawned.\n" +
-						"- LesserSummonGuns spell animation does not work. Cosmetic only.\n" +
 						"Good luck!");
 			}
 		}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/SpawnedAntag.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/SpawnedAntag.cs
@@ -66,7 +66,8 @@ namespace Antagonists
 		/// </summary>
 		public string GetObjectivesForPlayer()
 		{
-			StringBuilder objSB = new StringBuilder($"</i><size=60><color=red>You are a <b>{Antagonist.AntagName}</b>!</color></size>\n", 200);
+			// TODO: remove the leading space before "You are a {Antagonist.AntagName}!" once issue #5775 is fixed.
+			StringBuilder objSB = new StringBuilder($"</i><size=60><color=red> You are a <b>{Antagonist.AntagName}</b>!</color></size>\n", 200);
 			var objectiveList = Objectives.ToList();
 			objSB.AppendLine("Your objectives are:");
 			for (int i = 0; i < objectiveList.Count; i++)


### PR DESCRIPTION
- Decouples spawning from after-spawning logic for antagonist-specific code. Fixes #5215 and other issues when respawning players as antagonist (such as wizards not receiving a free random role or random name, populated papers, when respawned).
- Adds workaround for issue where players are informed of objectives via speech bubbles and not an entry in the chat log. See #5775.
- Cigarettes no longer hide the identity of the smoker. Fixes the now-unique example given in #5688.
- `ThrowableBreakable` component no longer generates NREs during startup.
