### PR TITLE
Action text fixes

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/ActionText.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/ActionText.prefab
@@ -297,12 +297,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 1}
   m_Children: []
-  m_Father: {fileID: 7341837746916561269}
-  m_RootOrder: 2
+  m_Father: {fileID: 1342098051280551072}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 60}
+  m_AnchoredPosition: {x: 0, y: 30}
   m_SizeDelta: {x: 402.0502, y: 11.687805}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &815085186194895361
@@ -431,12 +431,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 1}
   m_Children: []
-  m_Father: {fileID: 7341837746916561269}
+  m_Father: {fileID: 1342098051280551072}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.52, y: 60.38}
+  m_AnchoredPosition: {x: -0.52, y: 30.38}
   m_SizeDelta: {x: 402.0502, y: 11.687805}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4278017040112183851
@@ -563,9 +563,11 @@ RectTransform:
   m_GameObject: {fileID: 4267109952729068407}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_LocalScale: {x: 0.014, y: 0.014, z: 1}
   m_Children:
-  - {fileID: 3119847811727090344}
+  - {fileID: 4255611843299778718}
+  - {fileID: 6948691429242389416}
+  - {fileID: 4075245203103321142}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -586,20 +588,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 42b94ceedb6cf904cb85ba3ed64a07d6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  DefaultPosition: {x: 0, y: 0, z: 0}
-  rectTransform: {fileID: 3119847811727090344}
+  rectTransform: {fileID: 1342098051280551072}
   Text: {fileID: 4959930966760570427}
   BackText: {fileID: 1675148404708509141}
-  Distancey: 100
-  Distancex: 60
-  Timey: 5
-  Timex: 5
-  Decay: 0.98
-  DoFade: 0
-  MultiplierGameObject: {fileID: 7514494341537554577}
   Multiplier: {fileID: 1906625697204299991}
   backMultiplier: {fileID: 1122498894322966162}
+  MultiplierGameObject: {fileID: 7514494341537554577}
   image: {fileID: 3882366549755703928}
+  Timey: 5
+  Timex: 5
+  DoFade: 0
   CountInstance: 1
 --- !u!223 &25652208321719599
 Canvas:
@@ -622,80 +620,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!1 &4528193915983766988
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3119847811727090344}
-  m_Layer: 5
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &3119847811727090344
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4528193915983766988}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 7341837746916561269}
-  m_Father: {fileID: 1342098051280551072}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 402.0502, y: 11.687805}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &7293373522406142998
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7341837746916561269}
-  m_Layer: 5
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &7341837746916561269
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7293373522406142998}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 4075245203103321142}
-  - {fileID: 6948691429242389416}
-  - {fileID: 4255611843299778718}
-  m_Father: {fileID: 3119847811727090344}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &7514494341537554577
 GameObject:
   m_ObjectHideFlags: 0
@@ -727,12 +651,12 @@ RectTransform:
   m_Children:
   - {fileID: 3221620346096102070}
   - {fileID: 3322095083457317491}
-  m_Father: {fileID: 7341837746916561269}
-  m_RootOrder: 0
+  m_Father: {fileID: 1342098051280551072}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 90.29, y: 57.54}
+  m_AnchoredPosition: {x: 90.29, y: 27.54}
   m_SizeDelta: {x: 29.899704, y: 23.935417}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &123461439767213257

--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.Process.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.Process.cs
@@ -382,12 +382,12 @@ public partial class Chat
 	/// This should only be called via UpdateChatMessage
 	/// on the client. Do not use for anything else!
 	/// </summary>
-	public static void ProcessUpdateChatMessage(uint recipient, uint originator, string message,
-		string messageOthers, ChatChannel channels, ChatModifier modifiers, string speaker, bool stripTags = true)
+	public static void ProcessUpdateChatMessage(uint recipientUint, uint originatorUint, string message,
+		string messageOthers, ChatChannel channels, ChatModifier modifiers, string speaker, GameObject recipient, bool stripTags = true)
 	{
 
 		var isOriginator = true;
-		if (recipient != originator)
+		if (recipientUint != originatorUint)
 		{
 			isOriginator = false;
 			if (!string.IsNullOrEmpty(messageOthers))
@@ -398,10 +398,10 @@ public partial class Chat
 			}
 		}
 
-		if (GhostValidationRejection(originator, channels)) return;
+		if (GhostValidationRejection(originatorUint, channels)) return;
 
 		var msg = ProcessMessageFurther(message, speaker, channels, modifiers, stripTags);
-		Instance.addChatLogClient.Invoke(msg, channels, isOriginator);
+		ChatRelay.Instance.UpdateClientChat(msg, channels, isOriginator, recipient);
 	}
 
 	private static bool GhostValidationRejection(uint originator, ChatChannel channels)

--- a/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/Chat.cs
@@ -31,31 +31,12 @@ public partial class Chat : MonoBehaviour
 		}
 	}
 
-	//Connections to scene based ChatRelay. This is null if in the lobby
-	private ChatRelay chatRelay;
-	private Action<ChatEvent> addChatLogServer;
-	private Action<string, ChatChannel, bool> addChatLogClient;
-	private Action<string> addAdminPriv;
-	private Action<string> addMentorPriv;
 	//Does the ghost hear everyone or just local
 	public bool GhostHearAll { get; set; } = true;
 
 	public bool OOCMute = false;
 
 	private static Regex htmlRegex = new Regex(@"^(http|https)://.*$");
-
-	/// <summary>
-	/// Set the scene based chat relay at the start of every round
-	/// </summary>
-	public static void RegisterChatRelay(ChatRelay relay, Action<ChatEvent> serverChatMethod,
-		Action<string, ChatChannel, bool> clientChatMethod, Action<string> adminMethod, Action<string> mentorMethod)
-	{
-		Instance.chatRelay = relay;
-		Instance.addChatLogServer = serverChatMethod;
-		Instance.addChatLogClient = clientChatMethod;
-		Instance.addAdminPriv = adminMethod;
-		Instance.addMentorPriv = mentorMethod;
-	}
 
 	public static void InvokeChatEvent(ChatEvent chatEvent)
 	{
@@ -83,7 +64,7 @@ public partial class Chat : MonoBehaviour
 			}
 
 			chatEvent.channels = channel;
-			Instance.addChatLogServer.Invoke(chatEvent);
+			ChatRelay.Instance.PropagateChatToClients(chatEvent);
 			discordMessageBuilder.Append($"[{channel}] ");
 		}
 
@@ -169,7 +150,7 @@ public partial class Chat : MonoBehaviour
 				}
 			}
 
-			Instance.addChatLogServer.Invoke(chatEvent);
+			ChatRelay.Instance.PropagateChatToClients(chatEvent);
 
 			//Sends OOC message to a discord webhook
 			DiscordWebhookMessage.Instance.AddWebHookMessageToQueue(DiscordWebhookURLs.DiscordWebhookOOCURL, message, chatEvent.speaker, ServerData.ServerConfig.DiscordWebhookOOCMentionsID);
@@ -251,7 +232,7 @@ public partial class Chat : MonoBehaviour
 	{
 		if (!IsServer()) return;
 
-		Instance.addChatLogServer.Invoke(new ChatEvent
+		ChatRelay.Instance.PropagateChatToClients(new ChatEvent
 		{
 			message = message,
 			channels = ChatChannel.System,
@@ -268,7 +249,7 @@ public partial class Chat : MonoBehaviour
 	{
 		if (!IsServer()) return;
 
-		Instance.addChatLogServer.Invoke(new ChatEvent
+		ChatRelay.Instance.PropagateChatToClients(new ChatEvent
 		{
 			message = message,
 			channels = ChatChannel.System
@@ -291,7 +272,7 @@ public partial class Chat : MonoBehaviour
 		//dont send message if originator message is blank
 		if (string.IsNullOrWhiteSpace(originatorMessage)) return;
 
-		Instance.addChatLogServer.Invoke(new ChatEvent
+		ChatRelay.Instance.PropagateChatToClients(new ChatEvent
 		{
 			channels = ChatChannel.Action,
 			speaker = originator.name,
@@ -324,7 +305,7 @@ public partial class Chat : MonoBehaviour
 	{
 		if (!IsServer()) return;
 
-		Instance.addChatLogServer.Invoke(new ChatEvent
+		ChatRelay.Instance.PropagateChatToClients(new ChatEvent
 		{
 			channels = ChatChannel.Combat,
 			message = originatorMsg,
@@ -437,7 +418,7 @@ public partial class Chat : MonoBehaviour
 			pos = posOverride;
 		}
 
-		Instance.addChatLogServer.Invoke(new ChatEvent
+		ChatRelay.Instance.PropagateChatToClients(new ChatEvent
 		{
 			channels = ChatChannel.Combat,
 			message = message,
@@ -467,7 +448,7 @@ public partial class Chat : MonoBehaviour
 
 		var message =
 			$"{victim.ExpensiveName()} has been hit by a {item.Item()?.ArticleName ?? item.name}{InTheZone(effectiveHitZone)}";
-		Instance.addChatLogServer.Invoke(new ChatEvent
+		ChatRelay.Instance.PropagateChatToClients(new ChatEvent
 		{
 			channels = ChatChannel.Combat,
 			message = message,
@@ -511,7 +492,7 @@ public partial class Chat : MonoBehaviour
 		if (!IsServer()) return;
 		Instance.TryStopCoroutine(ref composeMessageHandle);
 
-		Instance.addChatLogServer.Invoke(new ChatEvent
+		ChatRelay.Instance.PropagateChatToClients(new ChatEvent
 		{
 			channels = ChatChannel.Local,
 			message = message,
@@ -564,7 +545,7 @@ public partial class Chat : MonoBehaviour
 	/// <param name="message"> The message to add to the client chat stream</param>
 	public static void AddExamineMsgToClient(string message)
 	{
-		Instance.addChatLogClient.Invoke(message, ChatChannel.Examine, true);
+		ChatRelay.Instance.UpdateClientChat(message, ChatChannel.Examine, true, PlayerManager.LocalPlayer);
 	}
 
 	/// <summary>
@@ -600,17 +581,17 @@ public partial class Chat : MonoBehaviour
 	public static void AddWarningMsgToClient(string message)
 	{
 		message = ProcessMessageFurther(message, "", ChatChannel.Warning, ChatModifier.None); //TODO: Put processing in a unified place for server and client.
-		Instance.addChatLogClient.Invoke(message, ChatChannel.Warning, true);
+		ChatRelay.Instance.UpdateClientChat(message, ChatChannel.Warning, true, PlayerManager.LocalPlayer);
 	}
 
 	public static void AddAdminPrivMsg(string message)
 	{
-		Instance.addAdminPriv.Invoke(message);
+		ChatRelay.Instance.AddAdminPrivMessageToClient(message);
 	}
 
 	public static void AddMentorPrivMsg(string message)
 	{
-		Instance.addMentorPriv.Invoke(message);
+		ChatRelay.Instance.AddMentorPrivMessageToClient(message);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
+++ b/UnityProject/Assets/Scripts/Core/Chat/ChatRelay.cs
@@ -16,7 +16,6 @@ public class ChatRelay : NetworkBehaviour
 	public static ChatRelay Instance;
 
 	private ChatChannel namelessChannels;
-	public List<ChatEvent> ChatLog { get; } = new List<ChatEvent>();
 	private LayerMask layerMask;
 	private LayerMask npcMask;
 
@@ -34,7 +33,6 @@ public class ChatRelay : NetworkBehaviour
 		if (Instance == null)
 		{
 			Instance = this;
-			Chat.RegisterChatRelay(Instance, PropagateChatToClients, AddToChatLogClient, AddAdminPrivMessageToClient, AddMentorPrivMessageToClient);
 		}
 		else
 		{
@@ -53,7 +51,7 @@ public class ChatRelay : NetworkBehaviour
 	}
 
 	[Server]
-	private void PropagateChatToClients(ChatEvent chatEvent)
+	public void PropagateChatToClients(ChatEvent chatEvent)
 	{
 		List<ConnectedPlayer> players = PlayerList.Instance.AllPlayers;
 
@@ -165,14 +163,9 @@ public class ChatRelay : NetworkBehaviour
 		}
 	}
 
-	[Client]
-	private void AddToChatLogClient(string message, ChatChannel channels, bool isOriginator)
-	{
-		UpdateClientChat(message, channels, isOriginator);
-	}
 
 	[Client]
-	private void AddAdminPrivMessageToClient(string message)
+	public void AddAdminPrivMessageToClient(string message)
 	{
 		trySendingTTS(message);
 
@@ -180,7 +173,7 @@ public class ChatRelay : NetworkBehaviour
 	}
 
 	[Client]
-	private void AddMentorPrivMessageToClient(string message)
+	public void AddMentorPrivMessageToClient(string message)
 	{
 		trySendingTTS(message);
 
@@ -188,7 +181,7 @@ public class ChatRelay : NetworkBehaviour
 	}
 
 	[Client]
-	private void UpdateClientChat(string message, ChatChannel channels, bool isOriginator)
+	public void UpdateClientChat(string message, ChatChannel channels, bool isOriginator, GameObject recipient)
 	{
 		if (string.IsNullOrEmpty(message)) return;
 
@@ -206,8 +199,7 @@ public class ChatRelay : NetworkBehaviour
 			{
 				if(isOriginator)
 				{
-					ChatBubbleManager.ShowAction(Regex.Replace(message, "<.*?>", string.Empty));
-					return;
+					ChatBubbleManager.Instance.ShowAction(Regex.Replace(message, "[.*?]", string.Empty), recipient);
 				}
 			}
 

--- a/UnityProject/Assets/Scripts/Messages/Server/UpdateChatMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/UpdateChatMessage.cs
@@ -24,7 +24,8 @@ public class UpdateChatMessage : ServerMessage
 	public override void Process()
 	{
 		LoadNetworkObject(Recipient);
-		Chat.ProcessUpdateChatMessage(Recipient, Originator, Message, OthersMessage, Channels, ChatModifiers, Speaker, StripTags);
+		var recipientObject = NetworkObject;
+		Chat.ProcessUpdateChatMessage(Recipient, Originator, Message, OthersMessage, Channels, ChatModifiers, Speaker, recipientObject, StripTags);
 	}
 
 	/// <summary>

--- a/UnityProject/Assets/Scripts/UI/Core/ChatBubble/ActionText.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/ChatBubble/ActionText.cs
@@ -8,99 +8,110 @@ using UnityEngine.UI;
 
 public class ActionText : MonoBehaviour
 {
-	public Vector3 DefaultPosition;
-
 	public RectTransform rectTransform;
 	public TMP_Text Text;
 	public TMP_Text BackText;
-	public float Distancey = 500;
-	public float Distancex = 500;
+	public TMP_Text Multiplier;
+	public TMP_Text backMultiplier;
+	public GameObject MultiplierGameObject;
+	public Image image;
+
+	private float Distancey = 1;
+	private float Distancex = 1;
 	public float Timey = 5;
 	public float Timex = 5;
 
-
-	public float Decay = 0.95f;
-
+	private float timeToFade;
 	public bool DoFade = false;
-
-
-	public GameObject MultiplierGameObject;
-	public TMP_Text Multiplier;
-	public TMP_Text backMultiplier;
-
-	public Image image;
-
 	public int CountInstance = 1;
-	public void SetUp(string InString)
+
+	public void SetUp(string InString, GameObject recipient)
 	{
-		CountInstance = 1;
+		transform.SetParent(recipient.transform);
+		var canvas = GetComponent<Canvas>();
+		transform.localScale = new Vector3(0.014f, 0.014f, 0);
+		//canvas.sortingLayerID = SortingLayer.NameToID("UI");
+		canvas.sortingLayerName = "UI";
 		MultiplierGameObject.SetActive(false);
-		LeanTween.cancel(this.gameObject);
-		this.rectTransform.localPosition = DefaultPosition;
 		Text.text = InString;
 		BackText.text = InString;
-		LeanTween.moveY(rectTransform, Distancey, Timey).setEaseInOutQuad();
-		LeanTween.moveX(rectTransform, Distancex, Timex).setEaseInOutQuad();
+		rectTransform.localPosition = Vector3.zero;
+		StartMoving();
 		DoFade = true;
-		this.gameObject.SetActive(true);
+		gameObject.SetActive(true);
 	}
 
-	public void AddCopy()
+	private void StartMoving()
 	{
+		LeanTween.moveY(rectTransform, Distancey, Timey).setEaseInOutQuad();
+		LeanTween.moveX(rectTransform, Distancex, Timex).setEaseInOutQuad();
+	}
+
+	public void AddMultiplier()
+	{
+		LeanTween.cancel(rectTransform);
+		rectTransform.localPosition = Vector3.zero;
+		RestoreAlpha();
+
 		MultiplierGameObject.SetActive(true);
 		CountInstance++;
 		var intxt = "X"+CountInstance;
 		Multiplier.text = intxt;
 		backMultiplier.text = intxt;
-		var flot = Text.alpha;
-		flot += 0.3f;
-		if (flot > 1)
-		{
-			Text.alpha = 1;
-		}
 
-		Text.alpha = flot;
-
-
+		StartMoving();
 	}
+
+
 
 	public void Update()
 	{
 		if (DoFade)
 		{
-			float CurrentAlpha = Text.alpha * Decay;
-			Text.alpha = CurrentAlpha;
-			BackText.alpha = CurrentAlpha;
-
-			var colo = image.color;
-			colo.a = CurrentAlpha + 0.2f;
-			image.color = colo;
-			Multiplier.alpha = CurrentAlpha + 0.2f;
-			backMultiplier.alpha = CurrentAlpha + 0.2f;
-
-			if (CurrentAlpha < 0.01)
+			timeToFade += Time.deltaTime;
+			if (timeToFade > 2)
 			{
-				LeanTween.cancel(this.gameObject);
-				DoFade = false;
-				Reset();
+				float CurrentAlpha = Text.alpha - 0.03f;
+				Text.alpha = CurrentAlpha;
+				BackText.alpha = CurrentAlpha;
+
+				var colo = image.color;
+				colo.a = CurrentAlpha + 0.2f;
+				image.color = colo;
+				Multiplier.alpha = CurrentAlpha + 0.2f;
+				backMultiplier.alpha = CurrentAlpha + 0.2f;
+
+				if (CurrentAlpha < 0.01)
+				{
+					Reset();
+				}
 			}
 		}
 	}
 
-	[NaughtyAttributes.Button()]
-	public void Reset()
+	private void RestoreAlpha()
 	{
+		timeToFade = 0;
 		Text.alpha = 1;
 		BackText.alpha = 1;
-		DoFade = false;
-		this.gameObject.SetActive(false);
-		this.rectTransform.SetPositionAndRotation(DefaultPosition, this.rectTransform.rotation);
-
 		var colo = image.color;
 		colo.a = 1;
 		image.color = colo;
 		Multiplier.alpha = 1;
 		backMultiplier.alpha = 1;
+	}
 
+	[NaughtyAttributes.Button()]
+	public void Reset()
+	{
+		CountInstance = 1;
+		LeanTween.cancel(rectTransform);
+		transform.SetParent(ChatBubbleManager.Instance.transform);
+		Text.text = "";
+		DoFade = false;
+		MultiplierGameObject.SetActive(false);
+		gameObject.SetActive(false);
+		rectTransform.SetPositionAndRotation(Vector3.zero, rectTransform.rotation);
+		RestoreAlpha();
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Core/ChatBubble/ChatBubbleManager.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/ChatBubble/ChatBubbleManager.cs
@@ -82,22 +82,16 @@ public class ChatBubbleManager : MonoBehaviour, IInitialise
 	/// Display a chat bubble and make it follow a transform target
 	/// </summary>
 	/// <param name="msg">Text to show in the Action</param>
-	public static void ShowAction(string msg)
+	public void ShowAction(string msg, GameObject recipient)
 	{
-
-		var index = Instance.actionPool.FindIndex(x => x.Text.text == msg);
+		var index = actionPool.FindIndex(x => x.Text.text == msg);
 
 		if (index != -1)
 		{
-			if (Instance.actionPool[index].gameObject.activeInHierarchy)
-			{
-				Instance.actionPool[index].AddCopy();
-				return;
-			}
+			actionPool[index].AddMultiplier();
+			return;
 		}
-
-
-		Instance.GetChatBubbleActionText().SetUp(msg);
+		GetChatBubbleActionText().SetUp(msg, recipient);
 	}
 
 
@@ -120,9 +114,7 @@ public class ChatBubbleManager : MonoBehaviour, IInitialise
 	ActionText SpawnNewActionText()
 	{
 		var obj = Instantiate(ActionPrefab, Vector3.zero, Quaternion.identity);
-		obj.transform.SetParent(transform,
-			false); // Suggestion by compiler, instead of obj.transform.parent = transform;
-		obj.transform.localScale = Vector3.one * 2f;
+		obj.transform.SetParent(transform, false);
 		obj.SetActive(false);
 		return obj.GetComponent<ActionText>();
 	}
@@ -149,7 +141,6 @@ public class ChatBubbleManager : MonoBehaviour, IInitialise
 		var obj = Instantiate(chatBubblePrefab, Vector3.zero, Quaternion.identity);
 		obj.transform.SetParent(transform,
 			false); // Suggestion by compiler, instead of obj.transform.parent = transform;
-		obj.transform.localScale = Vector3.one * 2f;
 		obj.SetActive(false);
 		return obj.GetComponent<ChatBubble>();
 	}


### PR DESCRIPTION
### Purpose
Fixes action text unintended behavior.
Action text will now restart completely when the same action arrives again.
Action text fade out will be way faster but trigger after two seconds.
Changes action text to be in world position canvas, being set under the player object.
Fixes action text regex not removing characters properly.
Remplaces all chatrelay invoke calls with more simple and straightforward ones.
Fixes #5795
Fixes #5643
