### PR TITLE
Adds field to spawn in paper with text already written on them

### DIFF
--- a/UnityProject/Assets/Scripts/Items/Others/Paper.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/Paper.cs
@@ -1,9 +1,15 @@
 ﻿using System;
 using UnityEngine;
 using Mirror;
+using WebSocketSharp;
 
-public class Paper : NetworkBehaviour
+public class Paper : NetworkBehaviour, IServerSpawn
 {
+	[SerializeField]
+	[TextArea]
+	[Tooltip("Text that this paper will have on spawn, useful for mapping in little bits of " +
+	         "lore.")]
+	private string initialText;
 	public string ServerString { get; private set; }
 
 	///<Summary>
@@ -56,5 +62,13 @@ public class Paper : NetworkBehaviour
 	{
 		EnsureInit();
 		spriteHandler.ChangeSprite((int) state);
+	}
+
+	public void OnSpawnServer(SpawnInfo info)
+	{
+		if (initialText.IsNullOrEmpty() == false)
+		{
+			SetServerString(initialText);
+		}
 	}
 }


### PR DESCRIPTION
### Purpose
Just a small pr that will allow mappers to map paper that already has text written on them, as a way to leave little pieces of lore around their maps.

### How it works
![image](https://user-images.githubusercontent.com/43683714/107155694-956e3b80-6958-11eb-85ba-09f0a0cbbc14.png)
There is a new string field which when not null or empty, will call to ``SetServerString()`` method when ``OnSpawnServer()`` triggers.
Mapper would have to edit the paper manually in their scene hierarchy or create variants of the base paper if they want to do further operations with them, like making a RandomLoot object with lore.