### PR TITLE
Adds Emag functionality to Cleanbots & Floorbots

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Cleanbot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Cleanbot.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: 822779961239697815}
   - component: {fileID: -8380667346639020303}
   - component: {fileID: 6801814165055322343}
-  - component: {fileID: -3116353301156381755}
+  - component: {fileID: 7814011675513677028}
   m_Layer: 12
   m_Name: Cleanbot
   m_TagString: Untagged
@@ -180,11 +180,12 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  CB_REAGENT: {fileID: 11400000, guid: e165b9d67b5163a9ea82a4c4fed31f7d, type: 2}
   target: 1
   actionPerformTime: 3
   hasFoodPrefereces: 0
   foodPreferences: []
-  isEmagged: 0
+  IsEmagged: 0
 --- !u!114 &822779961239697815
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -261,7 +262,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &-3116353301156381755
+--- !u!114 &7814011675513677028
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -270,13 +271,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 5037153879944481302}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5df1ff7b4dd8bda40b50411f4993071a, type: 3}
+  m_Script: {fileID: 11500000, guid: afb628790013e924eaf42c312e660ee9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  spriteRenderer: {fileID: 7911763529354618204}
-  emaggedSprite: {fileID: 21300000, guid: 2847c9a92bb748c46a8c3fb227e116c7, type: 3}
+  SPRITE_RENDERER: {fileID: 7911763529354618204}
+  EMAGGED_SPRITE: {fileID: 21300000, guid: 2847c9a92bb748c46a8c3fb227e116c7, type: 3}
 --- !u!1 &6180971314615384560
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Cleanbot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Cleanbot.prefab
@@ -276,7 +276,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  SPRITE_HANDLER: {fileID: 802417937811619490}
+  spriteHandler: {fileID: 802417937811619490}
   EMAGGED_SPRITE: {fileID: 21300000, guid: 2847c9a92bb748c46a8c3fb227e116c7, type: 3}
 --- !u!1 &6180971314615384560
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Cleanbot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Cleanbot.prefab
@@ -18,6 +18,7 @@ GameObject:
   - component: {fileID: 822779961239697815}
   - component: {fileID: -8380667346639020303}
   - component: {fileID: 6801814165055322343}
+  - component: {fileID: -3116353301156381755}
   m_Layer: 12
   m_Name: Cleanbot
   m_TagString: Untagged
@@ -83,7 +84,13 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   floorDecal: {fileID: 0}
   isInitiallyNotPushable: 0
-  pushPullSound: 
+  pushPullSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1
@@ -177,6 +184,7 @@ MonoBehaviour:
   actionPerformTime: 3
   hasFoodPrefereces: 0
   foodPreferences: []
+  isEmagged: 0
 --- !u!114 &822779961239697815
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -253,6 +261,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &-3116353301156381755
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5037153879944481302}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5df1ff7b4dd8bda40b50411f4993071a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteRenderer: {fileID: 7911763529354618204}
+  emaggedSprite: {fileID: 21300000, guid: 2847c9a92bb748c46a8c3fb227e116c7, type: 3}
 --- !u!1 &6180971314615384560
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Cleanbot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Cleanbot.prefab
@@ -276,7 +276,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  SPRITE_RENDERER: {fileID: 7911763529354618204}
+  SPRITE_HANDLER: {fileID: 802417937811619490}
   EMAGGED_SPRITE: {fileID: 21300000, guid: 2847c9a92bb748c46a8c3fb227e116c7, type: 3}
 --- !u!1 &6180971314615384560
 GameObject:
@@ -288,6 +288,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7877259472688728073}
   - component: {fileID: 7911763529354618204}
+  - component: {fileID: 802417937811619490}
   m_Layer: 12
   m_Name: Sprite
   m_TagString: Untagged
@@ -349,7 +350,7 @@ SpriteRenderer:
   m_SortingLayerID: -229502157
   m_SortingLayer: 21
   m_SortingOrder: 11
-  m_Sprite: {fileID: 21300000, guid: b6deaa8f228322c4789b1c364991728e, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 0780c4ed6d62a6d4792f45ae36d4429b, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -360,3 +361,23 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &802417937811619490
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6180971314615384560}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetworkThis: 1
+  SubCatalogue: []
+  PresentSpriteSet: {fileID: 11400000, guid: 03dfe5b183bb53c42bc38c702e7e8ca3, type: 2}
+  randomInitialSprite: 0
+  pushTextureOnStartUp: 1
+  variantIndex: 0
+  palette: []
+  Sprites: []

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/CleanbotWooden.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/CleanbotWooden.prefab
@@ -12,6 +12,12 @@ PrefabInstance:
       propertyPath: EatFoodA.AssetAddress
       value: Assets/Prefabs/AmbientTracks/Ambient04.prefab
       objectReference: {fileID: 0}
+    - target: {fileID: 802417937811619490, guid: 52e52506ef7e83e41a024f96fadc9304,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: b642ad52ac41723428e8fb0940d84402,
+        type: 2}
     - target: {fileID: 822779961239697815, guid: 52e52506ef7e83e41a024f96fadc9304,
         type: 3}
       propertyPath: butcherSound.AssetAddress
@@ -98,7 +104,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 3093160451266126740, guid: d546bfef3536f9342894606705d01a9e,
+      objectReference: {fileID: 21300000, guid: 1ae605d0f683bf948aeb84d933d729d7,
         type: 3}
     m_RemovedComponents:
     - {fileID: -3116353301156381755, guid: 52e52506ef7e83e41a024f96fadc9304, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/CleanbotWooden.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/CleanbotWooden.prefab
@@ -1,5 +1,21 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &7031484669288739102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6390563642695955054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5df1ff7b4dd8bda40b50411f4993071a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  spriteRenderer: {fileID: 8107741572011646244}
+  emaggedSprite: {fileID: 21300000, guid: bd95a76ea5bef07478a4a984d8605672, type: 3}
 --- !u!1001 &2110014500151851128
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -24,6 +40,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -39,6 +60,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -51,16 +77,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2153581049189395837, guid: 52e52506ef7e83e41a024f96fadc9304,
         type: 3}
@@ -88,5 +104,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 3093160451266126740, guid: d546bfef3536f9342894606705d01a9e,
         type: 3}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: -3116353301156381755, guid: 52e52506ef7e83e41a024f96fadc9304, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 52e52506ef7e83e41a024f96fadc9304, type: 3}
+--- !u!1 &6390563642695955054 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5037153879944481302, guid: 52e52506ef7e83e41a024f96fadc9304,
+    type: 3}
+  m_PrefabInstance: {fileID: 2110014500151851128}
+  m_PrefabAsset: {fileID: 0}
+--- !u!212 &8107741572011646244 stripped
+SpriteRenderer:
+  m_CorrespondingSourceObject: {fileID: 7911763529354618204, guid: 52e52506ef7e83e41a024f96fadc9304,
+    type: 3}
+  m_PrefabInstance: {fileID: 2110014500151851128}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/CleanbotWooden.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/CleanbotWooden.prefab
@@ -1,21 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &7031484669288739102
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6390563642695955054}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5df1ff7b4dd8bda40b50411f4993071a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  syncMode: 0
-  syncInterval: 0.1
-  spriteRenderer: {fileID: 8107741572011646244}
-  emaggedSprite: {fileID: 21300000, guid: bd95a76ea5bef07478a4a984d8605672, type: 3}
 --- !u!1001 &2110014500151851128
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -98,6 +82,18 @@ PrefabInstance:
       propertyPath: m_Name
       value: CleanbotWooden
       objectReference: {fileID: 0}
+    - target: {fileID: 7814011675513677028, guid: 52e52506ef7e83e41a024f96fadc9304,
+        type: 3}
+      propertyPath: emaggedSprite
+      value: 
+      objectReference: {fileID: 21300000, guid: bd95a76ea5bef07478a4a984d8605672,
+        type: 3}
+    - target: {fileID: 7814011675513677028, guid: 52e52506ef7e83e41a024f96fadc9304,
+        type: 3}
+      propertyPath: EMAGGED_SPRITE
+      value: 
+      objectReference: {fileID: 21300000, guid: bd95a76ea5bef07478a4a984d8605672,
+        type: 3}
     - target: {fileID: 7911763529354618204, guid: 52e52506ef7e83e41a024f96fadc9304,
         type: 3}
       propertyPath: m_Sprite
@@ -107,15 +103,3 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: -3116353301156381755, guid: 52e52506ef7e83e41a024f96fadc9304, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 52e52506ef7e83e41a024f96fadc9304, type: 3}
---- !u!1 &6390563642695955054 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5037153879944481302, guid: 52e52506ef7e83e41a024f96fadc9304,
-    type: 3}
-  m_PrefabInstance: {fileID: 2110014500151851128}
-  m_PrefabAsset: {fileID: 0}
---- !u!212 &8107741572011646244 stripped
-SpriteRenderer:
-  m_CorrespondingSourceObject: {fileID: 7911763529354618204, guid: 52e52506ef7e83e41a024f96fadc9304,
-    type: 3}
-  m_PrefabInstance: {fileID: 2110014500151851128}
-  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Floorbot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Floorbot.prefab
@@ -276,7 +276,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  SPRITE_RENDERER: {fileID: 4443060873987540845}
+  SPRITE_HANDLER: {fileID: 984450164018126074}
   EMAGGED_SPRITE: {fileID: 21300000, guid: 1bb9bd1eab4a0454394041a1c21c90be, type: 3}
 --- !u!1 &4825667868636187068
 GameObject:
@@ -288,6 +288,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2505666480836295323}
   - component: {fileID: 4443060873987540845}
+  - component: {fileID: 984450164018126074}
   m_Layer: 12
   m_Name: Sprite
   m_TagString: Untagged
@@ -349,7 +350,7 @@ SpriteRenderer:
   m_SortingLayerID: -229502157
   m_SortingLayer: 21
   m_SortingOrder: 11
-  m_Sprite: {fileID: 21300000, guid: fbef0531e2d0c404eb39646b93b4d746, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 217874afca46cdf43b523338886a7053, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -360,3 +361,23 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &984450164018126074
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4825667868636187068}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db025f3627a11af4fb670ccd1e2188ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  NetworkThis: 1
+  SubCatalogue: []
+  PresentSpriteSet: {fileID: 11400000, guid: 721ecc7a3b346db4886ee0f07f65515c, type: 2}
+  randomInitialSprite: 0
+  pushTextureOnStartUp: 1
+  variantIndex: 0
+  palette: []
+  Sprites: []

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Floorbot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Floorbot.prefab
@@ -18,6 +18,7 @@ GameObject:
   - component: {fileID: 5455455252294224591}
   - component: {fileID: 7304802151653684397}
   - component: {fileID: 9084638841217414174}
+  - component: {fileID: 5579325328306395513}
   m_Layer: 12
   m_Name: Floorbot
   m_TagString: Untagged
@@ -83,7 +84,13 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   floorDecal: {fileID: 0}
   isInitiallyNotPushable: 0
-  pushPullSound: 
+  pushPullSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1
@@ -108,6 +115,8 @@ MonoBehaviour:
   objectType: 0
   AtmosPassable: 1
   Passable: 1
+  ReachableThrough: 1
+  passableExclusionsToThis: []
 --- !u!114 &5133121035479701040
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -122,6 +131,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  snapToGridOnStart: 1
   IsFixedMatrix: 0
 --- !u!114 &2008208207829246944
 MonoBehaviour:
@@ -163,8 +173,18 @@ MonoBehaviour:
   performingAction: 0
   activated: 1
   tickRate: 1
+  EatFoodA:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   target: 2
   actionPerformTime: 3
+  hasFoodPrefereces: 0
+  foodPreferences: []
+  isEmagged: 0
 --- !u!114 &5455455252294224591
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -177,8 +197,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f68d36ed5e334f99b82dc3801757e89, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &7304802151653684397
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -193,7 +220,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  soundOnHit: 
+  initialIntegrity: 100
+  soundOnHit:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  damageDeflection: 0
   Armor:
     Melee: 0
     Bullet: 0
@@ -214,7 +249,6 @@ MonoBehaviour:
     Indestructable: 0
     FreezeProof: 0
   HeatResistance: 100
-  initialIntegrity: 100
 --- !u!114 &9084638841217414174
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -227,9 +261,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &5579325328306395513
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2293724657804988958}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5df1ff7b4dd8bda40b50411f4993071a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  forceHidden: 0
+  spriteRenderer: {fileID: 4443060873987540845}
+  emaggedSprite: {fileID: 21300000, guid: 1bb9bd1eab4a0454394041a1c21c90be, type: 3}
 --- !u!1 &4825667868636187068
 GameObject:
   m_ObjectHideFlags: 0
@@ -276,6 +323,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -298,7 +346,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -229502157
-  m_SortingLayer: 15
+  m_SortingLayer: 21
   m_SortingOrder: 11
   m_Sprite: {fileID: 21300000, guid: fbef0531e2d0c404eb39646b93b4d746, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Floorbot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Floorbot.prefab
@@ -276,7 +276,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  SPRITE_HANDLER: {fileID: 984450164018126074}
+  spriteHandler: {fileID: 984450164018126074}
   EMAGGED_SPRITE: {fileID: 21300000, guid: 1bb9bd1eab4a0454394041a1c21c90be, type: 3}
 --- !u!1 &4825667868636187068
 GameObject:

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Floorbot.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/Bot/Resources/Floorbot.prefab
@@ -18,7 +18,7 @@ GameObject:
   - component: {fileID: 5455455252294224591}
   - component: {fileID: 7304802151653684397}
   - component: {fileID: 9084638841217414174}
-  - component: {fileID: 5579325328306395513}
+  - component: {fileID: 5388507486581408330}
   m_Layer: 12
   m_Name: Floorbot
   m_TagString: Untagged
@@ -180,11 +180,12 @@ MonoBehaviour:
       m_AssetGUID: 
       m_SubObjectName: 
       m_SubObjectType: 
+  CB_REAGENT: {fileID: 0}
   target: 2
   actionPerformTime: 3
   hasFoodPrefereces: 0
   foodPreferences: []
-  isEmagged: 0
+  IsEmagged: 0
 --- !u!114 &5455455252294224591
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -261,7 +262,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62cc3ef7cd9082443aaf3c255851d15a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &5579325328306395513
+--- !u!114 &5388507486581408330
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -270,13 +271,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 2293724657804988958}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5df1ff7b4dd8bda40b50411f4993071a, type: 3}
+  m_Script: {fileID: 11500000, guid: afb628790013e924eaf42c312e660ee9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  spriteRenderer: {fileID: 4443060873987540845}
-  emaggedSprite: {fileID: 21300000, guid: 1bb9bd1eab4a0454394041a1c21c90be, type: 3}
+  SPRITE_RENDERER: {fileID: 4443060873987540845}
+  EMAGGED_SPRITE: {fileID: 21300000, guid: 1bb9bd1eab4a0454394041a1c21c90be, type: 3}
 --- !u!1 &4825667868636187068
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/NPC/AI/MobExplore.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/MobExplore.cs
@@ -6,6 +6,7 @@ using Items;
 using NaughtyAttributes;
 using Objects.Construction;
 using AddressableReferences;
+using Chemistry;
 
 namespace Systems.MobAIs
 {
@@ -27,6 +28,9 @@ namespace Systems.MobAIs
 			injuredPeople,
 			players
 		}
+
+		[Tooltip("The reagent used by emagged cleanbots")]
+		[SerializeField] private Reagent CB_REAGENT;
 
 		public event Action FoodEatenEvent;
 
@@ -54,7 +58,7 @@ namespace Systems.MobAIs
 		// Position at which an action is performed
 		protected Vector3Int actionPosition;
 
-		public bool isEmagged = false;
+		public bool IsEmagged = false;
 		private InteractableTiles interactableTiles {
 			get {
 				if (_interactableTiles == null)
@@ -141,12 +145,11 @@ namespace Systems.MobAIs
 							return registerObj.Matrix.Get<ItemAttributesV2>(checkPos, true).Any(IsInFoodPreferences);
 						return registerObj.Matrix.GetFirst<Edible>(checkPos, true) != null;
 					case Target.dirtyFloor:
-					if (!isEmagged)
-						return (registerObj.Matrix.Get<FloorDecal>(checkPos, true).Any(p => p.Cleanable));
-						else return (registerObj.Matrix.Get<FloorDecal>(checkPos, true).Any(p => p.Cleanable) || !registerObj.Matrix.Get<FloorDecal>(checkPos, true).Any());
+						if (IsEmagged == false) return (registerObj.Matrix.Get<FloorDecal>(checkPos, true).Any(p => p.Cleanable));
+						else return (registerObj.Matrix.Get<FloorDecal>(checkPos, true).Any(p => p.Cleanable) || (!registerObj.Matrix.Get<FloorDecal>(checkPos, true).Any() && interactableTiles.MetaTileMap.GetTile(checkPos)?.LayerType == LayerType.Floors));
 
 					case Target.missingFloor:
-						if (!isEmagged) return (interactableTiles.MetaTileMap.GetTile(checkPos)?.LayerType == LayerType.Base || interactableTiles.MetaTileMap.GetTile(checkPos)?.LayerType == LayerType.Underfloor); // Checks the topmost tile if its the base or underfloor layer (below the floor)
+						if (IsEmagged == false) return (interactableTiles.MetaTileMap.GetTile(checkPos)?.LayerType == LayerType.Base || interactableTiles.MetaTileMap.GetTile(checkPos)?.LayerType == LayerType.Underfloor); // Checks the topmost tile if its the base or underfloor layer (below the floor)
 						else return interactableTiles.MetaTileMap.GetTile(checkPos)?.LayerType == LayerType.Floors;
 
 
@@ -235,10 +238,11 @@ namespace Systems.MobAIs
 				case Target.dirtyFloor:
 					var matrixInfo = MatrixManager.AtPoint(checkPos, true);
 					var worldPos = MatrixManager.LocalToWorldInt(checkPos, matrixInfo);
-					matrixInfo.MetaDataLayer.Clean(worldPos, checkPos, false);
+					if (IsEmagged) matrixInfo.MetaDataLayer.ReagentReact(new ReagentMix(CB_REAGENT,5,283.15f),worldPos,checkPos);
+					else matrixInfo.MetaDataLayer.Clean(worldPos, checkPos, false);
 					break;
 				case Target.missingFloor:
-					if (!isEmagged) interactableTiles.TileChangeManager.UpdateTile(checkPos, TileType.Floor, "Floor");
+					if (IsEmagged == false) interactableTiles.TileChangeManager.UpdateTile(checkPos, TileType.Floor, "Floor");
 					else interactableTiles.TileChangeManager.RemoveTile(checkPos, LayerType.Floors, true);
 
 					break;

--- a/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
+++ b/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
@@ -8,7 +8,7 @@ namespace Robotics
 	public class InteractableBot : NetworkBehaviour, ICheckedInteractable<HandApply>
 	{
 
-		[SerializeField] private SpriteHandler SPRITE_HANDLER;
+		[SerializeField] private SpriteHandler spriteHandler;
 		[SerializeField] private Sprite EMAGGED_SPRITE;
 
 		private MobExplore mobController;

--- a/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
+++ b/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
@@ -3,52 +3,56 @@ using UnityEngine;
 using Mirror;
 using Systems.MobAIs;
 
-public class InteractableBot : NetworkBehaviour, IPredictedCheckedInteractable<HandApply>
+namespace Robotics
 {
-	HandApply interaction;
-	public SpriteRenderer spriteRenderer;
-	public Sprite emaggedSprite;
-
-	private MobExplore mobController;
-	public MobExplore MobController
+	public class InteractableBot : NetworkBehaviour, IPredictedCheckedInteractable<HandApply>
 	{
-		get
+		HandApply interaction;
+
+		[SerializeField] private SpriteRenderer SPRITE_RENDERER;
+		[SerializeField] private Sprite EMAGGED_SPRITE;
+
+		private MobExplore mobController;
+		public MobExplore MobController
 		{
-			if (!mobController)
+			get
 			{
-				mobController = GetComponent<MobExplore>();
+				if (!mobController)
+				{
+					mobController = GetComponent<MobExplore>();
+				}
+				return mobController;
 			}
-			return mobController;
 		}
-	}
-	public void ClientPredictInteraction(HandApply interaction) { }
+		public void ClientPredictInteraction(HandApply interaction) { }
 
-	public void ServerRollbackClient(HandApply interaction) { }
+		public void ServerRollbackClient(HandApply interaction) { }
 
-	public bool WillInteract(HandApply interaction, NetworkSide side)
-	{
-		if (!DefaultWillInteract.Default(interaction, side)) return false;
-		if (interaction.TargetObject != gameObject) return false;
-		if (interaction.HandObject != null && interaction.Intent == Intent.Harm) return false;
-
-		return MobController != null;
-	}
-	public void ServerPerformInteraction(HandApply interaction)
-	{
-		this.interaction = interaction;
-
-		if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag)
-			&& interaction.HandObject.TryGetComponent<Emag>(out var emag)
-			&& emag.EmagHasCharges())
+		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
-			TryEmag(emag, interaction);
-		}		
-	}
-	public void TryEmag(Emag emag, HandApply interaction)
-	{
-		if (MobController == null) return;
-		MobController.isEmagged = true;
-		if(emaggedSprite != null && spriteRenderer != null) spriteRenderer.sprite = emaggedSprite;
-		emag.UseCharge(interaction);
+			if (!DefaultWillInteract.Default(interaction, side)) return false;
+			if (interaction.TargetObject != gameObject) return false;
+			if (interaction.HandObject != null && interaction.Intent == Intent.Harm) return false;
+
+			return MobController != null;
+		}
+		public void ServerPerformInteraction(HandApply interaction)
+		{
+			this.interaction = interaction;
+
+			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag)
+				&& interaction.HandObject.TryGetComponent<Emag>(out var emag)
+				&& emag.EmagHasCharges())
+			{
+				TryEmag(emag, interaction);
+			}
+		}
+		public void TryEmag(Emag emag, HandApply interaction)
+		{
+			if (MobController == null) return;
+			MobController.IsEmagged = true;
+			if (EMAGGED_SPRITE != null && SPRITE_RENDERER != null) SPRITE_RENDERER.sprite = EMAGGED_SPRITE;
+			emag.UseCharge(interaction);
+		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
+++ b/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections;
+using UnityEngine;
+using Mirror;
+using Systems.MobAIs;
+
+public class InteractableBot : NetworkBehaviour, IPredictedCheckedInteractable<HandApply>
+{
+	HandApply interaction;
+	public SpriteRenderer spriteRenderer;
+	public Sprite emaggedSprite;
+
+	private MobExplore mobController;
+	public MobExplore MobController
+	{
+		get
+		{
+			if (!mobController)
+			{
+				mobController = GetComponent<MobExplore>();
+			}
+			return mobController;
+		}
+	}
+	public void ClientPredictInteraction(HandApply interaction) { }
+
+	public void ServerRollbackClient(HandApply interaction) { }
+
+	public bool WillInteract(HandApply interaction, NetworkSide side)
+	{
+		if (!DefaultWillInteract.Default(interaction, side)) return false;
+		if (interaction.TargetObject != gameObject) return false;
+		if (interaction.HandObject != null && interaction.Intent == Intent.Harm) return false;
+
+		return MobController != null;
+	}
+	public void ServerPerformInteraction(HandApply interaction)
+	{
+		this.interaction = interaction;
+
+		if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag)
+			&& interaction.HandObject.TryGetComponent<Emag>(out var emag)
+			&& emag.EmagHasCharges())
+		{
+			TryEmag(emag, interaction);
+		}		
+	}
+	public void TryEmag(Emag emag, HandApply interaction)
+	{
+		if (MobController == null) return;
+		MobController.isEmagged = true;
+		if(emaggedSprite != null && spriteRenderer != null) spriteRenderer.sprite = emaggedSprite;
+		emag.UseCharge(interaction);
+	}
+}

--- a/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
+++ b/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
@@ -5,11 +5,10 @@ using Systems.MobAIs;
 
 namespace Robotics
 {
-	public class InteractableBot : NetworkBehaviour, IPredictedCheckedInteractable<HandApply>
+	public class InteractableBot : NetworkBehaviour, ICheckedInteractable<HandApply>
 	{
-		HandApply interaction;
 
-		[SerializeField] private SpriteRenderer SPRITE_RENDERER;
+		[SerializeField] private SpriteHandler SPRITE_HANDLER;
 		[SerializeField] private Sprite EMAGGED_SPRITE;
 
 		private MobExplore mobController;
@@ -24,9 +23,6 @@ namespace Robotics
 				return mobController;
 			}
 		}
-		public void ClientPredictInteraction(HandApply interaction) { }
-
-		public void ServerRollbackClient(HandApply interaction) { }
 
 		public bool WillInteract(HandApply interaction, NetworkSide side)
 		{
@@ -38,20 +34,18 @@ namespace Robotics
 		}
 		public void ServerPerformInteraction(HandApply interaction)
 		{
-			this.interaction = interaction;
-
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag)
 				&& interaction.HandObject.TryGetComponent<Emag>(out var emag)
 				&& emag.EmagHasCharges())
 			{
-				TryEmag(emag, interaction);
+				PerformEmag(emag, interaction);
 			}
 		}
-		public void TryEmag(Emag emag, HandApply interaction)
+		public void PerformEmag(Emag emag, HandApply interaction)
 		{
 			if (MobController == null) return;
 			MobController.IsEmagged = true;
-			if (EMAGGED_SPRITE != null && SPRITE_RENDERER != null) SPRITE_RENDERER.sprite = EMAGGED_SPRITE;
+			if (EMAGGED_SPRITE != null && SPRITE_HANDLER != null) SPRITE_HANDLER.SetSprite(EMAGGED_SPRITE);
 			emag.UseCharge(interaction);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
+++ b/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs
@@ -8,7 +8,7 @@ namespace Robotics
 	public class InteractableBot : NetworkBehaviour, ICheckedInteractable<HandApply>
 	{
 
-		[SerializeField] private SpriteHandler SPRITE_HANDLER;
+		[SerializeField] private SpriteHandler spriteHandler;
 		[SerializeField] private Sprite EMAGGED_SPRITE;
 
 		private MobExplore mobController;
@@ -32,6 +32,7 @@ namespace Robotics
 
 			return MobController != null;
 		}
+
 		public void ServerPerformInteraction(HandApply interaction)
 		{
 			if (Validations.HasItemTrait(interaction.HandObject, CommonTraits.Instance.Emag)
@@ -41,11 +42,12 @@ namespace Robotics
 				PerformEmag(emag, interaction);
 			}
 		}
+
 		public void PerformEmag(Emag emag, HandApply interaction)
 		{
 			if (MobController == null) return;
 			MobController.IsEmagged = true;
-			if (EMAGGED_SPRITE != null && SPRITE_HANDLER != null) SPRITE_HANDLER.SetSprite(EMAGGED_SPRITE);
+			if (EMAGGED_SPRITE != null && spriteHandler != null) spriteHandler.SetSprite(EMAGGED_SPRITE);
 			emag.UseCharge(interaction);
 		}
 	}

--- a/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs.meta
+++ b/UnityProject/Assets/Scripts/Robotics/Bots/InteractableBot.cs.meta
@@ -1,11 +1,9 @@
 fileFormatVersion: 2
-guid: f1b8bd5d209198a459a56b1b6032b5bc
+guid: afb628790013e924eaf42c312e660ee9
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences:
-  - brain: {instanceID: 0}
-  - CB_REAGENT: {fileID: 11400000, guid: e165b9d67b5163a9ea82a4c4fed31f7d, type: 2}
+  defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 


### PR DESCRIPTION
### Purpose
Adds the ability to emag Cleanbots (Both variants) and Floorbots, aswell as providing a minor bugfix to Floorbots that would stop them from fixing floor tiles that had wires or pipes running underneath them.

### Notes
Emagged bots will have their sensors turn from green to red indicating sabotage.
Emagged Floorbots will seek out floor tiles and rip them up.
Emagged Cleanbots will run around spilling lube on tiles.


