### PR TITLE
Fixes two rare cases where the atmos thread would start or break at roundstart

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/EventManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/EventManager.cs
@@ -17,6 +17,7 @@ public enum EVENT
 	ChatUnfocused,
 	LoggedOut,
 	RoundStarted,
+	PostRoundStarted,
 	RoundEnded,
 	DisableInternals,
 	EnableInternals,

--- a/UnityProject/Assets/Scripts/Managers/GameManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.cs
@@ -388,6 +388,8 @@ public partial class GameManager : MonoBehaviour, IInitialise
 			var iServerSpawns = FindObjectsOfType<MonoBehaviour>().OfType<IServerSpawn>();
 			MappedOnSpawnServer(iServerSpawns);
 		}
+
+		EventManager.Broadcast(EVENT.PostRoundStarted);
 	}
 
 	public void MappedOnSpawnServer(IEnumerable<IServerSpawn> iServerSpawns)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosManager.cs
@@ -93,19 +93,19 @@ namespace Systems.Atmospherics
 
 		void OnEnable()
 		{
-			EventManager.AddHandler(EVENT.RoundStarted, OnRoundStart);
+			EventManager.AddHandler(EVENT.PostRoundStarted, OnPostRoundStart);
 			EventManager.AddHandler(EVENT.RoundEnded, OnRoundEnd);
 			SceneManager.activeSceneChanged += OnSceneChange;
 		}
 
 		void OnDisable()
 		{
-			EventManager.RemoveHandler(EVENT.RoundStarted, OnRoundStart);
+			EventManager.RemoveHandler(EVENT.PostRoundStarted, OnPostRoundStart);
 			EventManager.RemoveHandler(EVENT.RoundEnded, OnRoundEnd);
 			SceneManager.activeSceneChanged -= OnSceneChange;
 		}
 
-		void OnRoundStart()
+		void OnPostRoundStart()
 		{
 			if (Mode != AtmosMode.Manual)
 			{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosThread.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/AtmosThread.cs
@@ -46,9 +46,8 @@ public static class AtmosThread
 	{
 		if (!running)
 		{
-			new Thread(Run).Start();
-
 			running = true;
+			new Thread(Run).Start();
 		}
 	}
 


### PR DESCRIPTION
### Purpose
Fixes two rare cases where the atmos thread would start or break at roundstart.
Added PostRoundStarted broadcast event, to be caleld once the `OnSpawnServer()` calls finish

### Notes:
First one was if the thread started too fast and the `running = true` would not be set, making the loop of the thread never start.
Second one was having the thread also start too early, before the machines had their nodes ready (being set by `OnSpawnServer()`). In this case, now the atmos thread will start on a different broadcast event, called after all `OnSpawnServer()` calls are finished