### PR TITLE
Fixes some shuttles being marked as space matrix

### DIFF
--- a/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
+++ b/UnityProject/Assets/Scenes/AdditionalScenes/AncientStation.unity
@@ -8743,7 +8743,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 718838aab2564798b53f1d245f55680e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  IsSpaceMatrix: 1
+  IsSpaceMatrix: 0
   IsMainStation: 0
   IsLavaLand: 0
 --- !u!114 &494181325
@@ -25314,7 +25314,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: c39d19bba0ae67943a58040a898fdf54,
+      objectReference: {fileID: 21300000, guid: 1f98145bcaa7b9947888e1677211ece0,
         type: 3}
     - target: {fileID: 8568672687853555390, guid: 5e6f53b64c8b43c4285d171f4a9346a3,
         type: 3}


### PR DESCRIPTION
### Purpose
Sets the bool IsSpaceMatrix of the shuttles in Ancient station and Square station to false.

