### PR TITLE
Adds UI sprite scaling

### DIFF
--- a/UnityProject/Assets/Assets.asmdef
+++ b/UnityProject/Assets/Assets.asmdef
@@ -17,7 +17,8 @@
         "Lighting",
         "LeanTween",
         "Unity.Addressables",
-        "Unity.ResourceManager"
+        "Unity.ResourceManager",
+        "SpriteProcessing"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/UnityProject/Assets/Resources/Prefabs/UI/RightClick/RightClickButtonBase.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/UI/RightClick/RightClickButtonBase.prefab
@@ -103,6 +103,7 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.15
   divider: {fileID: 2376975122167300851}
+  selectionDelay: 0
 --- !u!114 &6868661415041801040
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UnityProject/Assets/Scripts/UI/Core/ImageExtensions.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/ImageExtensions.cs
@@ -1,0 +1,36 @@
+﻿using UI.Core.SpriteProcessing;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace UI.Core
+{
+	public static class ImageExtensions
+	{
+		/// <summary>
+		/// Modifies an image's pivot and scaling based on the non-transparent center and borders of a sprite.
+		/// </summary>
+		/// <param name="image">The UI Image to scale</param>
+		/// <param name="sprite">The sprite to get scaling data from</param>
+		/// <returns>The SpriteMetadata used to scale the image with</returns>
+		public static SpriteMetadata ApplySpriteScaling(this Image image, Sprite sprite)
+		{
+			if (image == null || sprite == null) return SpriteMetadata.Default;
+
+			var texData = TextureMetadataCache.GetTextureMetadataFor(sprite);
+			var spriteData = texData.GetSpriteData(sprite);
+			var imageTransform = (RectTransform)image.transform;
+			var imageRect = imageTransform.rect;
+			var adjustedSize = imageRect.width / sprite.textureRect.width;
+			var newPivot = spriteData.Offset * adjustedSize;
+			var localPos = imageTransform.localPosition;
+
+			newPivot.x = 0.5f - newPivot.x / imageRect.width;
+			newPivot.y = 0.5f + newPivot.y / imageRect.height;
+			imageTransform.pivot = newPivot;
+			imageTransform.localScale = new Vector3(spriteData.Scale, spriteData.Scale, 1);
+			imageTransform.localPosition = localPos;
+
+			return spriteData;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/UI/Core/ImageExtensions.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/ImageExtensions.cs
@@ -17,6 +17,9 @@ namespace UI.Core
 			if (image == null || sprite == null) return SpriteMetadata.Default;
 
 			var texData = TextureMetadataCache.GetTextureMetadataFor(sprite);
+
+			if (texData == null) return SpriteMetadata.Default;
+
 			var spriteData = texData.GetSpriteData(sprite);
 			var imageTransform = (RectTransform)image.transform;
 			var imageRect = imageTransform.rect;

--- a/UnityProject/Assets/Scripts/UI/Core/ImageExtensions.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/Core/ImageExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a4168c06176f7c0439b25aa68ae88e66
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/Core/RightClick/ItemRadial.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/RightClick/ItemRadial.cs
@@ -204,16 +204,8 @@ namespace UI.Core.RightClick
 		{
 			var scale = TotalRotation % ItemArcMeasure / ItemArcMeasure;
 
-			if (Mathf.Round(scale * 10) / 10 < 1)
-			{
-				LowerMaskItem.ScaleIcon(LeanTween.easeOutCirc(1, 0, scale));
-			}
-			else
-			{
-				LowerMaskItem.ScaleIcon(1);
-			}
-
-			UpperMaskItem.ScaleIcon(LeanTween.easeInCirc(0, 1, scale));
+			LowerMaskItem.ScaleIcon(scale, true);
+			UpperMaskItem.ScaleIcon(scale, false);
 		}
 
 		private void TweenArrows(bool forward)

--- a/UnityProject/Assets/Scripts/UI/Core/RightClick/RadialBranch.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/RightClick/RadialBranch.cs
@@ -151,9 +151,8 @@ namespace UI.Core.RightClick
 
 			var xPos = targetPos.x + (length * CurrentQuadrant.x);
 			var yPos = originPos.y + (LineToRadial.rect.height / 2) * CurrentQuadrant.y;
-			var newPos = new Vector2(xPos, yPos);
 
-			RepositionLineToRadial(newPos);
+			RepositionLineToRadial(new Vector2(xPos, yPos));
 			SetLineSize(LineFromOrigin, Math.Abs(originPos.x - (Origin.rect.width / 2 * CurrentQuadrant.x) - LineToRadial.anchoredPosition.x));
 
 			var lineToRadialLength = length <= 0 ? absDeltaY : distanceToRadial;

--- a/UnityProject/Assets/Scripts/UI/Core/RightClick/RightClickRadialButton.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/RightClick/RightClickRadialButton.cs
@@ -49,11 +49,16 @@ namespace UI.Core.RightClick
 
 		private System.Action SelectionDelegate { get; set; }
 
+		private System.Action<Color> UpdateColorDelegate { get; set; }
+
 		private PointerEventData LastPointerEnterData { get; set; }
+
+		private float IconScale { get; set; }
 
 		private void Awake()
 		{
 			SelectionDelegate = Select;
+			UpdateColorDelegate = UpdateColor;
 		}
 
 		public override void Setup(Radial<RightClickRadialButton> parent, int index)
@@ -126,6 +131,9 @@ namespace UI.Core.RightClick
 			{
 				icon.material.SetInt(IsPaletted, 0);
 			}
+
+			var spriteMetadata = icon.ApplySpriteScaling(itemInfo.IconSprite);
+			IconScale = spriteMetadata.Scale;
 		}
 
 		public void DisableItem()
@@ -139,7 +147,22 @@ namespace UI.Core.RightClick
 
 		private void SetColor(Color color, bool instant = false)
 		{
-			Mask.CrossFadeColor(color * colors.colorMultiplier, instant ? 0 : colors.fadeDuration, false, true);
+			var maskRenderer = Mask.canvasRenderer;
+			LeanTween.cancel(gameObject);
+			if (instant)
+			{
+				maskRenderer.SetColor(color);
+				return;
+			}
+			var duration = colors.fadeDuration;
+			var fromColor = maskRenderer.GetColor();
+			var toColor = color * colors.colorMultiplier;
+			LeanTween.value(gameObject, UpdateColorDelegate, fromColor, toColor, instant ? 0 : duration);
+		}
+
+		private void UpdateColor(Color color)
+		{
+			Mask.canvasRenderer.SetColor(color);
 		}
 
 		private Color CalculateHighlight(Color original)
@@ -163,9 +186,26 @@ namespace UI.Core.RightClick
 			SetColor(colors.normalColor);
 		}
 
-		public void ScaleIcon(float scale)
+		public void ScaleIcon(float scale, bool shrink)
 		{
-			icon.rectTransform.localScale = new Vector2(scale, scale);
+			var iconTransform = icon.transform;
+			float scaleMultiplier;
+			if (shrink)
+			{
+				if (Mathf.Round(scale * 100) / 100 < 1)
+				{
+					scaleMultiplier = LeanTween.easeOutCirc(1, 0, scale);
+				}
+				else
+				{
+					scaleMultiplier = 1;
+				}
+			}
+			else
+			{
+				scaleMultiplier = LeanTween.easeInCirc(0, 1, scale);
+			}
+			iconTransform.localScale = new Vector3(scaleMultiplier * IconScale, scaleMultiplier * IconScale, 1);
 		}
 
 		public void OnPointerEnter(PointerEventData eventData)

--- a/UnityProject/Assets/Scripts/UI/Core/RightClick/RightClickRadialButton.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/RightClick/RightClickRadialButton.cs
@@ -57,6 +57,7 @@ namespace UI.Core.RightClick
 
 		private void Awake()
 		{
+			icon.material = Instantiate(icon.material);
 			SelectionDelegate = Select;
 			UpdateColorDelegate = UpdateColor;
 		}

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing.meta
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a0d42de41866d643a6b56a3ef4b8f9a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/SpriteMetadata.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/SpriteMetadata.cs
@@ -18,7 +18,7 @@ namespace UI.Core.SpriteProcessing
 			Scale = scale;
 		}
 
-		public static unsafe SpriteMetadata Create(Texture2D texture, in Rect spriteRect)
+		public static unsafe SpriteMetadata Create(Texture2D texture, ref Rect spriteRect)
 		{
 			// Using GetPixelData and native arrays to avoid garbage created from GetPixels32. Indexing a native array
 			// is slow though, so access the pointers directly.

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/SpriteMetadata.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/SpriteMetadata.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using UnityEngine;
+
+namespace UI.Core.SpriteProcessing
+{
+	public readonly struct SpriteMetadata
+	{
+		public static readonly SpriteMetadata Default = new SpriteMetadata(Vector2.zero, 1f);
+
+		public Vector2 Offset { get; }
+
+		public float Scale { get; }
+
+		private SpriteMetadata(Vector2 offset, float scale)
+		{
+			Offset = offset;
+			Scale = scale;
+		}
+
+		public static SpriteMetadata Create(float texWidth, float texHeight, in Rect spriteRect, Color32[] pixels)
+		{
+			var spriteX = spriteRect.x;
+			var spriteY = spriteRect.y;
+			var xMax = spriteRect.xMax;
+			var yMax = spriteRect.yMax;
+			var left = xMax;
+			var top = spriteY;
+
+			// Start in the top left. Check left to right, top to bottom (note: texture pixel data is stored bottom to top),
+			// to find the top most and left most pixels. Loop through the x dimension using the left most non-transparent
+			// pixel as the bound.
+			for (var y = yMax; y > spriteY && left > spriteX; --y)
+			{
+				int pixelIndex = (int)((y - 1) * texWidth + spriteX);
+
+				for (var x = spriteX; x < left; ++x, ++pixelIndex)
+				{
+					if (pixels[pixelIndex].a <= 0) continue;
+
+					left = x;
+					if (y > top)
+					{
+						top = y;
+					}
+				}
+			}
+
+			var right = spriteX;
+			var bottom = yMax;
+
+			// Now start in the bottom right to find the furthest bottom and right pixels. Loop through the x dimension
+			// using the right most non-transparent pixel as the bound.
+			for (var y = spriteY; y < top && right < xMax; ++y)
+			{
+				int pixelIndex = (int)((texHeight - (yMax - y)) * texWidth + xMax - 1);
+				for (var x = xMax; x > right; --x, --pixelIndex)
+				{
+					if (pixels[pixelIndex].a <= 0) continue;
+
+					right = x;
+					if (y < bottom)
+					{
+						bottom = y;
+					}
+				}
+			}
+
+			int spriteWidth = (int)spriteRect.width;
+			int spriteHeight = (int)spriteRect.height;
+			var center = new Vector2(spriteX + spriteWidth / 2f, spriteY + spriteHeight / 2f);
+			var offsetX = (left - center.x + right - center.x) / 2;
+			var offsetY = (top - center.y + bottom - center.y) / 2;
+			var realSize = new Vector2(right - left, top - bottom);
+			var offset = new Vector2(-offsetX, offsetY);
+			var scale = realSize.x > realSize.y ? spriteWidth / realSize.x : spriteHeight / realSize.y;
+			return new SpriteMetadata(offset, Math.Max(1, scale));
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/SpriteMetadata.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/SpriteMetadata.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 494d612ac8b8fd44aa5f41f46890e803
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/SpriteProcessing.asmdef
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/SpriteProcessing.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "SpriteProcessing",
+    "references": [
+        "GUID:7c9a27d2b43f1ac479d159329c7eb9e6"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/SpriteProcessing.asmdef.meta
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/SpriteProcessing.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d7feb441ffdca7a4d986ef6ef58d6888
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadata.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadata.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using Unity.Collections;
+using UnityEngine;
+
+namespace UI.Core.SpriteProcessing
+{
+	/// <summary>
+	/// Stores sprite scaling information for a texture. Most sprites don't fill up the area of a texture and are
+	/// surrounded by transparent pixels. This class keeps data required to scale and center a sprite on a UI image
+	/// so that it gives the appearance of having no extraneous transparent pixels around it.
+	/// </summary>
+	public class TextureMetadata
+	{
+		// Largest texture I've seen is WinDoor which is 768x768. This should cover most cases. Default sprite metadata
+		// is used if the texture is larger.
+		private const int PixelCacheSize = 768;
+
+		public static readonly Color32[] PixelCache = new Color32[PixelCacheSize * PixelCacheSize];
+
+		private Dictionary<Vector2Int, SpriteMetadata> SpritesMetadata { get; } =
+			new Dictionary<Vector2Int, SpriteMetadata>();
+
+		public SpriteMetadata GetSpriteData(Sprite sprite)
+		{
+			var rect = sprite.textureRect;
+			var key = new Vector2Int((int)rect.x, (int)rect.y);
+
+			SpritesMetadata.TryGetValue(key, out var spriteData);
+			if (spriteData.Scale <= 0)
+			{
+				spriteData = CreateSpriteData(sprite.texture, rect);
+				SpritesMetadata.Add(key, spriteData);
+			}
+
+			return spriteData;
+		}
+
+		private SpriteMetadata CreateSpriteData(Texture2D texture, in Rect spriteRect)
+		{
+			if (texture.isReadable == false)
+			{
+				Logger.LogWarning(
+					$"Texture \"{texture.name}\" is not read enabled. Using default sprite metadata",
+					Category.UI);
+				return SpriteMetadata.Default;
+			}
+			var texWidth = texture.width;
+			var texHeight = texture.height;
+			var pixelCache = PixelCache;
+			if (texWidth * texHeight > pixelCache.Length)
+			{
+				return SpriteMetadata.Default;
+			}
+
+			// Using GetPixelData and native arrays to avoid garbage created from GetPixels32. Indexing a native array
+			// is slow though, so do a relatively quick copy to the pixel cache. Could avoid copying and the need for
+			// a cache with raw pointers (requires unsafe).
+			var pixels = texture.GetPixelData<Color32>(0);
+			NativeArray<Color32>.Copy(pixels, PixelCache, pixels.Length);
+			return SpriteMetadata.Create(texWidth, texHeight, spriteRect, pixelCache);
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadata.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadata.cs
@@ -21,14 +21,14 @@ namespace UI.Core.SpriteProcessing
 			SpritesMetadata.TryGetValue(key, out var spriteData);
 			if (spriteData.Scale <= 0)
 			{
-				spriteData = CreateSpriteData(sprite.texture, rect);
+				spriteData = CreateSpriteData(sprite.texture, ref rect);
 				SpritesMetadata.Add(key, spriteData);
 			}
 
 			return spriteData;
 		}
 
-		private SpriteMetadata CreateSpriteData(Texture2D texture, in Rect spriteRect)
+		private SpriteMetadata CreateSpriteData(Texture2D texture, ref Rect spriteRect)
 		{
 			if (texture.isReadable == false)
 			{
@@ -38,7 +38,7 @@ namespace UI.Core.SpriteProcessing
 				return SpriteMetadata.Default;
 			}
 
-			return SpriteMetadata.Create(texture, spriteRect);
+			return SpriteMetadata.Create(texture, ref spriteRect);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadata.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadata.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Unity.Collections;
 using UnityEngine;
 
 namespace UI.Core.SpriteProcessing
@@ -11,12 +10,6 @@ namespace UI.Core.SpriteProcessing
 	/// </summary>
 	public class TextureMetadata
 	{
-		// Largest texture I've seen is WinDoor which is 768x768. This should cover most cases. Default sprite metadata
-		// is used if the texture is larger.
-		private const int PixelCacheSize = 768;
-
-		public static readonly Color32[] PixelCache = new Color32[PixelCacheSize * PixelCacheSize];
-
 		private Dictionary<Vector2Int, SpriteMetadata> SpritesMetadata { get; } =
 			new Dictionary<Vector2Int, SpriteMetadata>();
 
@@ -44,20 +37,8 @@ namespace UI.Core.SpriteProcessing
 					Category.UI);
 				return SpriteMetadata.Default;
 			}
-			var texWidth = texture.width;
-			var texHeight = texture.height;
-			var pixelCache = PixelCache;
-			if (texWidth * texHeight > pixelCache.Length)
-			{
-				return SpriteMetadata.Default;
-			}
 
-			// Using GetPixelData and native arrays to avoid garbage created from GetPixels32. Indexing a native array
-			// is slow though, so do a relatively quick copy to the pixel cache. Could avoid copying and the need for
-			// a cache with raw pointers (requires unsafe).
-			var pixels = texture.GetPixelData<Color32>(0);
-			NativeArray<Color32>.Copy(pixels, PixelCache, pixels.Length);
-			return SpriteMetadata.Create(texWidth, texHeight, spriteRect, pixelCache);
+			return SpriteMetadata.Create(texture, spriteRect);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadata.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadata.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 663ca9d20c1fa44439fdce706aca249e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadataCache.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadataCache.cs
@@ -14,7 +14,7 @@ namespace UI.Core.SpriteProcessing
 			cache = new Dictionary<Texture2D, TextureMetadata>();
 		}
 		#else
-		private static readonly Dictionary<Texture2D, TextureMetadata> texturesMetadata =
+		private static readonly Dictionary<Texture2D, TextureMetadata> cache =
 			new Dictionary<Texture2D, TextureMetadata>();
 		#endif
 

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadataCache.cs
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadataCache.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace UI.Core.SpriteProcessing
+{
+	public static class TextureMetadataCache
+	{
+		#if UNITY_EDITOR
+		private static Dictionary<Texture2D, TextureMetadata> cache;
+
+		[RuntimeInitializeOnLoadMethod]
+		private static void ResetTexturesMetadata()
+		{
+			cache = new Dictionary<Texture2D, TextureMetadata>();
+		}
+		#else
+		private static readonly Dictionary<Texture2D, TextureMetadata> texturesMetadata =
+			new Dictionary<Texture2D, TextureMetadata>();
+		#endif
+
+		public static TextureMetadata GetTextureMetadataFor(Sprite sprite)
+		{
+			if (sprite == null) return null;
+
+			var texture = sprite.texture;
+
+			if (texture == null)
+			{
+				Logger.LogWarning($"No texture found for sprite \"{sprite.name}\". Unable to create sprite metadata.",
+					Category.UI);
+				return null;
+			}
+
+			cache.TryGetValue(texture, out var scaler);
+			if (scaler == null)
+			{
+				scaler = new TextureMetadata();
+				cache.Add(texture, scaler);
+			}
+			return scaler;
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadataCache.cs.meta
+++ b/UnityProject/Assets/Scripts/UI/Core/SpriteProcessing/TextureMetadataCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ccaf07b24eb81b499c9df2d9001b933
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose
Many small sprites can be hard to see/read in the UI and radial. This adds in processing for sprites to gather scaling and offset data without the need to modify all textures and sprites. UI images can apply sprite scaling with an extension method by passing it the sprite. This will also re-center images where the sprites were off center in the UI. Sprite/texture metadata is created lazily and cached.

Adds icon scaling for the radial menu.

![iconscaling](https://user-images.githubusercontent.com/2001506/107179742-29a5c600-698c-11eb-8d4e-26bcee09473b.png)
Note - Image is doubled in size to show affect. It looks better in-game. Some of the really small items actually look the same as they do in the world with scaling enabled.

Switches from using CrossFadeAlpha for highlighting in the radial menu and uses leantween instead.

### Notes:
Scaling for ItemSlots can be added with about 3 lines of code. However, some of the item slot images on the UI were made larger than the slot graphics so some images appear 2-3 pixels larger than the UI that houses the image if scaled. We may want to adjust the prefabs so the icons fit inside the slot graphics.
