### PR TITLE
Fixes an oversight from my last PR (Plasma Toxin Damage)

### DIFF
--- a/UnityProject/Assets/Scripts/Health/RespiratoryHealth/RespiratorySystem.cs
+++ b/UnityProject/Assets/Scripts/Health/RespiratoryHealth/RespiratorySystem.cs
@@ -162,13 +162,8 @@ public class RespiratorySystem : MonoBehaviour //Do not turn into NetBehaviour
 		if (plasmaPressure > PLASMA_SAFE_MAX)
 		{
 			plasmaDamage = (plasmaPressure - PLASMA_SAFE_MAX) / 5;
-			bloodSystem.ToxinLevel += plasmaDamage
-
-			if (bloodSystem.ToxinLevel > 100)
-			{
-				bloodSystem.ToxinLevel = 100;
-			}
-
+			bloodSystem.ToxinLevel = Mathf.Clamp(bloodSystem.ToxinLevel + plasmaDamage, 0, 100);
+		
 			if (Random.value < 0.1)
 			{
 				if (plasmaPressure < 5)

--- a/UnityProject/Assets/Scripts/Health/RespiratoryHealth/RespiratorySystem.cs
+++ b/UnityProject/Assets/Scripts/Health/RespiratoryHealth/RespiratorySystem.cs
@@ -162,9 +162,12 @@ public class RespiratorySystem : MonoBehaviour //Do not turn into NetBehaviour
 		if (plasmaPressure > PLASMA_SAFE_MAX)
 		{
 			plasmaDamage = (plasmaPressure - PLASMA_SAFE_MAX) / 5;
+			bloodSystem.ToxinLevel += plasmaDamage
 
-			if ((bloodSystem.ToxinLevel += plasmaDamage) <= 100) bloodSystem.ToxinLevel += plasmaDamage;
-			else bloodSystem.ToxinLevel = 100;
+			if (bloodSystem.ToxinLevel > 100)
+			{
+				bloodSystem.ToxinLevel = 100;
+			}
 
 			if (Random.value < 0.1)
 			{

--- a/UnityProject/Assets/Scripts/Health/RespiratoryHealth/RespiratorySystem.cs
+++ b/UnityProject/Assets/Scripts/Health/RespiratoryHealth/RespiratorySystem.cs
@@ -164,6 +164,7 @@ public class RespiratorySystem : MonoBehaviour //Do not turn into NetBehaviour
 			plasmaDamage = (plasmaPressure - PLASMA_SAFE_MAX) / 5;
 
 			if ((bloodSystem.ToxinLevel += plasmaDamage) <= 100) bloodSystem.ToxinLevel += plasmaDamage;
+			else bloodSystem.ToxinLevel = 100;
 
 			if (Random.value < 0.1)
 			{


### PR DESCRIPTION
An oversight in my plasma-breathing PR meant that in atmospheres containing more than 501kPa of Plasma, the resulting player would suffer no toxin damage from breathing it in. It's one line and an easy fix, just an oversight.

