### PR TITLE
Add Radiation Storm event

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/RadiationStorm.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/RadiationStorm.prefab
@@ -1,0 +1,154 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &18136514010077306
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 17891910219878129}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff9632be38569c1479a5e962ace88b8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  OutPuttingRadiation: 30000
+  color: {r: 0.3647059, g: 0.7921569, b: 0.19215687, a: 0}
+  DotSprite: {fileID: 21300000, guid: f003ff6932b0ffe448903064dbbc2fe5, type: 3}
+  SynchroniseStrength: 0
+--- !u!114 &402338397907348267
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 17891910219878129}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36622f2a7479a284db4943a1c060ddd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  peakRadiation: 30000
+  randomGrowthTime: {x: 2, y: 5}
+  lifeTime: {x: 30, y: 60}
+--- !u!1001 &4214670052447570104
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: f003ff6932b0ffe448903064dbbc2fe5,
+        type: 3}
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Color.a
+      value: 0.45490196
+      objectReference: {fileID: 0}
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Name
+      value: RadiationStorm
+      objectReference: {fileID: 0}
+    - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4732959556644653524, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4800765294880679425, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: Passable
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5388634654466307187, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Layer
+      value: 31
+      objectReference: {fileID: 0}
+    - target: {fileID: 5737521361753715499, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5971563122362279857, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6838691275677014393, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: initialName
+      value: radiation storm
+      objectReference: {fileID: 0}
+    - target: {fileID: 6838691275677014393, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: initialDescription
+      value: An area of intense ionizing electromagnetic radiation. Better stay clear!
+      objectReference: {fileID: 0}
+    - target: {fileID: 8652228875761003667, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: NetworkThis
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8652228875761003667, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: f82771928ecc722459fda4398bd811cc,
+        type: 2}
+    - target: {fileID: 8652228875761003667, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: pushTextureOnStartUp
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 7474997010728688467, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
+    - {fileID: 90804091474310291, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: ebb08cf966efc084aa918bd8d9429604, type: 3}
+--- !u!1 &17891910219878129 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
+    type: 3}
+  m_PrefabInstance: {fileID: 4214670052447570104}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Misc/RadiationStorm.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Misc/RadiationStorm.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8eba7f110a40abb4891c1a0b3412faa3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/InGameEventsManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/InGameEventsManager.prefab
@@ -283,7 +283,7 @@ MonoBehaviour:
   EndTimer: 0
   EventType: 1
   ChanceToHappen: 10
-  MinPlayersToTrigger: 0
+  MinPlayersToTrigger: 15
   parametersPageType: 0
   FakeEvent: 0
   AnnounceEvent: 1
@@ -305,6 +305,61 @@ MonoBehaviour:
   - {fileID: 4827737755655954553, guid: 8eb9df99f3d2dd54cab91b4d69a4fe56, type: 3}
   - {fileID: 4827737755655954553, guid: 017526359d2bfe146bc0bc49c7dd25cb, type: 3}
   mobCount: {x: 5, y: 10}
+--- !u!1 &2330691836870820202
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1614149104379286000}
+  - component: {fileID: 1444185421979299837}
+  m_Layer: 0
+  m_Name: RadiationStorm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1614149104379286000
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2330691836870820202}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6277872687871681347}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1444185421979299837
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2330691836870820202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6530a412ec3f61e4ab316ba7c6e27681, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  EventName: Radiation Storm
+  StartTimer: 10
+  EndTimer: 0
+  EventType: 1
+  ChanceToHappen: 30
+  MinPlayersToTrigger: 1
+  parametersPageType: 0
+  FakeEvent: 0
+  AnnounceEvent: 1
+  radiationSourcePrefab: {fileID: 17891910219878129, guid: 8eba7f110a40abb4891c1a0b3412faa3,
+    type: 3}
+  radiationSourceCound: {x: 5, y: 15}
 --- !u!1 &2418359854451674301
 GameObject:
   m_ObjectHideFlags: 0
@@ -604,6 +659,7 @@ Transform:
   - {fileID: 6017755624213906674}
   - {fileID: 8107459317429369441}
   - {fileID: 2967834443619550631}
+  - {fileID: 1614149104379286000}
   - {fileID: 7644278449202499015}
   m_Father: {fileID: 8934140032923375002}
   m_RootOrder: 0
@@ -1466,7 +1522,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5219137714795788897
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/InGameEventsManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/InGameEventsManager.prefab
@@ -235,6 +235,59 @@ MonoBehaviour:
   minStrength: 1000
   maxStrength: 1500
   timeBetweenExplosions: 0.25
+--- !u!1 &2176390301219290958
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1318916917475401147}
+  - component: {fileID: 7849438823070064729}
+  m_Layer: 0
+  m_Name: Fugitives
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1318916917475401147
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2176390301219290958}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6277872687871681347}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7849438823070064729
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2176390301219290958}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9e60c8a1f7899e2408bce7cd56fb3d6b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  EventName: Fugitives
+  StartTimer: 0
+  EndTimer: 0
+  EventType: 1
+  ChanceToHappen: 30
+  MinPlayersToTrigger: 1
+  parametersPageType: 0
+  FakeEvent: 0
+  AnnounceEvent: 1
+  ghostRole: {fileID: 11400000, guid: af2384fe291fd1e469745e1438edc9e4, type: 2}
 --- !u!1 &2185954026833562878
 GameObject:
   m_ObjectHideFlags: 0
@@ -264,7 +317,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8688883408302241468
 MonoBehaviour:
@@ -334,7 +387,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1444185421979299837
 MonoBehaviour:
@@ -359,7 +412,7 @@ MonoBehaviour:
   AnnounceEvent: 1
   radiationSourcePrefab: {fileID: 17891910219878129, guid: 8eba7f110a40abb4891c1a0b3412faa3,
     type: 3}
-  radiationSourceCound: {x: 5, y: 15}
+  numberOfStorms: {x: 10, y: 20}
 --- !u!1 &2418359854451674301
 GameObject:
   m_ObjectHideFlags: 0
@@ -565,7 +618,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2610571774784088097
 MonoBehaviour:
@@ -655,6 +708,7 @@ Transform:
   - {fileID: 6740344816744190755}
   - {fileID: 1590283313530423313}
   - {fileID: 4130085576290714883}
+  - {fileID: 1318916917475401147}
   - {fileID: 1368603534518432520}
   - {fileID: 6017755624213906674}
   - {fileID: 8107459317429369441}
@@ -912,7 +966,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2934142359551454669
 MonoBehaviour:
@@ -1004,7 +1058,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1734058573413260740
 MonoBehaviour:
@@ -1522,7 +1576,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6277872687871681347}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5219137714795788897
 MonoBehaviour:

--- a/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Antags/Fugitive.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Antagonists/Antags/Fugitive.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Fugitive
   m_EditorClassIdentifier: 
   antagName: Fugitive
-  antagJobType: 50
+  antagJobType: 51
   playSound: 0
   spawnSound: Notice1
   textColor: {r: 1, g: 0.3909036, b: 0, a: 1}
@@ -24,7 +24,7 @@ MonoBehaviour:
   coreObjectives:
   - {fileID: 11400000, guid: 748ac891cd195d145b7386127b0de87b, type: 2}
   antagOccupation: {fileID: 11400000, guid: 664fc7dd82e0d0f4aadd3a166f9bdb23, type: 2}
-  showInPreferences: 1
+  showInPreferences: 0
   timeToSendWarning: {x: 5, y: 15}
   warnMessage: 'We have reliable information to think there is a dangerous fugitive
     from SuperJail in your station.

--- a/UnityProject/Assets/Resources/ScriptableObjects/Occupations/Fugitive.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Occupations/Fugitive.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c58d5c5a6190436e9d4ae8e32a26ee6a, type: 3}
   m_Name: Fugitive
   m_EditorClassIdentifier: 
-  jobType: 50
+  jobType: 51
   isCrewmember: 0
   lateSpawnIsArrivals: 0
   inventoryPopulator: {fileID: 11400000, guid: dc124411c427acc43b9f28182ce2b9a9, type: 2}
@@ -30,4 +30,4 @@ MonoBehaviour:
   customProperties:
     m_keys: []
     m_values: 
-  isTargeteable: 0
+  isTargeteable: 1

--- a/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/Fugitive.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/Fugitive.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1bf4d5e2bd850949b9b9f6afe22de9b, type: 3}
+  m_Name: Fugitive
+  m_EditorClassIdentifier: 
+  name: Fugitive
+  description: Survive on the station after escaping from a NanoTrasen superjail.
+    Move in the shadows and keep out of sight.
+  sprite: {fileID: 11400000, guid: 6f2180fedef59fb41bf603daa92a001c, type: 2}
+  respawnType: 0
+  targetOccupation: {fileID: 11400000, guid: 664fc7dd82e0d0f4aadd3a166f9bdb23, type: 2}
+  targetAntagonist: {fileID: 0}
+  minPlayers: 1
+  maxPlayers: 3
+  timeout: 30
+  playerCountType: 1

--- a/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/Fugitive.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/Fugitive.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: af2384fe291fd1e469745e1438edc9e4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/GhostRoleList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/GhostRoleList.asset
@@ -15,3 +15,4 @@ MonoBehaviour:
   ghostRoles:
   - {fileID: 11400000, guid: ada7037abb771e547b7bbe997dd47401, type: 2}
   - {fileID: 11400000, guid: 46345f6d85b0c4845a2ab22c70741014, type: 2}
+  - {fileID: 11400000, guid: af2384fe291fd1e469745e1438edc9e4, type: 2}

--- a/UnityProject/Assets/Scripts/Objects/Engineering/Reactor/ReactorGraphiteChamber.cs
+++ b/UnityProject/Assets/Scripts/Objects/Engineering/Reactor/ReactorGraphiteChamber.cs
@@ -218,7 +218,7 @@ namespace Objects.Engineering
 				LeakedNeutrons =
 					(((LeakedNeutrons / (LeakedNeutrons + ((decimal)Math.Pow((double)LeakedNeutrons, (double)0.82M)))) -
 					  0.5M) * 2 * 36000);
-				radiationProducer.Setlevel((float)LeakedNeutrons);
+				radiationProducer.SetLevel((float)LeakedNeutrons);
 			}
 		}
 

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/EventRadiationStorm.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/EventRadiationStorm.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections;
+using UnityEngine;
+using NaughtyAttributes;
+using Managers;
+using Strings;
+
+namespace InGameEvents
+{
+	public class EventRadiationStorm : EventScriptBase
+	{
+		[Tooltip("The radiation storm object to randomly spawn around the station.")]
+		[SerializeField, BoxGroup("References")]
+		private GameObject radiationSourcePrefab = default;
+
+		[Tooltip("The number of radiation storm objects to spawn (randomly selected within the given range).")]
+		[SerializeField, BoxGroup("Settings"), MinMaxSlider(0, 100)]
+		private Vector2 numberOfStorms = new Vector2(10, 20);
+
+		public override void OnEventStart()
+		{
+			if (AnnounceEvent)
+			{
+				var text = "Ionizing electromagnetic emissions detected near the station. Avoid areas of high radiation.";
+
+				CentComm.MakeAnnouncement(ChatTemplates.CentcomAnnounce, text, CentComm.UpdateSound.Alert);
+			}
+
+			if (FakeEvent) return;
+
+			base.OnEventStart();
+		}
+
+		public override void OnEventStartTimed()
+		{
+			for (int i = 0; i < Random.Range(numberOfStorms.x, numberOfStorms.y); i++)
+			{
+				StartCoroutine(SpawnRadiationObject());
+			}
+		}
+
+		private IEnumerator SpawnRadiationObject()
+		{
+			yield return WaitFor.Seconds(Random.Range(0, 5));
+			Spawn.ServerPrefab(radiationSourcePrefab, RandomUtils.GetRandomPointOnStation(true, true));
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/EventRadiationStorm.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/EventRadiationStorm.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6530a412ec3f61e4ab316ba7c6e27681
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventPortalStorm.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventPortalStorm.cs
@@ -54,23 +54,7 @@ namespace InGameEvents
 		private IEnumerator SpawnMob()
 		{
 			yield return WaitFor.Seconds(Random.Range(0, 5));
-			new SpawnByPortal(mobsToSpawn.PickRandom(), portalPrefab, GetRandomPoint(), portalSettings);
-		}
-
-		private Vector3Int GetRandomPoint()
-		{
-			var stationBounds = MatrixManager.MainStationMatrix.Bounds;
-
-			Vector3Int point = default;
-			for (int i = 0; i < 10; i++)
-			{
-				point = stationBounds.GetRandomPoint().CutToInt();
-				if (MatrixManager.IsSpaceAt(point, true)) continue;
-				if (MatrixManager.IsPassableAtAllMatricesOneTile(point, true) == false) continue;
-				break;
-			}
-
-			return point;
+			new SpawnByPortal(mobsToSpawn.PickRandom(), portalPrefab, RandomUtils.GetRandomPointOnStation(true, true), portalSettings);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventStartGhostRole.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventStartGhostRole.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+using UnityEngine;
+using Systems.GhostRoles;
+using ScriptableObjects;
+using Managers;
+using Strings;
+
+namespace InGameEvents
+{
+	public class EventStartGhostRole : EventScriptBase
+	{
+		[Tooltip("The ghost role to offer ghosts.")]
+		[SerializeField]
+		private GhostRoleData ghostRole = default;
+
+		[Tooltip("The text to use for Central Command announcements. Leave empty to disable.")]
+		[SerializeField]
+		private string message = default;
+
+		public override void OnEventStart()
+		{
+			if (AnnounceEvent && string.IsNullOrEmpty(message) == false)
+			{
+				CentComm.MakeAnnouncement(ChatTemplates.CentcomAnnounce, message, CentComm.UpdateSound.Alert);
+			}
+
+			if (FakeEvent) return;
+
+			base.OnEventStart();
+		}
+
+		public override void OnEventStartTimed()
+		{
+			GhostRoleManager.Instance.ServerCreateRole(ghostRole);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventStartGhostRole.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventStartGhostRole.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e60c8a1f7899e2408bce7cd56fb3d6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/RadiationStormObject.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/RadiationStormObject.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections;
+using UnityEngine;
+using Systems.Radiation;
+using NaughtyAttributes;
+
+namespace InGameEvents
+{
+	[RequireComponent(typeof(RadiationProducer))]
+	public class RadiationStormObject : MonoBehaviour
+	{
+		[Tooltip("The amount of radiation this source should emit at peak size.")]
+		[SerializeField, Range(10000, 100000)]
+		private int peakRadiation = 30000;
+
+		[Tooltip("How long this source takes to grow to full size (randomly selected within range).")]
+		[SerializeField, MinMaxSlider(0, 10)]
+		private Vector2 randomGrowthTime = new Vector2(2, 5);
+
+		[Tooltip("How long this source should live in total (randomly selected within range).")]
+		[SerializeField, MinMaxSlider(30, 120)]
+		private Vector2 lifeTime = new Vector2(30, 60);
+
+		private RadiationProducer radiator;
+
+		private float growthTime;
+		private float time;
+		private bool isGrowing = true;
+
+		private void Awake()
+		{
+			radiator = GetComponent<RadiationProducer>();
+
+			growthTime = Random.Range(randomGrowthTime.x, randomGrowthTime.y);
+		}
+
+		private void OnEnable()
+		{
+			if (CustomNetworkManager.IsServer)
+			{
+				UpdateManager.Add(CallbackType.UPDATE, UpdateRadiationOutput);
+			}
+		}
+
+		private void OnDisable()
+		{
+			if (CustomNetworkManager.IsServer)
+			{
+				UpdateManager.Remove(CallbackType.UPDATE, UpdateRadiationOutput);
+			}
+		}
+
+		private void Start()
+		{
+			float degrees = 720;
+			gameObject.LeanRotateZ(degrees, 20).setLoopClamp().setOnComplete(() =>
+			{
+				degrees += 360;
+			});
+
+			StartCoroutine(DelayDecay());
+		}
+
+		private void UpdateRadiationOutput()
+		{
+			if (isGrowing && time > growthTime) return;
+			if (isGrowing == false && time <= 0) return;
+
+			time += isGrowing ? Time.deltaTime : -Time.deltaTime;
+			radiator.SetLevel(peakRadiation * (time / growthTime));
+		}
+
+		private IEnumerator DelayDecay()
+		{
+			yield return WaitFor.Seconds(Random.Range(lifeTime.x, lifeTime.y) - growthTime);
+			isGrowing = false;
+			yield return WaitFor.Seconds(growthTime);
+			Despawn.ServerSingle(gameObject);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/RadiationStormObject.cs.meta
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/RadiationStormObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36622f2a7479a284db4943a1c060ddd8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/Systems/Radiation/RadiationProducer.cs
+++ b/UnityProject/Assets/Scripts/Systems/Radiation/RadiationProducer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using Light2D;
 using Mirror;
 using UnityEngine;
@@ -12,6 +13,7 @@ namespace Systems.Radiation
 		private GameObject mLightRendererObject;
 		private ObjectBehaviour objectBehaviour;
 		private RegisterObject registerObject;
+		[NonSerialized]
 		public int ObjectID = 0;
 		private LightSprite lightSprite;
 		public Sprite DotSprite;
@@ -68,7 +70,7 @@ namespace Systems.Radiation
 			}
 		}*/
 
-		public void Setlevel(float Invalue)
+		public void SetLevel(float Invalue)
 		{
 			SynchStrength(SynchroniseStrength, Invalue);
 		}

--- a/UnityProject/Assets/Scripts/Util/RandomUtils.cs
+++ b/UnityProject/Assets/Scripts/Util/RandomUtils.cs
@@ -22,4 +22,32 @@ public static class RandomUtils
 		Vector2 randomVector = UnityEngine.Random.insideUnitCircle;
 		return randomVector.normalized * minRadius + randomVector * (maxRadius - minRadius);
 	}
+
+	/// <summary>
+	/// Gets a random point on the main station matrix.
+	/// </summary>
+	public static Vector3Int GetRandomPointOnStation(bool avoidSpace = false, bool avoidImpassable = false)
+	{
+		var stationBounds = MatrixManager.MainStationMatrix.Bounds;
+
+		Vector3Int point = default;
+		for (int i = 0; i < 10; i++)
+		{
+			point = stationBounds.GetRandomPoint().CutToInt();
+
+			if (avoidSpace && MatrixManager.IsSpaceAt(point, CustomNetworkManager.IsServer))
+			{
+				continue;
+			}
+
+			if (avoidImpassable && MatrixManager.IsPassableAtAllMatricesOneTile(point, CustomNetworkManager.IsServer) == false)
+			{
+				continue;
+			}
+
+			break;
+		}
+
+		return point;
+	}
 }


### PR DESCRIPTION
- Adds the Radiation Storm event. Spawns a bunch of dangerous radiation sources around the station that the crew must avoid.
- Adds the Fugitives event. Creates a ghost role instance where ghosts can choose to become a fugitive. Removes fugitive from preferences.

CL:Added the Radiation Storm and Fugitives event.