### PR TITLE
Basic soap functionality.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Soap/Soap.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Soap/Soap.prefab
@@ -1,5 +1,19 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &2881235331250953825
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7785875528613525472}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 828bf7794ea3fad499f847fbf4dc0479, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uses: 100
+  useTime: 3.5
 --- !u!1001 &7786560402941971290
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10,6 +24,10 @@ PrefabInstance:
     - target: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_Name
       value: Soap
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalPosition.x
@@ -24,6 +42,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -34,14 +56,6 @@ PrefabInstance:
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -73,13 +87,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: itemSprites.InventoryIcon.Sprites.Array.size
-      value: 1
+      propertyPath: throwSpeed
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -93,10 +102,32 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: b73eb36c441df5e46a4289261ae6bc7f,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
       propertyPath: initialTraits.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 63ebb1ff93c93354994ab009bc8ccf7d,
         type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 918436086e140a84f90195ba00e99c4e,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: itemSprites.LeftHand.Texture
+      value: 
+      objectReference: {fileID: 2800000, guid: 49c14138d68feb744b0176e934b2e8d2, type: 3}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: itemSprites.RightHand.Texture
@@ -104,28 +135,20 @@ PrefabInstance:
       objectReference: {fileID: 2800000, guid: c95d6c712a528d940b2e6bb99b8b128b, type: 3}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: itemSprites.RightHand.Sprites.Array.data[0]
+      propertyPath: itemSprites.SpriteInventoryIcon
       value: 
-      objectReference: {fileID: 21300000, guid: c95d6c712a528d940b2e6bb99b8b128b,
-        type: 3}
+      objectReference: {fileID: 11400000, guid: bfaa82785b84df24492062575ad7310f,
+        type: 2}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: itemSprites.RightHand.Sprites.Array.data[1]
+      propertyPath: itemSprites.InventoryIcon.Texture
       value: 
-      objectReference: {fileID: 21300002, guid: c95d6c712a528d940b2e6bb99b8b128b,
-        type: 3}
+      objectReference: {fileID: 2800000, guid: 1b1c23fd0b8baef4cb021518fe270914, type: 3}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: itemSprites.RightHand.Sprites.Array.data[2]
+      propertyPath: itemSprites.LeftHand.EquippedData
       value: 
-      objectReference: {fileID: 21300004, guid: c95d6c712a528d940b2e6bb99b8b128b,
-        type: 3}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: itemSprites.RightHand.Sprites.Array.data[3]
-      value: 
-      objectReference: {fileID: 21300006, guid: c95d6c712a528d940b2e6bb99b8b128b,
-        type: 3}
+      objectReference: {fileID: 4900000, guid: c3d0430df3cfc694091a2e9e44e84782, type: 3}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: itemSprites.RightHand.EquippedData
@@ -133,9 +156,9 @@ PrefabInstance:
       objectReference: {fileID: 4900000, guid: cb6a4476a91967e41bc33e5495eef694, type: 3}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: itemSprites.LeftHand.Texture
+      propertyPath: itemSprites.InventoryIcon.EquippedData
       value: 
-      objectReference: {fileID: 2800000, guid: 49c14138d68feb744b0176e934b2e8d2, type: 3}
+      objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: itemSprites.LeftHand.Sprites.Array.data[0]
@@ -162,14 +185,33 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: itemSprites.LeftHand.EquippedData
+      propertyPath: itemSprites.RightHand.Sprites.Array.data[0]
       value: 
-      objectReference: {fileID: 4900000, guid: c3d0430df3cfc694091a2e9e44e84782, type: 3}
+      objectReference: {fileID: 21300000, guid: c95d6c712a528d940b2e6bb99b8b128b,
+        type: 3}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: itemSprites.InventoryIcon.Texture
+      propertyPath: itemSprites.RightHand.Sprites.Array.data[1]
       value: 
-      objectReference: {fileID: 2800000, guid: 1b1c23fd0b8baef4cb021518fe270914, type: 3}
+      objectReference: {fileID: 21300002, guid: c95d6c712a528d940b2e6bb99b8b128b,
+        type: 3}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: itemSprites.RightHand.Sprites.Array.data[2]
+      value: 
+      objectReference: {fileID: 21300004, guid: c95d6c712a528d940b2e6bb99b8b128b,
+        type: 3}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: itemSprites.RightHand.Sprites.Array.data[3]
+      value: 
+      objectReference: {fileID: 21300006, guid: c95d6c712a528d940b2e6bb99b8b128b,
+        type: 3}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: itemSprites.InventoryIcon.Sprites.Array.size
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: itemSprites.InventoryIcon.Sprites.Array.data[0]
@@ -194,34 +236,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300006, guid: d6c2af3c88699e146a41df8b9a15b0b8,
         type: 3}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: itemSprites.InventoryIcon.EquippedData
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: throwSpeed
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: itemSprites.SpriteInventoryIcon
-      value: 
-      objectReference: {fileID: 11400000, guid: bfaa82785b84df24492062575ad7310f,
-        type: 2}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: itemSprites.SpriteLeftHand
-      value: 
-      objectReference: {fileID: 11400000, guid: b73eb36c441df5e46a4289261ae6bc7f,
-        type: 2}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
-      propertyPath: itemSprites.SpriteRightHand
-      value: 
-      objectReference: {fileID: 11400000, guid: 918436086e140a84f90195ba00e99c4e,
-        type: 2}
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: PresentSpriteSet
@@ -230,3 +244,9 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+--- !u!1 &7785875528613525472 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298,
+    type: 3}
+  m_PrefabInstance: {fileID: 7786560402941971290}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Soap/SoapDeluxe.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Soap/SoapDeluxe.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &7669638074997585538
+--- !u!1001 &6492724540457398855
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -10,42 +10,41 @@ PrefabInstance:
     - target: {fileID: 2881235331250953825, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: useTime
-      value: 0.5
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4128362409855863911, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: PresentSpriteSet
       value: 
-      objectReference: {fileID: 11400000, guid: 363a6ab98f2372a49a77dc05e233dddf,
+      objectReference: {fileID: 11400000, guid: ff44681c37f0a8e41bda67a7663ccde5,
         type: 2}
     - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: initialDescription
-      value: An untrustworthy bar of soap made of strong chemical agents that dissolve
-        blood faster.
+      value: A deluxe Waffle Co. brand bar of soap. Smells of high-class luxury.
       objectReference: {fileID: 0}
     - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: itemSprites.SpriteLeftHand
       value: 
-      objectReference: {fileID: 11400000, guid: d635e24dd8cbd454fa9d06eb2f411c46,
+      objectReference: {fileID: 11400000, guid: a52cf892de5daff4a954861f008b2c32,
         type: 2}
     - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: itemSprites.SpriteRightHand
       value: 
-      objectReference: {fileID: 11400000, guid: f66b4b9790283f442b4107a3d847bb5b,
+      objectReference: {fileID: 11400000, guid: f4aa48d1ee144bb48868d8ba7e35f2a6,
         type: 2}
     - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: itemSprites.SpriteInventoryIcon
       value: 
-      objectReference: {fileID: 11400000, guid: 363a6ab98f2372a49a77dc05e233dddf,
+      objectReference: {fileID: 11400000, guid: ff44681c37f0a8e41bda67a7663ccde5,
         type: 2}
     - target: {fileID: 7785875528613525472, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: m_Name
-      value: SoapSyndicate
+      value: SoapDeluxe
       objectReference: {fileID: 0}
     - target: {fileID: 7791085151706811028, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
@@ -111,12 +110,12 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 5e7e73b24d127264b8e2a483b98882d7,
+      objectReference: {fileID: 21300000, guid: 38d8a36cc03765f468d2e8f69021b78d,
         type: 3}
     - target: {fileID: 8258904204275641670, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: useTime
-      value: 0.5
+      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 94dfead23e20498409009e55d3dfe3ca, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Soap/SoapDeluxe.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Soap/SoapDeluxe.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7ed3d06a4f7b5004e891a0b50e3b9466
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Soap/SoapHomemade.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Soap/SoapHomemade.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &7669638074997585538
+--- !u!1001 &4354313084480589454
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -10,42 +10,41 @@ PrefabInstance:
     - target: {fileID: 2881235331250953825, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: useTime
-      value: 0.5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4128362409855863911, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: PresentSpriteSet
       value: 
-      objectReference: {fileID: 11400000, guid: 363a6ab98f2372a49a77dc05e233dddf,
+      objectReference: {fileID: 11400000, guid: dae780d2123c6334dbe9c13e7b9dbe07,
         type: 2}
     - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: initialDescription
-      value: An untrustworthy bar of soap made of strong chemical agents that dissolve
-        blood faster.
+      value: A homemade bar of soap. Smells of... well...."
       objectReference: {fileID: 0}
     - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: itemSprites.SpriteLeftHand
       value: 
-      objectReference: {fileID: 11400000, guid: d635e24dd8cbd454fa9d06eb2f411c46,
+      objectReference: {fileID: 11400000, guid: 964456b2aceb83f48a9e847b596da17c,
         type: 2}
     - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: itemSprites.SpriteRightHand
       value: 
-      objectReference: {fileID: 11400000, guid: f66b4b9790283f442b4107a3d847bb5b,
+      objectReference: {fileID: 11400000, guid: 82f171647b74e7147808fac64b2cbd93,
         type: 2}
     - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: itemSprites.SpriteInventoryIcon
       value: 
-      objectReference: {fileID: 11400000, guid: 363a6ab98f2372a49a77dc05e233dddf,
+      objectReference: {fileID: 11400000, guid: dae780d2123c6334dbe9c13e7b9dbe07,
         type: 2}
     - target: {fileID: 7785875528613525472, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: m_Name
-      value: SoapSyndicate
+      value: SoapHomemade
       objectReference: {fileID: 0}
     - target: {fileID: 7791085151706811028, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
@@ -111,12 +110,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 5e7e73b24d127264b8e2a483b98882d7,
+      objectReference: {fileID: 21300000, guid: a693a6d96385f69478436867bafcb096,
         type: 3}
-    - target: {fileID: 8258904204275641670, guid: 94dfead23e20498409009e55d3dfe3ca,
-        type: 3}
-      propertyPath: useTime
-      value: 0.5
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 94dfead23e20498409009e55d3dfe3ca, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Soap/SoapHomemade.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Soap/SoapHomemade.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2ee249b0dc558324394e057103f3027f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Soap/SoapNanotrasen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Janitor/Soap/SoapNanotrasen.prefab
@@ -7,17 +7,80 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2881235331250953825, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: uses
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 2881235331250953825, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: useTime
+      value: 2.8
+      objectReference: {fileID: 0}
     - target: {fileID: 4128362409855863911, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: PresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 859417389fde79e4fa0051b5634b06e4,
         type: 2}
+    - target: {fileID: 7438100563850116741, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: maxCapacity
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 7438100563850116741, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: initialReagentMix.reagents.m_values.Array.data[0]
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: initialDescription
+      value: A heavy duty bar of Nanotrasen brand soap. Smells of plasma.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: itemSprites.SpriteLeftHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 1546dd0b04719094487e934ba092a7f1,
+        type: 2}
+    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: b264f19b093fb1e44b454d1f8b51ee8f,
+        type: 2}
     - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: itemSprites.LeftHand.Texture
       value: 
       objectReference: {fileID: 2800000, guid: 8ea87d123134e4649a89097a4ce71c6d, type: 3}
+    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: itemSprites.RightHand.Texture
+      value: 
+      objectReference: {fileID: 2800000, guid: d6c2af3c88699e146a41df8b9a15b0b8, type: 3}
+    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: itemSprites.SpriteInventoryIcon
+      value: 
+      objectReference: {fileID: 11400000, guid: 859417389fde79e4fa0051b5634b06e4,
+        type: 2}
+    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: itemSprites.InventoryIcon.Texture
+      value: 
+      objectReference: {fileID: 2800000, guid: 42296fc0903334847a740b9f100ff824, type: 3}
+    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: itemSprites.LeftHand.EquippedData
+      value: 
+      objectReference: {fileID: 4900000, guid: 714b8c6ba1929b744908be8203079222, type: 3}
+    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: itemSprites.RightHand.EquippedData
+      value: 
+      objectReference: {fileID: 4900000, guid: b559b3771f47a154d858fed88f6813df, type: 3}
     - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: itemSprites.LeftHand.Sprites.Array.data[0]
@@ -44,16 +107,6 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
-      propertyPath: itemSprites.LeftHand.EquippedData
-      value: 
-      objectReference: {fileID: 4900000, guid: 714b8c6ba1929b744908be8203079222, type: 3}
-    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
-        type: 3}
-      propertyPath: itemSprites.RightHand.Texture
-      value: 
-      objectReference: {fileID: 2800000, guid: d6c2af3c88699e146a41df8b9a15b0b8, type: 3}
-    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
-        type: 3}
       propertyPath: itemSprites.RightHand.Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 21300000, guid: d6c2af3c88699e146a41df8b9a15b0b8,
@@ -78,47 +131,19 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
-      propertyPath: itemSprites.RightHand.EquippedData
-      value: 
-      objectReference: {fileID: 4900000, guid: b559b3771f47a154d858fed88f6813df, type: 3}
-    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
-        type: 3}
-      propertyPath: itemSprites.InventoryIcon.Texture
-      value: 
-      objectReference: {fileID: 2800000, guid: 42296fc0903334847a740b9f100ff824, type: 3}
-    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
-        type: 3}
       propertyPath: itemSprites.InventoryIcon.Sprites.Array.data[0]
       value: 
       objectReference: {fileID: 21300000, guid: 42296fc0903334847a740b9f100ff824,
         type: 3}
-    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
-        type: 3}
-      propertyPath: initialDescription
-      value: A heavy duty bar of Nanotrasen brand soap. Smells of plasma.
-      objectReference: {fileID: 0}
-    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
-        type: 3}
-      propertyPath: itemSprites.SpriteInventoryIcon
-      value: 
-      objectReference: {fileID: 11400000, guid: 859417389fde79e4fa0051b5634b06e4,
-        type: 2}
-    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
-        type: 3}
-      propertyPath: itemSprites.SpriteLeftHand
-      value: 
-      objectReference: {fileID: 11400000, guid: 1546dd0b04719094487e934ba092a7f1,
-        type: 2}
-    - target: {fileID: 7701549257419364482, guid: 94dfead23e20498409009e55d3dfe3ca,
-        type: 3}
-      propertyPath: itemSprites.SpriteRightHand
-      value: 
-      objectReference: {fileID: 11400000, guid: b264f19b093fb1e44b454d1f8b51ee8f,
-        type: 2}
     - target: {fileID: 7785875528613525472, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
       propertyPath: m_Name
       value: SoapNanotrasen
+      objectReference: {fileID: 0}
+    - target: {fileID: 7791085151706811028, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7791085151706811028, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
@@ -137,6 +162,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7791085151706811028, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7791085151706811028, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -149,16 +179,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7791085151706811028, guid: 94dfead23e20498409009e55d3dfe3ca,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7791085151706811028, guid: 94dfead23e20498409009e55d3dfe3ca,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7791085151706811028, guid: 94dfead23e20498409009e55d3dfe3ca,
         type: 3}
@@ -186,5 +206,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 42296fc0903334847a740b9f100ff824,
         type: 3}
+    - target: {fileID: 8258904204275641670, guid: 94dfead23e20498409009e55d3dfe3ca,
+        type: 3}
+      propertyPath: useTime
+      value: 2.8
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 94dfead23e20498409009e55d3dfe3ca, type: 3}

--- a/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
@@ -1,0 +1,114 @@
+﻿using UnityEngine;
+using Objects.Construction;
+
+/// <summary>
+/// Main component for Mop. Allows mopping to be done on tiles.
+/// </summary>
+[RequireComponent(typeof(Pickupable))]
+public class Soap : MonoBehaviour, ICheckedInteractable<PositionalHandApply>, IExaminable, IServerSpawn
+{
+	private static readonly StandardProgressActionConfig ProgressConfig =
+		new StandardProgressActionConfig(StandardProgressActionType.Mop, true, false);
+
+	[Tooltip("How many times can the soap be used until it is deleted?")]
+	[SerializeField]
+	private int uses = 100;
+
+	private int maxUses;
+
+	[Tooltip("Time taken to clean something with the soap, measured in seconds.")]
+	[SerializeField]
+	private float useTime = 3.5f;
+
+
+	public void OnSpawnServer(SpawnInfo info)
+	{
+		maxUses = uses;
+	}
+
+	public bool WillInteract(PositionalHandApply interaction, NetworkSide side)
+	{
+		if (!DefaultWillInteract.Default(interaction, side)) return false;
+		//can only scrub tiles, for now
+		if (!Validations.HasComponent<InteractableTiles>(interaction.TargetObject)) return false;
+
+		//don't attempt to scrub walls
+		if (MatrixManager.IsWallAtAnyMatrix(interaction.WorldPositionTarget.RoundToInt(), isServer: side == NetworkSide.Server))
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	public void ServerPerformInteraction(PositionalHandApply interaction)
+	{
+		//server is performing server-side logic for the interaction
+		//do the scrubbing
+		void CompleteProgress()
+		{
+			CleanTile(interaction);
+			Chat.AddExamineMsg(interaction.Performer, "You finish scrubbing.");
+		}
+
+		//Start the progress bar:
+		var bar = StandardProgressAction.Create(ProgressConfig, CompleteProgress)
+			.ServerStartProgress(interaction.WorldPositionTarget.RoundToInt(),
+				useTime, interaction.Performer);
+		if (bar)
+		{
+			Chat.AddActionMsgToChat(interaction.Performer,
+				$"You begin to scrub the floor with the {gameObject.ExpensiveName()}...",
+				$"{interaction.Performer.name} begins to scrub the floor with the {gameObject.ExpensiveName()}.");
+		}
+	}
+
+	private void CleanTile(PositionalHandApply interaction)
+	{
+		var worldPos = interaction.WorldPositionTarget;
+		var checkPos = worldPos.RoundToInt();
+		var matrixInfo = MatrixManager.AtPoint(checkPos, true);
+		matrixInfo.MetaDataLayer.Clean(checkPos, checkPos, false);
+		UseUpSoap();
+	}
+
+	public void UseUpSoap()
+	{
+		uses -= 1;
+		if (uses == 0)
+		{
+			Despawn.ServerSingle(gameObject);
+		}
+	}
+
+	public string Examine(Vector3 worldPos = default)
+	{
+		float percentageLeft = (float) uses / (float) maxUses;
+		
+		if (percentageLeft <= 0.15f)
+		{
+			return "There's just a tiny bit left of what it used to be, you're not sure it'll last much longer.";
+		}
+		else if (percentageLeft > 0.15f && percentageLeft <= 0.30f)
+		{
+			return "It's dissolved quite a bit, but there's still some life to it.";
+		}
+		else if (percentageLeft > 0.30f && percentageLeft <= 0.50f)
+		{
+			return "It's past its prime, but it's definitely still good.";
+		}
+		else if (percentageLeft > 0.50f && percentageLeft <= 0.75f)
+		{
+			return "It's started to get a little smaller than it used to be, but it'll definitely still last for a while.";
+		}
+		else if (percentageLeft > 0.75f && percentageLeft < 1f)
+		{
+			return "It's seen some light use, but it's still pretty fresh.";
+		}
+		else
+		{
+			return "It looks like it just came out of the package.";
+		}
+	}
+
+}

--- a/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
+++ b/UnityProject/Assets/Scripts/Items/Tool/Soap.cs
@@ -2,7 +2,7 @@
 using Objects.Construction;
 
 /// <summary>
-/// Main component for Mop. Allows mopping to be done on tiles.
+/// Main component for soap. Allows cleaning of tiles and gradual degradation of the soap as it is used.
 /// </summary>
 [RequireComponent(typeof(Pickupable))]
 public class Soap : MonoBehaviour, ICheckedInteractable<PositionalHandApply>, IExaminable, IServerSpawn

--- a/UnityProject/Assets/Scripts/Items/Tool/Soap.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Tool/Soap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 828bf7794ea3fad499f847fbf4dc0479
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
- Soap can now be used on floors to clean them similar to mops. Every time you use soap it's amount of remaining uses goes down. Examining the soap will give different messages depending on how many uses are remaining. Once all uses are gone, the soap is destroyed. Fixes #5814.
- Added a few more soap items.

#### Changelog
CL: Added ability for soap to clean floors and to slowly get used up every time it's used to clean.
