### PR TITLE
finish ancient engineer first implementation

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/GhostRoleManager.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/NestedManagers/GhostRoleManager.prefab
@@ -44,3 +44,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ghostRoleList: {fileID: 11400000, guid: f2feab502b816a543b8bf6c81c8011a8, type: 2}
+  alwaysAvailableRoles:
+  - {fileID: 11400000, guid: 7fbf96e6e42920b47b8eedec97e8b4ce, type: 2}

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/SpawnPoints/SpawnPoint - AncientEngineering.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/SpawnPoints/SpawnPoint - AncientEngineering.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8765955179460633041
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8415436589546646139, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: category
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 8455254186339684859, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint - AncientEngineering
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457519270650750959, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457519270650750959, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457519270650750959, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457519270650750959, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457519270650750959, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457519270650750959, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457519270650750959, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457519270650750959, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457519270650750959, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457519270650750959, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457519270650750959, guid: 215773c88893e8140a4481bf7524e1ac,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 215773c88893e8140a4481bf7524e1ac, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/SceneConstruction/SpawnPoints/SpawnPoint - AncientEngineering.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/SceneConstruction/SpawnPoints/SpawnPoint - AncientEngineering.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 13a96d5c007d8e84c9853fda470c1c7c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/SubScenes/AdditionalSceneList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/SubScenes/AdditionalSceneList.asset
@@ -14,6 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AdditionalScenes:
   - LavaLand
+  - AncientStation
   defaultCentComScenes:
   - CentCom
   CentComScenes:

--- a/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/GhostRoleList.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/GhostRoleList.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 46345f6d85b0c4845a2ab22c70741014, type: 2}
   - {fileID: 11400000, guid: af2384fe291fd1e469745e1438edc9e4, type: 2}
   - {fileID: 11400000, guid: e0bcf33d6a9ef0443960a18ba45b742e, type: 2}
+  - {fileID: 11400000, guid: 7fbf96e6e42920b47b8eedec97e8b4ce, type: 2}

--- a/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/Occupations.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/Occupations.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5bf24022bd0f1b0479669c39fe0af31f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/Occupations/AncientEngineer.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/Occupations/AncientEngineer.asset
@@ -1,0 +1,26 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1bf4d5e2bd850949b9b9f6afe22de9b, type: 3}
+  m_Name: AncientEngineer
+  m_EditorClassIdentifier: 
+  name: Ancient Engineer
+  description: A dark feeling swells in your gut as you climb out of your pod. Work
+    as a team with your fellow survivors to restore your station or repair the shuttle
+    and explore the new world before you. Against the odds, survive and maybe thrive.
+  sprite: {fileID: 11400000, guid: 784f6d758c67445429a3d2fcb7022a94, type: 2}
+  respawnType: 0
+  targetOccupation: {fileID: 11400000, guid: 032c8cad66c40cb4dad54307acad9b2d, type: 2}
+  targetAntagonist: {fileID: 0}
+  minPlayers: 1
+  maxPlayers: 3
+  timeout: -1
+  playerCountType: 2

--- a/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/Occupations/AncientEngineer.asset.meta
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Systems/GhostRoles/Occupations/AncientEngineer.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7fbf96e6e42920b47b8eedec97e8b4ce
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
+++ b/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
@@ -144,7 +144,7 @@ PrefabInstance:
     - target: {fileID: 3718085451752902353, guid: 160baf50e4a27c24a8c1f40b3232c886,
         type: 3}
       propertyPath: m_RootOrder
-      value: 125
+      value: 123
       objectReference: {fileID: 0}
     - target: {fileID: 3718085451752902353, guid: 160baf50e4a27c24a8c1f40b3232c886,
         type: 3}
@@ -219,7 +219,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 114
+      value: 112
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -352,6 +352,18 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 5302155}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5302157 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2409827327891946488, guid: 3fdd9b0cc7f8f344585d7ff27eb83dc6,
+    type: 3}
+  m_PrefabInstance: {fileID: 5302155}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 817f11041af626f49bdae27be1c0fb60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &20932869
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -367,7 +379,7 @@ PrefabInstance:
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 167
+      value: 165
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
@@ -445,7 +457,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 75
+      value: 73
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -513,7 +525,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4297268230046392, guid: 69c27c4a07b053d458c6fec363e66403, type: 3}
       propertyPath: m_RootOrder
-      value: 39
+      value: 38
       objectReference: {fileID: 0}
     - target: {fileID: 4297268230046392, guid: 69c27c4a07b053d458c6fec363e66403, type: 3}
       propertyPath: m_LocalPosition.x
@@ -578,7 +590,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 63
+      value: 61
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -891,7 +903,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 113
+      value: 111
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -966,7 +978,7 @@ PrefabInstance:
     - target: {fileID: 2038054705163664627, guid: c9c8ffe7c5a0a044bbe8343e681e1fe2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 147
+      value: 145
       objectReference: {fileID: 0}
     - target: {fileID: 2038054705163664627, guid: c9c8ffe7c5a0a044bbe8343e681e1fe2,
         type: 3}
@@ -1046,7 +1058,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 106
+      value: 104
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -1131,7 +1143,7 @@ PrefabInstance:
     - target: {fileID: 4462439672258080633, guid: c84a09f09199afb48b0d8a0c5c2a5bea,
         type: 3}
       propertyPath: m_RootOrder
-      value: 198
+      value: 196
       objectReference: {fileID: 0}
     - target: {fileID: 4462439672258080633, guid: c84a09f09199afb48b0d8a0c5c2a5bea,
         type: 3}
@@ -1263,7 +1275,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 94
+      value: 92
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -1362,7 +1374,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 116
+      value: 114
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -1522,7 +1534,7 @@ PrefabInstance:
     - target: {fileID: 5035675889361153591, guid: 5f29a65f1a758eb4ca895615119e8ff7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 156
+      value: 154
       objectReference: {fileID: 0}
     - target: {fileID: 5035675889361153591, guid: 5f29a65f1a758eb4ca895615119e8ff7,
         type: 3}
@@ -1602,7 +1614,7 @@ PrefabInstance:
     - target: {fileID: 728450015767604076, guid: af583b1807508a84cbd05b036e027d96,
         type: 3}
       propertyPath: m_RootOrder
-      value: 61
+      value: 59
       objectReference: {fileID: 0}
     - target: {fileID: 728450015767604076, guid: af583b1807508a84cbd05b036e027d96,
         type: 3}
@@ -1687,7 +1699,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 225
+      value: 223
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -1779,7 +1791,7 @@ PrefabInstance:
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
       propertyPath: m_RootOrder
-      value: 121
+      value: 119
       objectReference: {fileID: 0}
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
@@ -1864,7 +1876,7 @@ PrefabInstance:
     - target: {fileID: 3682557958087281322, guid: 6bd9037fbb19a79409aab54675bc363e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 213
+      value: 211
       objectReference: {fileID: 0}
     - target: {fileID: 3682557958087281322, guid: 6bd9037fbb19a79409aab54675bc363e,
         type: 3}
@@ -1934,7 +1946,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 77
+      value: 75
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -2071,7 +2083,7 @@ PrefabInstance:
     - target: {fileID: 8031874825218677495, guid: 7f7934b263cb23040ade0147d14b39aa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 184
+      value: 182
       objectReference: {fileID: 0}
     - target: {fileID: 8031874825218677495, guid: 7f7934b263cb23040ade0147d14b39aa,
         type: 3}
@@ -2141,7 +2153,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 21
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -2248,7 +2260,7 @@ PrefabInstance:
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
       propertyPath: m_RootOrder
-      value: 182
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
@@ -2333,7 +2345,7 @@ PrefabInstance:
     - target: {fileID: 5167623093684579179, guid: f25a6f263584e6848819e145b53ee65b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 159
+      value: 157
       objectReference: {fileID: 0}
     - target: {fileID: 5167623093684579179, guid: f25a6f263584e6848819e145b53ee65b,
         type: 3}
@@ -2403,7 +2415,7 @@ PrefabInstance:
     - target: {fileID: 2054426006668562447, guid: 08be734c1a459464f9c78d3b21384339,
         type: 3}
       propertyPath: m_RootOrder
-      value: 197
+      value: 195
       objectReference: {fileID: 0}
     - target: {fileID: 2054426006668562447, guid: 08be734c1a459464f9c78d3b21384339,
         type: 3}
@@ -2498,7 +2510,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 294
+      value: 292
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -2635,7 +2647,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4868564961159832, guid: 85791fbcb6be942d1b318907cb2edec3, type: 3}
       propertyPath: m_RootOrder
-      value: 48
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 4868564961159832, guid: 85791fbcb6be942d1b318907cb2edec3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2710,7 +2722,7 @@ PrefabInstance:
     - target: {fileID: 5895499867514145751, guid: dd553da79275dac409d269c0d6ec571c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 249
+      value: 247
       objectReference: {fileID: 0}
     - target: {fileID: 5895499867514145751, guid: dd553da79275dac409d269c0d6ec571c,
         type: 3}
@@ -2780,7 +2792,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 34
+      value: 33
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -2887,7 +2899,7 @@ PrefabInstance:
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 172
+      value: 170
       objectReference: {fileID: 0}
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
@@ -2978,7 +2990,7 @@ PrefabInstance:
     - target: {fileID: 8031874825218677495, guid: 1002c0247e412884e91c857ce6e51d9c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 179
+      value: 177
       objectReference: {fileID: 0}
     - target: {fileID: 8031874825218677495, guid: 1002c0247e412884e91c857ce6e51d9c,
         type: 3}
@@ -3053,7 +3065,7 @@ PrefabInstance:
     - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 256
+      value: 254
       objectReference: {fileID: 0}
     - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
         type: 3}
@@ -3143,7 +3155,7 @@ PrefabInstance:
     - target: {fileID: 6284585900848704128, guid: a223c02f818b8d74abd3e94371d523d4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 45
+      value: 44
       objectReference: {fileID: 0}
     - target: {fileID: 6284585900848704128, guid: a223c02f818b8d74abd3e94371d523d4,
         type: 3}
@@ -3235,7 +3247,7 @@ PrefabInstance:
     - target: {fileID: 7360425322471321201, guid: bc0cd2a586c78b846a43622b6ea5c953,
         type: 3}
       propertyPath: m_RootOrder
-      value: 157
+      value: 155
       objectReference: {fileID: 0}
     - target: {fileID: 7360425322471321201, guid: bc0cd2a586c78b846a43622b6ea5c953,
         type: 3}
@@ -3312,50 +3324,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 160468098}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &160494698
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 160494699}
-  - component: {fileID: 160494700}
-  m_Layer: 29
-  m_Name: WizardSpawnPoint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &160494699
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 160494698}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -1, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 8082954268645528609}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &160494700
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 160494698}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8de3e7e4629e452a9546be4e9b7a3182, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  category: 38
 --- !u!1001 &167717124
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3366,7 +3334,7 @@ PrefabInstance:
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 259
+      value: 257
       objectReference: {fileID: 0}
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
@@ -3456,7 +3424,7 @@ PrefabInstance:
     - target: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 194
+      value: 192
       objectReference: {fileID: 0}
     - target: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
         type: 3}
@@ -3541,7 +3509,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -3638,7 +3606,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 16
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -3847,7 +3815,7 @@ PrefabInstance:
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 53
+      value: 52
       objectReference: {fileID: 0}
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
@@ -3960,7 +3928,7 @@ PrefabInstance:
     - target: {fileID: 3129593617119727172, guid: aca91ff2eea9cc64aa3bb9deb8964ab1,
         type: 3}
       propertyPath: m_RootOrder
-      value: 209
+      value: 207
       objectReference: {fileID: 0}
     - target: {fileID: 3129593617119727172, guid: aca91ff2eea9cc64aa3bb9deb8964ab1,
         type: 3}
@@ -4035,7 +4003,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 66
+      value: 64
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -4187,7 +4155,7 @@ PrefabInstance:
     - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 299
+      value: 297
       objectReference: {fileID: 0}
     - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
         type: 3}
@@ -4289,7 +4257,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 237
+      value: 235
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -4408,7 +4376,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 297
+      value: 295
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -4579,7 +4547,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 312
+      value: 310
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -4676,7 +4644,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 80
+      value: 78
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4746,7 +4714,7 @@ PrefabInstance:
     - target: {fileID: 629953639410381570, guid: 381f8f36a2bad374a821a168f8e565b6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 192
+      value: 190
       objectReference: {fileID: 0}
     - target: {fileID: 629953639410381570, guid: 381f8f36a2bad374a821a168f8e565b6,
         type: 3}
@@ -4821,7 +4789,7 @@ PrefabInstance:
     - target: {fileID: 1327387949770221707, guid: dbfef72a303adaa489b990c1ac8a96da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 206
+      value: 204
       objectReference: {fileID: 0}
     - target: {fileID: 1327387949770221707, guid: dbfef72a303adaa489b990c1ac8a96da,
         type: 3}
@@ -4958,7 +4926,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 282
+      value: 280
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -5109,7 +5077,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 238
+      value: 236
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -5213,7 +5181,7 @@ PrefabInstance:
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 171
+      value: 169
       objectReference: {fileID: 0}
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
@@ -5385,7 +5353,7 @@ PrefabInstance:
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 190
+      value: 188
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -5475,7 +5443,7 @@ PrefabInstance:
     - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
         type: 3}
       propertyPath: m_RootOrder
-      value: 153
+      value: 151
       objectReference: {fileID: 0}
     - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
         type: 3}
@@ -5560,7 +5528,7 @@ PrefabInstance:
     - target: {fileID: 8131242747770038361, guid: 790a543a09ecd4442acbf99db25be404,
         type: 3}
       propertyPath: m_RootOrder
-      value: 253
+      value: 251
       objectReference: {fileID: 0}
     - target: {fileID: 8131242747770038361, guid: 790a543a09ecd4442acbf99db25be404,
         type: 3}
@@ -5682,7 +5650,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 83
+      value: 81
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -5843,7 +5811,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 240
+      value: 238
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -5937,7 +5905,7 @@ PrefabInstance:
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
       propertyPath: m_RootOrder
-      value: 276
+      value: 274
       objectReference: {fileID: 0}
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
@@ -6022,7 +5990,7 @@ PrefabInstance:
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 262
+      value: 260
       objectReference: {fileID: 0}
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
@@ -6102,7 +6070,7 @@ PrefabInstance:
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 260
+      value: 258
       objectReference: {fileID: 0}
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
@@ -6190,7 +6158,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_RootOrder
-      value: 215
+      value: 213
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6255,7 +6223,7 @@ PrefabInstance:
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 168
+      value: 166
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
@@ -6333,7 +6301,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 69
+      value: 67
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6455,7 +6423,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 308
+      value: 306
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -6564,7 +6532,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 286
+      value: 284
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -6703,7 +6671,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 229
+      value: 227
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -6800,7 +6768,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -6887,7 +6855,7 @@ PrefabInstance:
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 126
+      value: 124
       objectReference: {fileID: 0}
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
@@ -6982,7 +6950,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 232
+      value: 230
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -7074,7 +7042,7 @@ PrefabInstance:
     - target: {fileID: 5193296327940958646, guid: 63a58edd1e5377040a9ea82e307c1f04,
         type: 3}
       propertyPath: m_RootOrder
-      value: 161
+      value: 159
       objectReference: {fileID: 0}
     - target: {fileID: 5193296327940958646, guid: 63a58edd1e5377040a9ea82e307c1f04,
         type: 3}
@@ -7364,7 +7332,7 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   FuelLevel: 0
-  Connector: {fileID: 0}
+  Connector: {fileID: 5302157}
   MatrixMove: {fileID: 406892959}
   FuelConsumption: 0
   MassConsumption: 0.1
@@ -7617,7 +7585,7 @@ PrefabInstance:
     - target: {fileID: 2484719566607390486, guid: a6a04b99723d3ae42958de4193b9920d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 202
+      value: 200
       objectReference: {fileID: 0}
     - target: {fileID: 2484719566607390486, guid: a6a04b99723d3ae42958de4193b9920d,
         type: 3}
@@ -7697,7 +7665,7 @@ PrefabInstance:
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
       propertyPath: m_RootOrder
-      value: 54
+      value: 53
       objectReference: {fileID: 0}
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
@@ -7772,7 +7740,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 27
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -7869,7 +7837,7 @@ PrefabInstance:
     - target: {fileID: 2038054705163664627, guid: c9c8ffe7c5a0a044bbe8343e681e1fe2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 148
+      value: 146
       objectReference: {fileID: 0}
     - target: {fileID: 2038054705163664627, guid: c9c8ffe7c5a0a044bbe8343e681e1fe2,
         type: 3}
@@ -7959,7 +7927,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 115
+      value: 113
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -8044,7 +8012,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 298
+      value: 296
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -8253,7 +8221,7 @@ PrefabInstance:
     - target: {fileID: 7777312831022217093, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
       propertyPath: m_RootOrder
-      value: 176
+      value: 174
       objectReference: {fileID: 0}
     - target: {fileID: 7777312831022217093, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
@@ -8338,7 +8306,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -8425,7 +8393,7 @@ PrefabInstance:
     - target: {fileID: 5674645506955800181, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
       propertyPath: m_RootOrder
-      value: 140
+      value: 138
       objectReference: {fileID: 0}
     - target: {fileID: 5674645506955800181, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
@@ -8520,7 +8488,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 295
+      value: 293
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -8763,7 +8731,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 228
+      value: 226
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -8907,7 +8875,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 93
+      value: 91
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -9011,7 +8979,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -9098,7 +9066,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 31
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -9195,7 +9163,7 @@ PrefabInstance:
     - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
         type: 3}
       propertyPath: m_RootOrder
-      value: 204
+      value: 202
       objectReference: {fileID: 0}
     - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
         type: 3}
@@ -9265,6 +9233,81 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 521894590}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &529418159
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 932796153661386794, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint - AncientEngineering (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 317
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 8.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 13a96d5c007d8e84c9853fda470c1c7c, type: 3}
+--- !u!4 &529418160 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+    type: 3}
+  m_PrefabInstance: {fileID: 529418159}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &529858407
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9332,7 +9375,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 314
+      value: 312
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -9426,7 +9469,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 19
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -9528,7 +9571,7 @@ PrefabInstance:
     - target: {fileID: 7662282495583499656, guid: 7f32e42309899114b9c122f261161bc5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 142
+      value: 140
       objectReference: {fileID: 0}
     - target: {fileID: 7662282495583499656, guid: 7f32e42309899114b9c122f261161bc5,
         type: 3}
@@ -9613,7 +9656,7 @@ PrefabInstance:
     - target: {fileID: 9031523234013953791, guid: b087cae0f7059d946a59146ea8d0fb04,
         type: 3}
       propertyPath: m_RootOrder
-      value: 252
+      value: 250
       objectReference: {fileID: 0}
     - target: {fileID: 9031523234013953791, guid: b087cae0f7059d946a59146ea8d0fb04,
         type: 3}
@@ -9683,7 +9726,7 @@ PrefabInstance:
     - target: {fileID: 2054426006668562447, guid: 08be734c1a459464f9c78d3b21384339,
         type: 3}
       propertyPath: m_RootOrder
-      value: 196
+      value: 194
       objectReference: {fileID: 0}
     - target: {fileID: 2054426006668562447, guid: 08be734c1a459464f9c78d3b21384339,
         type: 3}
@@ -10272,7 +10315,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 302
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -10394,7 +10437,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 218
+      value: 216
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -10469,7 +10512,7 @@ PrefabInstance:
     - target: {fileID: 8066134277105145184, guid: 8edc1f3642b9f28429c21e6c30566791,
         type: 3}
       propertyPath: m_RootOrder
-      value: 254
+      value: 252
       objectReference: {fileID: 0}
     - target: {fileID: 8066134277105145184, guid: 8edc1f3642b9f28429c21e6c30566791,
         type: 3}
@@ -10586,7 +10629,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 284
+      value: 282
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -10695,7 +10738,7 @@ PrefabInstance:
     - target: {fileID: 446201704680789046, guid: b09e9d95fbf80594c8bbcf60be9b3f93,
         type: 3}
       propertyPath: m_RootOrder
-      value: 208
+      value: 206
       objectReference: {fileID: 0}
     - target: {fileID: 446201704680789046, guid: b09e9d95fbf80594c8bbcf60be9b3f93,
         type: 3}
@@ -10877,7 +10920,7 @@ PrefabInstance:
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
       propertyPath: m_RootOrder
-      value: 122
+      value: 120
       objectReference: {fileID: 0}
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
@@ -10958,7 +11001,7 @@ PrefabInstance:
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 270
+      value: 268
       objectReference: {fileID: 0}
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
@@ -11059,7 +11102,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -12036,7 +12079,7 @@ PrefabInstance:
     - target: {fileID: 5218729519462851643, guid: 4a5b6baeb439ba249b1abfcd81f5d624,
         type: 3}
       propertyPath: m_RootOrder
-      value: 177
+      value: 175
       objectReference: {fileID: 0}
     - target: {fileID: 5218729519462851643, guid: 4a5b6baeb439ba249b1abfcd81f5d624,
         type: 3}
@@ -12119,7 +12162,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 73
+      value: 71
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12199,7 +12242,7 @@ PrefabInstance:
     - target: {fileID: 7203165141458395214, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
       propertyPath: m_RootOrder
-      value: 134
+      value: 132
       objectReference: {fileID: 0}
     - target: {fileID: 7203165141458395214, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
@@ -12279,7 +12322,7 @@ PrefabInstance:
     - target: {fileID: 9173161790594611747, guid: 25108e21a69d52c46a538e66eb85db0a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 136
+      value: 134
       objectReference: {fileID: 0}
     - target: {fileID: 9173161790594611747, guid: 25108e21a69d52c46a538e66eb85db0a,
         type: 3}
@@ -12359,7 +12402,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 117
+      value: 115
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -12491,7 +12534,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 279
+      value: 277
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -12595,7 +12638,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -12692,7 +12735,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -12779,7 +12822,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 257
+      value: 255
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -12941,7 +12984,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 35
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -13033,7 +13076,7 @@ PrefabInstance:
     - target: {fileID: 2484719566607390486, guid: a6a04b99723d3ae42958de4193b9920d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 201
+      value: 199
       objectReference: {fileID: 0}
     - target: {fileID: 2484719566607390486, guid: a6a04b99723d3ae42958de4193b9920d,
         type: 3}
@@ -13118,7 +13161,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 248
+      value: 246
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -13210,7 +13253,7 @@ PrefabInstance:
     - target: {fileID: 550404675964371356, guid: 89f38936254ca964a85299ce289225ad,
         type: 3}
       propertyPath: m_RootOrder
-      value: 183
+      value: 181
       objectReference: {fileID: 0}
     - target: {fileID: 550404675964371356, guid: 89f38936254ca964a85299ce289225ad,
         type: 3}
@@ -13434,7 +13477,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 292
+      value: 290
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -13558,7 +13601,7 @@ PrefabInstance:
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 50
+      value: 49
       objectReference: {fileID: 0}
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
@@ -13661,7 +13704,7 @@ PrefabInstance:
     - target: {fileID: 228549275771145858, guid: 6d8f04f09fd70254ead647566210cd74,
         type: 3}
       propertyPath: m_RootOrder
-      value: 130
+      value: 128
       objectReference: {fileID: 0}
     - target: {fileID: 228549275771145858, guid: 6d8f04f09fd70254ead647566210cd74,
         type: 3}
@@ -13756,7 +13799,7 @@ PrefabInstance:
     - target: {fileID: 7203165141458395214, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
       propertyPath: m_RootOrder
-      value: 139
+      value: 137
       objectReference: {fileID: 0}
     - target: {fileID: 7203165141458395214, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
@@ -13831,7 +13874,7 @@ PrefabInstance:
     - target: {fileID: 296282586161115487, guid: 1849f051284c432478d5aaba34cec853,
         type: 3}
       propertyPath: m_RootOrder
-      value: 266
+      value: 264
       objectReference: {fileID: 0}
     - target: {fileID: 296282586161115487, guid: 1849f051284c432478d5aaba34cec853,
         type: 3}
@@ -13906,7 +13949,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 64
+      value: 62
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -14073,7 +14116,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 107
+      value: 105
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -14152,7 +14195,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 67647418286998, guid: 4c38ee85ca3f4664f81d94e975c92fc7, type: 3}
       propertyPath: m_RootOrder
-      value: 152
+      value: 150
       objectReference: {fileID: 0}
     - target: {fileID: 67647418286998, guid: 4c38ee85ca3f4664f81d94e975c92fc7, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14226,7 +14269,7 @@ PrefabInstance:
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 264
+      value: 262
       objectReference: {fileID: 0}
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
@@ -14309,7 +14352,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 221
+      value: 219
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14374,7 +14417,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 29
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -14474,7 +14517,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 219
+      value: 217
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14549,7 +14592,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 234
+      value: 232
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -14770,7 +14813,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 223
+      value: 221
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -14877,7 +14920,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 293
+      value: 291
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -15021,7 +15064,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 310
+      value: 308
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -15210,7 +15253,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 277
+      value: 275
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -15314,7 +15357,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 102
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -15394,7 +15437,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 65
+      value: 63
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -15576,7 +15619,7 @@ PrefabInstance:
     - target: {fileID: 7999698691295358753, guid: f3706893770084a45ae509ebf6836cc9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 40
+      value: 39
       objectReference: {fileID: 0}
     - target: {fileID: 7999698691295358753, guid: f3706893770084a45ae509ebf6836cc9,
         type: 3}
@@ -15654,7 +15697,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4271421665851644, guid: 1581b03bb13b84328a0f9fe743bb5bbf, type: 3}
       propertyPath: m_RootOrder
-      value: 49
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 4271421665851644, guid: 1581b03bb13b84328a0f9fe743bb5bbf, type: 3}
       propertyPath: m_LocalPosition.x
@@ -15746,7 +15789,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -15890,7 +15933,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 311
+      value: 309
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -15987,7 +16030,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_RootOrder
-      value: 43
+      value: 42
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16072,7 +16115,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 289
+      value: 287
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -16186,7 +16229,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 103
+      value: 101
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -16266,7 +16309,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 28
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -16366,7 +16409,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_RootOrder
-      value: 42
+      value: 41
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16436,7 +16479,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 105
+      value: 103
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -16526,7 +16569,7 @@ PrefabInstance:
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 56
+      value: 55
       objectReference: {fileID: 0}
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
@@ -16606,7 +16649,7 @@ PrefabInstance:
     - target: {fileID: 7720111631785481682, guid: 10b4df308fde4ce4da5578a90de97c13,
         type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 7720111631785481682, guid: 10b4df308fde4ce4da5578a90de97c13,
         type: 3}
@@ -16703,7 +16746,7 @@ PrefabInstance:
     - target: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 195
+      value: 193
       objectReference: {fileID: 0}
     - target: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
         type: 3}
@@ -16873,7 +16916,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -16960,7 +17003,7 @@ PrefabInstance:
     - target: {fileID: 1775224900688995769, guid: 64b0546c6b2243241846fced5f70f123,
         type: 3}
       propertyPath: m_RootOrder
-      value: 258
+      value: 256
       objectReference: {fileID: 0}
     - target: {fileID: 1775224900688995769, guid: 64b0546c6b2243241846fced5f70f123,
         type: 3}
@@ -17045,7 +17088,7 @@ PrefabInstance:
     - target: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 162
+      value: 160
       objectReference: {fileID: 0}
     - target: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
         type: 3}
@@ -17125,7 +17168,7 @@ PrefabInstance:
     - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
         type: 3}
       propertyPath: m_RootOrder
-      value: 154
+      value: 152
       objectReference: {fileID: 0}
     - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
         type: 3}
@@ -17203,7 +17246,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 72
+      value: 70
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -17273,7 +17316,7 @@ PrefabInstance:
     - target: {fileID: 3246771360178382922, guid: cbae9a210d638ba4b9402e836c970fa2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 144
+      value: 142
       objectReference: {fileID: 0}
     - target: {fileID: 3246771360178382922, guid: cbae9a210d638ba4b9402e836c970fa2,
         type: 3}
@@ -17370,7 +17413,7 @@ PrefabInstance:
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
       propertyPath: m_RootOrder
-      value: 55
+      value: 54
       objectReference: {fileID: 0}
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
@@ -17541,7 +17584,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 89
+      value: 87
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -17675,7 +17718,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 90
+      value: 88
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -17779,7 +17822,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 109
+      value: 107
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -17879,7 +17922,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 304
+      value: 302
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -18064,7 +18107,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: c1aebfea91112ef4a83ba10f37d3f437,
         type: 3}
       propertyPath: m_RootOrder
-      value: 112
+      value: 110
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: c1aebfea91112ef4a83ba10f37d3f437,
         type: 3}
@@ -18147,7 +18190,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 71
+      value: 69
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -18212,7 +18255,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 110
+      value: 108
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -18292,7 +18335,7 @@ PrefabInstance:
     - target: {fileID: 8793194575595567163, guid: 7ba0f8027fae0b747803eabaf13523c7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 200
+      value: 198
       objectReference: {fileID: 0}
     - target: {fileID: 8793194575595567163, guid: 7ba0f8027fae0b747803eabaf13523c7,
         type: 3}
@@ -18382,7 +18425,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 233
+      value: 231
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -18479,7 +18522,7 @@ PrefabInstance:
     - target: {fileID: 3295880826340575877, guid: e89c616b1df1e724baef0e39ac0037f3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 175
+      value: 173
       objectReference: {fileID: 0}
     - target: {fileID: 3295880826340575877, guid: e89c616b1df1e724baef0e39ac0037f3,
         type: 3}
@@ -18606,7 +18649,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 241
+      value: 239
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -18705,7 +18748,7 @@ PrefabInstance:
     - target: {fileID: 2194074672386895265, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
         type: 3}
       propertyPath: m_RootOrder
-      value: 275
+      value: 273
       objectReference: {fileID: 0}
     - target: {fileID: 2194074672386895265, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
         type: 3}
@@ -18790,7 +18833,7 @@ PrefabInstance:
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
       propertyPath: m_RootOrder
-      value: 181
+      value: 179
       objectReference: {fileID: 0}
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
@@ -18870,7 +18913,7 @@ PrefabInstance:
     - target: {fileID: 7720111631785481682, guid: 10b4df308fde4ce4da5578a90de97c13,
         type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 7720111631785481682, guid: 10b4df308fde4ce4da5578a90de97c13,
         type: 3}
@@ -18977,7 +19020,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 87
+      value: 85
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -19071,7 +19114,7 @@ PrefabInstance:
     - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 210
+      value: 208
       objectReference: {fileID: 0}
     - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
         type: 3}
@@ -19182,7 +19225,7 @@ PrefabInstance:
     - target: {fileID: 7089628496362807847, guid: c5aecb2f211bbae49916919ff6128733,
         type: 3}
       propertyPath: m_RootOrder
-      value: 188
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 7089628496362807847, guid: c5aecb2f211bbae49916919ff6128733,
         type: 3}
@@ -19311,7 +19354,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 278
+      value: 276
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -19566,7 +19609,7 @@ PrefabInstance:
     - target: {fileID: 5730203012241659306, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 186
+      value: 184
       objectReference: {fileID: 0}
     - target: {fileID: 5730203012241659306, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
@@ -19651,7 +19694,7 @@ PrefabInstance:
     - target: {fileID: 7184381825146832964, guid: 2e464f403424dbd409a91b0abbb4121c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 150
+      value: 148
       objectReference: {fileID: 0}
     - target: {fileID: 7184381825146832964, guid: 2e464f403424dbd409a91b0abbb4121c,
         type: 3}
@@ -19736,7 +19779,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 285
+      value: 283
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -19850,7 +19893,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 101
+      value: 99
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -19930,7 +19973,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 23
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -20032,7 +20075,7 @@ PrefabInstance:
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 261
+      value: 259
       objectReference: {fileID: 0}
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
@@ -20117,7 +20160,7 @@ PrefabInstance:
     - target: {fileID: 6518921224212731652, guid: f5de4bfc8649c7a428e694010049af77,
         type: 3}
       propertyPath: m_RootOrder
-      value: 203
+      value: 201
       objectReference: {fileID: 0}
     - target: {fileID: 6518921224212731652, guid: f5de4bfc8649c7a428e694010049af77,
         type: 3}
@@ -20202,7 +20245,7 @@ PrefabInstance:
     - target: {fileID: 7777312831022217093, guid: fd2b975bb2d60fb429c193f9ef1d31b0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 145
+      value: 143
       objectReference: {fileID: 0}
     - target: {fileID: 7777312831022217093, guid: fd2b975bb2d60fb429c193f9ef1d31b0,
         type: 3}
@@ -20334,7 +20377,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 315
+      value: 313
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -20433,7 +20476,7 @@ PrefabInstance:
     - target: {fileID: 4462439672258080633, guid: c84a09f09199afb48b0d8a0c5c2a5bea,
         type: 3}
       propertyPath: m_RootOrder
-      value: 199
+      value: 197
       objectReference: {fileID: 0}
     - target: {fileID: 4462439672258080633, guid: c84a09f09199afb48b0d8a0c5c2a5bea,
         type: 3}
@@ -20508,7 +20551,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 100
+      value: 98
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -20645,7 +20688,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 280
+      value: 278
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -20749,7 +20792,7 @@ PrefabInstance:
     - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 131
+      value: 129
       objectReference: {fileID: 0}
     - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
         type: 3}
@@ -20829,7 +20872,7 @@ PrefabInstance:
     - target: {fileID: 728450015767604076, guid: af583b1807508a84cbd05b036e027d96,
         type: 3}
       propertyPath: m_RootOrder
-      value: 62
+      value: 60
       objectReference: {fileID: 0}
     - target: {fileID: 728450015767604076, guid: af583b1807508a84cbd05b036e027d96,
         type: 3}
@@ -20961,7 +21004,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 305
+      value: 303
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -21058,7 +21101,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 70
+      value: 68
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21123,7 +21166,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 97
+      value: 95
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -21206,7 +21249,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 78
+      value: 76
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21281,7 +21324,7 @@ PrefabInstance:
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 58
+      value: 56
       objectReference: {fileID: 0}
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
@@ -21361,7 +21404,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 26
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -21538,7 +21581,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 67647418286998, guid: 4c38ee85ca3f4664f81d94e975c92fc7, type: 3}
       propertyPath: m_RootOrder
-      value: 151
+      value: 149
       objectReference: {fileID: 0}
     - target: {fileID: 67647418286998, guid: 4c38ee85ca3f4664f81d94e975c92fc7, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21664,7 +21707,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 313
+      value: 311
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -21761,7 +21804,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 74
+      value: 72
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21868,7 +21911,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 236
+      value: 234
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -21977,7 +22020,7 @@ PrefabInstance:
     - target: {fileID: 4049041059155957662, guid: dd86caf1f673b7642be83819773021d8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 272
+      value: 270
       objectReference: {fileID: 0}
     - target: {fileID: 4049041059155957662, guid: dd86caf1f673b7642be83819773021d8,
         type: 3}
@@ -22062,7 +22105,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 36
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -22159,7 +22202,7 @@ PrefabInstance:
     - target: {fileID: 8954212430775875356, guid: 60badd0969907f044819febb546b443f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 123
+      value: 121
       objectReference: {fileID: 0}
     - target: {fileID: 8954212430775875356, guid: 60badd0969907f044819febb546b443f,
         type: 3}
@@ -22234,7 +22277,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 30
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -22346,7 +22389,7 @@ PrefabInstance:
     - target: {fileID: 6409286586645294639, guid: 133b93fb7d8a5794bbfff599bea64863,
         type: 3}
       propertyPath: m_RootOrder
-      value: 143
+      value: 141
       objectReference: {fileID: 0}
     - target: {fileID: 6409286586645294639, guid: 133b93fb7d8a5794bbfff599bea64863,
         type: 3}
@@ -22444,7 +22487,7 @@ PrefabInstance:
     - target: {fileID: 3130401872829826601, guid: 66f05879999b49141bbfc4e0fdc9903a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 251
+      value: 249
       objectReference: {fileID: 0}
     - target: {fileID: 3130401872829826601, guid: 66f05879999b49141bbfc4e0fdc9903a,
         type: 3}
@@ -22519,7 +22562,7 @@ PrefabInstance:
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 128
+      value: 126
       objectReference: {fileID: 0}
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
@@ -22604,7 +22647,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 224
+      value: 222
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -22701,7 +22744,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -22803,7 +22846,7 @@ PrefabInstance:
     - target: {fileID: 2402019029272391321, guid: a85bb77436de9574c8523fe45acffb14,
         type: 3}
       propertyPath: m_RootOrder
-      value: 119
+      value: 117
       objectReference: {fileID: 0}
     - target: {fileID: 2402019029272391321, guid: a85bb77436de9574c8523fe45acffb14,
         type: 3}
@@ -22888,7 +22931,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 287
+      value: 285
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -23044,7 +23087,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 85
+      value: 83
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -23158,7 +23201,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 296
+      value: 294
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -23329,7 +23372,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 92
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -23433,7 +23476,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 32
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -23520,7 +23563,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 222
+      value: 220
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -23610,7 +23653,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 227
+      value: 225
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -23707,7 +23750,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 231
+      value: 229
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -23814,7 +23857,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 95
+      value: 93
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -23908,7 +23951,7 @@ PrefabInstance:
     - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 247
+      value: 245
       objectReference: {fileID: 0}
     - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
         type: 3}
@@ -23998,7 +24041,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 290
+      value: 288
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -24117,7 +24160,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 230
+      value: 228
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -24214,7 +24257,7 @@ PrefabInstance:
     - target: {fileID: 5895499867514145751, guid: dd553da79275dac409d269c0d6ec571c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 250
+      value: 248
       objectReference: {fileID: 0}
     - target: {fileID: 5895499867514145751, guid: dd553da79275dac409d269c0d6ec571c,
         type: 3}
@@ -24341,7 +24384,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 303
+      value: 301
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -24482,7 +24525,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 242
+      value: 240
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -24589,7 +24632,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 79
+      value: 77
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -24744,7 +24787,7 @@ PrefabInstance:
     - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 301
+      value: 299
       objectReference: {fileID: 0}
     - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
         type: 3}
@@ -24814,7 +24857,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 108
+      value: 106
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -24897,7 +24940,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 220
+      value: 218
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -24972,7 +25015,7 @@ PrefabInstance:
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 173
+      value: 171
       objectReference: {fileID: 0}
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
@@ -25050,6 +25093,12 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8082954268645528609}
     m_Modifications:
+    - target: {fileID: 5373161607043217008, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: d04e66db37d051241af5586e1bdfff93,
+        type: 3}
     - target: {fileID: 8568672687853555390, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
       propertyPath: m_Name
@@ -25058,7 +25107,7 @@ PrefabInstance:
     - target: {fileID: 8573033213633377226, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 138
+      value: 136
       objectReference: {fileID: 0}
     - target: {fileID: 8573033213633377226, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
@@ -25154,7 +25203,7 @@ PrefabInstance:
     - target: {fileID: 8582924881145235216, guid: 66a5287d0bf216847a2f4fe34228a0cf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 133
+      value: 131
       objectReference: {fileID: 0}
     - target: {fileID: 8582924881145235216, guid: 66a5287d0bf216847a2f4fe34228a0cf,
         type: 3}
@@ -25281,7 +25330,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 309
+      value: 307
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -25375,7 +25424,7 @@ PrefabInstance:
     - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 300
+      value: 298
       objectReference: {fileID: 0}
     - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
         type: 3}
@@ -25460,7 +25509,7 @@ PrefabInstance:
     - target: {fileID: 5521070544968489048, guid: a565b378d835ddf478bee7e52e6b95dd,
         type: 3}
       propertyPath: m_RootOrder
-      value: 185
+      value: 183
       objectReference: {fileID: 0}
     - target: {fileID: 5521070544968489048, guid: a565b378d835ddf478bee7e52e6b95dd,
         type: 3}
@@ -25543,7 +25592,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_RootOrder
-      value: 216
+      value: 214
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -25603,7 +25652,7 @@ PrefabInstance:
     - target: {fileID: 254800111756226720, guid: c4c22bdc7cdd546479ac1de5589b5617,
         type: 3}
       propertyPath: m_RootOrder
-      value: 47
+      value: 46
       objectReference: {fileID: 0}
     - target: {fileID: 254800111756226720, guid: c4c22bdc7cdd546479ac1de5589b5617,
         type: 3}
@@ -25688,7 +25737,7 @@ PrefabInstance:
     - target: {fileID: 1194072455337391194, guid: 007d9f81d20c55d479d86a1d7d4343db,
         type: 3}
       propertyPath: m_RootOrder
-      value: 120
+      value: 118
       objectReference: {fileID: 0}
     - target: {fileID: 1194072455337391194, guid: 007d9f81d20c55d479d86a1d7d4343db,
         type: 3}
@@ -25778,7 +25827,7 @@ PrefabInstance:
     - target: {fileID: 7553721075204866577, guid: 7a167eaa044fd7142ad12de730b62846,
         type: 3}
       propertyPath: m_RootOrder
-      value: 274
+      value: 272
       objectReference: {fileID: 0}
     - target: {fileID: 7553721075204866577, guid: 7a167eaa044fd7142ad12de730b62846,
         type: 3}
@@ -25851,7 +25900,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 217
+      value: 215
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -25919,7 +25968,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 76
+      value: 74
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -25989,7 +26038,7 @@ PrefabInstance:
     - target: {fileID: 629953639410381570, guid: 381f8f36a2bad374a821a168f8e565b6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 193
+      value: 191
       objectReference: {fileID: 0}
     - target: {fileID: 629953639410381570, guid: 381f8f36a2bad374a821a168f8e565b6,
         type: 3}
@@ -26084,7 +26133,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 96
+      value: 94
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -26193,7 +26242,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 288
+      value: 286
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -26775,7 +26824,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 91
+      value: 89
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -26884,7 +26933,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 291
+      value: 289
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -27023,7 +27072,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -27120,7 +27169,7 @@ PrefabInstance:
     - target: {fileID: 7720111631785481682, guid: 10b4df308fde4ce4da5578a90de97c13,
         type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 7720111631785481682, guid: 10b4df308fde4ce4da5578a90de97c13,
         type: 3}
@@ -27213,7 +27262,7 @@ PrefabInstance:
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 268
+      value: 266
       objectReference: {fileID: 0}
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
@@ -27309,7 +27358,7 @@ PrefabInstance:
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 263
+      value: 261
       objectReference: {fileID: 0}
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
@@ -27436,7 +27485,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 84
+      value: 82
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -27540,7 +27589,7 @@ PrefabInstance:
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
       propertyPath: m_RootOrder
-      value: 38
+      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
@@ -27623,7 +27672,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4549118663027890, guid: 9a960afa1c32b4a208621260530a2d8a, type: 3}
       propertyPath: m_RootOrder
-      value: 178
+      value: 176
       objectReference: {fileID: 0}
     - target: {fileID: 4549118663027890, guid: 9a960afa1c32b4a208621260530a2d8a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -27688,7 +27737,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 68
+      value: 66
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -28007,7 +28056,7 @@ PrefabInstance:
     - target: {fileID: 5730203012241659306, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 187
+      value: 185
       objectReference: {fileID: 0}
     - target: {fileID: 5730203012241659306, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
@@ -28102,7 +28151,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 88
+      value: 86
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -28201,7 +28250,7 @@ PrefabInstance:
     - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
         type: 3}
       propertyPath: m_RootOrder
-      value: 255
+      value: 253
       objectReference: {fileID: 0}
     - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
         type: 3}
@@ -28286,7 +28335,7 @@ PrefabInstance:
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 51
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
@@ -28384,7 +28433,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 67
+      value: 65
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -28556,7 +28605,7 @@ PrefabInstance:
     - target: {fileID: 7360425322471321201, guid: bc0cd2a586c78b846a43622b6ea5c953,
         type: 3}
       propertyPath: m_RootOrder
-      value: 158
+      value: 156
       objectReference: {fileID: 0}
     - target: {fileID: 7360425322471321201, guid: bc0cd2a586c78b846a43622b6ea5c953,
         type: 3}
@@ -28796,7 +28845,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 281
+      value: 279
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -28890,7 +28939,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 98
+      value: 96
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -28975,7 +29024,7 @@ PrefabInstance:
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
       propertyPath: m_RootOrder
-      value: 60
+      value: 58
       objectReference: {fileID: 0}
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
@@ -29050,7 +29099,7 @@ PrefabInstance:
     - target: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 166
+      value: 164
       objectReference: {fileID: 0}
     - target: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
         type: 3}
@@ -29130,7 +29179,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 22
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -29237,7 +29286,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 25
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -29506,7 +29555,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 104
+      value: 102
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -29713,7 +29762,7 @@ PrefabInstance:
     - target: {fileID: 6511207373575406613, guid: 1488f67a55cb9b84098e095e65e5a2b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 189
+      value: 187
       objectReference: {fileID: 0}
     - target: {fileID: 6511207373575406613, guid: 1488f67a55cb9b84098e095e65e5a2b3,
         type: 3}
@@ -29793,7 +29842,7 @@ PrefabInstance:
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 191
+      value: 189
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -29915,7 +29964,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 244
+      value: 242
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -30019,7 +30068,7 @@ PrefabInstance:
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 127
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
@@ -30124,7 +30173,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 235
+      value: 233
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -30218,7 +30267,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -30372,7 +30421,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 246
+      value: 244
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -30471,7 +30520,7 @@ PrefabInstance:
     - target: {fileID: 5193296327940958646, guid: 63a58edd1e5377040a9ea82e307c1f04,
         type: 3}
       propertyPath: m_RootOrder
-      value: 160
+      value: 158
       objectReference: {fileID: 0}
     - target: {fileID: 5193296327940958646, guid: 63a58edd1e5377040a9ea82e307c1f04,
         type: 3}
@@ -30541,6 +30590,81 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1788468032}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1800652675
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 932796153661386794, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint - AncientEngineering (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 315
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.99
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 11.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 13a96d5c007d8e84c9853fda470c1c7c, type: 3}
+--- !u!4 &1800652676 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1800652675}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1802957303
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -30556,7 +30680,7 @@ PrefabInstance:
     - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
         type: 3}
       propertyPath: m_RootOrder
-      value: 46
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
         type: 3}
@@ -30808,7 +30932,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 245
+      value: 243
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -30908,7 +31032,7 @@ PrefabInstance:
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 267
+      value: 265
       objectReference: {fileID: 0}
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
@@ -31041,7 +31165,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 243
+      value: 241
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -31150,7 +31274,7 @@ PrefabInstance:
     - target: {fileID: 311235556692342817, guid: 7953abf1584ad8241b2281698de84f40,
         type: 3}
       propertyPath: m_RootOrder
-      value: 82
+      value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 311235556692342817, guid: 7953abf1584ad8241b2281698de84f40,
         type: 3}
@@ -31252,7 +31376,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -31339,7 +31463,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 81
+      value: 79
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -31511,7 +31635,7 @@ PrefabInstance:
     - target: {fileID: 1194072455337391194, guid: 007d9f81d20c55d479d86a1d7d4343db,
         type: 3}
       propertyPath: m_RootOrder
-      value: 124
+      value: 122
       objectReference: {fileID: 0}
     - target: {fileID: 1194072455337391194, guid: 007d9f81d20c55d479d86a1d7d4343db,
         type: 3}
@@ -31596,7 +31720,7 @@ PrefabInstance:
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 52
+      value: 51
       objectReference: {fileID: 0}
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
@@ -31705,7 +31829,7 @@ PrefabInstance:
     - target: {fileID: 5453087981515002643, guid: 34894a7b128fef84588648dd03311de5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 207
+      value: 205
       objectReference: {fileID: 0}
     - target: {fileID: 5453087981515002643, guid: 34894a7b128fef84588648dd03311de5,
         type: 3}
@@ -31780,7 +31904,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 24
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -31974,7 +32098,7 @@ PrefabInstance:
     - target: {fileID: 8573033213633377226, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 137
+      value: 135
       objectReference: {fileID: 0}
     - target: {fileID: 8573033213633377226, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
@@ -32055,7 +32179,7 @@ PrefabInstance:
     - target: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 164
+      value: 162
       objectReference: {fileID: 0}
     - target: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
         type: 3}
@@ -32145,7 +32269,7 @@ PrefabInstance:
     - target: {fileID: 6752097109298067032, guid: 13186a514a60194429e94407b6cf1e0a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 165
+      value: 163
       objectReference: {fileID: 0}
     - target: {fileID: 6752097109298067032, guid: 13186a514a60194429e94407b6cf1e0a,
         type: 3}
@@ -32359,7 +32483,7 @@ PrefabInstance:
     - target: {fileID: 5327488673359562728, guid: 29ecbf5a1d918574cbcf5853927e0944,
         type: 3}
       propertyPath: m_RootOrder
-      value: 129
+      value: 127
       objectReference: {fileID: 0}
     - target: {fileID: 5327488673359562728, guid: 29ecbf5a1d918574cbcf5853927e0944,
         type: 3}
@@ -32445,7 +32569,7 @@ PrefabInstance:
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 269
+      value: 267
       objectReference: {fileID: 0}
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
@@ -32541,7 +32665,7 @@ PrefabInstance:
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
       propertyPath: m_RootOrder
-      value: 59
+      value: 57
       objectReference: {fileID: 0}
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
@@ -32626,7 +32750,7 @@ PrefabInstance:
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
       propertyPath: m_RootOrder
-      value: 180
+      value: 178
       objectReference: {fileID: 0}
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
@@ -32711,7 +32835,7 @@ PrefabInstance:
     - target: {fileID: 8582924881145235216, guid: 66a5287d0bf216847a2f4fe34228a0cf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 132
+      value: 130
       objectReference: {fileID: 0}
     - target: {fileID: 8582924881145235216, guid: 66a5287d0bf216847a2f4fe34228a0cf,
         type: 3}
@@ -32784,7 +32908,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: a6f87f3db636f2c4ba3aa4763aba4c3b, type: 3}
       propertyPath: m_RootOrder
-      value: 41
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: a6f87f3db636f2c4ba3aa4763aba4c3b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -32854,7 +32978,7 @@ PrefabInstance:
     - target: {fileID: 2186281498986418755, guid: 53f6552a4b56f2d49892b40149511a62,
         type: 3}
       propertyPath: m_RootOrder
-      value: 149
+      value: 147
       objectReference: {fileID: 0}
     - target: {fileID: 2186281498986418755, guid: 53f6552a4b56f2d49892b40149511a62,
         type: 3}
@@ -32939,7 +33063,7 @@ PrefabInstance:
     - target: {fileID: 296282586161115487, guid: 1849f051284c432478d5aaba34cec853,
         type: 3}
       propertyPath: m_RootOrder
-      value: 265
+      value: 263
       objectReference: {fileID: 0}
     - target: {fileID: 296282586161115487, guid: 1849f051284c432478d5aaba34cec853,
         type: 3}
@@ -33019,7 +33143,7 @@ PrefabInstance:
     - target: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 212
+      value: 210
       objectReference: {fileID: 0}
     - target: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
         type: 3}
@@ -33151,7 +33275,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 307
+      value: 305
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -33265,7 +33389,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 306
+      value: 304
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -33369,7 +33493,7 @@ PrefabInstance:
     - target: {fileID: 9173161790594611747, guid: 25108e21a69d52c46a538e66eb85db0a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 135
+      value: 133
       objectReference: {fileID: 0}
     - target: {fileID: 9173161790594611747, guid: 25108e21a69d52c46a538e66eb85db0a,
         type: 3}
@@ -33884,7 +34008,7 @@ PrefabInstance:
     - target: {fileID: 4799658863714516831, guid: fff8b3ada084c1b408e9c34ee1a1dd27,
         type: 3}
       propertyPath: m_RootOrder
-      value: 205
+      value: 203
       objectReference: {fileID: 0}
     - target: {fileID: 4799658863714516831, guid: fff8b3ada084c1b408e9c34ee1a1dd27,
         type: 3}
@@ -34011,7 +34135,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 239
+      value: 237
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -34110,7 +34234,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 118
+      value: 116
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -34190,7 +34314,7 @@ PrefabInstance:
     - target: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 211
+      value: 209
       objectReference: {fileID: 0}
     - target: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
         type: 3}
@@ -34255,6 +34379,81 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1998515046}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2008841493
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 932796153661386794, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint - AncientEngineering
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 314
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.99
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 9.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 13a96d5c007d8e84c9853fda470c1c7c, type: 3}
+--- !u!4 &2008841494 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2008841493}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2011198309
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -34275,7 +34474,7 @@ PrefabInstance:
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 5204881048006630104, guid: 1172c577b92e17940afd7e1729f184f6,
         type: 3}
@@ -34367,7 +34566,7 @@ PrefabInstance:
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 169
+      value: 167
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
@@ -34967,7 +35166,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: 35eed4273d90143b0926de4715bbc06e, type: 3}
       propertyPath: m_RootOrder
-      value: 37
+      value: 36
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: 35eed4273d90143b0926de4715bbc06e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -35042,7 +35241,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 17
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -35149,7 +35348,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 226
+      value: 224
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -35246,7 +35445,7 @@ PrefabInstance:
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 174
+      value: 172
       objectReference: {fileID: 0}
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
@@ -35327,7 +35526,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 111
+      value: 109
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -35412,7 +35611,7 @@ PrefabInstance:
     - target: {fileID: 1427000246303903125, guid: 288980126acf5f441841169958c31630,
         type: 3}
       propertyPath: m_RootOrder
-      value: 141
+      value: 139
       objectReference: {fileID: 0}
     - target: {fileID: 1427000246303903125, guid: 288980126acf5f441841169958c31630,
         type: 3}
@@ -35487,7 +35686,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 33
+      value: 32
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -35587,7 +35786,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_RootOrder
-      value: 44
+      value: 43
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_LocalPosition.x
@@ -35662,7 +35861,7 @@ PrefabInstance:
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 170
+      value: 168
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
@@ -35737,7 +35936,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 99
+      value: 97
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -35822,7 +36021,7 @@ PrefabInstance:
     - target: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 163
+      value: 161
       objectReference: {fileID: 0}
     - target: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
         type: 3}
@@ -35902,7 +36101,7 @@ PrefabInstance:
     - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
         type: 3}
       propertyPath: m_RootOrder
-      value: 155
+      value: 153
       objectReference: {fileID: 0}
     - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
         type: 3}
@@ -36029,7 +36228,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 86
+      value: 84
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -36138,7 +36337,7 @@ PrefabInstance:
     - target: {fileID: 3050131568678634113, guid: fe66ec36f566be84a9ccbc5a90aacd6f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 146
+      value: 144
       objectReference: {fileID: 0}
     - target: {fileID: 3050131568678634113, guid: fe66ec36f566be84a9ccbc5a90aacd6f,
         type: 3}
@@ -36213,7 +36412,7 @@ PrefabInstance:
     - target: {fileID: 3318137014604025332, guid: 9759789a5180a46419c8a7e2e50748e2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 273
+      value: 271
       objectReference: {fileID: 0}
     - target: {fileID: 3318137014604025332, guid: 9759789a5180a46419c8a7e2e50748e2,
         type: 3}
@@ -36283,6 +36482,81 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2097319811}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2106513272
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 932796153661386794, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint - AncientEngineering (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 316
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 13a96d5c007d8e84c9853fda470c1c7c, type: 3}
+--- !u!4 &2106513273 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2106513272}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2111543442
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -36303,7 +36577,7 @@ PrefabInstance:
     - target: {fileID: 3682557958087281322, guid: 6bd9037fbb19a79409aab54675bc363e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 214
+      value: 212
       objectReference: {fileID: 0}
     - target: {fileID: 3682557958087281322, guid: 6bd9037fbb19a79409aab54675bc363e,
         type: 3}
@@ -36430,7 +36704,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 283
+      value: 281
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -36529,7 +36803,7 @@ PrefabInstance:
     - target: {fileID: 4049041059155957662, guid: 9944313d68658b341966d43e2c218eaa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 271
+      value: 269
       objectReference: {fileID: 0}
     - target: {fileID: 4049041059155957662, guid: 9944313d68658b341966d43e2c218eaa,
         type: 3}
@@ -70163,7 +70437,6 @@ Transform:
   m_LocalPosition: {x: 0.5, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 160494699}
   - {fileID: 471706601}
   - {fileID: 689306732}
   - {fileID: 1831768220}
@@ -70478,6 +70751,10 @@ Transform:
   - {fileID: 1227645379}
   - {fileID: 529858408}
   - {fileID: 1160712260}
+  - {fileID: 2008841494}
+  - {fileID: 1800652676}
+  - {fileID: 2106513273}
+  - {fileID: 529418160}
   m_Father: {fileID: 5748139787505685872}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
+++ b/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
@@ -144,7 +144,7 @@ PrefabInstance:
     - target: {fileID: 3718085451752902353, guid: 160baf50e4a27c24a8c1f40b3232c886,
         type: 3}
       propertyPath: m_RootOrder
-      value: 123
+      value: 124
       objectReference: {fileID: 0}
     - target: {fileID: 3718085451752902353, guid: 160baf50e4a27c24a8c1f40b3232c886,
         type: 3}
@@ -219,7 +219,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 112
+      value: 113
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -379,7 +379,7 @@ PrefabInstance:
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 165
+      value: 166
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
@@ -457,7 +457,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 73
+      value: 74
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -525,7 +525,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4297268230046392, guid: 69c27c4a07b053d458c6fec363e66403, type: 3}
       propertyPath: m_RootOrder
-      value: 38
+      value: 39
       objectReference: {fileID: 0}
     - target: {fileID: 4297268230046392, guid: 69c27c4a07b053d458c6fec363e66403, type: 3}
       propertyPath: m_LocalPosition.x
@@ -590,7 +590,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 61
+      value: 62
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -903,7 +903,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 111
+      value: 112
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -978,7 +978,7 @@ PrefabInstance:
     - target: {fileID: 2038054705163664627, guid: c9c8ffe7c5a0a044bbe8343e681e1fe2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 145
+      value: 146
       objectReference: {fileID: 0}
     - target: {fileID: 2038054705163664627, guid: c9c8ffe7c5a0a044bbe8343e681e1fe2,
         type: 3}
@@ -1058,7 +1058,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 104
+      value: 105
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -1143,7 +1143,7 @@ PrefabInstance:
     - target: {fileID: 4462439672258080633, guid: c84a09f09199afb48b0d8a0c5c2a5bea,
         type: 3}
       propertyPath: m_RootOrder
-      value: 196
+      value: 197
       objectReference: {fileID: 0}
     - target: {fileID: 4462439672258080633, guid: c84a09f09199afb48b0d8a0c5c2a5bea,
         type: 3}
@@ -1275,7 +1275,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 92
+      value: 93
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -1374,7 +1374,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 114
+      value: 115
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -1534,7 +1534,7 @@ PrefabInstance:
     - target: {fileID: 5035675889361153591, guid: 5f29a65f1a758eb4ca895615119e8ff7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 154
+      value: 155
       objectReference: {fileID: 0}
     - target: {fileID: 5035675889361153591, guid: 5f29a65f1a758eb4ca895615119e8ff7,
         type: 3}
@@ -1614,7 +1614,7 @@ PrefabInstance:
     - target: {fileID: 728450015767604076, guid: af583b1807508a84cbd05b036e027d96,
         type: 3}
       propertyPath: m_RootOrder
-      value: 59
+      value: 60
       objectReference: {fileID: 0}
     - target: {fileID: 728450015767604076, guid: af583b1807508a84cbd05b036e027d96,
         type: 3}
@@ -1699,7 +1699,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 223
+      value: 224
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -1791,7 +1791,7 @@ PrefabInstance:
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
       propertyPath: m_RootOrder
-      value: 119
+      value: 120
       objectReference: {fileID: 0}
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
@@ -1876,7 +1876,7 @@ PrefabInstance:
     - target: {fileID: 3682557958087281322, guid: 6bd9037fbb19a79409aab54675bc363e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 211
+      value: 212
       objectReference: {fileID: 0}
     - target: {fileID: 3682557958087281322, guid: 6bd9037fbb19a79409aab54675bc363e,
         type: 3}
@@ -1946,7 +1946,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 75
+      value: 76
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -2083,7 +2083,7 @@ PrefabInstance:
     - target: {fileID: 8031874825218677495, guid: 7f7934b263cb23040ade0147d14b39aa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 182
+      value: 183
       objectReference: {fileID: 0}
     - target: {fileID: 8031874825218677495, guid: 7f7934b263cb23040ade0147d14b39aa,
         type: 3}
@@ -2260,7 +2260,7 @@ PrefabInstance:
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
       propertyPath: m_RootOrder
-      value: 180
+      value: 181
       objectReference: {fileID: 0}
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
@@ -2345,7 +2345,7 @@ PrefabInstance:
     - target: {fileID: 5167623093684579179, guid: f25a6f263584e6848819e145b53ee65b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 157
+      value: 158
       objectReference: {fileID: 0}
     - target: {fileID: 5167623093684579179, guid: f25a6f263584e6848819e145b53ee65b,
         type: 3}
@@ -2415,7 +2415,7 @@ PrefabInstance:
     - target: {fileID: 2054426006668562447, guid: 08be734c1a459464f9c78d3b21384339,
         type: 3}
       propertyPath: m_RootOrder
-      value: 195
+      value: 196
       objectReference: {fileID: 0}
     - target: {fileID: 2054426006668562447, guid: 08be734c1a459464f9c78d3b21384339,
         type: 3}
@@ -2510,7 +2510,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 292
+      value: 293
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -2647,7 +2647,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4868564961159832, guid: 85791fbcb6be942d1b318907cb2edec3, type: 3}
       propertyPath: m_RootOrder
-      value: 47
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 4868564961159832, guid: 85791fbcb6be942d1b318907cb2edec3, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2722,7 +2722,7 @@ PrefabInstance:
     - target: {fileID: 5895499867514145751, guid: dd553da79275dac409d269c0d6ec571c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 247
+      value: 248
       objectReference: {fileID: 0}
     - target: {fileID: 5895499867514145751, guid: dd553da79275dac409d269c0d6ec571c,
         type: 3}
@@ -2899,7 +2899,7 @@ PrefabInstance:
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 170
+      value: 171
       objectReference: {fileID: 0}
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
@@ -2990,7 +2990,7 @@ PrefabInstance:
     - target: {fileID: 8031874825218677495, guid: 1002c0247e412884e91c857ce6e51d9c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 177
+      value: 178
       objectReference: {fileID: 0}
     - target: {fileID: 8031874825218677495, guid: 1002c0247e412884e91c857ce6e51d9c,
         type: 3}
@@ -3065,7 +3065,7 @@ PrefabInstance:
     - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 254
+      value: 255
       objectReference: {fileID: 0}
     - target: {fileID: 7045011890306318302, guid: 4e067333d18d9724690055be203850b5,
         type: 3}
@@ -3155,7 +3155,7 @@ PrefabInstance:
     - target: {fileID: 6284585900848704128, guid: a223c02f818b8d74abd3e94371d523d4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 44
+      value: 45
       objectReference: {fileID: 0}
     - target: {fileID: 6284585900848704128, guid: a223c02f818b8d74abd3e94371d523d4,
         type: 3}
@@ -3247,7 +3247,7 @@ PrefabInstance:
     - target: {fileID: 7360425322471321201, guid: bc0cd2a586c78b846a43622b6ea5c953,
         type: 3}
       propertyPath: m_RootOrder
-      value: 155
+      value: 156
       objectReference: {fileID: 0}
     - target: {fileID: 7360425322471321201, guid: bc0cd2a586c78b846a43622b6ea5c953,
         type: 3}
@@ -3334,7 +3334,7 @@ PrefabInstance:
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 257
+      value: 258
       objectReference: {fileID: 0}
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
@@ -3424,7 +3424,7 @@ PrefabInstance:
     - target: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 192
+      value: 193
       objectReference: {fileID: 0}
     - target: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
         type: 3}
@@ -3815,7 +3815,7 @@ PrefabInstance:
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 52
+      value: 53
       objectReference: {fileID: 0}
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
@@ -3928,7 +3928,7 @@ PrefabInstance:
     - target: {fileID: 3129593617119727172, guid: aca91ff2eea9cc64aa3bb9deb8964ab1,
         type: 3}
       propertyPath: m_RootOrder
-      value: 207
+      value: 208
       objectReference: {fileID: 0}
     - target: {fileID: 3129593617119727172, guid: aca91ff2eea9cc64aa3bb9deb8964ab1,
         type: 3}
@@ -4003,7 +4003,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 64
+      value: 65
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -4068,7 +4068,7 @@ PrefabInstance:
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: connectedDevices.Array.size
-      value: 10
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -4119,7 +4119,7 @@ PrefabInstance:
         type: 3}
       propertyPath: connectedDevices.Array.data[9]
       value: 
-      objectReference: {fileID: 1418975194}
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cd57203a8d3f54f478446e9b0ced6cf9, type: 3}
 --- !u!4 &196305287 stripped
@@ -4155,7 +4155,7 @@ PrefabInstance:
     - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 297
+      value: 298
       objectReference: {fileID: 0}
     - target: {fileID: 1323765633690383871, guid: d56b65cebb41c78479fed5218fb0344c,
         type: 3}
@@ -4257,7 +4257,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 235
+      value: 236
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -4376,7 +4376,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 295
+      value: 296
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -4547,7 +4547,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 310
+      value: 314
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -4644,7 +4644,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 78
+      value: 79
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4714,7 +4714,7 @@ PrefabInstance:
     - target: {fileID: 629953639410381570, guid: 381f8f36a2bad374a821a168f8e565b6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 190
+      value: 191
       objectReference: {fileID: 0}
     - target: {fileID: 629953639410381570, guid: 381f8f36a2bad374a821a168f8e565b6,
         type: 3}
@@ -4789,7 +4789,7 @@ PrefabInstance:
     - target: {fileID: 1327387949770221707, guid: dbfef72a303adaa489b990c1ac8a96da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 204
+      value: 205
       objectReference: {fileID: 0}
     - target: {fileID: 1327387949770221707, guid: dbfef72a303adaa489b990c1ac8a96da,
         type: 3}
@@ -4926,7 +4926,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 280
+      value: 281
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -5077,7 +5077,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 236
+      value: 237
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -5181,7 +5181,7 @@ PrefabInstance:
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 169
+      value: 170
       objectReference: {fileID: 0}
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
@@ -5353,7 +5353,7 @@ PrefabInstance:
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 188
+      value: 189
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -5443,7 +5443,7 @@ PrefabInstance:
     - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
         type: 3}
       propertyPath: m_RootOrder
-      value: 151
+      value: 152
       objectReference: {fileID: 0}
     - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
         type: 3}
@@ -5528,7 +5528,7 @@ PrefabInstance:
     - target: {fileID: 8131242747770038361, guid: 790a543a09ecd4442acbf99db25be404,
         type: 3}
       propertyPath: m_RootOrder
-      value: 251
+      value: 252
       objectReference: {fileID: 0}
     - target: {fileID: 8131242747770038361, guid: 790a543a09ecd4442acbf99db25be404,
         type: 3}
@@ -5650,7 +5650,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 81
+      value: 82
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -5811,7 +5811,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 238
+      value: 239
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -5905,7 +5905,7 @@ PrefabInstance:
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
       propertyPath: m_RootOrder
-      value: 274
+      value: 275
       objectReference: {fileID: 0}
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
@@ -5990,7 +5990,7 @@ PrefabInstance:
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 260
+      value: 261
       objectReference: {fileID: 0}
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
@@ -6070,7 +6070,7 @@ PrefabInstance:
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 258
+      value: 259
       objectReference: {fileID: 0}
     - target: {fileID: 3327308291878936282, guid: c0e96760c016b6140ba8c3979e9213f7,
         type: 3}
@@ -6158,7 +6158,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_RootOrder
-      value: 213
+      value: 214
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6223,7 +6223,7 @@ PrefabInstance:
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 166
+      value: 167
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
@@ -6301,7 +6301,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 67
+      value: 68
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6423,7 +6423,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 306
+      value: 310
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -6532,7 +6532,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 284
+      value: 285
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -6671,7 +6671,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 227
+      value: 228
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -6855,7 +6855,7 @@ PrefabInstance:
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 124
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
@@ -6950,7 +6950,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 230
+      value: 231
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -7042,7 +7042,7 @@ PrefabInstance:
     - target: {fileID: 5193296327940958646, guid: 63a58edd1e5377040a9ea82e307c1f04,
         type: 3}
       propertyPath: m_RootOrder
-      value: 159
+      value: 160
       objectReference: {fileID: 0}
     - target: {fileID: 5193296327940958646, guid: 63a58edd1e5377040a9ea82e307c1f04,
         type: 3}
@@ -7338,6 +7338,86 @@ MonoBehaviour:
   MassConsumption: 0.1
   CalculatedMassConsumption: 0
   optimumMassConsumption: 0.05
+--- !u!1001 &414982091
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 4954479433304004807, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: sceneId
+      value: 2495703313
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 301
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.008
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 23.945
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4996160304479888755, guid: 9363154ec4a288f41b8c9681e3531539,
+        type: 3}
+      propertyPath: m_Name
+      value: OP70Handgun
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9363154ec4a288f41b8c9681e3531539, type: 3}
+--- !u!4 &414982092 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4991799778364495879, guid: 9363154ec4a288f41b8c9681e3531539,
+    type: 3}
+  m_PrefabInstance: {fileID: 414982091}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &419265580
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7585,7 +7665,7 @@ PrefabInstance:
     - target: {fileID: 2484719566607390486, guid: a6a04b99723d3ae42958de4193b9920d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 200
+      value: 201
       objectReference: {fileID: 0}
     - target: {fileID: 2484719566607390486, guid: a6a04b99723d3ae42958de4193b9920d,
         type: 3}
@@ -7665,7 +7745,7 @@ PrefabInstance:
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
       propertyPath: m_RootOrder
-      value: 53
+      value: 54
       objectReference: {fileID: 0}
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
@@ -7837,7 +7917,7 @@ PrefabInstance:
     - target: {fileID: 2038054705163664627, guid: c9c8ffe7c5a0a044bbe8343e681e1fe2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 146
+      value: 147
       objectReference: {fileID: 0}
     - target: {fileID: 2038054705163664627, guid: c9c8ffe7c5a0a044bbe8343e681e1fe2,
         type: 3}
@@ -7927,7 +8007,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 113
+      value: 114
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -8012,7 +8092,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 296
+      value: 297
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -8221,7 +8301,7 @@ PrefabInstance:
     - target: {fileID: 7777312831022217093, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
       propertyPath: m_RootOrder
-      value: 174
+      value: 175
       objectReference: {fileID: 0}
     - target: {fileID: 7777312831022217093, guid: 229f1c93e0e4ada439cfe4b781f65997,
         type: 3}
@@ -8393,7 +8473,7 @@ PrefabInstance:
     - target: {fileID: 5674645506955800181, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
       propertyPath: m_RootOrder
-      value: 138
+      value: 139
       objectReference: {fileID: 0}
     - target: {fileID: 5674645506955800181, guid: c3e6805b264a935428b0de415ea57943,
         type: 3}
@@ -8488,7 +8568,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 293
+      value: 294
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -8543,7 +8623,7 @@ PrefabInstance:
     - target: {fileID: 5448639519452539588, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: listOfLights.Array.size
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5448639519452539588, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -8565,6 +8645,11 @@ PrefabInstance:
       propertyPath: listOfLights.Array.data[3]
       value: 
       objectReference: {fileID: 1191174596}
+    - target: {fileID: 5448639519452539588, guid: f2432d244a6b7774ea00ff013beb7dcb,
+        type: 3}
+      propertyPath: listOfLights.Array.data[4]
+      value: 
+      objectReference: {fileID: 997802874}
     - target: {fileID: 8799116497260486352, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: RelatedAPC
@@ -8731,7 +8816,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 226
+      value: 227
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -8875,7 +8960,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 91
+      value: 92
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -9163,7 +9248,7 @@ PrefabInstance:
     - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
         type: 3}
       propertyPath: m_RootOrder
-      value: 202
+      value: 203
       objectReference: {fileID: 0}
     - target: {fileID: 928039887571597778, guid: 68a3eee06f0a8cf4da5d8ab811ce1c73,
         type: 3}
@@ -9248,7 +9333,7 @@ PrefabInstance:
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 317
+      value: 321
       objectReference: {fileID: 0}
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
@@ -9375,7 +9460,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 312
+      value: 316
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -9571,7 +9656,7 @@ PrefabInstance:
     - target: {fileID: 7662282495583499656, guid: 7f32e42309899114b9c122f261161bc5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 140
+      value: 141
       objectReference: {fileID: 0}
     - target: {fileID: 7662282495583499656, guid: 7f32e42309899114b9c122f261161bc5,
         type: 3}
@@ -9656,7 +9741,7 @@ PrefabInstance:
     - target: {fileID: 9031523234013953791, guid: b087cae0f7059d946a59146ea8d0fb04,
         type: 3}
       propertyPath: m_RootOrder
-      value: 250
+      value: 251
       objectReference: {fileID: 0}
     - target: {fileID: 9031523234013953791, guid: b087cae0f7059d946a59146ea8d0fb04,
         type: 3}
@@ -9726,7 +9811,7 @@ PrefabInstance:
     - target: {fileID: 2054426006668562447, guid: 08be734c1a459464f9c78d3b21384339,
         type: 3}
       propertyPath: m_RootOrder
-      value: 194
+      value: 195
       objectReference: {fileID: 0}
     - target: {fileID: 2054426006668562447, guid: 08be734c1a459464f9c78d3b21384339,
         type: 3}
@@ -10153,6 +10238,26 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
+  - first: {x: 28, y: 21, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 2
+      m_TileSpriteIndex: 8
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 29, y: 21, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 2
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
   - first: {x: 36, y: 21, z: 0}
     second:
       serializedVersion: 2
@@ -10164,6 +10269,16 @@ Tilemap:
       dummyAlignment: 0
       m_AllTileFlags: 2147483648
   - first: {x: 21, y: 22, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 2
+      m_TileSpriteIndex: 3
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 2147483648
+  - first: {x: 29, y: 22, z: 0}
     second:
       serializedVersion: 2
       m_TileIndex: 2
@@ -10219,16 +10334,16 @@ Tilemap:
     m_Data: {fileID: 0}
   - m_RefCount: 3
     m_Data: {fileID: 11400000, guid: 71416f6cff737438f9dd90a1cd47c640, type: 2}
-  - m_RefCount: 27
+  - m_RefCount: 30
     m_Data: {fileID: 11400000, guid: cf31da1d9b545944fb7423aac9d9b7d3, type: 2}
   m_TileSpriteArray:
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
+  - m_RefCount: 1
+    m_Data: {fileID: 21300018, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300004, guid: c2a766fe0315373409b87a70f5366f91, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300008, guid: c2a766fe0315373409b87a70f5366f91, type: 3}
-  - m_RefCount: 4
+  - m_RefCount: 5
     m_Data: {fileID: 21300004, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
   - m_RefCount: 3
     m_Data: {fileID: 21300022, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
@@ -10238,14 +10353,14 @@ Tilemap:
     m_Data: {fileID: 21300008, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
   - m_RefCount: 7
     m_Data: {fileID: 21300006, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
-  - m_RefCount: 6
+  - m_RefCount: 7
     m_Data: {fileID: 21300002, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300022, guid: c2a766fe0315373409b87a70f5366f91, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300000, guid: fa4608352c8b8294d9b7cdfbb03f1747, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 30
+  - m_RefCount: 33
     m_Data:
       e00: 1
       e01: 0
@@ -10264,7 +10379,7 @@ Tilemap:
       e32: 0
       e33: 1
   m_TileColorArray:
-  - m_RefCount: 30
+  - m_RefCount: 33
     m_Data: {r: 1, g: 1, b: 1, a: 1}
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
@@ -10315,7 +10430,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 300
+      value: 304
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -10437,7 +10552,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 216
+      value: 217
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -10512,7 +10627,7 @@ PrefabInstance:
     - target: {fileID: 8066134277105145184, guid: 8edc1f3642b9f28429c21e6c30566791,
         type: 3}
       propertyPath: m_RootOrder
-      value: 252
+      value: 253
       objectReference: {fileID: 0}
     - target: {fileID: 8066134277105145184, guid: 8edc1f3642b9f28429c21e6c30566791,
         type: 3}
@@ -10629,7 +10744,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 282
+      value: 283
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -10738,7 +10853,7 @@ PrefabInstance:
     - target: {fileID: 446201704680789046, guid: b09e9d95fbf80594c8bbcf60be9b3f93,
         type: 3}
       propertyPath: m_RootOrder
-      value: 206
+      value: 207
       objectReference: {fileID: 0}
     - target: {fileID: 446201704680789046, guid: b09e9d95fbf80594c8bbcf60be9b3f93,
         type: 3}
@@ -10920,7 +11035,7 @@ PrefabInstance:
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
       propertyPath: m_RootOrder
-      value: 120
+      value: 121
       objectReference: {fileID: 0}
     - target: {fileID: 3546756579768976802, guid: 517c48fc4fc1cba48908d11ec58451ce,
         type: 3}
@@ -11001,7 +11116,7 @@ PrefabInstance:
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 268
+      value: 269
       objectReference: {fileID: 0}
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
@@ -12079,7 +12194,7 @@ PrefabInstance:
     - target: {fileID: 5218729519462851643, guid: 4a5b6baeb439ba249b1abfcd81f5d624,
         type: 3}
       propertyPath: m_RootOrder
-      value: 175
+      value: 176
       objectReference: {fileID: 0}
     - target: {fileID: 5218729519462851643, guid: 4a5b6baeb439ba249b1abfcd81f5d624,
         type: 3}
@@ -12162,7 +12277,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 71
+      value: 72
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12242,7 +12357,7 @@ PrefabInstance:
     - target: {fileID: 7203165141458395214, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
       propertyPath: m_RootOrder
-      value: 132
+      value: 133
       objectReference: {fileID: 0}
     - target: {fileID: 7203165141458395214, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
@@ -12322,7 +12437,7 @@ PrefabInstance:
     - target: {fileID: 9173161790594611747, guid: 25108e21a69d52c46a538e66eb85db0a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 134
+      value: 135
       objectReference: {fileID: 0}
     - target: {fileID: 9173161790594611747, guid: 25108e21a69d52c46a538e66eb85db0a,
         type: 3}
@@ -12402,7 +12517,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 115
+      value: 116
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -12534,7 +12649,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 277
+      value: 278
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -12822,7 +12937,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 255
+      value: 256
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -13076,7 +13191,7 @@ PrefabInstance:
     - target: {fileID: 2484719566607390486, guid: a6a04b99723d3ae42958de4193b9920d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 199
+      value: 200
       objectReference: {fileID: 0}
     - target: {fileID: 2484719566607390486, guid: a6a04b99723d3ae42958de4193b9920d,
         type: 3}
@@ -13161,7 +13276,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 246
+      value: 247
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -13253,7 +13368,7 @@ PrefabInstance:
     - target: {fileID: 550404675964371356, guid: 89f38936254ca964a85299ce289225ad,
         type: 3}
       propertyPath: m_RootOrder
-      value: 181
+      value: 182
       objectReference: {fileID: 0}
     - target: {fileID: 550404675964371356, guid: 89f38936254ca964a85299ce289225ad,
         type: 3}
@@ -13477,7 +13592,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 290
+      value: 291
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -13601,7 +13716,7 @@ PrefabInstance:
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 49
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
@@ -13704,7 +13819,7 @@ PrefabInstance:
     - target: {fileID: 228549275771145858, guid: 6d8f04f09fd70254ead647566210cd74,
         type: 3}
       propertyPath: m_RootOrder
-      value: 128
+      value: 129
       objectReference: {fileID: 0}
     - target: {fileID: 228549275771145858, guid: 6d8f04f09fd70254ead647566210cd74,
         type: 3}
@@ -13799,7 +13914,7 @@ PrefabInstance:
     - target: {fileID: 7203165141458395214, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
       propertyPath: m_RootOrder
-      value: 137
+      value: 138
       objectReference: {fileID: 0}
     - target: {fileID: 7203165141458395214, guid: 5dce4d3e01518474bb9bb8085b718980,
         type: 3}
@@ -13874,7 +13989,7 @@ PrefabInstance:
     - target: {fileID: 296282586161115487, guid: 1849f051284c432478d5aaba34cec853,
         type: 3}
       propertyPath: m_RootOrder
-      value: 264
+      value: 265
       objectReference: {fileID: 0}
     - target: {fileID: 296282586161115487, guid: 1849f051284c432478d5aaba34cec853,
         type: 3}
@@ -13949,7 +14064,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 62
+      value: 63
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -14116,7 +14231,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 105
+      value: 106
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -14195,7 +14310,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 67647418286998, guid: 4c38ee85ca3f4664f81d94e975c92fc7, type: 3}
       propertyPath: m_RootOrder
-      value: 150
+      value: 151
       objectReference: {fileID: 0}
     - target: {fileID: 67647418286998, guid: 4c38ee85ca3f4664f81d94e975c92fc7, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14269,7 +14384,7 @@ PrefabInstance:
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 262
+      value: 263
       objectReference: {fileID: 0}
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
@@ -14352,7 +14467,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 219
+      value: 220
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14517,7 +14632,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 217
+      value: 218
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14592,7 +14707,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 232
+      value: 233
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -14813,7 +14928,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 221
+      value: 222
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -14920,7 +15035,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 291
+      value: 292
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -15064,7 +15179,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 308
+      value: 312
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -15253,7 +15368,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 275
+      value: 276
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -15357,7 +15472,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 100
+      value: 101
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -15437,7 +15552,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 63
+      value: 64
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -15619,7 +15734,7 @@ PrefabInstance:
     - target: {fileID: 7999698691295358753, guid: f3706893770084a45ae509ebf6836cc9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 39
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 7999698691295358753, guid: f3706893770084a45ae509ebf6836cc9,
         type: 3}
@@ -15697,7 +15812,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4271421665851644, guid: 1581b03bb13b84328a0f9fe743bb5bbf, type: 3}
       propertyPath: m_RootOrder
-      value: 48
+      value: 49
       objectReference: {fileID: 0}
     - target: {fileID: 4271421665851644, guid: 1581b03bb13b84328a0f9fe743bb5bbf, type: 3}
       propertyPath: m_LocalPosition.x
@@ -15933,7 +16048,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 309
+      value: 313
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -16030,7 +16145,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_RootOrder
-      value: 42
+      value: 43
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16115,7 +16230,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 287
+      value: 288
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -16229,7 +16344,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 101
+      value: 102
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -16409,7 +16524,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_RootOrder
-      value: 41
+      value: 42
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16479,7 +16594,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 103
+      value: 104
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -16569,7 +16684,7 @@ PrefabInstance:
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 55
+      value: 56
       objectReference: {fileID: 0}
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
@@ -16746,7 +16861,7 @@ PrefabInstance:
     - target: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 193
+      value: 194
       objectReference: {fileID: 0}
     - target: {fileID: 8605860254165158179, guid: c9d03be44229a74469be1b6738941ec3,
         type: 3}
@@ -17003,7 +17118,7 @@ PrefabInstance:
     - target: {fileID: 1775224900688995769, guid: 64b0546c6b2243241846fced5f70f123,
         type: 3}
       propertyPath: m_RootOrder
-      value: 256
+      value: 257
       objectReference: {fileID: 0}
     - target: {fileID: 1775224900688995769, guid: 64b0546c6b2243241846fced5f70f123,
         type: 3}
@@ -17088,7 +17203,7 @@ PrefabInstance:
     - target: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 160
+      value: 161
       objectReference: {fileID: 0}
     - target: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
         type: 3}
@@ -17168,7 +17283,7 @@ PrefabInstance:
     - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
         type: 3}
       propertyPath: m_RootOrder
-      value: 152
+      value: 153
       objectReference: {fileID: 0}
     - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
         type: 3}
@@ -17246,7 +17361,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 70
+      value: 71
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -17316,7 +17431,7 @@ PrefabInstance:
     - target: {fileID: 3246771360178382922, guid: cbae9a210d638ba4b9402e836c970fa2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 142
+      value: 143
       objectReference: {fileID: 0}
     - target: {fileID: 3246771360178382922, guid: cbae9a210d638ba4b9402e836c970fa2,
         type: 3}
@@ -17413,7 +17528,7 @@ PrefabInstance:
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
       propertyPath: m_RootOrder
-      value: 54
+      value: 55
       objectReference: {fileID: 0}
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
@@ -17581,10 +17696,15 @@ PrefabInstance:
       propertyPath: sceneId
       value: 162592490
       objectReference: {fileID: 0}
+    - target: {fileID: 6093979353265471059, guid: c937e0abe85aca9499d09951de736ec6,
+        type: 3}
+      propertyPath: relatedLightSwitch
+      value: 
+      objectReference: {fileID: 490701685}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 87
+      value: 88
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -17666,6 +17786,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 053e2d398d507cc449f05be2499aa497, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &997802874 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6093979353265471059, guid: c937e0abe85aca9499d09951de736ec6,
+    type: 3}
+  m_PrefabInstance: {fileID: 997802871}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1001537897
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17718,7 +17850,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 88
+      value: 89
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -17822,7 +17954,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 107
+      value: 108
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -17922,7 +18054,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 302
+      value: 306
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -18107,7 +18239,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: c1aebfea91112ef4a83ba10f37d3f437,
         type: 3}
       propertyPath: m_RootOrder
-      value: 110
+      value: 111
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: c1aebfea91112ef4a83ba10f37d3f437,
         type: 3}
@@ -18190,7 +18322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 69
+      value: 70
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -18255,7 +18387,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 108
+      value: 109
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -18335,7 +18467,7 @@ PrefabInstance:
     - target: {fileID: 8793194575595567163, guid: 7ba0f8027fae0b747803eabaf13523c7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 198
+      value: 199
       objectReference: {fileID: 0}
     - target: {fileID: 8793194575595567163, guid: 7ba0f8027fae0b747803eabaf13523c7,
         type: 3}
@@ -18425,7 +18557,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 231
+      value: 232
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -18522,7 +18654,7 @@ PrefabInstance:
     - target: {fileID: 3295880826340575877, guid: e89c616b1df1e724baef0e39ac0037f3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 173
+      value: 174
       objectReference: {fileID: 0}
     - target: {fileID: 3295880826340575877, guid: e89c616b1df1e724baef0e39ac0037f3,
         type: 3}
@@ -18649,7 +18781,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 239
+      value: 240
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -18748,7 +18880,7 @@ PrefabInstance:
     - target: {fileID: 2194074672386895265, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
         type: 3}
       propertyPath: m_RootOrder
-      value: 273
+      value: 274
       objectReference: {fileID: 0}
     - target: {fileID: 2194074672386895265, guid: c27cb1a9c87d9c94abaaf3bd9df216df,
         type: 3}
@@ -18833,7 +18965,7 @@ PrefabInstance:
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
       propertyPath: m_RootOrder
-      value: 179
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
@@ -19020,7 +19152,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 85
+      value: 86
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -19114,7 +19246,7 @@ PrefabInstance:
     - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 208
+      value: 209
       objectReference: {fileID: 0}
     - target: {fileID: 2039161782966546691, guid: 7147422770216fc47b220e213ce8395c,
         type: 3}
@@ -19225,7 +19357,7 @@ PrefabInstance:
     - target: {fileID: 7089628496362807847, guid: c5aecb2f211bbae49916919ff6128733,
         type: 3}
       propertyPath: m_RootOrder
-      value: 186
+      value: 187
       objectReference: {fileID: 0}
     - target: {fileID: 7089628496362807847, guid: c5aecb2f211bbae49916919ff6128733,
         type: 3}
@@ -19354,7 +19486,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 276
+      value: 277
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -19609,7 +19741,7 @@ PrefabInstance:
     - target: {fileID: 5730203012241659306, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 184
+      value: 185
       objectReference: {fileID: 0}
     - target: {fileID: 5730203012241659306, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
@@ -19694,7 +19826,7 @@ PrefabInstance:
     - target: {fileID: 7184381825146832964, guid: 2e464f403424dbd409a91b0abbb4121c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 148
+      value: 149
       objectReference: {fileID: 0}
     - target: {fileID: 7184381825146832964, guid: 2e464f403424dbd409a91b0abbb4121c,
         type: 3}
@@ -19779,7 +19911,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 283
+      value: 284
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -19893,7 +20025,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 99
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -20075,7 +20207,7 @@ PrefabInstance:
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 259
+      value: 260
       objectReference: {fileID: 0}
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
@@ -20160,7 +20292,7 @@ PrefabInstance:
     - target: {fileID: 6518921224212731652, guid: f5de4bfc8649c7a428e694010049af77,
         type: 3}
       propertyPath: m_RootOrder
-      value: 201
+      value: 202
       objectReference: {fileID: 0}
     - target: {fileID: 6518921224212731652, guid: f5de4bfc8649c7a428e694010049af77,
         type: 3}
@@ -20245,7 +20377,7 @@ PrefabInstance:
     - target: {fileID: 7777312831022217093, guid: fd2b975bb2d60fb429c193f9ef1d31b0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 143
+      value: 144
       objectReference: {fileID: 0}
     - target: {fileID: 7777312831022217093, guid: fd2b975bb2d60fb429c193f9ef1d31b0,
         type: 3}
@@ -20377,7 +20509,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 313
+      value: 317
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -20476,7 +20608,7 @@ PrefabInstance:
     - target: {fileID: 4462439672258080633, guid: c84a09f09199afb48b0d8a0c5c2a5bea,
         type: 3}
       propertyPath: m_RootOrder
-      value: 197
+      value: 198
       objectReference: {fileID: 0}
     - target: {fileID: 4462439672258080633, guid: c84a09f09199afb48b0d8a0c5c2a5bea,
         type: 3}
@@ -20551,7 +20683,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 98
+      value: 99
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -20688,7 +20820,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 278
+      value: 279
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -20792,7 +20924,7 @@ PrefabInstance:
     - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 129
+      value: 130
       objectReference: {fileID: 0}
     - target: {fileID: 3018541687849032159, guid: d2f2400aac0da54468da76680579c29b,
         type: 3}
@@ -20872,7 +21004,7 @@ PrefabInstance:
     - target: {fileID: 728450015767604076, guid: af583b1807508a84cbd05b036e027d96,
         type: 3}
       propertyPath: m_RootOrder
-      value: 60
+      value: 61
       objectReference: {fileID: 0}
     - target: {fileID: 728450015767604076, guid: af583b1807508a84cbd05b036e027d96,
         type: 3}
@@ -21004,7 +21136,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 303
+      value: 307
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -21101,7 +21233,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 68
+      value: 69
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21166,7 +21298,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 95
+      value: 96
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -21249,7 +21381,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 76
+      value: 77
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21324,7 +21456,7 @@ PrefabInstance:
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 56
+      value: 57
       objectReference: {fileID: 0}
     - target: {fileID: 7304379382918517758, guid: e007b4548279217449b704355d9e112b,
         type: 3}
@@ -21581,7 +21713,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 67647418286998, guid: 4c38ee85ca3f4664f81d94e975c92fc7, type: 3}
       propertyPath: m_RootOrder
-      value: 149
+      value: 150
       objectReference: {fileID: 0}
     - target: {fileID: 67647418286998, guid: 4c38ee85ca3f4664f81d94e975c92fc7, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21707,7 +21839,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 311
+      value: 315
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -21804,7 +21936,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 72
+      value: 73
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21911,7 +22043,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 234
+      value: 235
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -22005,6 +22137,91 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8cd47c8a7b3ca4905983be3a08c1caf0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1240751654
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 8399202269906357691, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_Name
+      value: PistolMagazine9mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 303
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 34.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8438156590381850731, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: snapToGridOnStart
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8438549908676571151, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: sceneId
+      value: 3328612865
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 678d8623073f29f4cb23d4cb26359cd4, type: 3}
+--- !u!4 &1240751655 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+    type: 3}
+  m_PrefabInstance: {fileID: 1240751654}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1245742465
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -22020,7 +22237,7 @@ PrefabInstance:
     - target: {fileID: 4049041059155957662, guid: dd86caf1f673b7642be83819773021d8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 270
+      value: 271
       objectReference: {fileID: 0}
     - target: {fileID: 4049041059155957662, guid: dd86caf1f673b7642be83819773021d8,
         type: 3}
@@ -22202,7 +22419,7 @@ PrefabInstance:
     - target: {fileID: 8954212430775875356, guid: 60badd0969907f044819febb546b443f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 121
+      value: 122
       objectReference: {fileID: 0}
     - target: {fileID: 8954212430775875356, guid: 60badd0969907f044819febb546b443f,
         type: 3}
@@ -22389,7 +22606,7 @@ PrefabInstance:
     - target: {fileID: 6409286586645294639, guid: 133b93fb7d8a5794bbfff599bea64863,
         type: 3}
       propertyPath: m_RootOrder
-      value: 141
+      value: 142
       objectReference: {fileID: 0}
     - target: {fileID: 6409286586645294639, guid: 133b93fb7d8a5794bbfff599bea64863,
         type: 3}
@@ -22487,7 +22704,7 @@ PrefabInstance:
     - target: {fileID: 3130401872829826601, guid: 66f05879999b49141bbfc4e0fdc9903a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 249
+      value: 250
       objectReference: {fileID: 0}
     - target: {fileID: 3130401872829826601, guid: 66f05879999b49141bbfc4e0fdc9903a,
         type: 3}
@@ -22562,7 +22779,7 @@ PrefabInstance:
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 126
+      value: 127
       objectReference: {fileID: 0}
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
@@ -22647,7 +22864,7 @@ PrefabInstance:
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
       propertyPath: m_RootOrder
-      value: 222
+      value: 223
       objectReference: {fileID: 0}
     - target: {fileID: 955873216377829782, guid: 1f10fce737097ce44affadeeb9bea4da,
         type: 3}
@@ -22846,7 +23063,7 @@ PrefabInstance:
     - target: {fileID: 2402019029272391321, guid: a85bb77436de9574c8523fe45acffb14,
         type: 3}
       propertyPath: m_RootOrder
-      value: 117
+      value: 118
       objectReference: {fileID: 0}
     - target: {fileID: 2402019029272391321, guid: a85bb77436de9574c8523fe45acffb14,
         type: 3}
@@ -22931,7 +23148,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 285
+      value: 286
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -23087,7 +23304,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 83
+      value: 84
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -23201,7 +23418,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 294
+      value: 295
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -23372,7 +23589,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 90
+      value: 91
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -23563,7 +23780,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 220
+      value: 221
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -23653,7 +23870,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 225
+      value: 226
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -23750,7 +23967,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 229
+      value: 230
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -23857,7 +24074,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 93
+      value: 94
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -23951,7 +24168,7 @@ PrefabInstance:
     - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 245
+      value: 246
       objectReference: {fileID: 0}
     - target: {fileID: 3063805286163523616, guid: 703ee43e84da301438311278f13a496f,
         type: 3}
@@ -24041,7 +24258,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 288
+      value: 289
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -24160,7 +24377,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 228
+      value: 229
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -24257,7 +24474,7 @@ PrefabInstance:
     - target: {fileID: 5895499867514145751, guid: dd553da79275dac409d269c0d6ec571c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 248
+      value: 249
       objectReference: {fileID: 0}
     - target: {fileID: 5895499867514145751, guid: dd553da79275dac409d269c0d6ec571c,
         type: 3}
@@ -24384,7 +24601,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 301
+      value: 305
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -24525,7 +24742,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 240
+      value: 241
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -24632,7 +24849,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 77
+      value: 78
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -24787,7 +25004,7 @@ PrefabInstance:
     - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 299
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 6439005145208020592, guid: a12add7b219842843b678dec171704cb,
         type: 3}
@@ -24857,7 +25074,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 106
+      value: 107
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -24940,7 +25157,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 218
+      value: 219
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -25015,7 +25232,7 @@ PrefabInstance:
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 171
+      value: 172
       objectReference: {fileID: 0}
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
@@ -25097,7 +25314,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: d04e66db37d051241af5586e1bdfff93,
+      objectReference: {fileID: 21300000, guid: 1f98145bcaa7b9947888e1677211ece0,
         type: 3}
     - target: {fileID: 8568672687853555390, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
@@ -25107,7 +25324,7 @@ PrefabInstance:
     - target: {fileID: 8573033213633377226, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 136
+      value: 137
       objectReference: {fileID: 0}
     - target: {fileID: 8573033213633377226, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
@@ -25203,7 +25420,7 @@ PrefabInstance:
     - target: {fileID: 8582924881145235216, guid: 66a5287d0bf216847a2f4fe34228a0cf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 131
+      value: 132
       objectReference: {fileID: 0}
     - target: {fileID: 8582924881145235216, guid: 66a5287d0bf216847a2f4fe34228a0cf,
         type: 3}
@@ -25330,7 +25547,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 307
+      value: 311
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -25424,7 +25641,7 @@ PrefabInstance:
     - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 298
+      value: 299
       objectReference: {fileID: 0}
     - target: {fileID: 2478198559564463639, guid: 63c4576068eee0e4cb8cb02ef5b3bebf,
         type: 3}
@@ -25509,7 +25726,7 @@ PrefabInstance:
     - target: {fileID: 5521070544968489048, guid: a565b378d835ddf478bee7e52e6b95dd,
         type: 3}
       propertyPath: m_RootOrder
-      value: 183
+      value: 184
       objectReference: {fileID: 0}
     - target: {fileID: 5521070544968489048, guid: a565b378d835ddf478bee7e52e6b95dd,
         type: 3}
@@ -25592,7 +25809,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_RootOrder
-      value: 214
+      value: 215
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: b5d421f0156248b4297eecc918b8758a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -25652,7 +25869,7 @@ PrefabInstance:
     - target: {fileID: 254800111756226720, guid: c4c22bdc7cdd546479ac1de5589b5617,
         type: 3}
       propertyPath: m_RootOrder
-      value: 46
+      value: 47
       objectReference: {fileID: 0}
     - target: {fileID: 254800111756226720, guid: c4c22bdc7cdd546479ac1de5589b5617,
         type: 3}
@@ -25737,7 +25954,7 @@ PrefabInstance:
     - target: {fileID: 1194072455337391194, guid: 007d9f81d20c55d479d86a1d7d4343db,
         type: 3}
       propertyPath: m_RootOrder
-      value: 118
+      value: 119
       objectReference: {fileID: 0}
     - target: {fileID: 1194072455337391194, guid: 007d9f81d20c55d479d86a1d7d4343db,
         type: 3}
@@ -25827,7 +26044,7 @@ PrefabInstance:
     - target: {fileID: 7553721075204866577, guid: 7a167eaa044fd7142ad12de730b62846,
         type: 3}
       propertyPath: m_RootOrder
-      value: 272
+      value: 273
       objectReference: {fileID: 0}
     - target: {fileID: 7553721075204866577, guid: 7a167eaa044fd7142ad12de730b62846,
         type: 3}
@@ -25900,7 +26117,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_RootOrder
-      value: 215
+      value: 216
       objectReference: {fileID: 0}
     - target: {fileID: 4726396450817676, guid: e4b5330dc21e94b0494056c5ef239d49, type: 3}
       propertyPath: m_LocalPosition.x
@@ -25968,7 +26185,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_RootOrder
-      value: 74
+      value: 75
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: e84d2342632015b4b8ce3227cb04533b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -26038,7 +26255,7 @@ PrefabInstance:
     - target: {fileID: 629953639410381570, guid: 381f8f36a2bad374a821a168f8e565b6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 191
+      value: 192
       objectReference: {fileID: 0}
     - target: {fileID: 629953639410381570, guid: 381f8f36a2bad374a821a168f8e565b6,
         type: 3}
@@ -26133,7 +26350,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 94
+      value: 95
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -26242,7 +26459,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 286
+      value: 287
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -26824,7 +27041,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 89
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -26933,7 +27150,7 @@ PrefabInstance:
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 289
+      value: 290
       objectReference: {fileID: 0}
     - target: {fileID: 5430074769912739366, guid: f2432d244a6b7774ea00ff013beb7dcb,
         type: 3}
@@ -27262,7 +27479,7 @@ PrefabInstance:
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 266
+      value: 267
       objectReference: {fileID: 0}
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
@@ -27358,7 +27575,7 @@ PrefabInstance:
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 261
+      value: 262
       objectReference: {fileID: 0}
     - target: {fileID: 2283422890222151078, guid: 9b996da43261266449d4ad99b2ddac7f,
         type: 3}
@@ -27485,7 +27702,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 82
+      value: 83
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -27589,7 +27806,7 @@ PrefabInstance:
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
       propertyPath: m_RootOrder
-      value: 37
+      value: 38
       objectReference: {fileID: 0}
     - target: {fileID: 1925386106379506438, guid: 99fa44696e5676a41bb345c085b3e768,
         type: 3}
@@ -27672,7 +27889,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4549118663027890, guid: 9a960afa1c32b4a208621260530a2d8a, type: 3}
       propertyPath: m_RootOrder
-      value: 176
+      value: 177
       objectReference: {fileID: 0}
     - target: {fileID: 4549118663027890, guid: 9a960afa1c32b4a208621260530a2d8a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -27737,7 +27954,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 66
+      value: 67
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -28056,7 +28273,7 @@ PrefabInstance:
     - target: {fileID: 5730203012241659306, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 185
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 5730203012241659306, guid: 6f371050bff8b32438f91c7c680900bb,
         type: 3}
@@ -28151,7 +28368,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 86
+      value: 87
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -28250,7 +28467,7 @@ PrefabInstance:
     - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
         type: 3}
       propertyPath: m_RootOrder
-      value: 253
+      value: 254
       objectReference: {fileID: 0}
     - target: {fileID: 4249355701057277291, guid: 8fb9b82aab871a54fb9bdb7e4a985821,
         type: 3}
@@ -28335,7 +28552,7 @@ PrefabInstance:
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 50
+      value: 51
       objectReference: {fileID: 0}
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
@@ -28433,7 +28650,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 65
+      value: 66
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -28564,7 +28781,7 @@ PrefabInstance:
         type: 3}
       propertyPath: connectedDevices.Array.data[11]
       value: 
-      objectReference: {fileID: 919143042}
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cd57203a8d3f54f478446e9b0ced6cf9, type: 3}
 --- !u!4 &1694884341 stripped
@@ -28605,7 +28822,7 @@ PrefabInstance:
     - target: {fileID: 7360425322471321201, guid: bc0cd2a586c78b846a43622b6ea5c953,
         type: 3}
       propertyPath: m_RootOrder
-      value: 156
+      value: 157
       objectReference: {fileID: 0}
     - target: {fileID: 7360425322471321201, guid: bc0cd2a586c78b846a43622b6ea5c953,
         type: 3}
@@ -28845,7 +29062,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 279
+      value: 280
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -28939,7 +29156,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 96
+      value: 97
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -29024,7 +29241,7 @@ PrefabInstance:
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
       propertyPath: m_RootOrder
-      value: 58
+      value: 59
       objectReference: {fileID: 0}
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
@@ -29099,7 +29316,7 @@ PrefabInstance:
     - target: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 164
+      value: 165
       objectReference: {fileID: 0}
     - target: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
         type: 3}
@@ -29555,7 +29772,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 102
+      value: 103
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -29762,7 +29979,7 @@ PrefabInstance:
     - target: {fileID: 6511207373575406613, guid: 1488f67a55cb9b84098e095e65e5a2b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 187
+      value: 188
       objectReference: {fileID: 0}
     - target: {fileID: 6511207373575406613, guid: 1488f67a55cb9b84098e095e65e5a2b3,
         type: 3}
@@ -29842,7 +30059,7 @@ PrefabInstance:
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 189
+      value: 190
       objectReference: {fileID: 0}
     - target: {fileID: 2650052370968986085, guid: 82cb1c39112974a498a9756981eb07d0,
         type: 3}
@@ -29912,6 +30129,91 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1764626439}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1770617772
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 8399202269906357691, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_Name
+      value: PistolMagazine9mm
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 302
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 33.78
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8438156590381850731, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: snapToGridOnStart
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8438549908676571151, guid: 678d8623073f29f4cb23d4cb26359cd4,
+        type: 3}
+      propertyPath: sceneId
+      value: 2615049372
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 678d8623073f29f4cb23d4cb26359cd4, type: 3}
+--- !u!4 &1770617773 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8402722768730730703, guid: 678d8623073f29f4cb23d4cb26359cd4,
+    type: 3}
+  m_PrefabInstance: {fileID: 1770617772}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1777094596
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -29964,7 +30266,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 242
+      value: 243
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -30068,7 +30370,7 @@ PrefabInstance:
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 125
+      value: 126
       objectReference: {fileID: 0}
     - target: {fileID: 5766763191504408339, guid: b83b68cfa4a201748aeeece963a989c3,
         type: 3}
@@ -30173,7 +30475,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 233
+      value: 234
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -30421,7 +30723,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 244
+      value: 245
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -30520,7 +30822,7 @@ PrefabInstance:
     - target: {fileID: 5193296327940958646, guid: 63a58edd1e5377040a9ea82e307c1f04,
         type: 3}
       propertyPath: m_RootOrder
-      value: 158
+      value: 159
       objectReference: {fileID: 0}
     - target: {fileID: 5193296327940958646, guid: 63a58edd1e5377040a9ea82e307c1f04,
         type: 3}
@@ -30605,7 +30907,7 @@ PrefabInstance:
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 315
+      value: 319
       objectReference: {fileID: 0}
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
@@ -30680,7 +30982,7 @@ PrefabInstance:
     - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
         type: 3}
       propertyPath: m_RootOrder
-      value: 45
+      value: 46
       objectReference: {fileID: 0}
     - target: {fileID: 5604492423533202098, guid: e947d751522b07a4186cd276fb16eefe,
         type: 3}
@@ -30932,7 +31234,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 243
+      value: 244
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -31032,7 +31334,7 @@ PrefabInstance:
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 265
+      value: 266
       objectReference: {fileID: 0}
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
@@ -31165,7 +31467,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 241
+      value: 242
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -31274,7 +31576,7 @@ PrefabInstance:
     - target: {fileID: 311235556692342817, guid: 7953abf1584ad8241b2281698de84f40,
         type: 3}
       propertyPath: m_RootOrder
-      value: 80
+      value: 81
       objectReference: {fileID: 0}
     - target: {fileID: 311235556692342817, guid: 7953abf1584ad8241b2281698de84f40,
         type: 3}
@@ -31463,7 +31765,7 @@ PrefabInstance:
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 79
+      value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 1235378994494485645, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -31635,7 +31937,7 @@ PrefabInstance:
     - target: {fileID: 1194072455337391194, guid: 007d9f81d20c55d479d86a1d7d4343db,
         type: 3}
       propertyPath: m_RootOrder
-      value: 122
+      value: 123
       objectReference: {fileID: 0}
     - target: {fileID: 1194072455337391194, guid: 007d9f81d20c55d479d86a1d7d4343db,
         type: 3}
@@ -31720,7 +32022,7 @@ PrefabInstance:
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 51
+      value: 52
       objectReference: {fileID: 0}
     - target: {fileID: 4751204249681072796, guid: be26d178314bedc419e95cd4466da4e5,
         type: 3}
@@ -31829,7 +32131,7 @@ PrefabInstance:
     - target: {fileID: 5453087981515002643, guid: 34894a7b128fef84588648dd03311de5,
         type: 3}
       propertyPath: m_RootOrder
-      value: 205
+      value: 206
       objectReference: {fileID: 0}
     - target: {fileID: 5453087981515002643, guid: 34894a7b128fef84588648dd03311de5,
         type: 3}
@@ -32098,7 +32400,7 @@ PrefabInstance:
     - target: {fileID: 8573033213633377226, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 135
+      value: 136
       objectReference: {fileID: 0}
     - target: {fileID: 8573033213633377226, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
@@ -32179,7 +32481,7 @@ PrefabInstance:
     - target: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 162
+      value: 163
       objectReference: {fileID: 0}
     - target: {fileID: 3956749382267164151, guid: 423cab216aa4e354f8159742cc80d10a,
         type: 3}
@@ -32269,7 +32571,7 @@ PrefabInstance:
     - target: {fileID: 6752097109298067032, guid: 13186a514a60194429e94407b6cf1e0a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 163
+      value: 164
       objectReference: {fileID: 0}
     - target: {fileID: 6752097109298067032, guid: 13186a514a60194429e94407b6cf1e0a,
         type: 3}
@@ -32483,7 +32785,7 @@ PrefabInstance:
     - target: {fileID: 5327488673359562728, guid: 29ecbf5a1d918574cbcf5853927e0944,
         type: 3}
       propertyPath: m_RootOrder
-      value: 127
+      value: 128
       objectReference: {fileID: 0}
     - target: {fileID: 5327488673359562728, guid: 29ecbf5a1d918574cbcf5853927e0944,
         type: 3}
@@ -32569,7 +32871,7 @@ PrefabInstance:
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 267
+      value: 268
       objectReference: {fileID: 0}
     - target: {fileID: 461637258738260195, guid: d243343741d540446b159becf769231a,
         type: 3}
@@ -32665,7 +32967,7 @@ PrefabInstance:
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
       propertyPath: m_RootOrder
-      value: 57
+      value: 58
       objectReference: {fileID: 0}
     - target: {fileID: 4316376699312728761, guid: d4a3f41d96f2c4143b8556508db41c57,
         type: 3}
@@ -32750,7 +33052,7 @@ PrefabInstance:
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
       propertyPath: m_RootOrder
-      value: 178
+      value: 179
       objectReference: {fileID: 0}
     - target: {fileID: 3967934396199251458, guid: c0cbb1853d350404685a523d617f3458,
         type: 3}
@@ -32835,7 +33137,7 @@ PrefabInstance:
     - target: {fileID: 8582924881145235216, guid: 66a5287d0bf216847a2f4fe34228a0cf,
         type: 3}
       propertyPath: m_RootOrder
-      value: 130
+      value: 131
       objectReference: {fileID: 0}
     - target: {fileID: 8582924881145235216, guid: 66a5287d0bf216847a2f4fe34228a0cf,
         type: 3}
@@ -32908,7 +33210,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: a6f87f3db636f2c4ba3aa4763aba4c3b, type: 3}
       propertyPath: m_RootOrder
-      value: 40
+      value: 41
       objectReference: {fileID: 0}
     - target: {fileID: 4025345055859194, guid: a6f87f3db636f2c4ba3aa4763aba4c3b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -32978,7 +33280,7 @@ PrefabInstance:
     - target: {fileID: 2186281498986418755, guid: 53f6552a4b56f2d49892b40149511a62,
         type: 3}
       propertyPath: m_RootOrder
-      value: 147
+      value: 148
       objectReference: {fileID: 0}
     - target: {fileID: 2186281498986418755, guid: 53f6552a4b56f2d49892b40149511a62,
         type: 3}
@@ -33063,7 +33365,7 @@ PrefabInstance:
     - target: {fileID: 296282586161115487, guid: 1849f051284c432478d5aaba34cec853,
         type: 3}
       propertyPath: m_RootOrder
-      value: 263
+      value: 264
       objectReference: {fileID: 0}
     - target: {fileID: 296282586161115487, guid: 1849f051284c432478d5aaba34cec853,
         type: 3}
@@ -33143,7 +33445,7 @@ PrefabInstance:
     - target: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 210
+      value: 211
       objectReference: {fileID: 0}
     - target: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
         type: 3}
@@ -33275,7 +33577,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 305
+      value: 309
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -33389,7 +33691,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 304
+      value: 308
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -33493,7 +33795,7 @@ PrefabInstance:
     - target: {fileID: 9173161790594611747, guid: 25108e21a69d52c46a538e66eb85db0a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 133
+      value: 134
       objectReference: {fileID: 0}
     - target: {fileID: 9173161790594611747, guid: 25108e21a69d52c46a538e66eb85db0a,
         type: 3}
@@ -34008,7 +34310,7 @@ PrefabInstance:
     - target: {fileID: 4799658863714516831, guid: fff8b3ada084c1b408e9c34ee1a1dd27,
         type: 3}
       propertyPath: m_RootOrder
-      value: 203
+      value: 204
       objectReference: {fileID: 0}
     - target: {fileID: 4799658863714516831, guid: fff8b3ada084c1b408e9c34ee1a1dd27,
         type: 3}
@@ -34135,7 +34437,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 237
+      value: 238
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -34234,7 +34536,7 @@ PrefabInstance:
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 116
+      value: 117
       objectReference: {fileID: 0}
     - target: {fileID: 8613666963711853450, guid: 1d35052f4fc2cad4d8226d1a63e4a1b3,
         type: 3}
@@ -34314,7 +34616,7 @@ PrefabInstance:
     - target: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 209
+      value: 210
       objectReference: {fileID: 0}
     - target: {fileID: 1304001640488763778, guid: 151d489becc4ca64f878f37a991c138e,
         type: 3}
@@ -34394,7 +34696,7 @@ PrefabInstance:
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 314
+      value: 318
       objectReference: {fileID: 0}
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
@@ -34566,7 +34868,7 @@ PrefabInstance:
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 167
+      value: 168
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
@@ -35166,7 +35468,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: 35eed4273d90143b0926de4715bbc06e, type: 3}
       propertyPath: m_RootOrder
-      value: 36
+      value: 37
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: 35eed4273d90143b0926de4715bbc06e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -35348,7 +35650,7 @@ PrefabInstance:
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
       propertyPath: m_RootOrder
-      value: 224
+      value: 225
       objectReference: {fileID: 0}
     - target: {fileID: 3222826840089673925, guid: 54a552cbe4002ac44ae29b958a90e545,
         type: 3}
@@ -35445,7 +35747,7 @@ PrefabInstance:
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 172
+      value: 173
       objectReference: {fileID: 0}
     - target: {fileID: 8182938654540533794, guid: 1a00e842e154f7d43811c5d45328988c,
         type: 3}
@@ -35526,7 +35828,7 @@ PrefabInstance:
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 109
+      value: 110
       objectReference: {fileID: 0}
     - target: {fileID: 1489681963208858109, guid: 91d832be818283a4188516804e8d5ef0,
         type: 3}
@@ -35611,7 +35913,7 @@ PrefabInstance:
     - target: {fileID: 1427000246303903125, guid: 288980126acf5f441841169958c31630,
         type: 3}
       propertyPath: m_RootOrder
-      value: 139
+      value: 140
       objectReference: {fileID: 0}
     - target: {fileID: 1427000246303903125, guid: 288980126acf5f441841169958c31630,
         type: 3}
@@ -35786,7 +36088,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_RootOrder
-      value: 43
+      value: 44
       objectReference: {fileID: 0}
     - target: {fileID: 4734855229797344, guid: d72e24d0fc40a7545aad2f4e4f978d33, type: 3}
       propertyPath: m_LocalPosition.x
@@ -35861,7 +36163,7 @@ PrefabInstance:
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 168
+      value: 169
       objectReference: {fileID: 0}
     - target: {fileID: 1743249209741925138, guid: 5a7af30c589b41a449d0ba74c9e1771c,
         type: 3}
@@ -35936,7 +36238,7 @@ PrefabInstance:
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 97
+      value: 98
       objectReference: {fileID: 0}
     - target: {fileID: 2913148756339950521, guid: ed4e62dc12dca724ba1e5f374965096b,
         type: 3}
@@ -36021,7 +36323,7 @@ PrefabInstance:
     - target: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 161
+      value: 162
       objectReference: {fileID: 0}
     - target: {fileID: 8630552864855298094, guid: d0eb5dacbdcd4844e8c76aabde50434f,
         type: 3}
@@ -36101,7 +36403,7 @@ PrefabInstance:
     - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
         type: 3}
       propertyPath: m_RootOrder
-      value: 153
+      value: 154
       objectReference: {fileID: 0}
     - target: {fileID: 6935233708640276445, guid: 5a31eb85267283041aa9613772d08f90,
         type: 3}
@@ -36228,7 +36530,7 @@ PrefabInstance:
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 84
+      value: 85
       objectReference: {fileID: 0}
     - target: {fileID: 6612476612709513004, guid: c937e0abe85aca9499d09951de736ec6,
         type: 3}
@@ -36337,7 +36639,7 @@ PrefabInstance:
     - target: {fileID: 3050131568678634113, guid: fe66ec36f566be84a9ccbc5a90aacd6f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 144
+      value: 145
       objectReference: {fileID: 0}
     - target: {fileID: 3050131568678634113, guid: fe66ec36f566be84a9ccbc5a90aacd6f,
         type: 3}
@@ -36402,6 +36704,86 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2088325954}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2094716542
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8082954268645528609}
+    m_Modifications:
+    - target: {fileID: 1279209798155289386, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: sceneId
+      value: 3556218082
+      objectReference: {fileID: 0}
+    - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 36
+      objectReference: {fileID: 0}
+    - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7214057705511220808, guid: 21bb3b22e17572f479870465dd940c9d,
+        type: 3}
+      propertyPath: m_Name
+      value: OfficeChairDark
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 21bb3b22e17572f479870465dd940c9d, type: 3}
+--- !u!4 &2094716543 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7208238290007470226, guid: 21bb3b22e17572f479870465dd940c9d,
+    type: 3}
+  m_PrefabInstance: {fileID: 2094716542}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2097319811
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -36412,7 +36794,7 @@ PrefabInstance:
     - target: {fileID: 3318137014604025332, guid: 9759789a5180a46419c8a7e2e50748e2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 271
+      value: 272
       objectReference: {fileID: 0}
     - target: {fileID: 3318137014604025332, guid: 9759789a5180a46419c8a7e2e50748e2,
         type: 3}
@@ -36497,7 +36879,7 @@ PrefabInstance:
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 316
+      value: 320
       objectReference: {fileID: 0}
     - target: {fileID: 934999662234404414, guid: 13a96d5c007d8e84c9853fda470c1c7c,
         type: 3}
@@ -36577,7 +36959,7 @@ PrefabInstance:
     - target: {fileID: 3682557958087281322, guid: 6bd9037fbb19a79409aab54675bc363e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 212
+      value: 213
       objectReference: {fileID: 0}
     - target: {fileID: 3682557958087281322, guid: 6bd9037fbb19a79409aab54675bc363e,
         type: 3}
@@ -36704,7 +37086,7 @@ PrefabInstance:
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
       propertyPath: m_RootOrder
-      value: 281
+      value: 282
       objectReference: {fileID: 0}
     - target: {fileID: 8016220542479582908, guid: fde32c02abddc814f9366ff1fb21f234,
         type: 3}
@@ -36803,7 +37185,7 @@ PrefabInstance:
     - target: {fileID: 4049041059155957662, guid: 9944313d68658b341966d43e2c218eaa,
         type: 3}
       propertyPath: m_RootOrder
-      value: 269
+      value: 270
       objectReference: {fileID: 0}
     - target: {fileID: 4049041059155957662, guid: 9944313d68658b341966d43e2c218eaa,
         type: 3}
@@ -38968,7 +39350,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 2
-      m_TileSpriteIndex: 14
+      m_TileSpriteIndex: 8
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -39178,7 +39560,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 1
-      m_TileSpriteIndex: 8
+      m_TileSpriteIndex: 14
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -41682,7 +42064,7 @@ Tilemap:
   - m_RefCount: 7
     m_Data: {fileID: 21300018, guid: 311271c83c0b5f846884d0b57f9c22bf, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300082, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
+    m_Data: {fileID: 21300040, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 21300044, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 9
@@ -41694,7 +42076,7 @@ Tilemap:
   - m_RefCount: 1
     m_Data: {fileID: 21300088, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
   - m_RefCount: 1
-    m_Data: {fileID: 21300040, guid: b058b7252e3d4da4b8bd51add65b0930, type: 3}
+    m_Data: {fileID: 21300082, guid: 4f0c6985232dd6d4a9c7c0377b4113bd, type: 3}
   - m_RefCount: 3
     m_Data: {fileID: 21300024, guid: 9a57bbba7ca1dfd4ba417567ec2fee4f, type: 3}
   - m_RefCount: 2
@@ -70473,6 +70855,7 @@ Transform:
   - {fileID: 133013514}
   - {fileID: 705611284}
   - {fileID: 1245892666}
+  - {fileID: 2094716543}
   - {fileID: 2028599474}
   - {fileID: 1659743421}
   - {fileID: 36131557}
@@ -70737,6 +71120,9 @@ Transform:
   - {fileID: 217183661}
   - {fileID: 1546658234}
   - {fileID: 1501292282}
+  - {fileID: 414982092}
+  - {fileID: 1770617773}
+  - {fileID: 1240751655}
   - {fileID: 590623774}
   - {fileID: 1426489647}
   - {fileID: 1009124364}

--- a/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
+++ b/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
@@ -25314,7 +25314,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: 1f98145bcaa7b9947888e1677211ece0,
+      objectReference: {fileID: 21300000, guid: c39d19bba0ae67943a58040a898fdf54,
         type: 3}
     - target: {fileID: 8568672687853555390, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}
@@ -28720,7 +28720,7 @@ PrefabInstance:
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
       propertyPath: connectedDevices.Array.size
-      value: 12
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 8342472905829387893, guid: cd57203a8d3f54f478446e9b0ced6cf9,
         type: 3}
@@ -32390,7 +32390,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: c39d19bba0ae67943a58040a898fdf54,
+      objectReference: {fileID: 21300000, guid: d04e66db37d051241af5586e1bdfff93,
         type: 3}
     - target: {fileID: 8568672687853555390, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}

--- a/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnPoint.cs
+++ b/UnityProject/Assets/Scripts/Managers/NetworkManagement/SpawnPoint.cs
@@ -105,6 +105,7 @@ namespace Systems.Spawns
 
 			{ JobType.SYNDICATE, SpawnPointCategory.NuclearOperative },
 			{ JobType.WIZARD, SpawnPointCategory.WizardFederation },
+			{JobType.ANCIENT_ENGINEER, SpawnPointCategory.AncientEngineering},
 		};
 
 		private static readonly Dictionary<SpawnPointCategory, string> iconNames = new Dictionary<SpawnPointCategory, string>()
@@ -147,6 +148,7 @@ namespace Systems.Spawns
 			{SpawnPointCategory.MaintSpawns, "Mapping/mapping_mouse.png"},
 			{SpawnPointCategory.WizardFederation, "Mapping/mapping_wiznerd_spawn.png"},
 			{SpawnPointCategory.SpaceExterior, "Mapping/mapping_carp_spawn.png"},
+			{SpawnPointCategory.AncientEngineering, "Mapping/mapping_station_engineer.png"}
 		};
 
 	}
@@ -196,5 +198,6 @@ namespace Systems.Spawns
 		MaintSpawns,
 		WizardFederation,
 		SpaceExterior,
+		AncientEngineering,
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/AdditionalSceneListSO.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/AdditionalSceneListSO.cs
@@ -11,34 +11,39 @@ public class AdditionalSceneListSO : ScriptableObject
 	[InfoBox("Add your additional scenes to this list for it to be " +
 	         "spawned at runtime. Remember to also add your scene to " +
 	         "the build settings list",EInfoBoxType.Normal)]
+
+	[Scene]
 	public List<string> AdditionalScenes = new List<string>();
 
+	[Scene]
 	[Tooltip("Default Central Command scene used if no specific map is set")]
 	public List<string> defaultCentComScenes = new List<string>();
 
 	[Tooltip("List of CentCom scenes that will be picked randomly at round load unless specific map is set")]
 	public List<CentComData> CentComScenes = new List<CentComData>();
 
+	[Scene]
 	[Tooltip("List of Syndie bases that will be picked randomly at round load unless specific map is set")]
 	public List<string> defaultSyndicateScenes = new List<string>();
 
 	[Tooltip("Used to set a specific scene to load for a map")]
 	public List<SyndicateData> SyndicateScenes = new List<SyndicateData>();
 
+	[Scene]
 	[Tooltip("List of wizard scenes that will be picked randomly at round load, if wizard gamemode.")]
 	public List<string> WizardScenes = new List<string>();
 
 	[Serializable]
 	public class CentComData
 	{
-		public string CentComSceneName;
-		public string DependentScene = null;
+		[Scene] public string CentComSceneName;
+		[Scene] public string DependentScene = null;
 	}
 
 	[Serializable]
 	public class SyndicateData
 	{
-		public string SyndicateSceneName;
-		public string DependentScene = null;
+		[Scene] public string SyndicateSceneName;
+		[Scene] public string DependentScene = null;
 	}
 }

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/AsteroidListSO.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/AsteroidListSO.cs
@@ -10,5 +10,6 @@ public class AsteroidListSO : ScriptableObject
 	[InfoBox("Add your asteroid scenes to this list for it to be " +
 	         "spawned at runtime. Remember to also add your scene to " +
 	         "the build settings list",EInfoBoxType.Normal)]
+	[Scene]
 	public List<string> Asteroids = new List<string>();
 }

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/AwayWorldListSO.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/AwayWorldListSO.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using NaughtyAttributes;
 using UnityEngine;
 
@@ -10,6 +9,7 @@ public class AwayWorldListSO : ScriptableObject
 	[InfoBox("Add your Away site scenes to this list for it to be included in possible " +
 	         "away sites from the Station Gateway. Remember to also add your scene to " +
 	         "the build settings list",EInfoBoxType.Normal)]
+	[Scene]
 	public List<string> AwayWorlds = new List<string>();
 
 	public string GetRandomAwaySite()

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/MainStationListSO.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/MainStationListSO.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using NaughtyAttributes;
 using UnityEngine;
@@ -10,6 +9,7 @@ public class MainStationListSO : ScriptableObject
 	[Header("Provide the exact name of the scene in the fields below:")]
 	[InfoBox("Remember to also add your scene to " +
 	         "the build settings list",EInfoBoxType.Normal)]
+	[Scene]
 	public List<string> MainStations = new List<string>();
 
 	public string GetRandomMainStation()

--- a/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
+++ b/UnityProject/Assets/Scripts/Managers/SubSceneManager/SubSceneManager.SceneList.cs
@@ -12,10 +12,7 @@ public partial class SubSceneManager
 	private string serverChosenAwaySite = "loading";
 	private string serverChosenMainStation = "loading";
 
-	public static string ServerChosenMainStation
-	{
-		get { return Instance.serverChosenMainStation; }
-	}
+	public static string ServerChosenMainStation => Instance.serverChosenMainStation;
 
 	public static string AdminForcedMainStation = "Random";
 	public static string AdminForcedAwaySite = "Random";
@@ -46,7 +43,6 @@ public partial class SubSceneManager
 			yield return StartCoroutine(ServerLoadCentCom(loadTimer));
 			//Load Additional Scenes:
 			yield return StartCoroutine(ServerLoadAdditionalScenes(loadTimer));
-
 		}
 
 		netIdentity.isDirty = true;

--- a/UnityProject/Assets/Scripts/ScriptableObjects/GhostRoleList.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/GhostRoleList.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
 using NaughtyAttributes;
 

--- a/UnityProject/Assets/Scripts/Systems/GhostRoles/GhostRoleManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/GhostRoles/GhostRoleManager.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using Messages.Server;
 using Messages.Client;
+using NaughtyAttributes;
 using ScriptableObjects;
 using UI.Systems.Ghost;
 
@@ -19,6 +20,12 @@ namespace Systems.GhostRoles
 		private GhostRoleList ghostRoleList = default;
 		/// <summary> A list of all ghost roles that can be created.</summary>
 		public List<GhostRoleData> GhostRoles => ghostRoleList.GhostRoles;
+
+		[SerializeField]
+		[ReorderableList]
+		[Foldout("Always available roles")]
+		[Tooltip("These roles will always be available when a round starts")]
+		private List<GhostRoleData> alwaysAvailableRoles = default;
 
 		public static GhostRoleManager Instance { get; private set; }
 
@@ -56,6 +63,12 @@ namespace Systems.GhostRoles
 		{
 			serverAvailableRoles.Clear();
 			clientAvailableRoles.Clear();
+
+			if (CustomNetworkManager.IsServer == false) return;
+			foreach (var role in alwaysAvailableRoles)
+			{
+				ServerCreateRole(role);
+			}
 		}
 
 		#endregion Lifecycle
@@ -72,7 +85,7 @@ namespace Systems.GhostRoles
 			if (roleIndex < 0)
 			{
 				Logger.LogError(
-						$"Ghost role \"{roleData}\" was not found in {nameof(GhostRoleList)} SO! Cannot inform clients about the ghost role.");
+					$"Ghost role \"{roleData}\" was not found in {nameof(GhostRoleList)} SO! Cannot inform clients about the ghost role.");
 				return default;
 			}
 
@@ -104,7 +117,7 @@ namespace Systems.GhostRoles
 		/// <param name="key">The key used to identify the role for modifying.</param>
 		/// <returns>Returns the GhostRoleClient generated or found by the key.</returns>
 		public GhostRoleClient ClientAddOrUpdateRole(
-				uint key, int typeIndex, int minPlayers, int maxPlayers, int playerCount, float timeRemaining)
+			uint key, int typeIndex, int minPlayers, int maxPlayers, int playerCount, float timeRemaining)
 		{
 			if (typeIndex > GhostRoles.Count)
 			{
@@ -134,11 +147,9 @@ namespace Systems.GhostRoles
 				clientAvailableRoles.Remove(key);
 				return default;
 			}
-			else
-			{
-				UIManager.GhostRoleWindow.AddOrUpdateEntry(key, role);
-				return clientAvailableRoles[key];
-			}
+
+			UIManager.GhostRoleWindow.AddOrUpdateEntry(key, role);
+			return clientAvailableRoles[key];
 		}
 
 		/// <summary>

--- a/UnityProject/ProjectSettings/EditorBuildSettings.asset
+++ b/UnityProject/ProjectSettings/EditorBuildSettings.asset
@@ -95,6 +95,9 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/MainStations/UnRealStation.unity
     guid: b8524fde26e59bd43a00d265821ac745
+  - enabled: 1
+    path: Assets/Scenes/AdditionalScenes/AncientStation.unity
+    guid: 33ae55578dfdf7545b2b64b39eb28a70
   m_configObjects:
     com.unity.addressableassets: {fileID: 11400000, guid: 7ac8cd75382a23042b1a13021adfae5d,
       type: 2}


### PR DESCRIPTION
### Purpose
Finished work started with #5936 by making the Ancient Engineer ghost role available from the start of the round.

Added an ``alwaysAvailable`` ghost role list on ``GhostRoleManager``. ``GhostRoleData`` added to this list will be available from the start of the round automatically.

### Notes:
Added ``[Scene]`` decorator from NaughtyAttributes to all scriptable objects that handled scenes as a safer way to handle scenes than plain strings. Internally it still is just a string with the scene name, but in inspector it shows as a dropdown and you can choose scenes added to build settings.
![image](https://user-images.githubusercontent.com/43683714/106970213-2b248380-672b-11eb-8e48-e5bf67f6a9c9.png)
![image](https://user-images.githubusercontent.com/43683714/106970631-1399ca80-672c-11eb-9b54-9e0fca2ad628.png)
