### PR TITLE
Allow Xenos to become queens

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Facehugger.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Facehugger.prefab
@@ -70,7 +70,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -229502157
-  m_SortingLayer: 16
+  m_SortingLayer: 21
   m_SortingOrder: 11
   m_Sprite: {fileID: 21300016, guid: 4866054b12864074ca72678ebef13a7c, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -104,6 +104,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 62f9dd9c0e6eb4b47878239644a1972c, type: 2}
   - {fileID: 11400000, guid: c0c0bf326972dd842b22fd3f4621a256, type: 2}
   PresentSpriteSet: {fileID: 11400000, guid: 4aa643bb597b9cc4881cd70a3cdf8994, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -151,13 +152,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea79a12bc31d4df394067a2be447854d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BlueDamageMonitorIcon: {fileID: 0}
-  GreenDamageMonitorIcon: {fileID: 0}
-  YellowDamageMonitorIcon: {fileID: 0}
-  OrangeDamageMonitorIcon: {fileID: 0}
-  DarkOrangeDamageMonitorIcon: {fileID: 0}
-  RedDamageMonitorIcon: {fileID: 0}
-  GrayDamageMonitorIcon: {fileID: 0}
   MaxDamage: 25
   Type: 1
   isBleeding: 0
@@ -217,13 +211,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea79a12bc31d4df394067a2be447854d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BlueDamageMonitorIcon: {fileID: 0}
-  GreenDamageMonitorIcon: {fileID: 0}
-  YellowDamageMonitorIcon: {fileID: 0}
-  OrangeDamageMonitorIcon: {fileID: 0}
-  DarkOrangeDamageMonitorIcon: {fileID: 0}
-  RedDamageMonitorIcon: {fileID: 0}
-  GrayDamageMonitorIcon: {fileID: 0}
   MaxDamage: 25
   Type: 0
   isBleeding: 0
@@ -396,7 +383,13 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   floorDecal: {fileID: 0}
   isInitiallyNotPushable: 0
-  pushPullSound: 
+  pushPullSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1
@@ -421,6 +414,7 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  ReachableThrough: 1
   passableExclusionsToThis: []
 --- !u!114 &4859363408336224435
 MonoBehaviour:
@@ -452,7 +446,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &4859213822428636291
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -585,10 +585,19 @@ MonoBehaviour:
   performingAction: 0
   activated: 0
   tickRate: 1
+  EatFoodA:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  CB_REAGENT: {fileID: 0}
   target: 0
   actionPerformTime: 0
   hasFoodPrefereces: 0
   foodPreferences: []
+  IsEmagged: 0
 --- !u!114 &2052235574987344614
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -634,11 +643,28 @@ MonoBehaviour:
   mobName: Facehugger
   knockedDownRotation: 90
   deathSounds:
-  - Facehugger
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Facehugger.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   randomSound:
-  - Facehugger
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Facehugger.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   playRandomSoundTimer: 3
   randomSoundProbability: 20
+  bite:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Facehugger.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   searchTickRate: 0.5
   currentStatus: 0
   maskObject: {fileID: 8320299039891337921, guid: 6fecf534029349145b17735e15c9498c,

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Xenomorph.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Xenomorph.prefab
@@ -70,7 +70,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -229502157
-  m_SortingLayer: 16
+  m_SortingLayer: 21
   m_SortingOrder: 11
   m_Sprite: {fileID: 21300000, guid: 27136b33862b18d4ba78141b64b98d1f, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -100,6 +100,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 168b86a8105cfe24e9d8e8355fc1630b, type: 2}
   - {fileID: 11400000, guid: 89bf18cf883b5694787c1667470999e3, type: 2}
   PresentSpriteSet: {fileID: 11400000, guid: 168b86a8105cfe24e9d8e8355fc1630b, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -147,13 +148,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea79a12bc31d4df394067a2be447854d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BlueDamageMonitorIcon: {fileID: 0}
-  GreenDamageMonitorIcon: {fileID: 0}
-  YellowDamageMonitorIcon: {fileID: 0}
-  OrangeDamageMonitorIcon: {fileID: 0}
-  DarkOrangeDamageMonitorIcon: {fileID: 0}
-  RedDamageMonitorIcon: {fileID: 0}
-  GrayDamageMonitorIcon: {fileID: 0}
   MaxDamage: 200
   Type: 1
   isBleeding: 0
@@ -213,13 +207,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea79a12bc31d4df394067a2be447854d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BlueDamageMonitorIcon: {fileID: 0}
-  GreenDamageMonitorIcon: {fileID: 0}
-  YellowDamageMonitorIcon: {fileID: 0}
-  OrangeDamageMonitorIcon: {fileID: 0}
-  DarkOrangeDamageMonitorIcon: {fileID: 0}
-  RedDamageMonitorIcon: {fileID: 0}
-  GrayDamageMonitorIcon: {fileID: 0}
   MaxDamage: 200
   Type: 0
   isBleeding: 0
@@ -292,10 +279,10 @@ GameObject:
   - component: {fileID: 3493423571535560689}
   - component: {fileID: 3651291330810827203}
   - component: {fileID: 3708589072684735304}
-  - component: {fileID: 8135233970803992685}
   - component: {fileID: -6344764635065190701}
   - component: {fileID: -9007657092435569662}
   - component: {fileID: -1428658440444101596}
+  - component: {fileID: 4330355114301591593}
   m_Layer: 12
   m_Name: NPC_Xenomorph
   m_TagString: Untagged
@@ -395,7 +382,13 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   floorDecal: {fileID: 0}
   isInitiallyNotPushable: 0
-  pushPullSound: 
+  pushPullSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1
@@ -420,6 +413,7 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  ReachableThrough: 1
   passableExclusionsToThis: []
 --- !u!114 &4859363408336224435
 MonoBehaviour:
@@ -451,7 +445,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &4859213822428636291
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -583,10 +583,19 @@ MonoBehaviour:
   performingAction: 0
   activated: 0
   tickRate: 1
+  EatFoodA:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  CB_REAGENT: {fileID: 0}
   target: 0
   actionPerformTime: 0
   hasFoodPrefereces: 0
   foodPreferences: []
+  IsEmagged: 0
 --- !u!114 &3708589072684735304
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -615,32 +624,17 @@ MonoBehaviour:
   spriteHolder: {fileID: 3392343644113499114}
   targetOtherPlayersWhoGetInWay: 1
   onlyHitTarget: 0
+  attackSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   hitDamage: 15
   attackVerb: slashed
   defaultTarget: 0
   meleeCoolDown: 0.4
---- !u!114 &8135233970803992685
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4827737755655954553}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 243a3c078e195af4dadbc9f673627997, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  mobName: Xenomorph
-  knockedDownRotation: -90
-  deathSounds:
-  - xenodie
-  randomSound:
-  - Hiss#
-  playRandomSoundTimer: 3
-  randomSoundProbability: 20
-  searchTickRate: 0.5
-  currentStatus: 0
 --- !u!114 &-6344764635065190701
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -692,3 +686,62 @@ MonoBehaviour:
   indexLeft: 3
   spriteHandlers:
   - {fileID: 1984430505557485568}
+--- !u!114 &4330355114301591593
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4827737755655954553}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ab0b22d0dd164c31bcc4746cd3300663, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mobName: Xenomorph
+  knockedDownRotation: -90
+  deathSounds:
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Xenodie.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  randomSounds:
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Hiss1.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Hiss2.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Hiss3.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Hiss4.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Hiss5.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  playRandomSoundTimer: 3
+  randomSoundProbability: 20
+  searchTickRate: 0.5
+  currentStatus: 0
+  queenCap: 1
+  queenPrefab: {fileID: 4827737755655954553, guid: 0ba932c09bd6f294384e8a4b9cef2160,
+    type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Xenomorph_Queen.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Mobs/NPC/Resources/Hostile/Xenomorph/NPC_Xenomorph_Queen.prefab
@@ -69,7 +69,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -229502157
-  m_SortingLayer: 16
+  m_SortingLayer: 21
   m_SortingOrder: 11
   m_Sprite: {fileID: -7221481357887369191, guid: 1a2abb432b2c73c4190f5ec4472f922e,
     type: 3}
@@ -126,13 +126,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea79a12bc31d4df394067a2be447854d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BlueDamageMonitorIcon: {fileID: 0}
-  GreenDamageMonitorIcon: {fileID: 0}
-  YellowDamageMonitorIcon: {fileID: 0}
-  OrangeDamageMonitorIcon: {fileID: 0}
-  DarkOrangeDamageMonitorIcon: {fileID: 0}
-  RedDamageMonitorIcon: {fileID: 0}
-  GrayDamageMonitorIcon: {fileID: 0}
   MaxDamage: 200
   Type: 1
   isBleeding: 0
@@ -192,13 +185,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea79a12bc31d4df394067a2be447854d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BlueDamageMonitorIcon: {fileID: 0}
-  GreenDamageMonitorIcon: {fileID: 0}
-  YellowDamageMonitorIcon: {fileID: 0}
-  OrangeDamageMonitorIcon: {fileID: 0}
-  DarkOrangeDamageMonitorIcon: {fileID: 0}
-  RedDamageMonitorIcon: {fileID: 0}
-  GrayDamageMonitorIcon: {fileID: 0}
   MaxDamage: 200
   Type: 0
   isBleeding: 0
@@ -377,7 +363,13 @@ MonoBehaviour:
   registerTile: {fileID: 0}
   floorDecal: {fileID: 0}
   isInitiallyNotPushable: 0
-  pushPullSound: 
+  pushPullSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   soundDelayTime: 0
   soundMinimumPitchVariance: 1
   soundMaximumPitchVariance: 1
@@ -402,6 +394,8 @@ MonoBehaviour:
   objectType: 1
   AtmosPassable: 1
   Passable: 0
+  ReachableThrough: 1
+  passableExclusionsToThis: []
 --- !u!114 &4859363408336224435
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -432,7 +426,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isMeleeable: 1
   butcherTime: 2
-  butcherSound: BladeSlice
+  butcherSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!114 &4859213822428636291
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -564,10 +564,19 @@ MonoBehaviour:
   performingAction: 0
   activated: 0
   tickRate: 1
+  EatFoodA:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  CB_REAGENT: {fileID: 0}
   target: 0
   actionPerformTime: 0
   hasFoodPrefereces: 0
   foodPreferences: []
+  IsEmagged: 0
 --- !u!114 &3708589072684735304
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -596,6 +605,13 @@ MonoBehaviour:
   spriteHolder: {fileID: 3392343644113499114}
   targetOtherPlayersWhoGetInWay: 1
   onlyHitTarget: 0
+  attackSound:
+    SetLoadSetting: 0
+    AssetAddress: 
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   hitDamage: 30
   attackVerb: slashed
   defaultTarget: 0
@@ -615,14 +631,48 @@ MonoBehaviour:
   mobName: Xenomorph
   knockedDownRotation: 90
   deathSounds:
-  - xenodie
-  randomSound:
-  - Hiss#
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Xenodie.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  randomSounds:
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Hiss1.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Hiss2.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Hiss3.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Hiss4.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  - SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/Hiss5.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
   playRandomSoundTimer: 3
   randomSoundProbability: 20
   searchTickRate: 0.5
   currentStatus: 0
-  huggerCap: 8
+  huggerCap: 20
   fertility: 50
   eggCooldown: 300
   alienEgg: {fileID: 5322418909914265045, guid: 9473c17e4e7f2f24d99f2d788030cd9f,

--- a/UnityProject/Assets/Resources/Prefabs/Objects/Alien/Alien Egg.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Objects/Alien/Alien Egg.prefab
@@ -1,22 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &7489533636973299563
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5322418909914265045}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 26ab0df8c17d54941b636a01aea0820b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  incubationTime: 300
-  initialState: 0
-  freezeCycle: 0
-  facehugger: {fileID: 4827737755655954553, guid: 89d417cb15d3feb4890b78355113e696,
-    type: 3}
 --- !u!114 &6004374242838787409
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -37,10 +20,35 @@ MonoBehaviour:
   - {fileID: 11400000, guid: c77d5b5b117de6a43bad018a8af80679, type: 2}
   - {fileID: 11400000, guid: 63d19d4a29255f64886cbcefa226b5c3, type: 2}
   PresentSpriteSet: {fileID: 11400000, guid: 1daa6d09df1808849b81a9186b5221c1, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
   Sprites: []
+--- !u!114 &7489533636973299563
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5322418909914265045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26ab0df8c17d54941b636a01aea0820b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  squishSFX:
+    SetLoadSetting: 0
+    AssetAddress: Assets/Prefabs/NPC/squish.prefab
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
+  incubationTime: 300
+  initialState: 0
+  freezeCycle: 0
+  facehugger: {fileID: 4827737755655954553, guid: 89d417cb15d3feb4890b78355113e696,
+    type: 3}
 --- !u!1001 &8331399007563543452
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -54,10 +62,20 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 4bdd2f1597cd59046a13d3e6c6f5f502,
         type: 3}
+    - target: {fileID: 4116897424394887774, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4197940402254186057, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
       propertyPath: m_Name
       value: Alien Egg
+      objectReference: {fileID: 0}
+    - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
@@ -76,6 +94,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -88,16 +111,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4204006106222477459, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
@@ -116,12 +129,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4732959556644653524, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
-      propertyPath: Resistances.AcidProof
-      value: 1
+      propertyPath: Armor.Fire
+      value: -50
       objectReference: {fileID: 0}
     - target: {fileID: 4732959556644653524, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
-      propertyPath: Resistances.UnAcidable
+      propertyPath: Resistances.AcidProof
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4732959556644653524, guid: ebb08cf966efc084aa918bd8d9429604,
@@ -131,13 +144,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4732959556644653524, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
-      propertyPath: Resistances.FreezeProof
+      propertyPath: Resistances.UnAcidable
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4732959556644653524, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}
-      propertyPath: Armor.Fire
-      value: -50
+      propertyPath: Resistances.FreezeProof
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5737521361753715499, guid: ebb08cf966efc084aa918bd8d9429604,
         type: 3}

--- a/UnityProject/Assets/Scripts/Managers/SoundManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/SoundManager.cs
@@ -726,7 +726,7 @@ public class SoundManager : MonoBehaviour
 	/// <summary>
 	/// Play sound locally at given world position.
 	/// </summary>
-	/// <param name="addressableAudioSources">Sound to be played.</param>
+	/// <param name="addressableAudioSource">Sound to be played.</param>
 	/// <param name="soundSpawnToken">The SoundSpawn Token that identifies the same sound spawn instance across server and clients</returns>
 	public static async Task PlayAtPosition(AddressableAudioSource addressableAudioSource, Vector3 worldPos,
 		GameObject gameObject = null, string soundSpawnToken = "", bool polyphonic = false,
@@ -745,7 +745,7 @@ public class SoundManager : MonoBehaviour
 		}
 
 
-		PlayAtPosition(new List<AddressableAudioSource>() {addressableAudioSource}, soundSpawnToken, worldPos,
+		_ = PlayAtPosition(new List<AddressableAudioSource>() {addressableAudioSource}, soundSpawnToken, worldPos,
 			polyphonic, isGlobal, netId, audioSourceParameters);
 	}
 

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
@@ -12,6 +12,10 @@ namespace Systems.MobAIs
 {
 	public class FaceHuggerAI : MobAI, ICheckedInteractable<HandApply>, IServerSpawn
 	{
+		[SerializeField]
+		[Tooltip("If true, this hugger won't be counted for the cap Queens use for lying eggs.")]
+		private bool ignoreInQueenCount = false;
+
 		[SerializeField] private List<AddressableAudioSource> deathSounds = default;
 
 		[SerializeField] private List<AddressableAudioSource> randomSound = default;
@@ -199,7 +203,11 @@ namespace Systems.MobAIs
 				transform.position,
 				Random.Range(0.9f, 1.1f),
 				sourceObj: gameObject);
-			XenoQueenAI.RemoveFacehuggerFromCount();
+
+			if (ignoreInQueenCount == false)
+			{
+				XenoQueenAI.RemoveFacehuggerFromCount();
+			}
 		}
 
 		/// <summary>
@@ -275,18 +283,19 @@ namespace Systems.MobAIs
 				}
 			}
 
-			if (damagedBy != mobMeleeAction.followTarget)
+			if (damagedBy.transform == mobMeleeAction.followTarget)
 			{
-				//80% chance the mob decides to attack the new attacker
-				if (Random.value < 0.8f)
-				{
-					var playerScript = damagedBy.GetComponent<PlayerScript>();
-					if (playerScript != null)
-					{
-						BeginAttack(damagedBy);
-						return;
-					}
-				}
+				return;
+			}
+			//80% chance the mob decides to attack the new attacker
+			if (Random.value > 0.8f)
+			{
+				return;
+			}
+			var playerScript = damagedBy.GetComponent<PlayerScript>();
+			if (playerScript != null)
+			{
+				BeginAttack(damagedBy);
 			}
 		}
 
@@ -435,7 +444,11 @@ namespace Systems.MobAIs
 
 		public void OnSpawnServer(SpawnInfo info)
 		{
-			XenoQueenAI.AddFacehuggerToCount();
+			if (ignoreInQueenCount == false)
+			{
+				XenoQueenAI.AddFacehuggerToCount();
+			}
+
 			mobSprite.SetToNPCLayer();
 			registerObject.RestoreAllToDefault();
 			simpleAnimal.SetDeadState(false);

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/FaceHuggerAI.cs
@@ -6,21 +6,29 @@ using Doors;
 using Systems.Mob;
 using Random = UnityEngine.Random;
 using AddressableReferences;
+using UnityEngine.Serialization;
 
 namespace Systems.MobAIs
 {
 	public class FaceHuggerAI : MobAI, ICheckedInteractable<HandApply>, IServerSpawn
 	{
-		[SerializeField] private List<string> deathSounds = new List<string>();
-		[SerializeField] private List<string> randomSound = new List<string>();
-		[Tooltip("Amount of time to wait between each random sound. Decreasing this value could affect performance!")]
+		[SerializeField] private List<AddressableAudioSource> deathSounds = default;
+
+		[SerializeField] private List<AddressableAudioSource> randomSound = default;
+
 		[SerializeField]
+		[Tooltip("Amount of time to wait between each random sound. Decreasing this value could affect performance!")]
 		private int playRandomSoundTimer = 3;
+
 		[SerializeField]
 		[Range(0,100)]
 		private int randomSoundProbability = 20;
-		[SerializeField] private AddressableAudioSource Bite = null;
+
+		[FormerlySerializedAs("Bite")] [SerializeField]
+		private AddressableAudioSource bite = null;
+
 		[SerializeField] private float searchTickRate = 0.5f;
+
 		private float movementTickRate = 1f;
 		private float moveWaitTime = 0f;
 		private float searchWaitTime = 0f;
@@ -191,7 +199,7 @@ namespace Systems.MobAIs
 				transform.position,
 				Random.Range(0.9f, 1.1f),
 				sourceObj: gameObject);
-			XenoQueenAI.CurrentHuggerAmt -= 1;
+			XenoQueenAI.RemoveFacehuggerFromCount();
 		}
 
 		/// <summary>
@@ -333,7 +341,7 @@ namespace Systems.MobAIs
 				verb);
 
 			SoundManager.PlayNetworkedAtPos(
-				Bite,
+				bite,
 				player.gameObject.RegisterTile().WorldPositionServer,
 				1f,
 				true,
@@ -427,13 +435,7 @@ namespace Systems.MobAIs
 
 		public void OnSpawnServer(SpawnInfo info)
 		{
-			//FIXME This shouldn't be called by client yet it seems it is
-			if (!isServer)
-			{
-				return;
-			}
-
-			XenoQueenAI.CurrentHuggerAmt++;
+			XenoQueenAI.AddFacehuggerToCount();
 			mobSprite.SetToNPCLayer();
 			registerObject.RestoreAllToDefault();
 			simpleAnimal.SetDeadState(false);

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
@@ -18,9 +18,13 @@ namespace Systems.MobAIs
 	public class GenericHostileAI : MobAI, IServerSpawn
 	{
 		[SerializeField]
-		protected List<string> deathSounds = new List<string>();
+		[Tooltip("Sounds played when this mob dies")]
+		protected List<AddressableAudioSource> deathSounds = default;
+
 		[SerializeField]
-		protected List<string> randomSound = new List<string>();
+		[Tooltip("Sounds played randomly while this mob is alive")]
+		protected List<AddressableAudioSource> randomSounds = default;
+
 		[Tooltip("Amount of time to wait between each random sound. Decreasing this value could affect performance!")]
 		[SerializeField]
 		protected int playRandomSoundTimer = 3;
@@ -162,7 +166,7 @@ namespace Systems.MobAIs
 
 		protected virtual void PlayRandomSound(bool force = false)
 		{
-			if (IsDead || IsUnconscious || randomSound.Count <= 0)
+			if (IsDead || IsUnconscious || randomSounds.Count <= 0)
 			{
 				return;
 			}
@@ -173,7 +177,7 @@ namespace Systems.MobAIs
 			}
 
 			SoundManager.PlayNetworkedAtPos(
-				randomSound.PickRandom(),
+				randomSounds,
 				transform.position,
 				Random.Range(0.9f, 1.1f),
 				sourceObj: gameObject);
@@ -190,7 +194,7 @@ namespace Systems.MobAIs
 			ResetBehaviours();
 			deathSoundPlayed = true;
 			SoundManager.PlayNetworkedAtPos(
-				deathSounds.PickRandom(),
+				deathSounds,
 				transform.position,
 				Random.Range(0.9f, 1.1f),
 				sourceObj: gameObject);

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/GenericHostileAI.cs
@@ -107,6 +107,7 @@ namespace Systems.MobAIs
 		protected virtual GameObject SearchForTarget()
 		{
 			var player = Physics2D.OverlapCircleAll(transform.position, 20f, hitMask);
+
 			//var hits = coneOfSight.GetObjectsInSight(hitMask, LayerTypeSelection.Walls, dirSprites.CurrentFacingDirection, 10f, 20);
 			if (player.Length == 0)
 			{
@@ -115,7 +116,10 @@ namespace Systems.MobAIs
 
 			foreach (var coll in player)
 			{
-				if (MatrixManager.Linecast(this.gameObject.WorldPosServer(), LayerTypeSelection.Walls, LayerMask.NameToLayer(""),
+				if (MatrixManager.Linecast(
+					gameObject.WorldPosServer(),
+					LayerTypeSelection.Walls,
+					LayerMask.NameToLayer(""),
 					coll.gameObject.WorldPosServer()).ItHit)
 				{
 					return coll.gameObject;
@@ -148,15 +152,13 @@ namespace Systems.MobAIs
 						nudgeDir = testDir;
 						break;
 					}
-					else
+
+					if (!registerObject.Matrix.GetFirst<DoorController>(checkTile, true))
 					{
-						if (!registerObject.Matrix.GetFirst<DoorController>(checkTile, true))
-						{
-							continue;
-						}
-						nudgeDir = testDir;
-						break;
+						continue;
 					}
+					nudgeDir = testDir;
+					break;
 				}
 			}
 
@@ -275,19 +277,23 @@ namespace Systems.MobAIs
 				}
 			}
 
-			if (damagedBy != mobMeleeAttack.followTarget)
+			if (damagedBy == null || damagedBy.transform == mobMeleeAttack.followTarget)
 			{
-				//80% chance the mob decides to attack the new attacker
-				if (Random.value < 0.8f)
-				{
-					var playerScript = damagedBy.GetComponent<PlayerScript>();
-					if (playerScript != null)
-					{
-						BeginAttack(damagedBy);
-						return;
-					}
-				}
+				return;
 			}
+
+			//80% chance the mob decides to attack the new attacker
+			if (Random.value > 0.8f)
+			{
+				return;
+			}
+			var playerScript = damagedBy.GetComponent<PlayerScript>();
+			if (playerScript == null)
+			{
+				return;
+			}
+
+			BeginAttack(damagedBy);
 		}
 
 		public override void LocalChatReceived(ChatEvent chatEvent)

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoAI.cs
@@ -1,22 +1,28 @@
 ﻿using System.Collections;
+using NaughtyAttributes;
 using UnityEngine;
 
 namespace Systems.MobAIs
 {
 	public class XenoAI: GenericHostileAI
 	{
+		[SerializeField][Tooltip("If true, this Xeno won't ever attempt to become Queen.")]
+		private bool disableAscension = false;
+
 		[SerializeField]
+		[HideIf(nameof(disableAscension))]
 		[Tooltip("How many queens could there be at once in a round. " +
 		         "If this cap is not reached, this Xeno could become a Queen to preserve the perfect life form!")]
 		private int queenCap = 1;
 
 		[SerializeField]
+		[HideIf(nameof(disableAscension))]
 		[Tooltip("Reference to the Queen prefab to be spawned if this xeno becomes a Queen")]
 		private GameObject queenPrefab = default;
 
 		private void TryBecomingQueen()
 		{
-			if (QueenCapReached())
+			if (disableAscension || QueenCapReached())
 			{
 				return;
 			}
@@ -24,7 +30,7 @@ namespace Systems.MobAIs
 			StartCoroutine(BecomeQueen());
 		}
 
-		IEnumerator BecomeQueen()
+		private IEnumerator BecomeQueen()
 		{
 			yield return WaitFor.Seconds(10);
 			if (QueenCapReached()) yield break;

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoAI.cs
@@ -1,0 +1,43 @@
+﻿using UnityEngine;
+
+namespace Systems.MobAIs
+{
+	public class XenoAI: GenericHostileAI
+	{
+		[SerializeField]
+		[Tooltip("How many queens could there be at once in a round. " +
+		         "If this cap is not reached, this Xeno could become a Queen to preserve the perfect life form!")]
+		private int queenCap = 1;
+
+		[SerializeField]
+		[Tooltip("Reference to the Queen prefab to be spawned if this xeno becomes a Queen")]
+		private GameObject queenPrefab = default;
+
+		private void TryBecomingQueen()
+		{
+			if (QueenCapReached())
+			{
+				return;
+			}
+
+			Spawn.ServerPrefab(queenPrefab, gameObject.AssumedWorldPosServer());
+			Despawn.ServerSingle(gameObject);
+		}
+
+		private bool QueenCapReached()
+		{
+			if (queenCap < 0)
+			{
+				return false;
+			}
+
+			return XenoQueenAI.CurrentQueensAmt >= queenCap;
+		}
+
+		protected override void OnSpawnMob()
+		{
+			base.OnSpawnMob();
+			TryBecomingQueen();
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoAI.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections;
+using UnityEngine;
 
 namespace Systems.MobAIs
 {
@@ -20,6 +21,13 @@ namespace Systems.MobAIs
 				return;
 			}
 
+			StartCoroutine(BecomeQueen());
+		}
+
+		IEnumerator BecomeQueen()
+		{
+			yield return WaitFor.Seconds(10);
+			if (QueenCapReached()) yield break;
 			Spawn.ServerPrefab(queenPrefab, gameObject.AssumedWorldPosServer());
 			Despawn.ServerSingle(gameObject);
 		}

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoAI.cs.meta
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoAI.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ab0b22d0dd164c31bcc4746cd3300663
+timeCreated: 1611799987

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoQueenAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoQueenAI.cs
@@ -6,33 +6,32 @@ namespace Systems.MobAIs
 {
 	public class XenoQueenAI: GenericHostileAI
 	{
-		[Tooltip("Max amount of active facehuggers that can be in the server at once")][SerializeField]
+		[SerializeField]
+		[Tooltip("Max amount of active facehuggers that can be in the server at once")]
 		private int huggerCap = 0;
 
-		[Tooltip("Chances of laying an egg. This gets rolled every time the Queen has no cd")]
 		[SerializeField]
 		[Range(0, 100)]
+		[Tooltip("Chances of laying an egg. This gets rolled every time the Queen has no cd")]
 		private int fertility = 30;
 
-		[Tooltip("Time in seconds between each roll for laying eggs")] [SerializeField]
+		[SerializeField]
+		[Tooltip("Time in seconds between each roll for laying eggs")]
 		private float eggCooldown = 400;
 
-		[Tooltip("Alien egg reference so we can spawn")][SerializeField]
+		[SerializeField]
+		[Tooltip("Alien egg reference so we can spawn")]
 		private GameObject alienEgg = null;
 
 		private static int currentHuggerAmt;
+		private static int currentQueensAmt;
 		private static bool resetHandlerAdded = false;
 
-		public static int CurrentHuggerAmt
-		{
-			get => currentHuggerAmt;
-			set => currentHuggerAmt = value;
-		}
+		public static int CurrentQueensAmt => currentQueensAmt;
 
-
-		private bool CapReached()
+		private bool HuggerCapReached()
 		{
-			if (currentHuggerAmt < 0)
+			if (huggerCap < 0)
 			{
 				return false;
 			}
@@ -42,7 +41,7 @@ namespace Systems.MobAIs
 
 		private void FertilityLoop()
 		{
-			if (CapReached())
+			if (HuggerCapReached())
 			{
 				StartCoroutine(Cooldown());
 				return;
@@ -62,14 +61,25 @@ namespace Systems.MobAIs
 			FertilityLoop();
 		}
 
+		public static void AddFacehuggerToCount()
+		{
+			currentHuggerAmt ++;
+		}
+
+		public static void RemoveFacehuggerFromCount()
+		{
+			currentHuggerAmt --;
+		}
+
 		private void LayEgg()
 		{
 			Spawn.ServerPrefab(alienEgg, gameObject.transform.position);
 		}
 
-		private static void ResetHuggerAmount()
+		private static void ResetStaticCounters()
 		{
 			currentHuggerAmt = 0;
+			currentQueensAmt = 0;
 		}
 
 		private static void AddResetHandler()
@@ -79,7 +89,7 @@ namespace Systems.MobAIs
 				return;
 			}
 
-			EventManager.AddHandler(EVENT.RoundStarted, ResetHuggerAmount);
+			EventManager.AddHandler(EVENT.RoundStarted, ResetStaticCounters);
 			resetHandlerAdded = true;
 		}
 
@@ -94,6 +104,13 @@ namespace Systems.MobAIs
 			}
 
 			BeginSearch();
+			currentQueensAmt ++;
+		}
+
+		protected override void HandleDeathOrUnconscious()
+		{
+			base.HandleDeathOrUnconscious();
+			currentQueensAmt--;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoQueenAI.cs
+++ b/UnityProject/Assets/Scripts/NPC/AI/Hostile/XenoQueenAI.cs
@@ -6,6 +6,8 @@ namespace Systems.MobAIs
 {
 	public class XenoQueenAI: GenericHostileAI
 	{
+		[SerializeField][Tooltip("If true, this Queen won't be counted when spawned for the queen cap.")]
+		private bool ignoreForQueenCount = false;
 		[SerializeField]
 		[Tooltip("Max amount of active facehuggers that can be in the server at once")]
 		private int huggerCap = 0;
@@ -104,13 +106,20 @@ namespace Systems.MobAIs
 			}
 
 			BeginSearch();
-			currentQueensAmt ++;
+
+			if (ignoreForQueenCount == false)
+			{
+				currentQueensAmt ++;
+			}
 		}
 
 		protected override void HandleDeathOrUnconscious()
 		{
 			base.HandleDeathOrUnconscious();
-			currentQueensAmt--;
+			if (ignoreForQueenCount == false)
+			{
+				currentQueensAmt--;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Purpose
This expands the xeno lifecycle in an attempt to preserve the perfect life form. Once spawned, xenos will check the amount of queens in the current round and in case the set cap (defaults to 1) isn't reached, they will try to become a queen themselves.

### Notes:
Minor changes:
- Converted death and random hostile sounds to Addressables, I set the Xeno sounds, the rest need setting.
- Might have fixed Queens not laying eggs.
- Increased the hugger cap for queens to 20 (it was 8). They weren't laying eggs because the huggers in caverna were enough to reach the cap.

CL: Xenomorphs can become Queens now if there are no Queens in the round.
CL: Fixed Queens not laying eggs.