### PR TITLE
ToggleMHelp was missing KeybindMetadata

### DIFF
--- a/UnityProject/Assets/Scripts/Core/Input System/KeybindManager.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/KeybindManager.cs
@@ -342,6 +342,7 @@ public class KeybindManager : MonoBehaviour {
 		{ KeyAction.ChatRadio,   new KeybindMetadata("Radio Chat", ActionType.Chat)},
 		{ KeyAction.ChatOOC,     new KeybindMetadata("OOC Chat", ActionType.Chat)},
 		{ KeyAction.ToggleAHelp, new KeybindMetadata("Toggle AHelp", ActionType.Chat)},
+		{ KeyAction.ToggleMHelp, new KeybindMetadata("Toggle MHelp", ActionType.Chat)},
 
 		// Body part selection
 		{ KeyAction.TargetHead, 	new KeybindMetadata("Target Head, Eyes and Mouth", ActionType.Targeting)},


### PR DESCRIPTION
Options were not displaying properly. A default keybind for ToggleMHelp was added without the backing metadata.
