### PR TITLE
Chat relay "you" hardcoded check replacement

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.Process.cs
@@ -385,13 +385,15 @@ public partial class Chat
 	public static void ProcessUpdateChatMessage(uint recipient, uint originator, string message,
 		string messageOthers, ChatChannel channels, ChatModifier modifiers, string speaker, bool stripTags = true)
 	{
-		//If there is a message in MessageOthers then determine
-		//if it should be the main message or not.
-		if (!string.IsNullOrEmpty(messageOthers))
+
+		var isOriginator = true;
+		if (recipient != originator)
 		{
-			//This is not the originator so use the messageOthers
-			if (recipient != originator)
+			isOriginator = false;
+			if (!string.IsNullOrEmpty(messageOthers))
 			{
+				//If there is a message in MessageOthers then determine
+				//if it should be the main message or not.
 				message = messageOthers;
 			}
 		}
@@ -399,7 +401,7 @@ public partial class Chat
 		if (GhostValidationRejection(originator, channels)) return;
 
 		var msg = ProcessMessageFurther(message, speaker, channels, modifiers, stripTags);
-		Instance.addChatLogClient.Invoke(msg, channels);
+		Instance.addChatLogClient.Invoke(msg, channels, isOriginator);
 	}
 
 	private static bool GhostValidationRejection(uint originator, ChatChannel channels)

--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
@@ -34,7 +34,7 @@ public partial class Chat : MonoBehaviour
 	//Connections to scene based ChatRelay. This is null if in the lobby
 	private ChatRelay chatRelay;
 	private Action<ChatEvent> addChatLogServer;
-	private Action<string, ChatChannel> addChatLogClient;
+	private Action<string, ChatChannel, bool> addChatLogClient;
 	private Action<string> addAdminPriv;
 	private Action<string> addMentorPriv;
 	//Does the ghost hear everyone or just local
@@ -48,7 +48,7 @@ public partial class Chat : MonoBehaviour
 	/// Set the scene based chat relay at the start of every round
 	/// </summary>
 	public static void RegisterChatRelay(ChatRelay relay, Action<ChatEvent> serverChatMethod,
-		Action<string, ChatChannel> clientChatMethod, Action<string> adminMethod, Action<string> mentorMethod)
+		Action<string, ChatChannel, bool> clientChatMethod, Action<string> adminMethod, Action<string> mentorMethod)
 	{
 		Instance.chatRelay = relay;
 		Instance.addChatLogServer = serverChatMethod;
@@ -564,7 +564,7 @@ public partial class Chat : MonoBehaviour
 	/// <param name="message"> The message to add to the client chat stream</param>
 	public static void AddExamineMsgToClient(string message)
 	{
-		Instance.addChatLogClient.Invoke(message, ChatChannel.Examine);
+		Instance.addChatLogClient.Invoke(message, ChatChannel.Examine, true);
 	}
 
 	/// <summary>
@@ -600,7 +600,7 @@ public partial class Chat : MonoBehaviour
 	public static void AddWarningMsgToClient(string message)
 	{
 		message = ProcessMessageFurther(message, "", ChatChannel.Warning, ChatModifier.None); //TODO: Put processing in a unified place for server and client.
-		Instance.addChatLogClient.Invoke(message, ChatChannel.Warning);
+		Instance.addChatLogClient.Invoke(message, ChatChannel.Warning, true);
 	}
 
 	public static void AddAdminPrivMsg(string message)

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
@@ -166,9 +166,9 @@ public class ChatRelay : NetworkBehaviour
 	}
 
 	[Client]
-	private void AddToChatLogClient(string message, ChatChannel channels)
+	private void AddToChatLogClient(string message, ChatChannel channels, bool isOriginator)
 	{
-		UpdateClientChat(message, channels);
+		UpdateClientChat(message, channels, isOriginator);
 	}
 
 	[Client]
@@ -188,7 +188,7 @@ public class ChatRelay : NetworkBehaviour
 	}
 
 	[Client]
-	private void UpdateClientChat(string message, ChatChannel channels)
+	private void UpdateClientChat(string message, ChatChannel channels, bool isOriginator)
 	{
 		if (string.IsNullOrEmpty(message)) return;
 
@@ -201,13 +201,10 @@ public class ChatRelay : NetworkBehaviour
 
 		if (channels != ChatChannel.None)
 		{
-			// TODO: remove hardcoded "You" check; chat bubbles should be on their own channel or similar - see issue #5775.
-
 			// replace action messages with chat bubble
 			if(channels.HasFlag(ChatChannel.Combat) || channels.HasFlag(ChatChannel.Action) || channels.HasFlag(ChatChannel.Examine))
 			{
-				string cleanMessage = Regex.Replace(message, "<.*?>", string.Empty);
-				if(cleanMessage.StartsWith("You"))
+				if(isOriginator)
 				{
 					ChatBubbleManager.ShowAction(Regex.Replace(message, "<.*?>", string.Empty));
 					return;

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/SpawnedAntag.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/SpawnedAntag.cs
@@ -66,8 +66,7 @@ namespace Antagonists
 		/// </summary>
 		public string GetObjectivesForPlayer()
 		{
-			// TODO: remove the leading space before "You are a {Antagonist.AntagName}!" once issue #5775 is fixed.
-			StringBuilder objSB = new StringBuilder($"</i><size=60><color=red> You are a <b>{Antagonist.AntagName}</b>!</color></size>\n", 200);
+			StringBuilder objSB = new StringBuilder($"</i><size=60><color=red>You are a <b>{Antagonist.AntagName}</b>!</color></size>\n", 200);
 			var objectiveList = Objectives.ToList();
 			objSB.AppendLine("Your objectives are:");
 			for (int i = 0; i < objectiveList.Count; i++)


### PR DESCRIPTION
### Purpose
Replaces the hardcoded "you" prefix search in chat relay messages, now it'll check if the originator is the recipient to decide to display a chat bubble or not.
Fixes #5775

