### PR TITLE
Fixes dummy players not spawning

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Lifecycle/PlayerSpawn.cs
@@ -334,9 +334,10 @@ public static class PlayerSpawn
 	/// <summary>
 	/// Spawns an assistant dummy
 	/// </summary>
-	public static void ServerSpawnDummy()
+	public static void ServerSpawnDummy(Transform spawnTransform = null)
 	{
-		Transform spawnTransform = GetSpawnForJob(JobType.ASSISTANT);
+		if(spawnTransform == null)
+			spawnTransform = GetSpawnForJob(JobType.ASSISTANT);
 		if (spawnTransform != null)
 		{
 			var dummy = ServerCreatePlayer(spawnTransform.position.RoundToInt());

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -149,10 +149,6 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 	private void Awake()
 	{
 		playerScript = GetComponent<PlayerScript>();
-	}
-
-	private void Start()
-	{
 		PlayerDirectional = gameObject.GetComponent<Directional>();
 
 		registerPlayer = GetComponent<RegisterPlayer>();

--- a/UnityProject/Assets/Scripts/Player/PlayerSync.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerSync.cs
@@ -507,7 +507,7 @@ public partial class PlayerSync : NetworkBehaviour, IPushable, IPlayerControllab
 			{
 				if (CommonInput.GetKeyDown(KeyCode.F7) && gameObject == PlayerManager.LocalPlayer)
 				{
-					PlayerSpawn.ServerSpawnDummy();
+					PlayerSpawn.ServerSpawnDummy(gameObject.transform);
 				}
 
 				if (serverState.Position != serverLerpState.Position)

--- a/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterSettings.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/Lobby/CharacterSettings.cs
@@ -29,7 +29,7 @@ public class CharacterSettings
 	public string FacialHairColor = "black";
 	public string SkinTone = "#ffe0d1";
 	public string UnderwearName = "Mankini";
-	public string SocksName = "Knee-High (Freedom)";
+	public string SocksName = "Knee-high (Freedom)";
 	public JobPrefsDict JobPreferences = new JobPrefsDict();
 	public AntagPrefsDict AntagPreferences = new AntagPrefsDict();
 


### PR DESCRIPTION
### Purpose
Fixes dummy players not spawning.
Moves F7 dummy player command spawn to be at the player's position.
Ensures PlayerMove registerPlayer is loaded on Awake() in case of dummy players spawning mid-movement.