### PR TITLE
Change MatrixInfo from struct to class

### DIFF
--- a/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
+++ b/UnityProject/Assets/IngameDebugConsole/Scripts/DebugLogUnitystationCommands.cs
@@ -305,7 +305,7 @@ namespace IngameDebugConsole
 
 				foreach ( var movableMatrix in matrices )
 				{
-					if ( movableMatrix.GameObject.name.ToLower().Contains( "verylarge" ) )
+					if ( movableMatrix == null || movableMatrix.GameObject.name.ToLower().Contains( "verylarge" ) )
 					{
 						continue;
 					}

--- a/UnityProject/Assets/Scripts/Core/Input System/WallMountHandApplySpawn.cs
+++ b/UnityProject/Assets/Scripts/Core/Input System/WallMountHandApplySpawn.cs
@@ -20,7 +20,7 @@ public class WallMountHandApplySpawn : MonoBehaviour, ICheckedInteractable<Posit
 	{
 		var roundTargetWorldPosition = interaction.WorldPositionTarget.RoundToInt();
 		MatrixInfo matrix = MatrixManager.AtPoint(roundTargetWorldPosition, true);
-		if (matrix.Matrix == null)
+		if (matrix?.Matrix == null)
 		{
 			return;
 		}

--- a/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
+++ b/UnityProject/Assets/Scripts/Items/Engineering/CableCoil.cs
@@ -58,11 +58,15 @@ public class CableCoil : NetworkBehaviour, ICheckedInteractable<ConnectionApply>
 		if (cableCoil != null)
 		{
 			Vector3Int worldPosInt = Vector3Int.RoundToInt(interaction.WorldPositionTarget);
-			MatrixInfo matrix = MatrixManager.AtPoint(worldPosInt, true);
-			var localPosInt = MatrixManager.WorldToLocalInt(worldPosInt, matrix);
+			var matrixInfo = MatrixManager.AtPoint(worldPosInt, true);
+			var localPosInt = MatrixManager.WorldToLocalInt(worldPosInt, matrixInfo);
+			var matrix = matrixInfo?.Matrix;
 
 			// if there is no matrix or IsClearUnderfloor == false - return
-			if (matrix.Matrix == null || !matrix.Matrix.IsClearUnderfloorConstruction(localPosInt, true)) return;
+			if (matrix == null || matrix.IsClearUnderfloorConstruction(localPosInt, true) == false)
+			{
+				return;
+			}
 
 			Connection WireEndB = interaction.WireEndB;
 			Connection WireEndA = interaction.WireEndA;

--- a/UnityProject/Assets/Scripts/Items/Others/NukeDiskScript.cs
+++ b/UnityProject/Assets/Scripts/Items/Others/NukeDiskScript.cs
@@ -98,7 +98,8 @@ namespace Items.Command
 
 			if (escapeShuttle != null && escapeShuttle.Status != EscapeShuttleStatus.DockedCentcom)
 			{
-				if (escapeShuttle.MatrixInfo.Bounds.Contains(registerItem.WorldPositionServer))
+				var matrixInfo = escapeShuttle.MatrixInfo;
+				if (matrixInfo == null || matrixInfo.Bounds.Contains(registerItem.WorldPositionServer))
 				{
 					return false;
 				}

--- a/UnityProject/Assets/Scripts/Managers/GameManager.Escape.cs
+++ b/UnityProject/Assets/Scripts/Managers/GameManager.Escape.cs
@@ -43,7 +43,7 @@ public partial class GameManager
 		if (PrimaryEscapeShuttle == null)
 		{
 			var shuttles = FindObjectsOfType<EscapeShuttle>();
-			if (shuttles.Length != 1)
+			if (shuttles.Length < 1)
 			{
 				Logger.LogError("Primary escape shuttle is missing from GameManager!", Category.Round);
 				return;
@@ -54,12 +54,17 @@ public partial class GameManager
 
 		//later, maybe: keep a list of all computers and call the shuttle automatically with a 25 min timer if they are deleted
 
+		if (primaryEscapeShuttle.MatrixInfo == null)
+		{
+			Logger.LogError("Primary escape shuttle has no associated matrix!");
+			return;
+		}
+
 		//Starting up at Centcom coordinates
 		if (GameManager.Instance.QuickLoad)
 		{
-			if (primaryEscapeShuttle?.MatrixInfo == null) return;
-			if (primaryEscapeShuttle?.MatrixInfo.MatrixMove == null) return;
-			if (primaryEscapeShuttle?.MatrixInfo.MatrixMove.InitialFacing == null) return;
+			if (primaryEscapeShuttle.MatrixInfo == null) return;
+			if (primaryEscapeShuttle.MatrixInfo.MatrixMove == null) return;
 		}
 
 		var orientation = primaryEscapeShuttle.MatrixInfo.MatrixMove.InitialFacing;

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/BoundsExtensions.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/BoundsExtensions.cs
@@ -7,7 +7,7 @@ public static class BoundsExtensions
 {
 	public static bool BoundsIntersect( this MatrixInfo matrix, MatrixInfo otherMatrix )
 	{
-		if ( matrix == otherMatrix )
+		if ( matrix == null || otherMatrix == null || matrix == otherMatrix )
 		{
 			return false;
 		}
@@ -20,7 +20,7 @@ public static class BoundsExtensions
 	public static bool BoundsIntersect( this MatrixInfo matrix, MatrixInfo otherMatrix, out Rect intersection )
 	{
 		intersection = Rect.zero;
-		if ( matrix == otherMatrix )
+		if ( matrix == null || otherMatrix == null || matrix == otherMatrix )
 		{
 			return false;
 		}

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
@@ -4,12 +4,12 @@ using UnityEngine;
 using Mirror;
 using Systems.Atmospherics;
 using TileManagement;
+using Object = UnityEngine.Object;
 
 /// Class that helps identify matrices
 public class MatrixInfo : IEquatable<MatrixInfo>
 {
-	public string Name => Matrix.gameObject.name;
-	public int Id;
+	public readonly int Id;
 	public Matrix Matrix;
 	public MetaTileMap MetaTileMap;
 	public MetaDataLayer MetaDataLayer;
@@ -17,27 +17,35 @@ public class MatrixInfo : IEquatable<MatrixInfo>
 	public TileChangeManager TileChangeManager;
 	public ReactionManager ReactionManager;
 	public GameObject GameObject;
-	public BoundsInt Bounds => MetaTileMap.GetBounds();
-	public BoundsInt WorldBounds => MetaTileMap.GetWorldBounds();
-	public Transform ObjectParent => MetaTileMap.ObjectLayer.transform;
-
 	public Vector3Int CachedOffset;
+
 	// position we were at when offset was last cached, to check if it is invalid
 	private Vector3 cachedPosition;
 
+	// Transform containing all the physical objects on the map
+	public Transform Objects;
+	public MatrixMove MatrixMove;
+	private Vector3Int initialOffset;
+	private uint netId;
+
+	public BoundsInt Bounds => MetaTileMap.GetBounds();
+
+	public BoundsInt WorldBounds => MetaTileMap.GetWorldBounds();
+
+	public Transform ObjectParent => MetaTileMap.ObjectLayer.transform;
+
 	public Color Color => Matrix ? Matrix.Color : Color.red;
+
 	public float Speed => MatrixMove ? MatrixMove.ServerState.Speed : 0f;
+
+	public string Name => Matrix.gameObject.name;
 
 	//todo: placeholder, should depend on solid tiles count instead (and use caching)
 	public float Mass => Bounds.size.sqrMagnitude/1000f;
+
 	public bool IsMovable => MatrixMove != null;
+
 	public Vector2Int MovementVector => ( IsMovable && MatrixMove.IsMovingServer ) ? MatrixMove.ServerState.FlyingDirection.VectorInt : Vector2Int.zero;
-
-	/// <summary>
-	/// Transform containing all the physical objects on the map
-	public Transform Objects;
-
-	private Vector3Int initialOffset;
 
 	public Vector3Int InitialOffset
 	{
@@ -72,10 +80,6 @@ public class MatrixInfo : IEquatable<MatrixInfo>
 		return CachedOffset;
 	}
 
-	public MatrixMove MatrixMove;
-
-	private uint netId;
-
 	public uint NetID
 	{
 		get
@@ -91,7 +95,12 @@ public class MatrixInfo : IEquatable<MatrixInfo>
 	}
 
 	/// Null object
-	public static readonly MatrixInfo Invalid = new MatrixInfo {Id = -1};
+	public static readonly MatrixInfo Invalid = new MatrixInfo(-1);
+
+	public MatrixInfo(int id)
+	{
+		Id = id;
+	}
 
 	public override string ToString()
 	{
@@ -117,20 +126,11 @@ public class MatrixInfo : IEquatable<MatrixInfo>
 		}
 	}
 
-	public bool Equals(MatrixInfo other)
-	{
-		return Id == other.Id;
-	}
+	public bool Equals(MatrixInfo other) => Id == other?.Id;
 
-	public override bool Equals(object obj)
-	{
-		return obj is MatrixInfo other && Equals( other );
-	}
+	public override bool Equals(object obj) => obj is MatrixInfo other && Equals(other);
 
-	public override int GetHashCode()
-	{
-		return Id;
-	}
+	public override int GetHashCode() => Id;
 
 	///Figuring out netId. NetworkIdentity is located on the pivot (parent) gameObject for MatrixMove-equipped matrices
 	private static uint getNetId(Matrix matrix)
@@ -163,26 +163,16 @@ public class MatrixInfo : IEquatable<MatrixInfo>
 
 	private sealed class IdEqualityComparer : IEqualityComparer<MatrixInfo>
 	{
-		public bool Equals( MatrixInfo x, MatrixInfo y )
-		{
-			return x.Id == y.Id;
-		}
+		public bool Equals(MatrixInfo x, MatrixInfo y) => x?.Id == y?.Id;
 
-		public int GetHashCode( MatrixInfo obj )
-		{
-			return obj.Id;
-		}
+		public int GetHashCode(MatrixInfo obj) => obj.Id;
 	}
 
 	public static IEqualityComparer<MatrixInfo> IdComparer { get; } = new IdEqualityComparer();
 
-	public static bool operator ==( MatrixInfo left, MatrixInfo right )
-	{
-		return left.Equals( right );
-	}
+	public static bool operator ==(MatrixInfo left, MatrixInfo right) =>
+		ReferenceEquals(left, null) == false && left.Equals(right);
 
-	public static bool operator !=( MatrixInfo left, MatrixInfo right )
-	{
-		return !left.Equals( right );
-	}
+	public static bool operator !=(MatrixInfo left, MatrixInfo right) =>
+		ReferenceEquals(left, null) == false && left.Equals(right) == false;
 }

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
@@ -5,7 +5,7 @@ using Systems.Atmospherics;
 using TileManagement;
 
 /// Struct that helps identify matrices
-public struct MatrixInfo
+public class MatrixInfo
 {
 	public string Name => Matrix.gameObject.name;
 	public int Id;

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 using Mirror;
 using Systems.Atmospherics;
 using TileManagement;
-using Object = UnityEngine.Object;
 
 /// Class that helps identify matrices
 public class MatrixInfo : IEquatable<MatrixInfo>

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixInfo.cs
@@ -1,11 +1,12 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Mirror;
 using Systems.Atmospherics;
 using TileManagement;
 
-/// Struct that helps identify matrices
-public class MatrixInfo
+/// Class that helps identify matrices
+public class MatrixInfo : IEquatable<MatrixInfo>
 {
 	public string Name => Matrix.gameObject.name;
 	public int Id;

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.Collisions.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.Collisions.cs
@@ -5,6 +5,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.Events;
 using Systems.Explosions;
+using Google.Protobuf;
 using Random = UnityEngine.Random;
 
 /// <summary>
@@ -36,7 +37,7 @@ public partial class MatrixManager
 			return;
 		}
 
-		if (matrixInfo.MatrixMove != null)
+		if (matrixInfo?.MatrixMove != null)
 		{
 			matrixInfo.MatrixMove.MatrixMoveEvents.OnStartMovementServer.AddListener( () =>
 			{
@@ -99,12 +100,7 @@ public partial class MatrixManager
 						toUpdate = new List<MatrixIntersection>();
 					}
 
-					toUpdate.Add( new MatrixIntersection
-					{
-						Matrix1 = trackedIntersection.Matrix1,
-						Matrix2 = trackedIntersection.Matrix2,
-						Rect = hotZone
-					} );
+					toUpdate.Add(trackedIntersection.Clone(ref hotZone));
 				}
 				else
 				{ //stop tracking non-intersecting ones
@@ -166,7 +162,7 @@ public partial class MatrixManager
 		List<MatrixIntersection> intersections = null;
 		foreach ( var otherMatrix in ActiveMatrices )
 		{
-			if ( matrix == otherMatrix )
+			if ( matrix == null || matrix == otherMatrix )
 			{
 				continue;
 			}
@@ -177,12 +173,7 @@ public partial class MatrixManager
 					intersections = new List<MatrixIntersection>();
 				}
 
-				intersections.Add( new MatrixIntersection
-				{
-					Matrix1 = matrix,
-					Matrix2 = otherMatrix,
-					Rect = hotZone
-				} );
+				intersections.Add(new MatrixIntersection(matrix, otherMatrix, hotZone));
 			}
 		}
 
@@ -221,9 +212,12 @@ public partial class MatrixManager
 
 	private void CheckTileCollisions( MatrixIntersection i )
 	{
+		if (i.Matrix1 == null || i.Matrix2 == null) return;
+
 		byte collisions = 0;
 		foreach ( Vector3Int worldPos in i.Rect.ToBoundsInt().allPositionsWithin )
 		{
+
 			Vector3Int cellPos1 = i.Matrix1.MetaTileMap.WorldToCell( worldPos );
 
 			if ( !i.Matrix1.Matrix.HasTile( cellPos1, true) )
@@ -374,6 +368,8 @@ public partial class MatrixManager
 
 		void RemoveUnderfloor(MatrixInfo matrix, Vector3Int cellPos)
 		{
+			if (matrix == null) return;
+
 			var Node = matrix.Matrix.GetMetaDataNode(cellPos);
 			if (Node != null)
 			{
@@ -386,6 +382,8 @@ public partial class MatrixManager
 
 		void ApplyTilemapDamage( MatrixInfo matrix, Vector3Int cellPos, float damage, Vector3Int worldPos )
 		{
+			if (matrix == null) return;
+
 			matrix.MetaTileMap.ApplyDamage( cellPos, damage, worldPos );
 			if ( damage > 9000 )
 			{
@@ -399,6 +397,8 @@ public partial class MatrixManager
 
 		void ApplyWireDamage( MatrixInfo matrix, Vector3Int cellPos )
 		{
+			if (matrix == null) return;
+
 			foreach ( var wire in matrix.Matrix.Get<CableInheritance>( cellPos, true ) )
 			{
 				if ( Random.value >= 0.5 )
@@ -414,6 +414,8 @@ public partial class MatrixManager
 
 		float ApplyIntegrityDamage( MatrixInfo matrix, Vector3Int cellPos, float damage )
 		{
+			if (matrix == null) return 0;
+
 			float resistance = 0f;
 			foreach ( var integrity in matrix.Matrix.Get<Integrity>( cellPos, true ) )
 			{
@@ -426,6 +428,8 @@ public partial class MatrixManager
 
 		float ApplyLivingDamage( MatrixInfo matrix, Vector3Int cellPos, float damage )
 		{
+			if (matrix == null) return 0;
+
 			byte count = 0;
 			foreach ( var healthBehaviour in matrix.Matrix.Get<LivingHealthBehaviour>( cellPos, true ) )
 			{
@@ -438,10 +442,8 @@ public partial class MatrixManager
 
 		void TryPushing( MatrixInfo matrix, Vector3Int cellPos, Vector2Int pushVector, float speed )
 		{
-			if ( pushVector == Vector2Int.zero )
-			{
-				return;
-			}
+			if (matrix == null || pushVector == Vector2Int.zero) return;
+
 			foreach ( var pushPull in matrix.Matrix.Get<PushPull>( cellPos, true ) )
 			{
 				byte pushes = (byte) Mathf.Clamp( speed / 4, 1, 4 );
@@ -510,21 +512,31 @@ public partial class MatrixManager
 /// First and second matrix are swappable – intersections (m1,m2) and (m2,m1) will be considered equal.
 /// Rect isn't checked for equality
 /// </summary>
-public struct MatrixIntersection
+public readonly struct MatrixIntersection
 {
-	public MatrixInfo Matrix1;
-	public MatrixInfo Matrix2;
-	public Rect Rect;
+	public readonly MatrixInfo Matrix1;
+	public readonly MatrixInfo Matrix2;
+	public readonly Rect Rect;
+
+	public MatrixIntersection(MatrixInfo matrix1, MatrixInfo matrix2, Rect rect)
+	{
+		Matrix1 = matrix1;
+		Matrix2 = matrix2;
+		Rect = rect;
+	}
+
+	public MatrixIntersection Clone() => new MatrixIntersection(Matrix1, Matrix2, Rect);
+
+	public MatrixIntersection Clone(ref Rect rect) => new MatrixIntersection(Matrix1, Matrix2, rect);
 
 	public override int GetHashCode()
 	{
 		return Matrix1.GetHashCode() ^ Matrix2.GetHashCode();
 	}
 
-	public bool Equals( MatrixIntersection other )
-	{
-		return (Matrix1.Equals( other.Matrix1 ) && Matrix2.Equals( other.Matrix2 ))
-		       || (Matrix1.Equals( other.Matrix2 ) && Matrix2.Equals( other.Matrix1 ));	}
+	public bool Equals(MatrixIntersection other) =>
+		Matrix1 == other.Matrix1 && Matrix2 == other.Matrix2
+		|| Matrix1 == other.Matrix2 && Matrix2 == other.Matrix1;
 
 	public override bool Equals( object obj )
 	{

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.Collisions.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.Collisions.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.Events;
 using Systems.Explosions;
-using Google.Protobuf;
 using Random = UnityEngine.Random;
 
 /// <summary>

--- a/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
+++ b/UnityProject/Assets/Scripts/Managers/MatrixManager/MatrixManager.cs
@@ -176,9 +176,8 @@ public partial class MatrixManager : MonoBehaviour
 	private static MatrixInfo CreateMatrixInfoFromMatrix(Matrix matrix, int id)
 	{
 		var gameObj = matrix.gameObject;
-		return new MatrixInfo
+		return new MatrixInfo(id)
 		{
-			Id = id,
 			Matrix = matrix,
 			GameObject = gameObj,
 			Objects = gameObj.transform.GetComponentInChildren<ObjectLayer>().transform,
@@ -354,11 +353,15 @@ public partial class MatrixManager : MonoBehaviour
 
 	public static bool LineIntersectsRect(Vector2 p1, Vector2 p2, BoundsInt r)
 	{
-		//return true;
-		return LineIntersectsLine(p1, p2, new Vector2(r.xMin, r.yMin), new Vector2(r.xMin, r.yMax)) ||
-		       LineIntersectsLine(p1, p2, new Vector2(r.xMin, r.yMin), new Vector2(r.xMax, r.yMin)) ||
-		       LineIntersectsLine(p1, p2, new Vector2(r.xMax, r.yMax), new Vector2(r.xMin, r.yMax)) ||
-		       LineIntersectsLine(p1, p2, new Vector2(r.xMax, r.yMax), new Vector2(r.xMax, r.yMin)) ||
+		var xMin = r.xMin;
+		var yMin = r.yMin;
+		var xMax = r.xMax;
+		var yMax = r.yMax;
+
+		return LineIntersectsLine(p1, p2, new Vector2(xMin, yMin), new Vector2(xMin, yMax)) ||
+		       LineIntersectsLine(p1, p2, new Vector2(xMin, yMin), new Vector2(xMax, yMin)) ||
+		       LineIntersectsLine(p1, p2, new Vector2(xMax, yMax), new Vector2(xMin, yMax)) ||
+		       LineIntersectsLine(p1, p2, new Vector2(xMax, yMax), new Vector2(xMax, yMin)) ||
 		       (FindPoint(r.min, r.max, p1) && FindPoint(r.min, r.max, p2));
 	}
 
@@ -658,6 +661,8 @@ public partial class MatrixManager : MonoBehaviour
 	{
 		foreach (MatrixInfo mat in Instance.ActiveMatrices)
 		{
+			if (mat == null) continue;
+
 			Vector3Int position = WorldToLocalInt(worldPosition, mat);
 			MetaDataNode node = mat.MetaDataLayer.Get(position, false);
 
@@ -908,17 +913,17 @@ public partial class MatrixManager : MonoBehaviour
 
 	public static bool IsTableAtAnyMatrix(Vector3Int worldTarget, bool isServer)
 	{
-		return AnyMatchInternal(mat => mat.Matrix.IsTableAt(WorldToLocalInt(worldTarget, mat), isServer));
+		return AnyMatchInternal(mat => mat != null && mat.Matrix.IsTableAt(WorldToLocalInt(worldTarget, mat), isServer));
 	}
 
 	public static bool IsWallAtAnyMatrix(Vector3Int worldTarget, bool isServer)
 	{
-		return AnyMatchInternal(mat => mat.Matrix.IsWallAt(WorldToLocalInt(worldTarget, mat), isServer));
+		return AnyMatchInternal(mat => mat != null && mat.Matrix.IsWallAt(WorldToLocalInt(worldTarget, mat), isServer));
 	}
 
 	public static bool IsWindowAtAnyMatrix(Vector3Int worldTarget, bool isServer)
 	{
-		return AnyMatchInternal(mat => mat.Matrix.IsWindowAt(WorldToLocalInt(worldTarget, mat), isServer));
+		return AnyMatchInternal(mat => mat != null && mat.Matrix.IsWindowAt(WorldToLocalInt(worldTarget, mat), isServer));
 	}
 
 	/// <Summary>
@@ -958,13 +963,13 @@ public partial class MatrixManager : MonoBehaviour
 	/// Get MatrixInfo by gameObject containing Matrix component
 	public static MatrixInfo Get(GameObject go)
 	{
-		return getInternal(mat => mat.GameObject == go);
+		return getInternal(mat => mat != null && mat.GameObject == go);
 	}
 
 	/// Get MatrixInfo by Objects layer transform
 	public static MatrixInfo Get(Transform objectParent)
 	{
-		return getInternal(mat => mat.ObjectParent == objectParent);
+		return getInternal(mat => mat != null && mat.ObjectParent == objectParent);
 	}
 
 	/// Get MatrixInfo by Matrix component
@@ -1089,7 +1094,7 @@ public partial class MatrixManager : MonoBehaviour
 	public static Vector3 LocalToWorld(Vector3 localPos, MatrixInfo matrix, MatrixState state = default(MatrixState))
 	{
 		//Invalid matrix info provided
-		if (matrix.Equals(MatrixInfo.Invalid) || localPos == TransformState.HiddenPos)
+		if (matrix == null || matrix.Equals(MatrixInfo.Invalid) || localPos == TransformState.HiddenPos)
 		{
 			return TransformState.HiddenPos;
 		}
@@ -1120,7 +1125,7 @@ public partial class MatrixManager : MonoBehaviour
 	public static Vector3 WorldToLocal(Vector3 worldPos, MatrixInfo matrix)
 	{
 		//Invalid matrix info provided
-		if (matrix.Equals(MatrixInfo.Invalid) || worldPos == TransformState.HiddenPos)
+		if (matrix == null || matrix.Equals(MatrixInfo.Invalid) || worldPos == TransformState.HiddenPos)
 		{
 			return TransformState.HiddenPos;
 		}

--- a/UnityProject/Assets/Scripts/Managers/PlayerList.cs
+++ b/UnityProject/Assets/Scripts/Managers/PlayerList.cs
@@ -113,7 +113,7 @@ public partial class PlayerList : NetworkBehaviour
 	/// </summary>
 	public List<ConnectedPlayer> GetPlayersOnMatrix(MatrixInfo matrix)
 	{
-		return InGamePlayers.FindAll(p => (p.Script != null) && p.Script.registerTile.Matrix.Id == matrix.Id);
+		return InGamePlayers.FindAll(p => (p.Script != null) && p.Script.registerTile.Matrix.Id == matrix?.Id);
 	}
 
 	public List<ConnectedPlayer> GetAlivePlayers(List<ConnectedPlayer> players = null)

--- a/UnityProject/Assets/Scripts/Player/PlayerMove.cs
+++ b/UnityProject/Assets/Scripts/Player/PlayerMove.cs
@@ -237,7 +237,7 @@ public class PlayerMove : NetworkBehaviour, IRightClickable, IServerSpawn, IActi
 		direction.y = Mathf.Clamp(direction.y, -1, 1);
 		//			Logger.LogTrace(direction.ToString(), Category.Movement);
 
-		if (matrixInfo.MatrixMove)
+		if (matrixInfo?.MatrixMove)
 		{
 			// Converting world direction to local direction
 			direction = Vector3Int.RoundToInt(matrixInfo.MatrixMove.FacingOffsetFromInitial.QuaternionInverted *

--- a/UnityProject/Assets/Scripts/ScriptableObjects/Audio/FootstepSounds.cs
+++ b/UnityProject/Assets/Scripts/ScriptableObjects/Audio/FootstepSounds.cs
@@ -51,6 +51,9 @@ public class FootstepSounds : MonoBehaviour
 	public static void FootstepAtPosition(Vector3 worldPos, StepType stepType,FloorSounds Override = null )
 	{
 		MatrixInfo matrix = MatrixManager.AtPoint(worldPos.RoundToInt(), false);
+
+		if (matrix == null) return;
+
 		var locPos = matrix.ObjectParent.transform.InverseTransformPoint(worldPos).RoundToInt();
 		var tile = matrix.MetaTileMap.GetTile(locPos) as BasicTile;
 

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/CargoEliminateSecurity.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/CargoEliminateSecurity.cs
@@ -14,7 +14,12 @@ namespace Antagonists
 
 		protected override bool CheckCompletion()
 		{
-			foreach (Transform t in GameManager.Instance.PrimaryEscapeShuttle.MatrixInfo.Objects.transform)
+			var transform = GameManager.Instance.PrimaryEscapeShuttle.OrNull()?.MatrixInfo?.Objects.OrNull()?.transform;
+
+			// If the primary shuttle doesn't exist in some form, should this return true?
+			if (transform == null) return true;
+
+			foreach (Transform t in transform)
 			{
 				var player = t.GetComponent<PlayerScript>();
 				if (player != null)

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/Escape.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/Escape.cs
@@ -31,7 +31,8 @@ namespace Antagonists
 		protected override bool CheckCompletion()
 		{
 			return !Owner.body.playerHealth.IsDead &&
-				ValidShuttles.Any( shuttle => Owner.body.registerTile.Matrix.Id == shuttle.MatrixInfo.Id && shuttle.HasWorkingThrusters);
+				ValidShuttles.Any( shuttle => shuttle.MatrixInfo != null
+					&& Owner.body.registerTile.Matrix.Id == shuttle.MatrixInfo.Id && shuttle.HasWorkingThrusters);
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/Hijack.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/EscapeObjectives/Hijack.cs
@@ -36,7 +36,8 @@ namespace Antagonists
 			}
 
 			//Shuttle must be functional and player be on it
-			if (!ValidShuttles.Any( shuttle => Owner.body.registerTile.Matrix.Id == shuttle.MatrixInfo.Id && shuttle.HasWorkingThrusters))
+			if (!ValidShuttles.Any( shuttle => shuttle.MatrixInfo != null
+				&& Owner.body.registerTile.Matrix.Id == shuttle.MatrixInfo.Id && shuttle.HasWorkingThrusters))
 			{
 				return false;
 			}

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/Maroon.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/Maroon.cs
@@ -85,12 +85,8 @@ namespace Antagonists
 			}
 
 			//If target is on functional escape shuttle, we failed
-			if (ValidShuttles.Any( shuttle => Target.registerTile.Matrix.Id == shuttle.MatrixInfo.Id && shuttle.HasWorkingThrusters))
-			{
-				return false;
-			}
-
-			return true;
+			return ValidShuttles.Any( shuttle => shuttle.MatrixInfo != null
+				&& Target.registerTile.Matrix.Id == shuttle.MatrixInfo.Id && shuttle.HasWorkingThrusters) == false;
 		}
 	}
 }

--- a/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/OnlyCargoMenEscape.cs
+++ b/UnityProject/Assets/Scripts/Systems/Antagonists/Objectives/OnlyCargoMenEscape.cs
@@ -18,7 +18,13 @@ namespace Antagonists
 		protected override bool CheckCompletion()
 		{
 			int playersFound = 0;
-			foreach (Transform t in GameManager.Instance.PrimaryEscapeShuttle.MatrixInfo.Objects.transform)
+			var primaryEscape = GameManager.Instance.PrimaryEscapeShuttle;
+			var objects = primaryEscape.OrNull()?.MatrixInfo?.Objects;
+			var objectsTransform = objects.OrNull()?.transform;
+
+			if (objectsTransform == null) return false;
+
+			foreach (Transform t in objectsTransform)
 			{
 				var player = t.GetComponent<PlayerScript>();
 				if (player != null)

--- a/UnityProject/Assets/Scripts/Systems/Electricity/Inheritance/CableInheritance.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/Inheritance/CableInheritance.cs
@@ -48,20 +48,15 @@ public class CableInheritance : NetworkBehaviour, ICheckedInteractable<Positiona
 	{
 		//wirecutters can be used to cut this cable
 		Vector3Int worldPosInt = interaction.WorldPositionTarget.To2Int().To3Int();
-		MatrixInfo matrix = MatrixManager.AtPoint(worldPosInt, true);
-		var localPosInt = MatrixManager.WorldToLocalInt(worldPosInt, matrix);
-		if (matrix.Matrix != null)
+		var matrixInfo = MatrixManager.AtPoint(worldPosInt, true);
+		var localPosInt = MatrixManager.WorldToLocalInt(worldPosInt, matrixInfo);
+		var matrix = matrixInfo?.Matrix;
+
+		if (matrix == null || matrix.IsClearUnderfloorConstruction(localPosInt, true) == false)
 		{
-			if (!matrix.Matrix.IsClearUnderfloorConstruction(localPosInt, true))
-			{
-
-				return;
-			}
-		}
-		else {
-
 			return;
 		}
+
 		wireConnect.DestroyThisPlease();
 	}
 

--- a/UnityProject/Assets/Scripts/Systems/Electricity/Wire/CableCategories/LowVoltageMachineConnector.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/Wire/CableCategories/LowVoltageMachineConnector.cs
@@ -49,10 +49,11 @@ public class LowVoltageMachineConnector : NetworkBehaviour, ICheckedInteractable
 	{
 		//wirecutters can be used to cut this cable
 		Vector3Int worldPosInt = interaction.WorldPositionTarget.To2Int().To3Int();
-		MatrixInfo matrix = MatrixManager.AtPoint(worldPosInt, true);
-		var localPosInt = MatrixManager.WorldToLocalInt(worldPosInt, matrix);
+		var matrixInfo = MatrixManager.AtPoint(worldPosInt, true);
+		var localPosInt = MatrixManager.WorldToLocalInt(worldPosInt, matrixInfo);
+		var matrix = matrixInfo?.Matrix;
 
-		if (matrix.Matrix == null || !matrix.Matrix.IsClearUnderfloorConstruction(localPosInt, true))
+		if (matrix == null || matrix.IsClearUnderfloorConstruction(localPosInt, true) == false)
 		{
 			return;
 		}

--- a/UnityProject/Assets/Scripts/Systems/Electricity/Wire/CableCategories/MediumMachineConnector.cs
+++ b/UnityProject/Assets/Scripts/Systems/Electricity/Wire/CableCategories/MediumMachineConnector.cs
@@ -39,10 +39,11 @@ public class MediumMachineConnector : NetworkBehaviour, ICheckedInteractable<Pos
 	{
 		//wirecutters can be used to cut this cable
 		Vector3Int worldPosInt = interaction.WorldPositionTarget.To2Int().To3Int();
-		MatrixInfo matrix = MatrixManager.AtPoint(worldPosInt, true);
-		var localPosInt = MatrixManager.WorldToLocalInt(worldPosInt, matrix);
+		var matrixInfo = MatrixManager.AtPoint(worldPosInt, true);
+		var localPosInt = MatrixManager.WorldToLocalInt(worldPosInt, matrixInfo);
+		var matrix = matrixInfo?.Matrix;
 
-		if (matrix.Matrix == null || !matrix.Matrix.IsClearUnderfloorConstruction(localPosInt, true))
+		if (matrix == null || matrix.IsClearUnderfloorConstruction(localPosInt, true) == false)
 		{
 			return;
 		}

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventAsteroids.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventAsteroids.cs
@@ -36,9 +36,19 @@ namespace InGameEvents
 		[SerializeField]
 		private int maxTimeBetweenMeteors = 10;
 
+		private bool IsMatrixInvalid()
+		{
+			if (stationMatrix != null) return false;
+
+			Logger.LogError($"Unable to start \"{nameof(EventAsteroids)}\". Main station may not be initialized yet.");
+			return true;
+		}
+
 		public override void OnEventStart()
 		{
 			stationMatrix = MatrixManager.MainStationMatrix;
+
+			if (IsMatrixInvalid()) return;
 
 			if (AnnounceEvent)
 			{
@@ -56,6 +66,8 @@ namespace InGameEvents
 
 		public override void OnEventStartTimed()
 		{
+			if (IsMatrixInvalid()) return;
+
 			int asteroidAmount = UnityEngine.Random.Range(minMeteorAmount, maxMeteorAmount);
 
 			for (var i = 1; i <= asteroidAmount; i++)
@@ -79,6 +91,8 @@ namespace InGameEvents
 
 		private IEnumerator SpawnMeteorsWithDelay(float asteroidAmount)
 		{
+			if (IsMatrixInvalid()) yield break;
+
 			for (var i = 1; i <= asteroidAmount; i++)
 			{
 				int multiplier = 1;

--- a/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventImmovableRod.cs
+++ b/UnityProject/Assets/Scripts/Systems/InGameEvents/InGameEventScripts/EventImmovableRod.cs
@@ -26,9 +26,19 @@ namespace InGameEvents
 
 		private const int DISTANCE_BETWEEN_EXPLOSIONS = 2;
 
+		private bool IsMatrixInvalid()
+		{
+			if (stationMatrix != null) return false;
+
+			Logger.LogError($"Unable to start \"{nameof(EventImmovableRod)}\". Main station may not be initialized yet.");
+			return true;
+		}
+
 		public override void OnEventStart()
 		{
 			stationMatrix = MatrixManager.MainStationMatrix;
+
+			if (IsMatrixInvalid()) return;
 
 			if (AnnounceEvent)
 			{
@@ -44,6 +54,8 @@ namespace InGameEvents
 
 		public override void OnEventStartTimed()
 		{
+			if (IsMatrixInvalid()) return;
+
 			var MaxCoord = new Vector2() { x = stationMatrix.WorldBounds.xMax , y = stationMatrix.WorldBounds.yMax };
 
 			var MinCoord = new Vector2() { x = stationMatrix.WorldBounds.xMin, y = stationMatrix.WorldBounds.yMin };
@@ -114,6 +126,8 @@ namespace InGameEvents
 
 		private IEnumerator SpawnMeteorsWithDelay(float immovableRodPathCoords, Queue<Vector3> impactCoords)
 		{
+			if (IsMatrixInvalid()) yield break;
+
 			var rod = Instantiate(immovableRodPrefab, position: impactCoords.Peek(), rotation: stationMatrix.ObjectParent.rotation, parent: stationMatrix.ObjectParent);
 
 			for (var i = 1; i <= immovableRodPathCoords; i++)

--- a/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
+++ b/UnityProject/Assets/Scripts/Tilemaps/Behaviours/Meta/MetaDataSystem.cs
@@ -246,7 +246,7 @@ public class MetaDataSystem : SubsystemBehaviour
 						MatrixInfo matrixInfo = MatrixManager.AtPoint(neighborWorldPosition.RoundToInt(), true);
 
 						// ignore tilemap of current node
-						if (matrixInfo.MetaTileMap != metaTileMap)
+						if (matrixInfo != null && matrixInfo.MetaTileMap != metaTileMap)
 						{
 							// Check if atmos can pass to the neighboring position
 							Vector3Int neighborlocalPosition = MatrixManager.WorldToLocalInt(neighborWorldPosition, matrixInfo);


### PR DESCRIPTION
### Purpose
While deep profiling I kept seeing some functions like WorldToLocal taking quite some time, more time than it really should have. Some of it made sense but there was definitely something off. While working on something related I noticed MatrixInfo was a struct. A struct with 14 fields (edit: was tired and misread the first time), 3 of those also structs. A struct that is copied in a lot of functions. Functions like WorldToLocal. This really should not be a struct.

Changing this to a class prevents copying all the fields each time it is passed along or returned from a function. This is a great time savings (around 30% for small functions) for anything that uses MatrixInfo. As an extreme example, there were some frames with 9700 WorldToLocal calls that took 50% of the total frame time. It was around 480+ms (with deep profiling on mind you) each time it happened. Those same 9700 calls took around 320 ms (again, deep profiling) when converting MatrixInfo to a class.