### PR TITLE
fix Fugitives not pointing to their correct spawn category

### DIFF
--- a/UnityProject/Assets/Resources/ScriptableObjects/Occupations/Fugitive.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Occupations/Fugitive.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c58d5c5a6190436e9d4ae8e32a26ee6a, type: 3}
   m_Name: Fugitive
   m_EditorClassIdentifier: 
-  jobType: 50
+  jobType: 51
   isCrewmember: 0
   lateSpawnIsArrivals: 0
   inventoryPopulator: {fileID: 11400000, guid: dc124411c427acc43b9f28182ce2b9a9, type: 2}
@@ -30,4 +30,4 @@ MonoBehaviour:
   customProperties:
     m_keys: []
     m_values: 
-  isTargeteable: 0
+  isTargeteable: 1


### PR DESCRIPTION
### Purpose
That's it, their job was PRISONER but the spawn category was for FUGITIVE.

