### PR TITLE
Clean up inspector a bit

### DIFF
--- a/UnityProject/Assets/Scripts/Clothing/RestraintOverlay.cs
+++ b/UnityProject/Assets/Scripts/Clothing/RestraintOverlay.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using AddressableReferences;
+using NaughtyAttributes;
 
 /// <summary>
 /// Handles the overlays for the handcuff sprites
@@ -17,6 +18,7 @@ public class RestraintOverlay : ClothingItem, IActionGUI
 	private float healthCache;
 	private Vector3Int positionCache;
 
+	[Foldout("restraintRemovalSound")]
 	[SerializeField] private AddressableAudioSource restraintRemovalSound = null;
 
 	[SerializeField]

--- a/UnityProject/Assets/Scripts/Clothing/RestraintOverlay.cs
+++ b/UnityProject/Assets/Scripts/Clothing/RestraintOverlay.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using UnityEngine;
 using AddressableReferences;
-using NaughtyAttributes;
 
 /// <summary>
 /// Handles the overlays for the handcuff sprites
@@ -18,7 +17,6 @@ public class RestraintOverlay : ClothingItem, IActionGUI
 	private float healthCache;
 	private Vector3Int positionCache;
 
-	[Foldout("restraintRemovalSound")]
 	[SerializeField] private AddressableAudioSource restraintRemovalSound = null;
 
 	[SerializeField]

--- a/UnityProject/Assets/Scripts/Health/Living/HumanHealth/PlayerHealth.cs
+++ b/UnityProject/Assets/Scripts/Health/Living/HumanHealth/PlayerHealth.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using AddressableReferences;
+using NaughtyAttributes;
 
 /// <summary>
 /// Provides central access to the Players Health
@@ -14,6 +15,7 @@ using AddressableReferences;
 public class PlayerHealth : LivingHealthBehaviour
 {
 
+	[Foldout("SmallElectricShock")]
 	[SerializeField] private AddressableAudioSource SmallElectricShock = null;
 
 	[SerializeField]

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -11,6 +11,7 @@ using Objects;
 using Object = System.Object;
 using Random = UnityEngine.Random;
 using Effects.Overlays;
+using NaughtyAttributes;
 
 /// <summary>
 /// Component which allows an object to have an integrity value (basically an object's version of HP),
@@ -64,6 +65,7 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	public float initialIntegrity = 100f;
 
 	[Tooltip("Sound to play when damage applied.")]
+	[Foldout("soundOnHit")]
 	public AddressableAudioSource soundOnHit;
 
 	[Tooltip("A damage threshold the attack needs to pass in order to apply damage to this item.")]

--- a/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
+++ b/UnityProject/Assets/Scripts/Health/Objects/Integrity.cs
@@ -64,10 +64,6 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	[Tooltip("This object's initial \"HP\"")]
 	public float initialIntegrity = 100f;
 
-	[Tooltip("Sound to play when damage applied.")]
-	[Foldout("soundOnHit")]
-	public AddressableAudioSource soundOnHit;
-
 	[Tooltip("A damage threshold the attack needs to pass in order to apply damage to this item.")]
 	public float damageDeflection = 0;
 
@@ -88,6 +84,10 @@ public class Integrity : NetworkBehaviour, IHealth, IFireExposable, IRightClicka
 	/// </summary>
 	[Tooltip("Below this temperature (in Kelvin) the object will be unaffected by fire exposure.")]
 	public float HeatResistance = 100;
+
+	[Tooltip("Sound to play when damage applied.")]
+	[Foldout("soundOnHit")]
+	public AddressableAudioSource soundOnHit = null;
 
 	[SyncVar(hook = nameof(SyncOnFire))]
 	private bool onFire = false;

--- a/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemAttributesV2.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using AddressableReferences;
 using Mirror;
 using AddressableReferences;
+using NaughtyAttributes;
 using UnityEngine;
 
 namespace Items
@@ -111,6 +112,7 @@ namespace Items
 
 		[Tooltip("Sound to be played when we click someone with harm intent")]
 		[SerializeField]
+		[Foldout("hitSound")]
 		private AddressableAudioSource hitSound = null;
 
 

--- a/UnityProject/Assets/Scripts/Items/ItemBreakable.cs
+++ b/UnityProject/Assets/Scripts/Items/ItemBreakable.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using AddressableReferences;
+using NaughtyAttributes;
 
 public class ItemBreakable : MonoBehaviour
 {
@@ -13,7 +14,9 @@ public class ItemBreakable : MonoBehaviour
 
 	public GameObject brokenItem;
 
-	[SerializeField] private AddressableAudioSource soundOnBreak = null;
+	[SerializeField]
+	[Foldout("soundOnBreak")]
+	private AddressableAudioSource soundOnBreak = null;
 
 	// Start is called before the first frame update
 	void Awake()

--- a/UnityProject/Assets/Scripts/Items/PlaceableTile.cs
+++ b/UnityProject/Assets/Scripts/Items/PlaceableTile.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.Serialization;
 using UnityEngine.Tilemaps;
 using AddressableReferences;
+using NaughtyAttributes;
 
 /// <summary>
 /// Allows an item to be placed in order to create a tile on the ground.
@@ -22,7 +23,9 @@ public class PlaceableTile : MonoBehaviour, ICheckedInteractable<PositionalHandA
 	[SerializeField]
 	private float placeTime = 1.0f;
 
-	[SerializeField] private AddressableAudioSource placeSound = null;
+	[SerializeField]
+	[Foldout("placeSound")]
+	private AddressableAudioSource placeSound = null;
 
 	[SerializeField]
 	private static readonly StandardProgressActionConfig ProgressConfig

--- a/UnityProject/Assets/Scripts/Items/Weapons/Meleeable.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Meleeable.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 using AddressableReferences;
+using NaughtyAttributes;
 
 //Do not derive from NetworkBehaviour, this is also used on tilemap layers
 /// <summary>
@@ -18,7 +19,9 @@ public class Meleeable : MonoBehaviour, IPredictedCheckedInteractable<Positional
 	[SerializeField]
 	private float butcherTime = 2.0f;
 
-	[SerializeField] private AddressableAudioSource butcherSound = null;
+	[SerializeField]
+	[Foldout("butcherSound")]
+	private AddressableAudioSource butcherSound = null;
 
 	/// <summary>
 	/// Which layers are allowed to be attacked on tiles regardless of intent

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -5,6 +5,7 @@ using AddressableReferences;
 using UnityEngine;
 using UnityEngine.Events;
 using Mirror;
+using NaughtyAttributes;
 using UnityEngine.Serialization;
 using Objects;
 using Objects.Construction;
@@ -165,6 +166,7 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 
 	[Tooltip("The sound to play when pushed/pulled")]
 	[SerializeField]
+	[Foldout("pushPullSound")]
 	private AddressableAudioSource pushPullSound = null;
 
 	[Tooltip("A minimum delay for the sound to be played again (in milliseconds)")]

--- a/UnityProject/Assets/Scripts/Objects/PushPull.cs
+++ b/UnityProject/Assets/Scripts/Objects/PushPull.cs
@@ -164,11 +164,6 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 		SyncIsNotPushable(isNotPushable, isPushable == false);
 	}
 
-	[Tooltip("The sound to play when pushed/pulled")]
-	[SerializeField]
-	[Foldout("pushPullSound")]
-	private AddressableAudioSource pushPullSound = null;
-
 	[Tooltip("A minimum delay for the sound to be played again (in milliseconds)")]
 	[SerializeField]
 	private int soundDelayTime = 0;
@@ -180,6 +175,11 @@ public class PushPull : NetworkBehaviour, IRightClickable/*, IServerSpawn*/
 	[Tooltip("A maximum pitch variance from original sound for random effect (ex: 0.5 = 50% normal pitch)")]
 	[SerializeField]
 	private float soundMaximumPitchVariance = 1;
+
+	[Tooltip("The sound to play when pushed/pulled")]
+	[SerializeField]
+	[Foldout("pushPullSound")]
+	private AddressableAudioSource pushPullSound = null;
 
 	private float lastPlayedSoundTime;
 


### PR DESCRIPTION
Adds boxgroup to some of the common scripts to hide the Addressable Sound stuff

If you find any more annoying ones, or want to add new sounds then add this: [Foldout("name")]

eg:

[SerializeField]
[Foldout("name")]
private AddressableAudioSource name = null;
