### PR TITLE
Add slight delay between item selection in radial.

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/UI/RightClick/RightClickItemButton.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/UI/RightClick/RightClickItemButton.prefab
@@ -7,10 +7,60 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 803781379966066027, guid: 251d79f398ee3c44fb381b0596389601,
+        type: 3}
+      propertyPath: selectionDelay
+      value: 0.15
+      objectReference: {fileID: 0}
     - target: {fileID: 2070733028221421905, guid: 251d79f398ee3c44fb381b0596389601,
         type: 3}
       propertyPath: m_Name
       value: RightClickItemButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 322
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 322
       objectReference: {fileID: 0}
     - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
         type: 3}
@@ -29,6 +79,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -44,12 +99,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
@@ -66,56 +121,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 322
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 322
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7157220621932612267, guid: 251d79f398ee3c44fb381b0596389601,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 251d79f398ee3c44fb381b0596389601, type: 3}

--- a/UnityProject/Assets/Scripts/UI/Core/RightClick/RightClickRadialButton.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/RightClick/RightClickRadialButton.cs
@@ -33,6 +33,10 @@ namespace UI.Core.RightClick
 		[SerializeField]
 		private RectTransform divider = default;
 
+		[Min(0)]
+		[SerializeField]
+		private float selectionDelay = default;
+
 		private Image mask;
 
 		private RightClickButton button;
@@ -40,6 +44,17 @@ namespace UI.Core.RightClick
 		private Image Mask => this.GetComponentByRef(ref mask);
 
 		private RightClickButton Button => this.GetComponentByRef(ref button);
+
+		private int SelectionDelayId { get; set; }
+
+		private System.Action SelectionDelegate { get; set; }
+
+		private PointerEventData LastPointerEnterData { get; set; }
+
+		private void Awake()
+		{
+			SelectionDelegate = Select;
+		}
 
 		public override void Setup(Radial<RightClickRadialButton> parent, int index)
 		{
@@ -154,24 +169,47 @@ namespace UI.Core.RightClick
 
 		public void OnPointerEnter(PointerEventData eventData)
 		{
-			var selected = Radial.Selected;
-			if (selected != this)
-			{
-				selected.OrNull()?.FadeOut(eventData);
-				Radial.Selected = this;
-			}
+			LastPointerEnterData = eventData;
 
-			if (eventData.dragging || Button.interactable == false)
+			if (ReferenceEquals(Radial.Selected, null) || selectionDelay < 0.01f)
+			{
+				Select();
+			}
+			else
+			{
+				SelectionDelayId = LeanTween.delayedCall(selectionDelay, SelectionDelegate).id;
+			}
+		}
+
+		private void Select()
+		{
+			if (LastPointerEnterData == null || Radial.isActiveAndEnabled == false)
 			{
 				return;
 			}
+
+			var selected = Radial.Selected;
+			if (selected != this)
+			{
+				selected.OrNull()?.FadeOut(LastPointerEnterData);
+				Radial.Selected = this;
+			}
+
+			if (LastPointerEnterData.dragging || Button.interactable == false)
+			{
+				return;
+			}
+
 			SetColor(colors.highlightedColor);
-			Button.OnPointerEnter(eventData);
-			Radial.Invoke(PointerEventType.PointerEnter, eventData, this);
+			Button.OnPointerEnter(LastPointerEnterData);
+			Radial.Invoke(PointerEventType.PointerEnter, LastPointerEnterData, this);
+			SelectionDelayId = 0;
 		}
 
 		public void OnPointerExit(PointerEventData eventData)
 		{
+			LeanTween.cancel(SelectionDelayId);
+			SelectionDelayId = 0;
 			Radial.Invoke(PointerEventType.PointerExit, eventData, this);
 		}
 


### PR DESCRIPTION
Getting back into things. A suggestion relayed to me was adding a brief delay to item selection on the radial.
If an item is currently selected in the radial menu, there will be a brief delay before another item is selected if you hover over it.
This gives you a brief window in which to move the mouse from a selected item over to the actions without accidentally selecting another item.
This only affects the item ring, the action ring is unaffected by this change.