### PR TITLE
Startup time improvement: MetaDataNode server only

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/UnderFloorLayer.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Layers/UnderFloorLayer.cs
@@ -14,40 +14,37 @@ public class UnderFloorLayer : Layer
 
 	public void InitialiseUnderFloorUtilities()
 	{
-		if (CustomNetworkManager.Instance._isServer)
+		BoundsInt bounds = Tilemap.cellBounds;
+
+		for (int n = bounds.xMin; n < bounds.xMax; n++)
 		{
-			BoundsInt bounds = Tilemap.cellBounds;
-
-			for (int n = bounds.xMin; n < bounds.xMax; n++)
+			for (int p = bounds.yMin; p < bounds.yMax; p++)
 			{
-				for (int p = bounds.yMin; p < bounds.yMax; p++)
+				Vector3Int localPlace = (new Vector3Int(n, p, 0));
+
+				for (int i = 0; i < 50; i++)
 				{
-					Vector3Int localPlace = (new Vector3Int(n, p, 0));
-
-					for (int i = 0; i < 50; i++)
+					localPlace.z = -i + 1;
+					var getTile = tilemap.GetTile(localPlace) as LayerTile;
+					if (getTile != null)
 					{
-						localPlace.z = -i + 1;
-						var getTile = tilemap.GetTile(localPlace) as LayerTile;
-						if (getTile != null)
+						if (!TileStore.ContainsKey((Vector2Int) localPlace))
 						{
-							if (!TileStore.ContainsKey((Vector2Int) localPlace))
-							{
-								TileStore.Add((Vector2Int) localPlace, new List<LayerTile>());
-							}
+							TileStore.Add((Vector2Int) localPlace, new List<LayerTile>());
+						}
 
-							TileStore[(Vector2Int) localPlace].Add(getTile);
+						TileStore[(Vector2Int) localPlace].Add(getTile);
 
-							var electricalCableTile = getTile as ElectricalCableTile;
-							if (electricalCableTile != null)
-							{
-								matrix.AddElectricalNode(new Vector3Int(n, p, localPlace.z), electricalCableTile);
-							}
+						var electricalCableTile = getTile as ElectricalCableTile;
+						if (electricalCableTile != null)
+						{
+							matrix.AddElectricalNode(new Vector3Int(n, p, localPlace.z), electricalCableTile);
+						}
 
-							var PipeTile = getTile as PipeTile;
-							if (PipeTile != null)
-							{
-								PipeTile.InitialiseNode(new Vector3Int(n, p, localPlace.z), matrix);
-							}
+						var PipeTile = getTile as PipeTile;
+						if (PipeTile != null)
+						{
+							PipeTile.InitialiseNode(new Vector3Int(n, p, localPlace.z), matrix);
 						}
 					}
 				}

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -55,6 +55,9 @@ public class MetaDataSystem : SubsystemBehaviour
 
 	public override void Initialize()
 	{
+		if (!CustomNetworkManager.IsServer)
+			return;
+
 		Stopwatch sw = new Stopwatch();
 		sw.Start();
 


### PR DESCRIPTION
### Purpose
Metadata nodes will now have their neighbors and types set up on the server only, as the client does not use them, increasing startup time.

