### PR TITLE
SeedExtractor Partial Fix to Dropping Seed Packets on Deconstruction

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
@@ -122,7 +122,8 @@ namespace Objects.Botany
 		[Server]
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-			if (interaction.HandObject != null) {
+			if (interaction.HandObject != null)
+			{
 				var grownFood = interaction.HandObject.GetComponent<GrownFood>();
 			
 				var foodAtributes = grownFood.GetComponentInParent<ItemAttributesV2>();
@@ -150,7 +151,10 @@ namespace Objects.Botany
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			return DefaultWillInteract.Default(interaction, side);
+			return DefaultWillInteract.Default(interaction, side) &&
+			   interaction.TargetObject == gameObject &&
+			   interaction.HandObject != null &&
+			   interaction.HandObject.TryGetComponent<GrownFood>(out _);
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
@@ -125,7 +125,8 @@ namespace Objects.Botany
 			if (interaction.HandObject != null)
 			{
 				var grownFood = interaction.HandObject.GetComponent<GrownFood>();
-			
+
+
 				var foodAtributes = grownFood.GetComponentInParent<ItemAttributesV2>();
 				if (!Inventory.ServerTransfer(interaction.HandSlot, storage.GetBestSlotFor(interaction.HandObject)))
 				{

--- a/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
@@ -97,6 +97,23 @@ namespace Objects.Botany
 		}
 
 		/// <summary>
+		/// Ejects all the seed packets when extractor is deconstructed
+		/// </summary>
+		[Server]
+		public void OnDespawnServer(DespawnInfo info)
+        {
+			Vector3 spawnPos = gameObject.RegisterTile().WorldPositionServer;
+			foreach (var packet in seedPackets)
+            {
+				CustomNetTransform netTransform = packet.GetComponent<CustomNetTransform>();
+				netTransform.AppearAtPosition(spawnPos);
+				netTransform.AppearAtPositionServer(spawnPos);
+			}
+
+
+		}
+
+		/// <summary>
 		/// Handles placing produce into the seed extractor
 		/// </summary>
 		/// <param name="interaction">contains information about the interaction</param>

--- a/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
@@ -133,11 +133,11 @@ namespace Objects.Botany
 						$"You try and place the {foodAtributes.ArticleName} into the seed extractor but it is full!",
 						$"{interaction.Performer.name} tries to place the {foodAtributes.ArticleName} into the seed extractor but it is full!");
 					return;
-				}
+			}
 
 				Chat.AddActionMsgToChat(interaction.Performer,
-						$"You place the {foodAtributes.ArticleName} into the seed extractor",
-						$"{interaction.Performer.name} places the {foodAtributes.name} into the seed extractor");
+				$"You place the {foodAtributes.ArticleName} into the seed extractor",
+				$"{interaction.Performer.name} places the {foodAtributes.name} into the seed extractor");
 				if (foodToBeProcessed.Count == 0 && currentState != PowerStates.Off)
 				{
 					Chat.AddLocalMsgToChat("The seed extractor begins processing", gameObject);

--- a/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
@@ -125,9 +125,8 @@ namespace Objects.Botany
 			if (interaction.HandObject != null)
 			{
 				var grownFood = interaction.HandObject.GetComponent<GrownFood>();
-
-
 				var foodAtributes = grownFood.GetComponentInParent<ItemAttributesV2>();
+
 				if (!Inventory.ServerTransfer(interaction.HandSlot, storage.GetBestSlotFor(interaction.HandObject)))
 				{
 					Chat.AddActionMsgToChat(interaction.Performer,

--- a/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
@@ -103,15 +103,14 @@ namespace Objects.Botany
 		/// </summary>
 		[Server]
 		public void OnDespawnServer(DespawnInfo info)
-        {
+		{
 			Vector3 spawnPos = gameObject.RegisterTile().WorldPositionServer;
 			foreach (var packet in seedPackets)
-            {
+			{
 				CustomNetTransform netTransform = packet.GetComponent<CustomNetTransform>();
 				netTransform.AppearAtPosition(spawnPos);
 				netTransform.AppearAtPositionServer(spawnPos);
 			}
-
 
 		}
 

--- a/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
@@ -10,13 +10,14 @@ using Items.Botany;
 namespace Objects.Botany
 {
 	[RequireComponent(typeof(HasNetworkTab))]
-	public class SeedExtractor : ManagedNetworkBehaviour, IInteractable<HandApply>, IServerSpawn, IAPCPowered
+	public class SeedExtractor : ManagedNetworkBehaviour, IInteractable<HandApply>, IServerLifecycle, IAPCPowered
 	{
 		private Queue<GrownFood> foodToBeProcessed;
 		private float processingProgress;
 		private PowerStates currentState = PowerStates.Off;
 
 		//Time it takes to process a single piece of produce
+		[SerializeField]
 		private float processingTime = 3f;
 
 		[Tooltip("Inventory to store food waiting to be processed")]
@@ -120,7 +121,7 @@ namespace Objects.Botany
 		[Server]
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-			var grownFood = interaction.HandObject?.GetComponent<GrownFood>();
+			var grownFood = interaction.HandObject.GetComponent<GrownFood>();
 			if (grownFood != null)
 			{
 				var foodAtributes = grownFood.GetComponentInParent<ItemAttributesV2>();

--- a/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
+++ b/UnityProject/Assets/Scripts/Objects/Botany/SeedExtractor.cs
@@ -10,7 +10,7 @@ using Items.Botany;
 namespace Objects.Botany
 {
 	[RequireComponent(typeof(HasNetworkTab))]
-	public class SeedExtractor : ManagedNetworkBehaviour, IInteractable<HandApply>, IServerLifecycle, IAPCPowered
+	public class SeedExtractor : ManagedNetworkBehaviour, ICheckedInteractable<HandApply>, IServerLifecycle, IAPCPowered
 	{
 		private Queue<GrownFood> foodToBeProcessed;
 		private float processingProgress;
@@ -98,7 +98,8 @@ namespace Objects.Botany
 		}
 
 		/// <summary>
-		/// Ejects all the seed packets when extractor is deconstructed
+		/// Ejects all the seed packets when extractor is deconstructed, but only will eject produce you
+		/// put in only if it hasn't been processed by the extractor
 		/// </summary>
 		[Server]
 		public void OnDespawnServer(DespawnInfo info)
@@ -121,9 +122,9 @@ namespace Objects.Botany
 		[Server]
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-			var grownFood = interaction.HandObject.GetComponent<GrownFood>();
-			if (grownFood != null)
-			{
+			if (interaction.HandObject != null) {
+				var grownFood = interaction.HandObject.GetComponent<GrownFood>();
+			
 				var foodAtributes = grownFood.GetComponentInParent<ItemAttributesV2>();
 				if (!Inventory.ServerTransfer(interaction.HandSlot, storage.GetBestSlotFor(interaction.HandObject)))
 				{
@@ -145,6 +146,11 @@ namespace Objects.Botany
 			}
 			//If no interaction happens
 			networkTab.ServerPerformInteraction(interaction);
+		}
+
+		public bool WillInteract(HandApply interaction, NetworkSide side)
+		{
+			return DefaultWillInteract.Default(interaction, side);
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Purpose
Partially fixes the SeedExtractor so now it will drop the seed packets upon deconstruction. Except when I mean seed packets I mean the variable inside SeedExtractor.cs called seedPackets and its contents being dropped on despawn. Also, the SeedExtractor only can drop produce that hasn't had the seeds extracted yet (i.e. when the device is not powered), any successful seed packets that get extracted don't get dropped.

Also adds SeedExtractor and MegaseedServitor to Botany and a cremator to the Morgue on TestStation.