### PR TITLE
Startup time improvement: AtmosSystem server only

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosSystem.cs
@@ -8,6 +8,9 @@ namespace Systems.Atmospherics
 
 		public override void Initialize()
 		{
+			if (!CustomNetworkManager.IsServer)
+				return;
+
 			BoundsInt bounds = metaTileMap.GetBounds();
 
 			foreach (Vector3Int position in bounds.allPositionsWithin)


### PR DESCRIPTION
### Purpose
AtmosSystem will now only initialize on the server, improving startup loading time on clients.
