### PR TITLE
implement the ability to saw off guns

### DIFF
--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/EnchantedBoltActionRifle.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/EnchantedBoltActionRifle.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2450369290078622294, guid: 035def552b915ed429f1572133201dcb,
+        type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5057286051627280538, guid: 035def552b915ed429f1572133201dcb,
         type: 3}
       propertyPath: ammoPrefab

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/MosinNagantM1891.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/MosinNagantM1891.prefab
@@ -123,6 +123,25 @@ MonoBehaviour:
   hidesSlots: 0
   hideClothingFlags: 0
   SpriteDataSO: []
+--- !u!114 &4221194372170591464
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8594955878468889041}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 80ea89a879a2d3c8ba477fca535a2332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ammoBackfire: 0
+  sawnSize: 3
+  sawnMaxRecoilVariance: 0.1
+  SawnCameraRecoilConfig:
+    Distance: 0.5
+    RecoilDuration: 0.1
+    RecoveryDuration: 0.6
 --- !u!1001 &5300130788311338973
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -278,6 +297,23 @@ PrefabInstance:
       propertyPath: PresentSpriteSet
       value: 
       objectReference: {fileID: 11400000, guid: 2817cc103e3fa5543b69878737228fde,
+        type: 2}
+    - target: {fileID: 7749759532473064843, guid: f0c995ee924eb904dae952cd56a8c1d6,
+        type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7749759532473064843, guid: f0c995ee924eb904dae952cd56a8c1d6,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 2817cc103e3fa5543b69878737228fde,
+        type: 2}
+    - target: {fileID: 7749759532473064843, guid: f0c995ee924eb904dae952cd56a8c1d6,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 7e96408f537cdd748984a7c3b4337162,
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f0c995ee924eb904dae952cd56a8c1d6, type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/ImprovisedShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/ImprovisedShotgun.prefab
@@ -47,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -69,7 +70,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -1463207863
-  m_SortingLayer: 11
+  m_SortingLayer: 13
   m_SortingOrder: 40
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -97,6 +98,7 @@ MonoBehaviour:
   NetworkThis: 1
   SubCatalogue: []
   PresentSpriteSet: {fileID: 0}
+  randomInitialSprite: 0
   pushTextureOnStartUp: 1
   variantIndex: 0
   palette: []
@@ -114,12 +116,18 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 80b6946b53e48b944b0b60b7ee05ce56,
         type: 2}
-    - target: {fileID: 4881930153370599954, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
+    - target: {fileID: 2877372072106784990, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
         type: 3}
-      propertyPath: genericInternalMag
+      propertyPath: SubCatalogue.Array.data[0]
       value: 
-      objectReference: {fileID: 484621910317547679, guid: 4a6e2f5fc0231d74fb2bb97ddc3fd9d8,
+      objectReference: {fileID: 11400000, guid: 80b6946b53e48b944b0b60b7ee05ce56,
+        type: 2}
+    - target: {fileID: 2877372072106784990, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
         type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 4660db7e1cecec14d86fd414926bd104,
+        type: 2}
     - target: {fileID: 4881930153370599954, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
         type: 3}
       propertyPath: MagSize
@@ -128,6 +136,12 @@ PrefabInstance:
     - target: {fileID: 4881930153370599954, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
         type: 3}
       propertyPath: ammoPrefab
+      value: 
+      objectReference: {fileID: 484621910317547679, guid: 4a6e2f5fc0231d74fb2bb97ddc3fd9d8,
+        type: 3}
+    - target: {fileID: 4881930153370599954, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
+        type: 3}
+      propertyPath: genericInternalMag
       value: 
       objectReference: {fileID: 484621910317547679, guid: 4a6e2f5fc0231d74fb2bb97ddc3fd9d8,
         type: 3}
@@ -149,6 +163,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8267456284761734701, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8267456284761734701, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -164,6 +183,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8267456284761734701, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8267456284761734701, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -176,16 +200,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8267456284761734701, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8267456284761734701, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8267456284761734701, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
         type: 3}
@@ -209,11 +223,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8378383212809989179, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
         type: 3}
-      propertyPath: initialTraits.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8378383212809989179, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
-        type: 3}
       propertyPath: initialName
       value: improvised shotgun
       objectReference: {fileID: 0}
@@ -221,6 +230,11 @@ PrefabInstance:
         type: 3}
       propertyPath: initialDescription
       value: Essentially a tube that aims shotgun shells.
+      objectReference: {fileID: 0}
+    - target: {fileID: 8378383212809989179, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
+        type: 3}
+      propertyPath: initialTraits.Array.size
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8378383212809989179, guid: 3da33d6eccc1bbe4cb49cdc7fd00662f,
         type: 3}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/RiotShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/RiotShotgun.prefab
@@ -1,5 +1,24 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &3522461120287781946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3814654046910142495}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 80ea89a879a2d3c8ba477fca535a2332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ammoBackfire: 1
+  sawnSize: 3
+  sawnMaxRecoilVariance: 0.1
+  SawnCameraRecoilConfig:
+    Distance: 0.5
+    RecoilDuration: 0.1
+    RecoveryDuration: 0.6
 --- !u!1001 &2004405186287819188
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15,24 +34,24 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: MagSize
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 2003804624138751089, guid: 6479114d4021fcc4480f216b37acc883,
         type: 3}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: MagSize
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: genericInternalMag
+      propertyPath: ammoPrefab
       value: 
       objectReference: {fileID: 5857423046154764512, guid: 743525ecb25075c4a931a26989c82712,
         type: 3}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: ammoPrefab
+      propertyPath: genericInternalMag
       value: 
       objectReference: {fileID: 5857423046154764512, guid: 743525ecb25075c4a931a26989c82712,
         type: 3}
@@ -43,14 +62,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3012018597040680649, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: initialDescription
-      value: A sturdy shotgun with a longer magazine and a fixed tactical stock designed
-        for non-lethal riot control.
+      propertyPath: initialName
+      value: riot shotgun
       objectReference: {fileID: 0}
     - target: {fileID: 3012018597040680649, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: initialName
-      value: riot shotgun
+      propertyPath: initialDescription
+      value: A sturdy shotgun with a longer magazine and a fixed tactical stock designed
+        for non-lethal riot control.
       objectReference: {fileID: 0}
     - target: {fileID: 3301342883353866999, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
@@ -70,6 +89,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -85,6 +109,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -97,16 +126,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
@@ -129,5 +148,28 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 281b21add084733448db245b3d4c8070,
         type: 2}
+    - target: {fileID: 8820110165900900908, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8820110165900900908, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 281b21add084733448db245b3d4c8070,
+        type: 2}
+    - target: {fileID: 8820110165900900908, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 8f1c60a43de133542bfc54d90e898ea2,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3da1d244806a96340a48e959ecc816e4, type: 3}
+--- !u!1 &3814654046910142495 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3396079434555916715, guid: 3da1d244806a96340a48e959ecc816e4,
+    type: 3}
+  m_PrefabInstance: {fileID: 2004405186287819188}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/S3HunterShotgun.prefab
+++ b/UnityProject/Assets/Resources/Prefabs/Items/Weapons/Projectiles/Guns/Ballistics/Shotguns/S3HunterShotgun.prefab
@@ -1,5 +1,23 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1369005104990738433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8261965186490909529}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 80ea89a879a2d3c8ba477fca535a2332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sawnSize: 3
+  sawnMaxRecoilVariance: 0.1
+  SawnCameraRecoilConfig:
+    Distance: 0.5
+    RecoilDuration: 0.1
+    RecoveryDuration: 0.6
 --- !u!1001 &6739964293130240754
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15,23 +33,8 @@ PrefabInstance:
         type: 2}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: ammoType
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: MagInternal
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
       propertyPath: MagSize
       value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: FiringSound
-      value: ShootLMG
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
@@ -40,22 +43,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: ammoPrefab
-      value: 
-      objectReference: {fileID: 3210688012413455863, guid: 7920d9c4fad7b044c99cec907164f7e8,
-        type: 3}
-    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: casingPrefabOverride
-      value: 
-      objectReference: {fileID: 7885110935015110955, guid: 4f1eb975ef940201eac8726b12289e87,
-        type: 3}
+      propertyPath: ammoType
+      value: 15
+      objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
       propertyPath: Projectile
       value: 
       objectReference: {fileID: 2003804624138751089, guid: 0db28ea7632de0b4593a32bba473e844,
         type: 3}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: ammoPrefab
+      value: 
+      objectReference: {fileID: 3210688012413455863, guid: 7920d9c4fad7b044c99cec907164f7e8,
+        type: 3}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: FiringSound
+      value: ShootLMG
+      objectReference: {fileID: 0}
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: MagInternal
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
       propertyPath: ProjectilesFired
@@ -72,15 +84,21 @@ PrefabInstance:
       propertyPath: allowMagazineRemoval
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3012018597040680649, guid: 3da1d244806a96340a48e959ecc816e4,
+    - target: {fileID: 2182328595051184352, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
-      propertyPath: initialDescription
-      value: A double-barreled shotgun. A true classic.
-      objectReference: {fileID: 0}
+      propertyPath: casingPrefabOverride
+      value: 
+      objectReference: {fileID: 7885110935015110955, guid: 4f1eb975ef940201eac8726b12289e87,
+        type: 3}
     - target: {fileID: 3012018597040680649, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
       propertyPath: initialName
       value: S3 Hunter shotgun
+      objectReference: {fileID: 0}
+    - target: {fileID: 3012018597040680649, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: initialDescription
+      value: A double-barreled shotgun. A true classic.
       objectReference: {fileID: 0}
     - target: {fileID: 3301342883353866999, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
@@ -100,6 +118,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -115,6 +138,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -127,16 +155,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3401007583477333215, guid: 3da1d244806a96340a48e959ecc816e4,
         type: 3}
@@ -159,5 +177,28 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 8fa9714320a32e947afac4d56ab8be39,
         type: 2}
+    - target: {fileID: 8820110165900900908, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: SubCatalogue.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8820110165900900908, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[0]
+      value: 
+      objectReference: {fileID: 11400000, guid: 8fa9714320a32e947afac4d56ab8be39,
+        type: 2}
+    - target: {fileID: 8820110165900900908, guid: 3da1d244806a96340a48e959ecc816e4,
+        type: 3}
+      propertyPath: SubCatalogue.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: f06bf921f31f79542aa93f8e6ae24eb2,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3da1d244806a96340a48e959ecc816e4, type: 3}
+--- !u!1 &8261965186490909529 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3396079434555916715, guid: 3da1d244806a96340a48e959ecc816e4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6739964293130240754}
+  m_PrefabAsset: {fileID: 0}

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -458,7 +458,7 @@ namespace Weapons
 
 					case 1:
 						// shooting a clusmy weapon as a non-clusmy person
-						ServerShoot(interaction.Performer, interaction.TargetVector.normalized, UIManager.DamageZone, true);
+						ServerShoot(interaction.Performer, interaction.TargetVector.normalized, BodyPartType.Head, true);
 						Chat.AddActionMsgToChat(interaction.Performer,
 						"You somehow shoot yourself in the face! How the hell?!",
 						$"{interaction.Performer.ExpensiveName()} somehow manages to shoot themself in the face!");

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -152,8 +152,13 @@ namespace Weapons
 		/// <summary>
 		/// Describes the recoil behavior of the camera when this gun is fired
 		/// </summary>
-		[Tooltip("Describes the recoil behavior of the camera when this gun is fired")]
-		public CameraRecoilConfig CameraRecoilConfig;
+		[Tooltip("Describes the recoil behavior of the camera when this gun is fired"), SyncVar(hook = nameof(SyncCameraRecoilConfig))]
+		public CameraRecoilConfig CameraRecoilConfig = new CameraRecoilConfig
+		{
+			Distance = 0.2f,
+			RecoilDuration = 0.05f,
+			RecoveryDuration = 0.6f
+		};
 
 		/// <summary>
 		/// The firemode this weapon will use (burst,semi,auto)
@@ -798,16 +803,6 @@ namespace Weapons
 				//add additional recoil after shooting for the next round
 				AppendRecoil();
 
-				//Default camera recoil params until each gun is configured separately
-				if (CameraRecoilConfig == null || CameraRecoilConfig.Distance == 0f)
-				{
-					CameraRecoilConfig = new CameraRecoilConfig
-					{
-						Distance = 0.2f,
-						RecoilDuration = 0.05f,
-						RecoveryDuration = 0.6f
-					};
-				}
 				Camera2DFollow.followControl.Recoil(-finalDirection, CameraRecoilConfig);
 			}
 
@@ -961,11 +956,19 @@ namespace Weapons
 		#region Weapon Network Supporting Methods
 
 		/// <summary>
-		/// Syncs server and client ammo.
+		/// Syncs suppressed bool.
 		/// </summary>
 		private void SyncIsSuppressed(bool oldValue, bool newValue)
 		{
 			isSuppressed = newValue;
+		}
+
+		/// <summary>
+		/// Syncs the recoil config.
+		/// </summary>
+		public void SyncCameraRecoilConfig(CameraRecoilConfig oldValue, CameraRecoilConfig newValue)
+		{
+			CameraRecoilConfig = newValue;
 		}
 
 		/// <summary>

--- a/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/Gun.cs
@@ -963,7 +963,6 @@ namespace Weapons
 		/// <summary>
 		/// Syncs suppressed bool.
 		/// </summary>
-		[Server]
 		private void SyncIsSuppressed(bool oldValue, bool newValue)
 		{
 			isSuppressed = newValue;
@@ -972,7 +971,6 @@ namespace Weapons
 		/// <summary>
 		/// Syncs the recoil config.
 		/// </summary>
-		[Server]
 		public void SyncCameraRecoilConfig(CameraRecoilConfig oldValue, CameraRecoilConfig newValue)
 		{
 			CameraRecoilConfig = newValue;
@@ -981,7 +979,6 @@ namespace Weapons
 		/// <summary>
 		/// Syncs the prediction bool
 		/// </summary>
-		[Server]
 		private void SyncPredictionCanFire(bool oldValue, bool newValue)
 		{
 			predictionCanFire = newValue;

--- a/UnityProject/Assets/Scripts/Items/Weapons/GunTrigger.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/GunTrigger.cs
@@ -7,6 +7,7 @@ namespace Weapons
 	{
 		[SerializeField]
 		private JobType setRestriction;
+		public JobType SetRestriction => setRestriction;
 		[SerializeField]
 		private bool allowClumsy;
 		[SerializeField]
@@ -14,14 +15,12 @@ namespace Weapons
 		[SerializeField]
 		private bool alwaysFail;
 
-		[HideInInspector, SyncVar(hook = nameof(SyncPredictionCanFire))]
-		public bool PredictionCanFire;
-
 		public string DeniedMessage;
 
 		public bool playHONK; //honk.
 		private float randomPitch => Random.Range( 0.7f, 1.2f );
 
+		[Server]
 		public int TriggerPull(GameObject shotBy)
 		{
 			if (playHONK)
@@ -55,38 +54,6 @@ namespace Weapons
 			{
 				return 0;
 			}
-		}
-
-		public bool TriggerPullClient()
-		{
-			return PredictionCanFire;
-		}
-
-		//Serverside method to update syncvar
-		public void UpdatePredictionCanFire(GameObject holder)
-		{
-			JobType job = PlayerList.Instance.Get(holder).Job;
-			if (holder == null)
-			{
-				SyncPredictionCanFire(PredictionCanFire, false);
-			}
-			else if (job == setRestriction || setRestriction == JobType.NULL)
-			{
-				SyncPredictionCanFire(PredictionCanFire, true);
-			}
-		}
-
-		public void ClearPredictionCanFire()
-		{
-			SyncPredictionCanFire(PredictionCanFire, false);
-		}
-
-		/// <summary>
-		/// Syncs the prediction bool
-		/// </summary>
-		private void SyncPredictionCanFire(bool oldValue, bool newValue)
-		{
-			PredictionCanFire = newValue;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Items/Weapons/SawnOff.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/SawnOff.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using Items;
+using AddressableReferences;
+using Mirror;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Serialization;
+using Weapons;
+
+[RequireComponent(typeof(ItemAttributesV2))]
+[RequireComponent(typeof(Gun))]
+public class SawnOff : MonoBehaviour, ICheckedInteractable<InventoryApply>
+{
+
+	private ItemAttributesV2 itemAttComp =>
+		gameObject.GetComponent<ItemAttributesV2>();
+
+	private bool isSawn = false;
+
+	[SerializeField, Tooltip("Determines if the gun will explode in the users face when sawn while it still contains ammo")]
+	private bool ammoBackfire = true;
+
+	private Gun gunComp =>
+		gameObject.GetComponent<Gun>();
+
+	private SpriteHandler spriteHandler;
+
+	[SerializeField]
+	private ItemSize sawnSize = ItemSize.Medium;
+	
+	[SerializeField]
+	private float sawnMaxRecoilVariance;
+
+	[SerializeField]
+	private CameraRecoilConfig SawnCameraRecoilConfig;
+
+	private void Awake()
+	{
+		spriteHandler = GetComponentInChildren<SpriteHandler>();
+		spriteHandler.ChangeSprite(0);
+	}
+
+	public bool WillInteract(InventoryApply interaction, NetworkSide side)
+	{
+		if (DefaultWillInteract.Default(interaction, side) == false) return false;
+		if (side == NetworkSide.Server && DefaultWillInteract.Default(interaction, side)) return true;
+
+		//only reload if the gun is the target and mag/clip is in hand slot
+		if (interaction.TargetObject == gameObject && interaction.IsFromHandSlot && side == NetworkSide.Client)
+		{
+			//TODO: switch this trait to the circular saw when that is implemented
+			if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Welder))
+			{
+				gunComp.CameraRecoilConfig = SawnCameraRecoilConfig;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public void ServerPerformInteraction(InventoryApply interaction)
+	{
+		if (interaction.TargetObject == gameObject && interaction.IsFromHandSlot)
+		{
+			//TODO: switch this trait to the circular saw when that is implemented
+			if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Welder) && gunComp.FireCountDown == 0)
+			{
+				if (isSawn)
+				{
+					Chat.AddExamineMsg(interaction.Performer, $"The {gameObject.ExpensiveName()} is already shortened!");
+				}
+
+				WaitFor.Seconds(0.25f);
+				if (ammoBackfire && gunComp.CurrentMagazine.ServerAmmoRemains != 0)
+				{
+					gunComp.ServerShoot(interaction.Performer, Vector2.zero, BodyPartType.Head, true);
+					Chat.AddActionMsgToChat(interaction.Performer,
+					$"The {gameObject.ExpensiveName()} goes off in  your face!",
+					$"The {gameObject.ExpensiveName()} goes off in {interaction.Performer.ExpensiveName()}'s face!");
+				}
+				else
+				{
+					Chat.AddActionMsgToChat(interaction.Performer,
+						$"You shorten the {gameObject.ExpensiveName()}.",
+						$"{interaction.Performer.ExpensiveName()} shortens the {gameObject.ExpensiveName()}");
+
+					itemAttComp.ServerSetSize(sawnSize);
+   					spriteHandler.ChangeSprite(1);
+   					gunComp.CameraRecoilConfig = SawnCameraRecoilConfig;
+   					gunComp.MaxRecoilVariance = sawnMaxRecoilVariance;
+					isSawn = true;
+				}
+			}
+		}
+	}
+}

--- a/UnityProject/Assets/Scripts/Items/Weapons/SawnOff.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/SawnOff.cs
@@ -50,12 +50,6 @@ public class SawnOff : MonoBehaviour, ICheckedInteractable<InventoryApply>
 			//TODO: switch this trait to the circular saw when that is implemented
 			if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Welder))
 			{
-				// Don't overwrite recoil conf if it isn't setup
-				// TODO: network this change using a syncvar serverside so it effects all clients
-				if (SawnCameraRecoilConfig.Distance != 0f)
-				{
-					gunComp.CameraRecoilConfig = SawnCameraRecoilConfig;
-				}
 				return true;
 			}
 		}
@@ -79,7 +73,7 @@ public class SawnOff : MonoBehaviour, ICheckedInteractable<InventoryApply>
 				{
 					gunComp.ServerShoot(interaction.Performer, Vector2.zero, BodyPartType.Head, true);
 					Chat.AddActionMsgToChat(interaction.Performer,
-					$"The {gameObject.ExpensiveName()} goes off in  your face!",
+					$"The {gameObject.ExpensiveName()} goes off in your face!",
 					$"The {gameObject.ExpensiveName()} goes off in {interaction.Performer.ExpensiveName()}'s face!");
 				}
 				else
@@ -92,10 +86,9 @@ public class SawnOff : MonoBehaviour, ICheckedInteractable<InventoryApply>
    					spriteHandler.ChangeSprite(1);
 
 					// Don't overwrite recoil conf if it isn't setup
-					// TODO: network this change using a syncvar serverside so it effects all clients
 					if (SawnCameraRecoilConfig.Distance != 0f)
 					{
-						gunComp.CameraRecoilConfig = SawnCameraRecoilConfig;
+						gunComp.SyncCameraRecoilConfig(gunComp.CameraRecoilConfig, SawnCameraRecoilConfig);
 					}
 
    					gunComp.MaxRecoilVariance = sawnMaxRecoilVariance;

--- a/UnityProject/Assets/Scripts/Items/Weapons/SawnOff.cs
+++ b/UnityProject/Assets/Scripts/Items/Weapons/SawnOff.cs
@@ -13,31 +13,29 @@ using Weapons;
 public class SawnOff : MonoBehaviour, ICheckedInteractable<InventoryApply>
 {
 
-	private ItemAttributesV2 itemAttComp =>
-		gameObject.GetComponent<ItemAttributesV2>();
+	private ItemAttributesV2 itemAttComp;
+	private Gun gunComp;
+	private SpriteHandler spriteHandler;
 
 	private bool isSawn = false;
 
 	[SerializeField, Tooltip("Determines if the gun will explode in the users face when sawn while it still contains ammo")]
 	private bool ammoBackfire = true;
 
-	private Gun gunComp =>
-		gameObject.GetComponent<Gun>();
-
-	private SpriteHandler spriteHandler;
-
-	[SerializeField]
+	[SerializeField, Tooltip("Sawn off item size")]
 	private ItemSize sawnSize = ItemSize.Medium;
 	
-	[SerializeField]
+	[SerializeField, Tooltip("Value that determines how far a shot will deviate. (Never set this higher then 0.5 unless you want questionable results.)")]
 	private float sawnMaxRecoilVariance;
 
-	[SerializeField]
+	[SerializeField, Tooltip("Recoil camera config to switch to when sawn off")]
 	private CameraRecoilConfig SawnCameraRecoilConfig;
 
 	private void Awake()
 	{
 		spriteHandler = GetComponentInChildren<SpriteHandler>();
+		itemAttComp = gameObject.GetComponent<ItemAttributesV2>();
+		gunComp = gameObject.GetComponent<Gun>();
 		spriteHandler.ChangeSprite(0);
 	}
 
@@ -46,13 +44,18 @@ public class SawnOff : MonoBehaviour, ICheckedInteractable<InventoryApply>
 		if (DefaultWillInteract.Default(interaction, side) == false) return false;
 		if (side == NetworkSide.Server && DefaultWillInteract.Default(interaction, side)) return true;
 
-		//only reload if the gun is the target and mag/clip is in hand slot
+		//only reload if the gun is the target and tool is in hand slot
 		if (interaction.TargetObject == gameObject && interaction.IsFromHandSlot && side == NetworkSide.Client)
 		{
 			//TODO: switch this trait to the circular saw when that is implemented
 			if (Validations.HasItemTrait(interaction.UsedObject, CommonTraits.Instance.Welder))
 			{
-				gunComp.CameraRecoilConfig = SawnCameraRecoilConfig;
+				// Don't overwrite recoil conf if it isn't setup
+				// TODO: network this change using a syncvar serverside so it effects all clients
+				if (SawnCameraRecoilConfig.Distance != 0f)
+				{
+					gunComp.CameraRecoilConfig = SawnCameraRecoilConfig;
+				}
 				return true;
 			}
 		}
@@ -87,7 +90,14 @@ public class SawnOff : MonoBehaviour, ICheckedInteractable<InventoryApply>
 
 					itemAttComp.ServerSetSize(sawnSize);
    					spriteHandler.ChangeSprite(1);
-   					gunComp.CameraRecoilConfig = SawnCameraRecoilConfig;
+
+					// Don't overwrite recoil conf if it isn't setup
+					// TODO: network this change using a syncvar serverside so it effects all clients
+					if (SawnCameraRecoilConfig.Distance != 0f)
+					{
+						gunComp.CameraRecoilConfig = SawnCameraRecoilConfig;
+					}
+
    					gunComp.MaxRecoilVariance = sawnMaxRecoilVariance;
 					isSawn = true;
 				}

--- a/UnityProject/Assets/Scripts/Items/Weapons/SawnOff.cs.meta
+++ b/UnityProject/Assets/Scripts/Items/Weapons/SawnOff.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80ea89a879a2d3c8ba477fca535a2332
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
adds:
 a component that can be added to any gun which allows it to be sawn off using a tool (currently this tool is the welder due to the saw not being a thing yet
 the ability to saw off the improvised shotgun, riot shotgun, bartender's shotgun and the mosin
 the shotguns that can be sawn off will explode in the holder's face if they attempt to saw it while it still has ammo within
 the mosin does not have this behavior due to its physical design
 sawn off weapons will have worse camera recoil and accuracy
 sawn off weapons will be smaller in size compared to the un-shortened counterpart
 sawn off weapon has alternate sprite
changes:
 when firing a gun that has the ultra honk pin as a non-clumsy person you will actually shoot yourself in the face to reflect the message displayed
removes:
 nothin