### PR TITLE
Fixes lockers having duplicate contents

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/EventManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/EventManager.cs
@@ -94,11 +94,17 @@ public class EventManager : MonoBehaviour
 	{
 		LogEventBroadcast(evnt);
 		if (eventTable.ContainsKey(evnt) == false || eventTable[evnt] == null) return;
-
-		eventTable[evnt]();
-		if (CustomNetworkManager.IsServer && network)
+		
+		if (CustomNetworkManager.IsServer)
 		{
-			TriggerEventMessage.SendToAll(evnt);
+			if (network)
+			{
+				TriggerEventMessage.SendToAll(evnt);
+			}
+			else
+			{
+				eventTable[evnt]();
+			}
 		}
 	}
 

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -694,7 +694,7 @@ public partial class GameManager : MonoBehaviour, IInitialise
 		Chat.AddGameWideSystemMsgToChat("<b>The round is now restarting...</b>");
 
 		//Notify all clients that the round has ended
-		TriggerEventMessage.SendToAll(EVENT.RoundEnded);
+		EventManager.Broadcast(EVENT.RoundEnded, true);
 
 		yield return WaitFor.Seconds(0.2f);
 


### PR DESCRIPTION
### Purpose
Fixes OnRoundStart being called twice, resulting in several issues, like lockers being populated twice.
Roundend event will now use the EventManager.
Fixes #5893

