### PR TITLE
Fixes #5801, vendor content saved to restock canister after deconstructing

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Others/VendingRestock.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/VendingRestock.cs
@@ -1,9 +1,18 @@
-﻿using System.Collections;
+﻿using Objects;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-//TODO: No point to this. Delete it and add Pickupable to VendingRestock, use ItemTraits instead of this marker component
 public class VendingRestock : Pickupable
-{
-	//Whatever
+{	
+	private List<VendorItem> previousVendorContent;
+	/// <summary>
+	/// The items previously offered by a deconstructed vendor
+	/// </summary>
+	public List<VendorItem> PreviousVendorContent => previousVendorContent;
+
+	public void SetPreviousVendorContent(List<VendorItem> items)
+	{
+		previousVendorContent = items;
+	}
 }


### PR DESCRIPTION
### Purpose
Fixes #5801

### Notes:
When a vendor is deconstructed, its items are saved to the vendor restock item and then reloaded if the machine is rebuilt with that restock item. If the restock item hasn't been spawned in, the items are temporarily saved in the machineframe until the restock item is spawned
