### PR TITLE
proper firing pins along with (some) pin variants

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Storage/Boxes/BoxOfFiringPinsStandard.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Storage/Boxes/BoxOfFiringPinsStandard.prefab
@@ -107,5 +107,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: BoxOfFiringPinsStandard
       objectReference: {fileID: 0}
+    - target: {fileID: 8654565269348869248, guid: 3e5919f639f566c4590d07d54ef256dd,
+        type: 3}
+      propertyPath: itemStoragePopulator
+      value: 
+      objectReference: {fileID: 11400000, guid: 6b53526dc791b5a44a98c0f1458ea9c4,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3e5919f639f566c4590d07d54ef256dd, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/BuzzsawLMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/BuzzsawLMG.prefab
@@ -70,7 +70,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 11
+  m_SortingLayer: 13
   m_SortingOrder: 42
   m_Sprite: {fileID: 21300000, guid: c0b04291170124b44b3bf2d024805e93, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -98,6 +98,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: 4f57749cea3a42f438cd8e62d34dd09d, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -172,7 +173,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 11
+  m_SortingLayer: 13
   m_SortingOrder: 41
   m_Sprite: {fileID: 21300000, guid: 4662033bc850185499d918f016b7da2d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -200,6 +201,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: 1d69824cf81322f49a32f340ef4ac35f, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -274,7 +276,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 11
+  m_SortingLayer: 13
   m_SortingOrder: 41
   m_Sprite: {fileID: 21300000, guid: 190faac9aa8e4f746bb6018dbcd36335, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -302,6 +304,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: 414529b7583f44c4dae2dffa78f64590, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -326,24 +329,26 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: ammoType
-      value: 13
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: FiringSound
-      value: ShootLMG
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
       propertyPath: FireRate
       value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: MaxRecoilVariance
-      value: 0.1
+      propertyPath: ammoType
+      value: 13
       objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 109032868588680718, guid: 445a2ff9261814a549e8c255bb2580aa,
+        type: 3}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: Projectile
+      value: 
+      objectReference: {fileID: 8102588510461803122, guid: b1795817e9b5b8949a120fba7a7fa53f,
+        type: 3}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: WeaponType
@@ -357,10 +362,19 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: Projectile
-      value: 
-      objectReference: {fileID: 8102588510461803122, guid: b1795817e9b5b8949a120fba7a7fa53f,
+      propertyPath: FiringSound
+      value: ShootLMG
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: allowPinSwap
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: MaxRecoilVariance
+      value: 0.1
+      objectReference: {fileID: 0}
     - target: {fileID: 4729653154424643162, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: itemStorageCapacity
@@ -379,6 +393,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -394,6 +413,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -406,16 +430,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
@@ -440,8 +454,13 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 1
+      propertyPath: initialName
+      value: Buzzsaw LMG
+      objectReference: {fileID: 0}
+    - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: initialSize
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
@@ -451,18 +470,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: initialName
-      value: Buzzsaw LMG
-      objectReference: {fileID: 0}
-    - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: initialTraits.Array.data[1]
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: initialSize
-      value: 5
+      propertyPath: initialTraits.Array.size
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
@@ -470,6 +479,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: c77ff2e08ec6dd741bb289f35dea2446,
         type: 2}
+    - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: initialTraits.Array.data[1]
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: itemSprites.SpriteRightHand

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/BuzzsawLMGUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/BuzzsawLMGUnrestricted.prefab
@@ -7,6 +7,17 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1324267755354293044, guid: 24274bda3be42c049b4bbb150f6e1220,
+        type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+    - target: {fileID: 1324267755354293044, guid: 24274bda3be42c049b4bbb150f6e1220,
+        type: 3}
+      propertyPath: allowPinSwap
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2494139950867988427, guid: 24274bda3be42c049b4bbb150f6e1220,
         type: 3}
       propertyPath: m_AssetId
@@ -16,6 +27,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: BuzzsawLMGUnrestricted
+      objectReference: {fileID: 0}
+    - target: {fileID: 2529686714885275403, guid: 24274bda3be42c049b4bbb150f6e1220,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2529686714885275403, guid: 24274bda3be42c049b4bbb150f6e1220,
         type: 3}
@@ -34,6 +50,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2529686714885275403, guid: 24274bda3be42c049b4bbb150f6e1220,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2529686714885275403, guid: 24274bda3be42c049b4bbb150f6e1220,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -46,16 +67,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2529686714885275403, guid: 24274bda3be42c049b4bbb150f6e1220,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2529686714885275403, guid: 24274bda3be42c049b4bbb150f6e1220,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2529686714885275403, guid: 24274bda3be42c049b4bbb150f6e1220,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/M90glCarbine.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/M90glCarbine.prefab
@@ -98,6 +98,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: 955f31a51796ad74ebbf82ce3f1de8a5, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -200,6 +201,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: d7cc6d627ada4eb449327d10e75bfc66, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -224,24 +226,26 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: ammoType
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: FiringSound
-      value: ShootSMG
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
       propertyPath: FireRate
       value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: MaxRecoilVariance
-      value: 0.08
+      propertyPath: ammoType
+      value: 7
       objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 109032868588680718, guid: 445a2ff9261814a549e8c255bb2580aa,
+        type: 3}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: Projectile
+      value: 
+      objectReference: {fileID: 952139322937657728, guid: cc1c44d01fdcc26409ca9bb9c3cfba80,
+        type: 3}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: WeaponType
@@ -255,10 +259,19 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: Projectile
-      value: 
-      objectReference: {fileID: 952139322937657728, guid: cc1c44d01fdcc26409ca9bb9c3cfba80,
+      propertyPath: FiringSound
+      value: ShootSMG
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: allowPinSwap
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: MaxRecoilVariance
+      value: 0.08
+      objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: FiringSoundA.AssetAddress
@@ -287,6 +300,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -302,6 +320,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -314,16 +337,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
@@ -348,14 +361,14 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: initialDescription
-      value: A three-round burst 5.56 toploading carbine, designated 'M-90gl'. Has
-        an attached underbarrel grenade launcher which can be toggled on and off.
+      propertyPath: initialName
+      value: M-90gl carbine
       objectReference: {fileID: 0}
     - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: initialName
-      value: M-90gl carbine
+      propertyPath: initialDescription
+      value: A three-round burst 5.56 toploading carbine, designated 'M-90gl'. Has
+        an attached underbarrel grenade launcher which can be toggled on and off.
       objectReference: {fileID: 0}
     - target: {fileID: 8614656532152377136, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifle.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifle.prefab
@@ -256,6 +256,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 109032868588680718, guid: 445a2ff9261814a549e8c255bb2580aa,
+        type: 3}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 21396104557255652, guid: b0bb7b40f7e10864e9bba0bd2123cfcb,
@@ -270,6 +276,11 @@ PrefabInstance:
         type: 3}
       propertyPath: FiringSound
       value: ShootLMG
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: allowPinSwap
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifleUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Migraine50SniperRifleUnrestricted.prefab
@@ -82,5 +82,16 @@ PrefabInstance:
       propertyPath: initialSize
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 7753174079917532174, guid: 24b21da59a1c48248805096709dceca1,
+        type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+    - target: {fileID: 7753174079917532174, guid: 24b21da59a1c48248805096709dceca1,
+        type: 3}
+      propertyPath: allowPinSwap
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 24b21da59a1c48248805096709dceca1, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Revolvers/ClumsyLucifer357Mag.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Revolvers/ClumsyLucifer357Mag.prefab
@@ -9,6 +9,12 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 597710880480496247, guid: 538cebc4fa9119344aa630d0f273bced,
         type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 3180408065467424056, guid: 5d6f0b7b8080082d1a7ef20866db5cda,
+        type: 3}
+    - target: {fileID: 597710880480496247, guid: 538cebc4fa9119344aa630d0f273bced,
+        type: 3}
       propertyPath: SuppressedSoundA.AssetAddress
       value: null
       objectReference: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/BulldozerShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/BulldozerShotgun.prefab
@@ -98,6 +98,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: 969f370ba378d7e479e68212bf295e8f, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -200,6 +201,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: 6345ccfc8983cdd489aa04c42d86260c, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -219,6 +221,17 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: FireRate
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 109032868588680718, guid: 445a2ff9261814a549e8c255bb2580aa,
+        type: 3}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: ammoPrefab
       value: 
       objectReference: {fileID: 3417397333577640349, guid: 857e3b9968507b6419c8eefb3f1dfd9b,
@@ -230,23 +243,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: allowPinSwap
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: allowMagazineRemoval
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: FireRate
-      value: 2
+      propertyPath: DryFireSound.AssetAddress
+      value: Assets/Prefabs/AmbientTracks/Ambient04.prefab
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
       propertyPath: FiringSoundA.AssetAddress
       value: Assets/Prefabs/Weapons/Gun/Shotgun/ShotgunShotAlt.prefab
-      objectReference: {fileID: 0}
-    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: DryFireSound.AssetAddress
-      value: Assets/Prefabs/AmbientTracks/Ambient04.prefab
       objectReference: {fileID: 0}
     - target: {fileID: 2297580117821714339, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
@@ -256,13 +269,19 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 3012018597040680649, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: initialName
+      value: Bulldozer shotgun
+      objectReference: {fileID: 0}
+    - target: {fileID: 3012018597040680649, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: initialSize
       value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3012018597040680649, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: initialName
-      value: Bulldozer shotgun
+      propertyPath: initialDescription
+      value: A semi-auto, mag-fed shotgun for combat in narrow corridors, used by
+        boarding parties. Compatible only with specialized 8-round drum magazines.
       objectReference: {fileID: 0}
     - target: {fileID: 3012018597040680649, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
@@ -276,12 +295,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: dc212bdd1c009e54facfad0baf16a9ab,
         type: 2}
-    - target: {fileID: 3012018597040680649, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: initialDescription
-      value: A semi-auto, mag-fed shotgun for combat in narrow corridors, used by
-        boarding parties. Compatible only with specialized 8-round drum magazines.
-      objectReference: {fileID: 0}
     - target: {fileID: 3301342883353866999, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
       propertyPath: m_Sprite
@@ -300,6 +313,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -315,6 +333,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -327,16 +350,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/BulldozerShotgunUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/BulldozerShotgunUnrestricted.prefab
@@ -1,92 +1,87 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &4831827971845020147
+--- !u!1001 &4946957088666105481
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1097236404156109225, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 5567773424383630383, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: pinPrefab
       value: 
       objectReference: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
         type: 3}
-    - target: {fileID: 1097236404156109225, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 5567773424383630383, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: allowPinSwap
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4486100461475949974, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 8947746899163356516, guid: 1e9a929a33dead54e9b3584af40d2605,
+        type: 3}
+      propertyPath: m_Name
+      value: BulldozerShotgunUnrestricted
+      objectReference: {fileID: 0}
+    - target: {fileID: 8952956248049344528, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4486100461475949974, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 8952956248049344528, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4486100461475949974, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 8952956248049344528, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4486100461475949974, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 8952956248049344528, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4486100461475949974, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 8952956248049344528, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4486100461475949974, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 8952956248049344528, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4486100461475949974, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 8952956248049344528, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4486100461475949974, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 8952956248049344528, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4486100461475949974, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 8952956248049344528, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4486100461475949974, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 8952956248049344528, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4486100461475949974, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 8952956248049344528, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4490747135017947362, guid: fc502f4e927543d4ea7c77161dc70761,
-        type: 3}
-      propertyPath: m_Name
-      value: M90glCarbineUnrestricted
-      objectReference: {fileID: 0}
-    - target: {fileID: 4595469467435609430, guid: fc502f4e927543d4ea7c77161dc70761,
+    - target: {fileID: 9059269917160906960, guid: 1e9a929a33dead54e9b3584af40d2605,
         type: 3}
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 7045527794374922624, guid: fc502f4e927543d4ea7c77161dc70761,
-        type: 3}
-      propertyPath: setRestriction
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: fc502f4e927543d4ea7c77161dc70761, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 1e9a929a33dead54e9b3584af40d2605, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/BulldozerShotgunUnrestricted.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/BulldozerShotgunUnrestricted.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 58a78671c388c4f6fa23a0574ec9399e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/StalkerSMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/StalkerSMG.prefab
@@ -70,7 +70,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 11
+  m_SortingLayer: 13
   m_SortingOrder: 41
   m_Sprite: {fileID: 21300000, guid: cc6ed7d412e250b56bc42bc03ebccafd, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -98,6 +98,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: 5f64abdb483eef948ade1ba613ea8252, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -172,7 +173,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 11
+  m_SortingLayer: 13
   m_SortingOrder: 41
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -200,6 +201,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 0}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -274,7 +276,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 11
+  m_SortingLayer: 13
   m_SortingOrder: 41
   m_Sprite: {fileID: 21300000, guid: 43428260f416ece488a701ea4a0a66e7, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -302,6 +304,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: 0ec115503b0ecce48abb14487e8706f0, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -376,7 +379,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 11
+  m_SortingLayer: 13
   m_SortingOrder: 40
   m_Sprite: {fileID: 21300000, guid: 87ec252503ed0c643af2895711c27261, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -404,6 +407,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 11400000, guid: 7442c26904ff7764e8b0fba0362f052a, type: 2}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -428,10 +432,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: ammoPrefab
-      value: 
-      objectReference: {fileID: 7508253555952636633, guid: 251c85198dd9873499087ca7a48dd1f7,
-        type: 3}
+      propertyPath: FireRate
+      value: 7
+      objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: ammoType
@@ -439,19 +442,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
-      propertyPath: FiringSound
-      value: ShootSMG
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 109032868588680718, guid: 445a2ff9261814a549e8c255bb2580aa,
         type: 3}
-      propertyPath: FireRate
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: MaxRecoilVariance
-      value: 0.05
-      objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: Projectile
@@ -462,6 +456,27 @@ PrefabInstance:
         type: 3}
       propertyPath: WeaponType
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: ammoPrefab
+      value: 
+      objectReference: {fileID: 7508253555952636633, guid: 251c85198dd9873499087ca7a48dd1f7,
+        type: 3}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: FiringSound
+      value: ShootSMG
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: allowPinSwap
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: MaxRecoilVariance
+      value: 0.05
       objectReference: {fileID: 0}
     - target: {fileID: 4729653154424643162, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
@@ -481,6 +496,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -496,6 +516,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -508,16 +533,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8175001912389225766, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/StalkerSMGUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/StalkerSMGUnrestricted.prefab
@@ -7,10 +7,26 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1914634472754848989, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
+        type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+    - target: {fileID: 1914634472754848989, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
+        type: 3}
+      propertyPath: allowPinSwap
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3057500474207377442, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
         type: 3}
       propertyPath: m_AssetId
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3164301845646694626, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3164301845646694626, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
         type: 3}
@@ -29,6 +45,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3164301845646694626, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3164301845646694626, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -41,16 +62,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3164301845646694626, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3164301845646694626, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3164301845646694626, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftLMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftLMG.prefab
@@ -117,6 +117,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1324267755354293044, guid: 24274bda3be42c049b4bbb150f6e1220,
         type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 2924494414112422035, guid: 12279ffb7a1786457b2cb1622619a80c,
+        type: 3}
+    - target: {fileID: 1324267755354293044, guid: 24274bda3be42c049b4bbb150f6e1220,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 8926349090719206047, guid: f29df69b3b938f941b3064a2cb7dc4b6,
@@ -135,6 +141,11 @@ PrefabInstance:
     - target: {fileID: 1324267755354293044, guid: 24274bda3be42c049b4bbb150f6e1220,
         type: 3}
       propertyPath: SpawnsCasing
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1324267755354293044, guid: 24274bda3be42c049b4bbb150f6e1220,
+        type: 3}
+      propertyPath: allowPinSwap
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1324267755354293044, guid: 24274bda3be42c049b4bbb150f6e1220,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftLMGUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftLMGUnrestricted.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3369941105774643026, guid: fa30aa9352ebf92499cf7e500e5ce0d9,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3369941105774643026, guid: fa30aa9352ebf92499cf7e500e5ce0d9,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -24,6 +29,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3369941105774643026, guid: fa30aa9352ebf92499cf7e500e5ce0d9,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3369941105774643026, guid: fa30aa9352ebf92499cf7e500e5ce0d9,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -36,16 +46,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3369941105774643026, guid: fa30aa9352ebf92499cf7e500e5ce0d9,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3369941105774643026, guid: fa30aa9352ebf92499cf7e500e5ce0d9,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3369941105774643026, guid: fa30aa9352ebf92499cf7e500e5ce0d9,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftSMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/DonksoftSMG.prefab
@@ -117,6 +117,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1914634472754848989, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
         type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 2924494414112422035, guid: 12279ffb7a1786457b2cb1622619a80c,
+        type: 3}
+    - target: {fileID: 1914634472754848989, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 8926349090719206047, guid: f29df69b3b938f941b3064a2cb7dc4b6,
@@ -135,6 +141,11 @@ PrefabInstance:
     - target: {fileID: 1914634472754848989, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
         type: 3}
       propertyPath: SpawnsCasing
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1914634472754848989, guid: 0a7ba29086818cf4a8010f3b2743a7ac,
+        type: 3}
+      propertyPath: allowPinSwap
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1914634472754848989, guid: 0a7ba29086818cf4a8010f3b2743a7ac,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceCrossbow.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceCrossbow.prefab
@@ -124,10 +124,21 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 7826977993599869970, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
         type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 2924494414112422035, guid: 12279ffb7a1786457b2cb1622619a80c,
+        type: 3}
+    - target: {fileID: 7826977993599869970, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
+        type: 3}
       propertyPath: ammoPrefab
       value: 
       objectReference: {fileID: 7053746915093191456, guid: 4aa80491623d49245995aa12a947e28f,
         type: 3}
+    - target: {fileID: 7826977993599869970, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
+        type: 3}
+      propertyPath: allowPinSwap
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7826977993599869970, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
         type: 3}
       propertyPath: FiringSoundA.AssetAddress

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForcePistol.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForcePistol.prefab
@@ -166,6 +166,12 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 8296188907648457845, guid: f99b98719ad16074496e272268d289f9,
         type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 2924494414112422035, guid: 12279ffb7a1786457b2cb1622619a80c,
+        type: 3}
+    - target: {fileID: 8296188907648457845, guid: f99b98719ad16074496e272268d289f9,
+        type: 3}
       propertyPath: WeaponType
       value: 0
       objectReference: {fileID: 0}
@@ -175,6 +181,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 8670478144276522147, guid: 215c07b6aa6d556439078165149ba3a5,
         type: 3}
+    - target: {fileID: 8296188907648457845, guid: f99b98719ad16074496e272268d289f9,
+        type: 3}
+      propertyPath: allowPinSwap
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8296188907648457845, guid: f99b98719ad16074496e272268d289f9,
         type: 3}
       propertyPath: FiringSoundA.AssetAddress

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForcePistolUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForcePistolUnrestricted.prefab
@@ -14,6 +14,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2666790930770459654, guid: cc4e10396fbb2f0419dc449ac6772323,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2666790930770459654, guid: cc4e10396fbb2f0419dc449ac6772323,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -29,6 +34,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2666790930770459654, guid: cc4e10396fbb2f0419dc449ac6772323,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2666790930770459654, guid: cc4e10396fbb2f0419dc449ac6772323,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -41,16 +51,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2666790930770459654, guid: cc4e10396fbb2f0419dc449ac6772323,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2666790930770459654, guid: cc4e10396fbb2f0419dc449ac6772323,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2666790930770459654, guid: cc4e10396fbb2f0419dc449ac6772323,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceSMG.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceSMG.prefab
@@ -437,6 +437,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 2924494414112422035, guid: 12279ffb7a1786457b2cb1622619a80c,
+        type: 3}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 8926349090719206047, guid: f29df69b3b938f941b3064a2cb7dc4b6,
@@ -460,6 +466,11 @@ PrefabInstance:
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
         type: 3}
       propertyPath: SpawnsCasing
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,
+        type: 3}
+      propertyPath: allowPinSwap
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4614094803234074905, guid: a940a8ef1ee65024fb0a322703040d98,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceSMGUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceSMGUnrestricted.prefab
@@ -10,7 +10,12 @@ PrefabInstance:
     - target: {fileID: 4776498211175996734, guid: f99b98719ad16074496e272268d289f9,
         type: 3}
       propertyPath: m_Name
-      value: FoamForceSMG
+      value: FoamForceSMGUnrestricted
+      objectReference: {fileID: 0}
+    - target: {fileID: 4781140486872850506, guid: f99b98719ad16074496e272268d289f9,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4781140486872850506, guid: f99b98719ad16074496e272268d289f9,
         type: 3}
@@ -29,6 +34,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4781140486872850506, guid: f99b98719ad16074496e272268d289f9,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4781140486872850506, guid: f99b98719ad16074496e272268d289f9,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -44,16 +54,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4781140486872850506, guid: f99b98719ad16074496e272268d289f9,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4781140486872850506, guid: f99b98719ad16074496e272268d289f9,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4781140486872850506, guid: f99b98719ad16074496e272268d289f9,
-        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
@@ -66,6 +66,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4890260796913819786, guid: f99b98719ad16074496e272268d289f9,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f99b98719ad16074496e272268d289f9, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceShotgun.prefab
@@ -117,6 +117,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 2924494414112422035, guid: 12279ffb7a1786457b2cb1622619a80c,
+        type: 3}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 8926349090719206047, guid: f29df69b3b938f941b3064a2cb7dc4b6,
@@ -135,6 +141,11 @@ PrefabInstance:
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
       propertyPath: SpawnsCasing
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: allowPinSwap
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceShotgunUnrestricted.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/ToyGuns/FoamForceShotgunUnrestricted.prefab
@@ -7,6 +7,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 6657246690269780205, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6765810922112325677, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6765810922112325677, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -24,6 +34,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6765810922112325677, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6765810922112325677, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -36,16 +51,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6765810922112325677, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6765810922112325677, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6765810922112325677, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
         type: 3}
@@ -65,7 +70,18 @@ PrefabInstance:
     - target: {fileID: 6771020270595663193, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
         type: 3}
       propertyPath: m_Name
-      value: FoamForceShotgun
+      value: FoamForceShotgunUnrestricted
+      objectReference: {fileID: 0}
+    - target: {fileID: 7826977993599869970, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
+        type: 3}
+      propertyPath: pinPrefab
+      value: 
+      objectReference: {fileID: 2924494414112422035, guid: 12279ffb7a1786457b2cb1622619a80c,
+        type: 3}
+    - target: {fileID: 7826977993599869970, guid: 60e97fd11e26a0c4cb7058adcf6d2be4,
+        type: 3}
+      propertyPath: allowPinSwap
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 60e97fd11e26a0c4cb7058adcf6d2be4, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/ElectronicFiringPin.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/ElectronicFiringPin.prefab
@@ -18,6 +18,15 @@ MonoBehaviour:
   allowClumsy: 0
   allowNonClumsy: 1
   PredictionCanFire: 0
+  DeniedMessage: The weapon displays 'User authentication failed'
+  playSound: 0
+  FailSound:
+    SetLoadSetting: 0
+    AssetAddress: null
+    AssetReference:
+      m_AssetGUID: 
+      m_SubObjectName: 
+      m_SubObjectType: 
 --- !u!1001 &6005496742146465823
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -28,6 +37,10 @@ PrefabInstance:
     - target: {fileID: 1011433845357754, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_Name
       value: ElectronicFiringPin
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalPosition.x
@@ -42,6 +55,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -52,14 +69,6 @@ PrefabInstance:
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4527534762131918, guid: a7abba22164ce49f0bf9b9b219f39298, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -76,7 +85,7 @@ PrefabInstance:
     - target: {fileID: 114738972662350094, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
       propertyPath: m_AssetId
-      value: 0c0328cbf94ffe648a0903cfc375ab91
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
@@ -84,14 +93,19 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: ad10d0157c6c00f42835d284c2a40b71,
         type: 3}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+    - target: {fileID: 212340400423555046, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: attackVerbs.Array.size
+      propertyPath: m_WasSpriteAssigned
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: initialTraits.Array.size
+      propertyPath: initialName
+      value: electronic firing pin
+      objectReference: {fileID: 0}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: initialSize
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
@@ -103,12 +117,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: initialName
-      value: electronic firing pin
+      propertyPath: attackVerbs.Array.size
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: initialSize
+      propertyPath: initialTraits.Array.size
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
@@ -124,15 +138,15 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}
-      propertyPath: itemSprites.SpriteRightHand
-      value: 
-      objectReference: {fileID: 11400000, guid: 1549ce680737125459163cf36dcbc345,
-        type: 2}
-    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
-        type: 3}
       propertyPath: initialTraits.Array.data[0]
       value: 
       objectReference: {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b,
+        type: 2}
+    - target: {fileID: 499351249353511896, guid: a7abba22164ce49f0bf9b9b219f39298,
+        type: 3}
+      propertyPath: itemSprites.SpriteRightHand
+      value: 
+      objectReference: {fileID: 11400000, guid: 1549ce680737125459163cf36dcbc345,
         type: 2}
     - target: {fileID: 6144467708197095229, guid: a7abba22164ce49f0bf9b9b219f39298,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/FoamForceFiringPin.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/FoamForceFiringPin.prefab
@@ -1,81 +1,81 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &3457396402027900791
+--- !u!1001 &8917616269599958070
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 3456283829597045344, guid: 688c2d387255bf24d808b12edcd11c46,
+    - target: {fileID: -1823804660457631684, guid: 0c0328cbf94ffe648a0903cfc375ab91,
         type: 3}
-      propertyPath: setRestriction
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098535763128206082, guid: 688c2d387255bf24d808b12edcd11c46,
-        type: 3}
-      propertyPath: m_Name
-      value: DonksoftSMGUnrestricted
-      objectReference: {fileID: 0}
-    - target: {fileID: 8102052139190828662, guid: 688c2d387255bf24d808b12edcd11c46,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8102052139190828662, guid: 688c2d387255bf24d808b12edcd11c46,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8102052139190828662, guid: 688c2d387255bf24d808b12edcd11c46,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8102052139190828662, guid: 688c2d387255bf24d808b12edcd11c46,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8102052139190828662, guid: 688c2d387255bf24d808b12edcd11c46,
-        type: 3}
-      propertyPath: m_LocalRotation.w
+      propertyPath: allowClumsy
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8102052139190828662, guid: 688c2d387255bf24d808b12edcd11c46,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8102052139190828662, guid: 688c2d387255bf24d808b12edcd11c46,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8102052139190828662, guid: 688c2d387255bf24d808b12edcd11c46,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8102052139190828662, guid: 688c2d387255bf24d808b12edcd11c46,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8102052139190828662, guid: 688c2d387255bf24d808b12edcd11c46,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8102052139190828662, guid: 688c2d387255bf24d808b12edcd11c46,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8212299379671039670, guid: 688c2d387255bf24d808b12edcd11c46,
+    - target: {fileID: 5962885801523618065, guid: 0c0328cbf94ffe648a0903cfc375ab91,
         type: 3}
       propertyPath: m_AssetId
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_Name
+      value: FoamForceFiringPin
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 688c2d387255bf24d808b12edcd11c46, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 0c0328cbf94ffe648a0903cfc375ab91, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/FoamForceFiringPin.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/FoamForceFiringPin.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 12279ffb7a1786457b2cb1622619a80c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/HonkFiringPin.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/HonkFiringPin.prefab
@@ -1,0 +1,122 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &126370022869161765
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -1823804660457631684, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: playHONK
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -1823804660457631684, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: playSound
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -1823804660457631684, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: alwaysFail
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -1823804660457631684, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: DeniedMessage
+      value: HONK!
+      objectReference: {fileID: 0}
+    - target: {fileID: 5883298772289728505, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5883298772289728505, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5883298772289728505, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5962885801523618065, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_Name
+      value: HonkFiringPin
+      objectReference: {fileID: 0}
+    - target: {fileID: 6177181837291090887, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: initialName
+      value: hilarious firing pin
+      objectReference: {fileID: 0}
+    - target: {fileID: 6177181837291090887, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: initialDescription
+      value: Advanced clowntech that can convert any firearm into a far more useful
+        object.
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c0328cbf94ffe648a0903cfc375ab91, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/HonkFiringPin.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/HonkFiringPin.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 16a3e68b2c9dcaf58928506e05687f16
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/SyndicateFiringPin.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/SyndicateFiringPin.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5969244520626711211
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -1823804660457631684, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: setRestriction
+      value: 36
+      objectReference: {fileID: 0}
+    - target: {fileID: 437490885783299874, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: PresentSpriteSet
+      value: 
+      objectReference: {fileID: 11400000, guid: ffa426c9e3c41244b97fa138cc0b7d31,
+        type: 2}
+    - target: {fileID: 5883298772289728505, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 72022347c56fec645aba48cc228db6e6,
+        type: 3}
+    - target: {fileID: 5962885801523618065, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6001005491807019473, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6004521592186936485, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: m_Name
+      value: SyndicateFiringPin
+      objectReference: {fileID: 0}
+    - target: {fileID: 6177181837291090887, guid: 0c0328cbf94ffe648a0903cfc375ab91,
+        type: 3}
+      propertyPath: initialName
+      value: syndicate firing pin
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c0328cbf94ffe648a0903cfc375ab91, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/SyndicateFiringPin.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/SyndicateFiringPin.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 445a2ff9261814a549e8c255bb2580aa
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/UltraHonkFiringPin.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/UltraHonkFiringPin.prefab
@@ -1,0 +1,96 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &9130969105725249208
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5946772887125669620, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5946772887125669620, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5946772887125669620, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5946772887125669620, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5946772887125669620, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5946772887125669620, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5946772887125669620, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5946772887125669620, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5946772887125669620, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5946772887125669620, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5946772887125669620, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5950570462548904832, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_Name
+      value: UltraHonkFiringPin
+      objectReference: {fileID: 0}
+    - target: {fileID: 5980949453699741236, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: m_AssetId
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6086956822628213986, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: initialName
+      value: ultra hilarious firing pin
+      objectReference: {fileID: 0}
+    - target: {fileID: 7453597634430191385, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: alwaysFail
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7453597634430191385, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: allowClumsy
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7453597634430191385, guid: 16a3e68b2c9dcaf58928506e05687f16,
+        type: 3}
+      propertyPath: allowNonClumsy
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 16a3e68b2c9dcaf58928506e05687f16, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/UltraHonkFiringPin.prefab.meta
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/UltraHonkFiringPin.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5d6f0b7b8080082d1a7ef20866db5cda
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Resources/ScriptableObjects/Machines/CargoData.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Machines/CargoData.asset
@@ -71,6 +71,14 @@ MonoBehaviour:
       - {fileID: 6733076708105069041, guid: d589c17f6fd91da4190edfdd2cb5aa53, type: 3}
       - {fileID: 6733076708105069041, guid: d589c17f6fd91da4190edfdd2cb5aa53, type: 3}
       TotalCreditExport: 750
+    - OrderName: Electronic Firing Pins Crate
+      CreditsCost: 2000
+      Crate: {fileID: 3660769828800606216, guid: 8e84a0677b6a4364386bae0efa717939,
+        type: 3}
+      Items:
+      - {fileID: 1778400137840477013, guid: 7cb77338112306243bbcdc1e68130e80, type: 3}
+      - {fileID: 1778400137840477013, guid: 7cb77338112306243bbcdc1e68130e80, type: 3}
+      TotalCreditExport: 750
   - CategoryName: Medical
     Supplies:
     - OrderName: First Aid Kit Crate

--- a/UnityProject/Assets/Resources/ScriptableObjects/Traits/CommonTraitsSingleton.asset
+++ b/UnityProject/Assets/Resources/ScriptableObjects/Traits/CommonTraitsSingleton.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   Gun: {fileID: 11400000, guid: 0ed64735be8ec47f99cd4c93bce388ac, type: 2}
   Suppressor: {fileID: 11400000, guid: dd2be8f193e2293b6a13e612f3d65b23, type: 2}
   WeaponCell: {fileID: 11400000, guid: e73f3e53735c02e4c94c5c57e59a1579, type: 2}
+  FiringPin: {fileID: 11400000, guid: 63d34fd3e4612c35095cbd3f31411d3b, type: 2}
   Ingredient: {fileID: 11400000, guid: f4bf367b42a325c4dbf26b76591e0ef1, type: 2}
   Food: {fileID: 11400000, guid: fe7314825ebf744c3b651ca76d282adc, type: 2}
   Cheese: {fileID: 11400000, guid: bd8363206e639c04886060de7cfcd2d1, type: 2}

--- a/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
+++ b/UnityProject/Assets/Scripts/Items/Traits/CommonTraits.cs
@@ -13,6 +13,7 @@ public class CommonTraits : SingletonScriptableObject<CommonTraits>
 	[BoxGroup("Guns")] public ItemTrait Gun;
 	[BoxGroup("Guns")] public ItemTrait Suppressor;
 	[BoxGroup("Guns")] public ItemTrait WeaponCell;
+	[BoxGroup("Guns")] public ItemTrait FiringPin;
 
 	[BoxGroup("Food and related")] public ItemTrait Ingredient;
 	[BoxGroup("Food and related")] public ItemTrait Food;

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -492,6 +492,10 @@ namespace Weapons
 						break;
 				}
 			}
+			else if (PlayerManager.LocalPlayer)
+			{
+				Chat.AddExamineMsgToClient("The " + gameObject.ExpensiveName() + "'s trigger is locked. It doesn't have a firing pin installed!");
+			}
 		}
 
 		public virtual void ServerPerformInteraction(HandActivate interaction)

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -63,7 +63,7 @@ namespace Weapons
 		/// The firing pin currently inside the weapon
 		/// </summary>
 		public GunTrigger FiringPin =>
-			pinSlot.Item.GetComponent<GunTrigger>();
+			pinSlot.Item != null ? pinSlot.Item.GetComponent<GunTrigger>() : null;
 
 		/// <summary>
 		/// The firing pin to initally spawn within the gun
@@ -160,6 +160,12 @@ namespace Weapons
 		/// </summary>
 		[Tooltip("The firemode this weapon will use")]
 		public WeaponType WeaponType;
+
+		/// <summary>
+		/// Bool that dictates if players can switch out the firing pin
+		/// </summary>
+		[SerializeField]
+		protected bool allowPinSwap = true;
 
 		/// <summary>
 		/// Used only in server, the queued up shots that need to be performed when the weapon FireCountDown hits
@@ -372,7 +378,10 @@ namespace Weapons
 			//only reload if the gun is the target and mag/clip is in hand slot
 			if (interaction.TargetObject == gameObject && interaction.IsFromHandSlot && side == NetworkSide.Client)
 			{
-				if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Suppressor) || interaction.IsAltClick)
+				if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Suppressor) ||
+					Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Wirecutter) ||
+					Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.FiringPin)  ||
+					interaction.IsAltClick)
 				{
 					return true;
 				}
@@ -412,6 +421,10 @@ namespace Weapons
 					DisplayShot(PlayerManager.LocalPlayer, dir, UIManager.DamageZone, isSuicide, CurrentMagazine.containedBullets[0].name, CurrentMagazine.containedProjectilesFired[0]);
 				}
 			}
+			else
+			{
+				Chat.AddExamineMsgToClient("The " + gameObject.ExpensiveName() + "'s trigger is locked. It doesn't have a firing pin installed!");
+			}
 		}
 
 		//nothing to rollback
@@ -439,8 +452,8 @@ namespace Weapons
 				switch (shotResult) {
 
 					case 0:
-						// job requirement not met
-						Chat.AddExamineMsgToClient($"The {gameObject.ExpensiveName()} displays \'User authentication failed\'");
+						//requirement to fire not met
+						Chat.AddExamineMsg(interaction.Performer, FiringPin.DeniedMessage);
 						break;
 
 					case 1:
@@ -505,6 +518,14 @@ namespace Weapons
 						SyncIsSuppressed(isSuppressed, true);
 						Inventory.ServerTransfer(interaction.FromSlot, suppressorSlot);
 					}
+					else if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Wirecutter) && allowPinSwap)
+					{
+						Inventory.ServerDrop(pinSlot);
+					}
+					else if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.FiringPin) && allowPinSwap)
+					{
+						Inventory.ServerTransfer(interaction.FromSlot, pinSlot);
+					}
 				}
 				else if (isSuppressed && isSuppressible && suppressorSlot.Item != null)
 				{
@@ -516,7 +537,9 @@ namespace Weapons
 
 		public virtual string Examine(Vector3 pos)
 		{
-			return WeaponType + " - Fires " + ammoType + " ammunition (" + (CurrentMagazine != null ? (CurrentMagazine.ServerAmmoRemains.ToString() + " rounds loaded in magazine") : "It's empty!") + ")";
+			return WeaponType + " - Fires " + ammoType + " ammunition (" + 
+			(CurrentMagazine != null ? (CurrentMagazine.ServerAmmoRemains.ToString() + " rounds loaded in magazine") : "It's empty!") + ")\n" + 
+			(FiringPin != null ? "It has a " + FiringPin.gameObject.ExpensiveName() + " installed." : "It doesn't have a firing pin installed, and won't fire.");
 		}
 
 		#endregion
@@ -621,7 +644,7 @@ namespace Weapons
 			}
 			else if (ammoType == magazine.ammoType)
 			{
-				Chat.AddExamineMsgToClient("You weapon is already loaded, you can't fit more Magazines in it, silly!");
+				Chat.AddExamineMsgToClient("Your weapon is already loaded, you can't fit more Magazines in it, silly!");
 				return false;
 			}
 			return false;

--- a/UnityProject/Assets/Scripts/Items/Weapons/GunElectrical.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/GunElectrical.cs
@@ -46,7 +46,9 @@ public class GunElectrical : Gun, ICheckedInteractable<HandActivate>
 		//only reload if the gun is the target and mag/clip is in hand slot
 		if (interaction.TargetObject == gameObject && interaction.IsFromHandSlot && side == NetworkSide.Client)
 		{
-			if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Screwdriver) && allowScrewdriver)
+			if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Screwdriver) && allowScrewdriver ||
+				Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Wirecutter) ||
+				Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.FiringPin))
 			{
 				return true;
 			}
@@ -112,6 +114,14 @@ public class GunElectrical : Gun, ICheckedInteractable<HandActivate>
 			{
 				base.RequestReload(mag.gameObject);
 			}
+			else if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Wirecutter) && allowPinSwap)
+			{
+				Inventory.ServerDrop(pinSlot);
+			}
+			else if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.FiringPin) && allowPinSwap)
+			{
+				Inventory.ServerTransfer(interaction.FromSlot, pinSlot);
+			}
 		}
 	}
 
@@ -124,7 +134,9 @@ public class GunElectrical : Gun, ICheckedInteractable<HandActivate>
 
 	public override String Examine(Vector3 pos)
 	{
-		string returnstring = WeaponType + " - Fires " + ammoType + " ammunition (" + (CurrentMagazine != null ? (Mathf.Floor(battery.Watts / firemodeUsage[currentFiremode]) + " rounds loaded in magazine") : "It's empty!") + ")";
+		string returnstring = WeaponType + " - Fires " + ammoType + " ammunition (" +
+		(CurrentMagazine != null ? (Mathf.Floor(battery.Watts / firemodeUsage[currentFiremode]) + " rounds loaded in magazine") : "It's empty!") + ")\n" +
+		(FiringPin != null ? "It has a " + FiringPin.gameObject.ExpensiveName() + " installed." : "It doesn't have a firing pin installed, and won't fire.");
 
 		if (firemodeProjectiles.Count > 1) {
 			returnstring += "\nIt is set to " + firemodeName[currentFiremode] + " mode.";

--- a/UnityProject/Assets/Scripts/Items/Weapons/GunTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/GunTrigger.cs
@@ -26,7 +26,7 @@ namespace Weapons
 		{
 			if (playHONK)
 			{
-				SoundManager.PlayNetworkedAtPos( SingletonSOSounds.Instance.ClownHonk, gameObject.AssumedWorldPosServer(), randomPitch, true, sourceObj: GetSourceObj());
+				SoundManager.PlayNetworkedAtPos( SingletonSOSounds.Instance.ClownHonk, shotBy.AssumedWorldPosServer(), randomPitch, true, sourceObj: shotBy);
 			}
 
 			if (alwaysFail)
@@ -88,12 +88,5 @@ namespace Weapons
 		{
 			PredictionCanFire = newValue;
 		}
-
-		private GameObject GetSourceObj()
-		{
-			ItemSlot itemslot = gameObject.GetComponent<Pickupable>().ItemSlot;
-			return itemslot != null ? itemslot.ItemStorage.gameObject : gameObject;
-		}
-
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/GunTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/GunTrigger.cs
@@ -11,12 +11,29 @@ namespace Weapons
 		private bool allowClumsy;
 		[SerializeField]
 		private bool allowNonClumsy;
+		[SerializeField]
+		private bool alwaysFail;
 
 		[HideInInspector, SyncVar(hook = nameof(SyncPredictionCanFire))]
 		public bool PredictionCanFire;
 
+		public string DeniedMessage;
+
+		public bool playHONK; //honk.
+		private float randomPitch => Random.Range( 0.7f, 1.2f );
+
 		public int TriggerPull(GameObject shotBy)
 		{
+			if (playHONK)
+			{
+				SoundManager.PlayNetworkedAtPos( SingletonSOSounds.Instance.ClownHonk, gameObject.AssumedWorldPosServer(), randomPitch, true, sourceObj: GetSourceObj());
+			}
+
+			if (alwaysFail)
+			{
+				return 0;
+			}
+
 			JobType job = PlayerList.Instance.Get(shotBy).Job;
 
 			if (job == setRestriction || (setRestriction == JobType.NULL &&
@@ -27,7 +44,7 @@ namespace Weapons
 			}
 			else if (setRestriction == JobType.NULL && (job == JobType.CLOWN && !allowClumsy))
 			{
-				//shooting a non-clusmy weapon as a clusmy person
+				//shooting a non-clumsy weapon as a clumsy person
 				return 3;
 			}
 			else if (setRestriction == JobType.NULL && (job != JobType.CLOWN && !allowNonClumsy))
@@ -70,6 +87,12 @@ namespace Weapons
 		private void SyncPredictionCanFire(bool oldValue, bool newValue)
 		{
 			PredictionCanFire = newValue;
+		}
+
+		private GameObject GetSourceObj()
+		{
+			ItemSlot itemslot = gameObject.GetComponent<Pickupable>().ItemSlot;
+			return itemslot != null ? itemslot.ItemStorage.gameObject : gameObject;
 		}
 
 	}


### PR DESCRIPTION
adds:
 syndicate pin that can only be fired by nuke ops
 honk pin that honks instead of firing
 ultra honk pin that makes non-clumsy shooters hit themselves and allows clumsy shooters to fire properly
 unobtainable foam force pin that is used only with foam force weapons (to allow the clown to shoot them)
 the ability to remove a firing pin from a gun with wire cutters
 the ability to insert firing pins into guns
 a boolean that prevents the firing pin from being changed (used with foam force weapons and also syndicate weapons)
 the ability to purchase two boxes of standard firing pins from cargo for 2000 credits
fixes:
 a spelling mistake related to the message you get when trying to load a weapon that already has a magazine
 some bug that sometimes caused a error to show in console when exiting play mode in the editor
removes:
 nothing