### PR TITLE
Fixes the atmos thread from stopping after the air alarm detects low or high pressures.

### DIFF
--- a/UnityProject/Assets/Scripts/Objects/Wallmounts/FireAlarm.cs
+++ b/UnityProject/Assets/Scripts/Objects/Wallmounts/FireAlarm.cs
@@ -71,7 +71,7 @@ namespace Objects.Wallmounts
 		{
 			var integrity = GetComponent<Integrity>();
 			integrity.OnExposedEvent.AddListener(SendCloseAlerts);
-			AtmosManager.Instance.AddFireAlarm(this);
+			UpdateManager.Add(UpdateMe, 1);
 			RegisterTile registerTile = GetComponent<RegisterTile>();
 			MetaDataLayer metaDataLayer = MatrixManager.AtPoint(registerTile.WorldPositionServer, true).MetaDataLayer;
 			var wallMount = GetComponent<WallmountBehavior>();
@@ -90,7 +90,7 @@ namespace Objects.Wallmounts
 
 		}
 
-		public void TickUpdate()
+		public void UpdateMe()
 		{
 			if (!activated)
 			{
@@ -103,7 +103,7 @@ namespace Objects.Wallmounts
 
 		public void OnDespawnServer(DespawnInfo info)
 		{
-			AtmosManager.Instance.RemoveFireAlarm(this);
+			UpdateManager.Remove(CallbackType.PERIODIC_UPDATE, UpdateMe);
 		}
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosManager.cs
@@ -23,7 +23,6 @@ namespace Systems.Atmospherics
 
 		public HashSet<PipeData> inGameNewPipes = new HashSet<PipeData>();
 		public HashSet<FireAlarm> inGameFireAlarms = new HashSet<FireAlarm>();
-		public ConcurrentBag<FireAlarm> fireAlarmToAdd = new ConcurrentBag<FireAlarm>();
 		public ConcurrentBag<PipeData> pipeToAdd = new ConcurrentBag<PipeData>();
 
 		public static int currentTick;
@@ -71,20 +70,12 @@ namespace Systems.Atmospherics
 		{
 			if (StopPipes == false)
 			{
-
 				foreach (var pipeData in pipeToAdd)
 				{
 					if(pipeData.MonoPipe == null)
 						continue;
 					pipeData.TickUpdate();
 				}
-			}
-
-			foreach (var fireAlarm in fireAlarmToAdd)
-			{
-				if(fireAlarm == null)
-					continue;
-				fireAlarm.TickUpdate();
 			}
 
 			currentTick = ++currentTick % Steps;
@@ -99,17 +90,6 @@ namespace Systems.Atmospherics
 		{
 			pipeToAdd.TryTake(out pipeData);
 		}
-
-		public void AddFireAlarm(FireAlarm fireAlarm)
-		{
-			fireAlarmToAdd.Add(fireAlarm);
-		}
-
-		public void RemoveFireAlarm(FireAlarm fireAlarm)
-		{
-			fireAlarmToAdd.TryTake(out fireAlarm);
-		}
-
 
 		void OnEnable()
 		{


### PR DESCRIPTION
### Purpose
Fixes the atmos thread from stopping after the air alarm detects low or high pressures.
Removes firelocks from the atmos thread to the main thread.