### PR TITLE
Readd self-examination and add wounds descriptions

### DIFF
--- a/UnityProject/Assets/Scripts/Health/BodyParts/BodyPartBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/BodyParts/BodyPartBehaviour.cs
@@ -1,12 +1,23 @@
-﻿using UnityEngine;
+﻿using System;
+using System.Text;
+using UnityEngine;
 
 public class BodyPartBehaviour : MonoBehaviour
 {
 	//Different types of damages for medical.
 	private float bruteDamage;
 	private float burnDamage;
-	public float BruteDamage { get { return bruteDamage; } set { bruteDamage = Mathf.Clamp(value, 0, 200); } }
-	public float BurnDamage { get { return burnDamage; } set { burnDamage = Mathf.Clamp(value, 0, 200); } }
+	public float BruteDamage
+	{
+		get => bruteDamage;
+		private set => bruteDamage = Mathf.Clamp(value, 0, MaxDamage);
+	}
+	public float BurnDamage
+	{
+		get => burnDamage;
+		private set => burnDamage = Mathf.Clamp(value, 0, MaxDamage);
+	}
+
 	public int MaxDamage = 200;
 	public BodyPartType Type;
 	public bool isBleeding = false;
@@ -15,6 +26,9 @@ public class BodyPartBehaviour : MonoBehaviour
 	public DamageSeverity Severity; //{ get; private set; }
 	public float OverallDamage => BruteDamage + BurnDamage;
 	public Armor armor = new Armor();
+
+	private int brutePercentage => Mathf.RoundToInt(bruteDamage / MaxDamage * 100);
+	private int burnPercentage => Mathf.RoundToInt(burnDamage / MaxDamage * 100);
 
 	void Start()
 	{
@@ -93,7 +107,7 @@ public class BodyPartBehaviour : MonoBehaviour
 	private void UpdateSeverity()
 	{
 		// update UI limbs depending on their severity of damage
-		float severity = (float)OverallDamage / MaxDamage;
+		float severity = OverallDamage / MaxDamage;
 		// If the limb is uninjured
 		if (severity <= 0)
 		{
@@ -148,5 +162,97 @@ public class BodyPartBehaviour : MonoBehaviour
 		BruteDamage = _bruteDamage;
 		BurnDamage = _burnDamage;
 		UpdateSeverity();
+	}
+
+	public string GetDamageDescription()
+	{
+		if (OverallDamage.IsBetween(0f, 10f))
+		{
+			return string.Empty;
+		}
+
+		var description = new StringBuilder();
+		description.Append(SeverityDescription);
+		description.Append(BruteDamageDescription);
+
+		if (brutePercentage > 10 && burnPercentage > 9)
+		{
+			description.Append(" and ");
+		}
+
+		description.Append(BurnDamageDescription);
+
+		return description.ToString();
+	}
+
+	private string BruteDamageDescription
+	{
+		get
+		{
+			switch (brutePercentage)
+			{
+				case int n when n.IsBetween(10, 20):
+					return "it has some negligible bruises";
+				case int n when n.IsBetween(21, 40):
+					return "it has minor bruises";
+				case int n when n.IsBetween(41, 60):
+					return "it has moderate bruises";
+				case int n when n.IsBetween(61, 80):
+					return "it has heavy bruises";
+				case int n when n.IsBetween(81, 100):
+					return "it looks ready to fall apart";
+				default:
+					return ".";
+			}
+		}
+	}
+
+	private string BurnDamageDescription
+	{
+		get
+		{
+			switch (burnPercentage)
+			{
+				case int n when n.IsBetween(10, 20):
+					return "it has some negligible burns.";
+				case int n when n.IsBetween(21, 40):
+					return "it has minor burns.";
+				case int n when n.IsBetween(41, 60):
+					return "it has moderate burns.";
+				case int n when n.IsBetween(61, 80):
+					return "it has heavy burns.";
+				case int n when n.IsBetween(81, 100):
+					return "it looks charred and about to crumble.";
+				default:
+					return ".";
+			}
+		}
+	}
+
+
+	private string SeverityDescription
+	{
+		get
+		{
+			switch (Severity)
+			{
+				case DamageSeverity.Light:
+				case DamageSeverity.LightModerate:
+					return "lightly damaged, ";
+
+				case DamageSeverity.Moderate:
+					return "moderately damaged, ";
+
+				case DamageSeverity.Bad:
+					return "badly damaged, ";
+
+				case DamageSeverity.Critical:
+					return "critically damaged, ";
+				case DamageSeverity.Max:
+					return "totally destroyed, ";
+				default:
+					return string.Empty;
+			}
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/LivingHealthBehaviour.cs
@@ -2,12 +2,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Systems.Atmospherics;
 using Light2D;
 using UnityEngine;
 using UnityEngine.Events;
 using Mirror;
 using UnityEngine.Profiling;
+using WebSocketSharp;
 
 /// <summary>
 /// The Required component for all living creatures
@@ -122,10 +124,20 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	private RegisterTile registerTile;
 	private ConsciousState consciousState;
 
-	public bool IsCrit => ConsciousState == ConsciousState.UNCONSCIOUS;
-	public bool IsSoftCrit => ConsciousState == ConsciousState.BARELY_CONSCIOUS;
+	public bool IsCrit => consciousState == ConsciousState.UNCONSCIOUS;
+	public bool IsSoftCrit => consciousState == ConsciousState.BARELY_CONSCIOUS;
 
-	public bool IsDead => ConsciousState == ConsciousState.DEAD;
+	public bool IsDead => consciousState == ConsciousState.DEAD;
+
+	public bool IsSSD => consciousState != ConsciousState.DEAD &&
+	                     this is PlayerHealth &&
+	                     TryGetComponent(out PlayerScript player) &&
+	                     player.mind.IsOnline() == false;
+
+	public bool IsBrainDead => consciousState == ConsciousState.DEAD &&
+	                           this is PlayerHealth &&
+	                           TryGetComponent(out PlayerScript player) &&
+	                           player.mind.IsOnline() == false;
 
 	/// <summary>
 	/// Has the heart stopped.
@@ -385,7 +397,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	{
 		TryGibbing(damage);
 
-		BodyPartBehaviour bodyPartBehaviour = GetBodyPart(damage, damageType, bodyPartAim);
+		var bodyPartBehaviour = GetBodyPart(damage, damageType, bodyPartAim);
 		if (bodyPartBehaviour == null)
 		{
 			return;
@@ -596,7 +608,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 	[Server]
 	public void CalculateOverallHealth()
 	{
-		float newHealth = 100;
+		float newHealth = maxHealth;
 		newHealth -= CalculateOverallBodyPartDamage();
 		newHealth -= CalculateOverallBloodLossDamage();
 		newHealth -= bloodSystem.OxygenDamage;
@@ -999,8 +1011,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 		var cs = GetComponentInParent<PlayerScript>()?.characterSettings;
 		if (cs != null)
 		{
-			theyPronoun = cs.TheyPronoun();
-			theyPronoun = theyPronoun[0].ToString().ToUpper() + theyPronoun.Substring(1);
+			theyPronoun = cs.TheyPronoun().Capitalize();
 			theirPronoun = cs.TheirPronoun();
 		}
 
@@ -1008,7 +1019,7 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 		if (IsDead)
 		{
 			healthString += "limp and unresponsive; there are no signs of life";
-			if (this is PlayerHealth && GetComponent<PlayerScript>().mind.IsOnline() == false)
+			if (IsSSD)
 			{
 				healthString += $" and {theirPronoun} soul has departed";
 			}
@@ -1048,11 +1059,51 @@ public abstract class LivingHealthBehaviour : NetworkBehaviour, IHealth, IFireEx
 			if (this is PlayerHealth && GetComponent<PlayerScript>().mind.IsOnline() == false)
 			{
 				healthString += $"\n{theyPronoun} has a blank, absent-minded stare and appears completely unresponsive to anything. " +
-						$"{theyPronoun} may snap out of it soon.";
+				                $"{theyPronoun} may snap out of it soon.";
 			}
 		}
 
 		return healthString;
+	}
+
+	public string GetShortStatus()
+	{
+		if (IsBrainDead)
+		{
+			return "BRAINDEAD";
+		}
+		if (IsDead)
+		{
+			return "DEAD";
+		}
+
+		if (IsSSD)
+		{
+			return "SSD";
+		}
+
+		if (IsCrit || IsSoftCrit)
+		{
+			return "CRITICAL";
+		}
+
+		return "OK";
+	}
+
+	public string GetWoundsDescription()
+	{
+		var description = new StringBuilder();
+
+		foreach (var part in BodyParts)
+		{
+			if (part.GetDamageDescription().IsNullOrEmpty())
+			{
+				continue;
+			}
+			description.AppendFormat("\n<b>{0}</b> is {1}.\n", part.Type.ToString(), part.GetDamageDescription());
+		}
+
+		return description.ToString();
 	}
 
 	public void OnSpawnServer(SpawnInfo info)

--- a/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestExamineMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Client/Interaction/RequestExamineMessage.cs
@@ -3,9 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Assets.Scripts.Player;
 using Messages.Client;
 using Mirror;
+using Player;
 using UnityEngine;
 
 /// <summary>
@@ -46,6 +46,7 @@ public class RequestExamineMessage : ClientMessage
 			// don't send text message target is player - instead send PlayerExaminationMessage
 
 			// Exception for player examine window.
+			//TODO make this be based on a setting clients can turn off
 			if (examinable is ExaminablePlayer examinablePlayer)
 			{
 				examinablePlayer.Examine(SentByPlayer.GameObject);

--- a/UnityProject/Assets/Scripts/UI/Core/PlayerExaminationMessage.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/PlayerExaminationMessage.cs
@@ -1,6 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
-using Assets.Scripts.Player;
+using Player;
 using UnityEngine;
 
 public class PlayerExaminationMessage : ServerMessage
@@ -11,11 +11,11 @@ public class PlayerExaminationMessage : ServerMessage
 	public string Status;
 
 	/// <summary>
-	/// List of informations divided by ';'
+	/// Extra information to be displayed on the extended examination view
 	/// </summary>
-	public string AdditionalInformations;
+	public string AdditionalInformation;
 	public uint ItemStorage;
-	
+
 	public bool Observed;
 
 	public override void Process()
@@ -31,7 +31,7 @@ public class PlayerExaminationMessage : ServerMessage
 
 		var itemStorage = storageObject.GetComponent<ItemStorage>();
 		if(Observed)
-			UIManager.PlayerExaminationWindow.ExaminePlayer(itemStorage, VisibleName, Species, Job, Status, AdditionalInformations);
+			UIManager.PlayerExaminationWindow.ExaminePlayer(itemStorage, VisibleName, Species, Job, Status, AdditionalInformation);
 		else
 			UIManager.PlayerExaminationWindow.CloseWindow();
 	}
@@ -48,7 +48,7 @@ public class PlayerExaminationMessage : ServerMessage
 			Species = species,
 			Job = job,
 			Status = status,
-			AdditionalInformations = additionalInformations,
+			AdditionalInformation = additionalInformations,
 			Observed = observed
 		};
 
@@ -64,7 +64,7 @@ public class PlayerExaminationMessage : ServerMessage
 			Species = examinablePlayer.GetPlayerSpeciesString(),
 			Job = examinablePlayer.GetPlayerJobString(),
 			Status = examinablePlayer.GetPlayerStatusString(),
-			AdditionalInformations = examinablePlayer.GetAdditionalInformations(),
+			AdditionalInformation = examinablePlayer.GetAdditionalInformation(),
 			Observed = observed
 		};
 

--- a/UnityProject/Assets/Scripts/UI/Core/PlayerExaminationWindowSlot.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/PlayerExaminationWindowSlot.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using UI.Core;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/UnityProject/Assets/Scripts/UI/Core/PlayerExaminationWindowUI.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/PlayerExaminationWindowUI.cs
@@ -1,233 +1,232 @@
 using System.Collections;
-using System.Collections.Generic;
-using AdminCommands;
-using Assets.Scripts.Player;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class PlayerExaminationWindowUI : MonoBehaviour
+namespace UI.Core
 {
-	[SerializeField] private Text playerName = default;
-	[SerializeField] private Text playerSpecies = default;
-	[SerializeField] private Text playerJob = default;
-	[SerializeField] private Text playerStatus = default;
-	[Space]
-	[SerializeField] private GameObject expandedView = default;
-	[SerializeField] private Text additionalInformationsText = default;
-
-	private PlayerExaminationWindowSlot[] examinationSlotsUI;
-
-	/// <summary>
-	/// Storage that is currenly displayed
-	/// </summary>
-	public ItemStorage CurrentOpenStorage { get; private set; }
-	private Equipment currentEquipment;
-
-	private void Start()
+	public class PlayerExaminationWindowUI : MonoBehaviour
 	{
-		// find all slots
-		examinationSlotsUI = GetComponentsInChildren<PlayerExaminationWindowSlot>();
+		[SerializeField] private Text playerName = default;
+		[SerializeField] private Text playerSpecies = default;
+		[SerializeField] private Text playerJob = default;
+		[SerializeField] private Text playerStatus = default;
+		[Space]
+		[SerializeField] private GameObject expandedView = default;
+		[SerializeField] private Text additionalInformationsText = default;
 
-		// set parent to this
-		foreach (var slotUI in examinationSlotsUI)
-			slotUI.parent = this;
+		private PlayerExaminationWindowSlot[] examinationSlotsUI;
 
-		gameObject.SetActive(false);
-	}
+		/// <summary>
+		/// Storage that is currenly displayed
+		/// </summary>
+		public ItemStorage CurrentOpenStorage { get; private set; }
+		private Equipment currentEquipment;
 
-	/// <summary>
-	/// Reset all components and disable window
-	/// </summary>
-	private void Reset()
-	{
-		playerName.text = string.Empty;
-		playerSpecies.text = string.Empty;
-		playerJob.text = string.Empty;
-		playerStatus.text = string.Empty;
-
-		additionalInformationsText.text = string.Empty;
-
-		if (CurrentOpenStorage != null)
+		private void Start()
 		{
+			// find all slots
+			examinationSlotsUI = GetComponentsInChildren<PlayerExaminationWindowSlot>();
+
+			// set parent to this
 			foreach (var slotUI in examinationSlotsUI)
 			{
-				// remove event listener
-				ItemSlot playerSlot = CurrentOpenStorage.GetNamedItemSlot(slotUI.UI_ItemSlot.NamedSlot);
-				playerSlot.OnSlotContentsChangeClient.RemoveListener(OnSlotContentsChangeClient);
-
-				// reset inventory slot
-				slotUI.Reset();
+				slotUI.parent = this;
 			}
+
+			gameObject.SetActive(false);
 		}
 
-		CurrentOpenStorage = null;
-		currentEquipment = null;
-
-		gameObject.SetActive(false);
-		expandedView.SetActive(false);
-	}
-
-	/// <summary>
-	/// Called when X button is clicked
-	/// </summary>
-	public void OnClickExit()
-	{
-		SoundManager.Play(SingletonSOSounds.Instance.Click01);
-
-		Reset();
-	}
-
-	/// <summary>
-	/// Called when expand/collapse button is clicked
-	/// </summary>
-	public void OnClickExpandCollapse()
-	{
-		SoundManager.Play(SingletonSOSounds.Instance.Click01);
-
-		expandedView.SetActive(!expandedView.activeSelf);
-	}
-
-	/// <summary>
-	/// Called when clicking other player's slot
-	/// </summary>
-	/// <param name="slot">clicket slot</param>
-	public void TryInteract(PlayerExaminationWindowSlot slot)
-	{
-		ItemSlot targetSlot = CurrentOpenStorage.GetNamedItemSlot(slot.UI_ItemSlot.NamedSlot);
-
-		if (slot.IsObscured || slot.IsPocket)
+		/// <summary>
+		/// Reset all components and disable window
+		/// </summary>
+		private void Reset()
 		{
-			// when player clicks on obscured slot/pocket second time
-			if (slot.IsQuestionMarkActive)
+			playerName.text = string.Empty;
+			playerSpecies.text = string.Empty;
+			playerJob.text = string.Empty;
+			playerStatus.text = string.Empty;
+
+			additionalInformationsText.text = string.Empty;
+
+			if (CurrentOpenStorage != null)
+			{
+				foreach (var slotUI in examinationSlotsUI)
+				{
+					// remove event listener
+					ItemSlot playerSlot = CurrentOpenStorage.GetNamedItemSlot(slotUI.UI_ItemSlot.NamedSlot);
+					playerSlot.OnSlotContentsChangeClient.RemoveListener(OnSlotContentsChangeClient);
+
+					// reset inventory slot
+					slotUI.Reset();
+				}
+			}
+
+			CurrentOpenStorage = null;
+			currentEquipment = null;
+
+			gameObject.SetActive(false);
+			expandedView.SetActive(false);
+		}
+
+		/// <summary>
+		/// Called when X button is clicked
+		/// </summary>
+		public void OnClickExit()
+		{
+			_ = SoundManager.Play(SingletonSOSounds.Instance.Click01);
+
+			Reset();
+		}
+
+		/// <summary>
+		/// Called when expand/collapse button is clicked
+		/// </summary>
+		public void OnClickExpandCollapse()
+		{
+			_ = SoundManager.Play(SingletonSOSounds.Instance.Click01);
+
+			expandedView.SetActive(!expandedView.activeSelf);
+		}
+
+		/// <summary>
+		/// Called when clicking other player's slot
+		/// </summary>
+		/// <param name="slot">clicket slot</param>
+		public void TryInteract(PlayerExaminationWindowSlot slot)
+		{
+			var targetSlot = CurrentOpenStorage.GetNamedItemSlot(slot.UI_ItemSlot.NamedSlot);
+
+			if (slot.IsObscured || slot.IsPocket)
+			{
+				// when player clicks on obscured slot/pocket second time
+				if (slot.IsQuestionMarkActive)
+				{
+					InteractWithOtherPlayersSlot(targetSlot);
+				}
+				// when player clicks on obscured slot/pocket first time
+				else
+				{
+					slot.SetQuestionMarkActive(targetSlot.IsOccupied);
+				}
+			}
+			else
 			{
 				InteractWithOtherPlayersSlot(targetSlot);
 			}
-			// when player clicks on obscured slot/pocket first time
-			else
-			{
-				if (targetSlot.IsOccupied)
-					slot.SetQuestionMarkActive(true);
-				else
-					slot.SetQuestionMarkActive(false);
-			}
-		}
-		else
-		{
-			InteractWithOtherPlayersSlot(targetSlot);
-		}
-	}
-
-	/// <summary>
-	/// TODO interactions
-	/// </summary>
-	private void InteractWithOtherPlayersSlot(ItemSlot targetSlot)
-	{
-		ItemSlot playerSlot;
-		var isGhost = PlayerManager.LocalPlayerScript.IsGhost;
-		if (isGhost)
-		{
-			if (PlayerList.Instance.IsClientAdmin)
-			{
-				playerSlot = AdminManager.Instance.LocalAdminGhostStorage.GetNamedItemSlot(NamedSlot.ghostStorage01);
-			}
-			else
-			{
-				return;
-			}
-		}
-		else
-		{
-			playerSlot = UIManager.Hands.CurrentSlot.ItemSlot;
-		}
-		OtherPlayerSlotTransferMessage.Send(playerSlot, targetSlot, isGhost);
-	}
-
-	/// <summary>
-	/// Enable window and start listening for inventory updates
-	/// </summary>
-	/// <param name="itemStorage">reference to player item storage</param>
-	/// <param name="visibleName">player's visible name</param>
-	/// <param name="species">player's species</param>
-	/// <param name="job">player's job</param>
-	/// <param name="status">player's status</param>
-	public void ExaminePlayer(ItemStorage itemStorage, string visibleName, string species, string job, string status, string additionalInformations)
-	{
-		Reset();
-
-		CurrentOpenStorage = itemStorage;
-		currentEquipment = itemStorage.gameObject.GetComponent<Equipment>();
-
-		UpdateStorageUI();
-
-		// display info
-		playerName.text = visibleName;
-		playerSpecies.text = species;
-		playerJob.text = job;
-		playerStatus.text = status;
-
-		// display additional informations
-		additionalInformationsText.text = additionalInformations;
-
-		// add listeners
-		foreach (var slotUI in examinationSlotsUI)
-		{
-			ItemSlot playerSlot = CurrentOpenStorage.GetNamedItemSlot(slotUI.UI_ItemSlot.NamedSlot);
-			playerSlot.OnSlotContentsChangeClient.AddListener(OnSlotContentsChangeClient);
 		}
 
-		gameObject.SetActive(true);
-	}
-
-	/// <summary>
-	/// Update ui inventory slots
-	/// </summary>
-	public void UpdateStorageUI(bool test = false)
-	{
-		foreach (var slotUI in examinationSlotsUI)
+		private void InteractWithOtherPlayersSlot(ItemSlot targetSlot)
 		{
-			// reset inventory slot
-			slotUI.Reset();
-
-			NamedSlot namedSlot = slotUI.UI_ItemSlot.NamedSlot;
-
-			// if slot is obscured - enable overlay
-			if (currentEquipment.IsSlotObscured(namedSlot))
+			ItemSlot playerSlot;
+			var isGhost = PlayerManager.LocalPlayerScript.IsGhost;
+			if (isGhost)
 			{
-				slotUI.SetObscuredOverlayActive(true);
-			}
-			// else link slot
-			else
-			{
-				if (!slotUI.IsPocket)
+				if (PlayerList.Instance.IsClientAdmin)
 				{
-					ItemSlot playerSlot = CurrentOpenStorage.GetNamedItemSlot(namedSlot);
+					playerSlot = AdminManager.Instance.LocalAdminGhostStorage.GetNamedItemSlot(NamedSlot.ghostStorage01);
+				}
+				else
+				{
+					return;
+				}
+			}
+			else
+			{
+				playerSlot = UIManager.Hands.CurrentSlot.ItemSlot;
+			}
+			OtherPlayerSlotTransferMessage.Send(playerSlot, targetSlot, isGhost);
+		}
+
+		/// <summary>
+		/// Enable window and start listening for inventory updates
+		/// </summary>
+		/// <param name="itemStorage">reference to player item storage</param>
+		/// <param name="visibleName">player's visible name</param>
+		/// <param name="species">player's species</param>
+		/// <param name="job">player's job</param>
+		/// <param name="status">player's status</param>
+		/// <param name="additionalInformation">extra information characters can see about this character</param>
+		public void ExaminePlayer(ItemStorage itemStorage, string visibleName, string species, string job, string status, string additionalInformation)
+		{
+			Reset();
+
+			CurrentOpenStorage = itemStorage;
+			currentEquipment = itemStorage.gameObject.GetComponent<Equipment>();
+
+			UpdateStorageUI();
+
+			// display info
+			playerName.text = visibleName;
+			playerSpecies.text = species;
+			playerJob.text = job;
+			playerStatus.text = status;
+
+			// display additional informations
+			additionalInformationsText.text = additionalInformation;
+
+			// add listeners
+			foreach (var slotUI in examinationSlotsUI)
+			{
+				ItemSlot playerSlot = CurrentOpenStorage.GetNamedItemSlot(slotUI.UI_ItemSlot.NamedSlot);
+				playerSlot.OnSlotContentsChangeClient.AddListener(OnSlotContentsChangeClient);
+			}
+
+			gameObject.SetActive(true);
+		}
+
+		/// <summary>
+		/// Update ui inventory slots
+		/// </summary>
+		public void UpdateStorageUI(bool test = false)
+		{
+			foreach (var slotUI in examinationSlotsUI)
+			{
+				// reset inventory slot
+				slotUI.Reset();
+
+				var namedSlot = slotUI.UI_ItemSlot.NamedSlot;
+
+				// if slot is obscured - enable overlay
+				if (currentEquipment.IsSlotObscured(namedSlot))
+				{
+					slotUI.SetObscuredOverlayActive(true);
+				}
+				// else link slot
+				else
+				{
+					if (slotUI.IsPocket)
+					{
+						continue;
+					}
+
+					var playerSlot = CurrentOpenStorage.GetNamedItemSlot(namedSlot);
 					slotUI.UI_ItemSlot.LinkSlot(playerSlot);
 				}
 			}
 		}
-	}
 
-	/// <summary>
-	/// Called on player inventory update
-	/// </summary>
-	private void OnSlotContentsChangeClient()
-	{
-		// need to wait one frame because item needs to refresh before updating UI
-		StartCoroutine(WaitOneFrameForUpdate());
-	}
+		/// <summary>
+		/// Called on player inventory update
+		/// </summary>
+		private void OnSlotContentsChangeClient()
+		{
+			// need to wait one frame because item needs to refresh before updating UI
+			StartCoroutine(WaitOneFrameForUpdate());
+		}
 
-	private IEnumerator WaitOneFrameForUpdate()
-	{
-		yield return null;
+		private IEnumerator WaitOneFrameForUpdate()
+		{
+			yield return null;
 
-		UpdateStorageUI();
-	}
+			UpdateStorageUI();
+		}
 
-	/// <summary>
-	/// Disable and reset window
-	/// </summary>
-	public void CloseWindow()
-	{
-		Reset();
+		/// <summary>
+		/// Disable and reset window
+		/// </summary>
+		public void CloseWindow()
+		{
+			Reset();
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Systems/UIManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Systems/UIManager.cs
@@ -4,6 +4,7 @@ using AdminTools;
 using Audio.Managers;
 using Initialisation;
 using Mirror;
+using UI.Core;
 using UI.Jobs;
 using UI.UI_Bottom;
 using UnityEngine;

--- a/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
+++ b/UnityProject/Assets/Scripts/Util/SweetExtensions.cs
@@ -398,18 +398,42 @@ public static class SweetExtensions
 	public static Vector3 GetRandomPoint(this Bounds bounds)
 	{
 		return new Vector3(
-				UnityEngine.Random.Range(bounds.min.x, bounds.max.x),
-				UnityEngine.Random.Range(bounds.min.y, bounds.max.y),
-				UnityEngine.Random.Range(bounds.min.z, bounds.max.z)
+			UnityEngine.Random.Range(bounds.min.x, bounds.max.x),
+			UnityEngine.Random.Range(bounds.min.y, bounds.max.y),
+			UnityEngine.Random.Range(bounds.min.z, bounds.max.z)
 		);
 	}
 
 	public static Vector3 GetRandomPoint(this BoundsInt bounds)
 	{
 		return new Vector3(
-				UnityEngine.Random.Range(bounds.min.x, bounds.max.x),
-				UnityEngine.Random.Range(bounds.min.y, bounds.max.y),
-				UnityEngine.Random.Range(bounds.min.z, bounds.max.z)
+			UnityEngine.Random.Range(bounds.min.x, bounds.max.x),
+			UnityEngine.Random.Range(bounds.min.y, bounds.max.y),
+			UnityEngine.Random.Range(bounds.min.z, bounds.max.z)
 		);
+	}
+
+	public static string Capitalize(this string text)
+	{
+		return text[0].ToString().ToUpper() + text.Substring(1);
+	}
+
+	/// <summary>
+	/// Extension for all IComparables, like numbers and dates. Returns true if given data
+	/// is between the min and max values. By default, it is inclusive.
+	/// </summary>
+	/// <param name="value">Value to compare</param>
+	/// <param name="min">Minimum value in the range</param>
+	/// <param name="max">Maximum value in the range</param>
+	/// <param name="inclusive">Changes the behavior for min and max, true by default</param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns>True if the given value is  between the given range</returns>
+	public static bool IsBetween<T>(this T value, T min, T max, bool inclusive=true) where T : IComparable
+	{
+		return inclusive
+			? Comparer<T>.Default.Compare(value, min) >= 0
+			  && Comparer<T>.Default.Compare(value, max) <= 0
+			: Comparer<T>.Default.Compare(value, min) > 0
+			  && Comparer<T>.Default.Compare(value, max) < 0;
 	}
 }


### PR DESCRIPTION
### Purpose
Readd self-examination interaction. It will return the classic description you found when examininig others as seen on this recent screenshot from tg:
![unknown](https://user-images.githubusercontent.com/43683714/105281350-b712a900-5b8a-11eb-8774-9f749a934dce.png)

Adds wounds descriptions for each body part to the new expanded view of the examination window. The numbers that determine the message might need a little tweaking in the future.

Adds a short one word status description to be seen on the status part of the new examination window.

### Notes:
I added two new extensions. 
Capitalize() is a string extension that will, welp, capitalize the word so the first letter of the string is Upcase.
IsBetween() is a IComparable extension that will return true if the IComparable is between the given range. This works for all IComparables, like numbers (of any type) and dates.

### Changelog:
CL: Readds self-examination
CL: Adds new wounds description per body part visible on the new extended view of the examination window.