### PR TITLE
Ghost Role Job Ban Check

### DIFF
--- a/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.Admin.cs
@@ -465,6 +465,9 @@ public partial class PlayerList
 
 	#region JobBans
 
+	/// <summary>
+	/// Checks job ban state, FALSE if banned
+	/// </summary>
 	public bool CheckJobBanState(string userID, JobType jobType)
 	{
 		//jobbanlist checking:

--- a/UnityProject/Assets/Scripts/Messages/Server/GhostRoles/GhostRoleResponseMessage.cs
+++ b/UnityProject/Assets/Scripts/Messages/Server/GhostRoles/GhostRoleResponseMessage.cs
@@ -21,6 +21,7 @@ namespace Messages.Server
 			{ GhostRoleResponseCode.AlreadyQueued, "You're already queued for a role!" },
 			{ GhostRoleResponseCode.QueueFull, "All positions have been filled for this role! You're too late." },
 			{ GhostRoleResponseCode.Error, "There was a problem giving you the role." },
+			{ GhostRoleResponseCode.JobBanned, "You are job banned from this role" }
 		};
 
 		// To be run on client
@@ -65,5 +66,6 @@ namespace Messages.Server
 		AlreadyQueued,
 		QueueFull,
 		Error,
+		JobBanned
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/GhostRoles/GhostRoleManager.cs
+++ b/UnityProject/Assets/Scripts/Systems/GhostRoles/GhostRoleManager.cs
@@ -222,6 +222,12 @@ namespace Systems.GhostRoles
 			}
 
 			GhostRoleServer role = serverAvailableRoles[key];
+
+			if (PlayerList.Instance.CheckJobBanState(player.UserId, role.RoleData.TargetOccupation.JobType) == false)
+			{
+				return GhostRoleResponseCode.JobBanned;
+			}
+
 			if (role.WaitingPlayers.Contains(player))
 			{
 				return GhostRoleResponseCode.AlreadyWaiting;


### PR DESCRIPTION
Adds a check to the ghost role manager to make sure player isnt job banned from role.