### PR TITLE
Fixes gases on non-station matrices

### DIFF
--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -290,9 +290,7 @@ namespace Systems.Atmospherics
 								new HashSet<Gas> { addFogNode.gas }); //Add it to fogTiles
 						}
 
-						tileChangeManager.UpdateTile(
-							new Vector3Int(addFogNode.metaDataNode.Position.x, addFogNode.metaDataNode.Position.y, 0),
-							TileType.Effects, addFogNode.gas.TileName);
+						tileChangeManager.UpdateTile(addFogNode.metaDataNode.Position, TileType.Effects, addFogNode.gas.TileName);
 					}
 				}
 			}
@@ -312,9 +310,7 @@ namespace Systems.Atmospherics
 
 						if (!fogTiles[removeFogNode.metaDataNode.Position].Contains(removeFogNode.gas)) continue;
 
-						tileChangeManager.RemoveTile(
-							new Vector3Int(removeFogNode.metaDataNode.Position.x, removeFogNode.metaDataNode.Position.y, 0),
-							LayerType.Effects, false);
+						tileChangeManager.RemoveTile(removeFogNode.metaDataNode.Position, LayerType.Effects, false);
 
 						if (fogTiles[removeFogNode.metaDataNode.Position].Count == 1)
 						{

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/Atmospherics/ReactionManager.cs
@@ -291,8 +291,7 @@ namespace Systems.Atmospherics
 						}
 
 						tileChangeManager.UpdateTile(
-							new Vector3Int(addFogNode.metaDataNode.Position.x, addFogNode.metaDataNode.Position.y,
-								addFogNode.gas.OverlayIndex),
+							new Vector3Int(addFogNode.metaDataNode.Position.x, addFogNode.metaDataNode.Position.y, 0),
 							TileType.Effects, addFogNode.gas.TileName);
 					}
 				}
@@ -314,8 +313,7 @@ namespace Systems.Atmospherics
 						if (!fogTiles[removeFogNode.metaDataNode.Position].Contains(removeFogNode.gas)) continue;
 
 						tileChangeManager.RemoveTile(
-							new Vector3Int(removeFogNode.metaDataNode.Position.x, removeFogNode.metaDataNode.Position.y,
-								removeFogNode.gas.OverlayIndex),
+							new Vector3Int(removeFogNode.metaDataNode.Position.x, removeFogNode.metaDataNode.Position.y, 0),
 							LayerType.Effects, false);
 
 						if (fogTiles[removeFogNode.metaDataNode.Position].Count == 1)


### PR DESCRIPTION
### Purpose
Fixes atmospherics reactions having its sprite effect hidden from sight.
Fixes #5685

Apparently the atmos effects were spawning a few z levels behind, they were visible on the station matrix because the grid scale was 0, pushing them to the 0 Z level, becoming visible